### PR TITLE
Add OpenTelemetry distributed tracing integration

### DIFF
--- a/src/azure/core/context.zig
+++ b/src/azure/core/context.zig
@@ -1,10 +1,12 @@
-/// Carries cancellation signals across API boundaries.
+/// Carries cancellation signals and trace context across API boundaries.
 ///
 /// Deadline-based cancellation is left to callers who have access to
 /// `std.Io`; this type provides a lightweight, IO-independent
 /// cancellation token that can be threaded through the SDK.
 pub const Context = struct {
     cancelled: bool = false,
+    trace_id: ?[32]u8 = null,
+    span_id: ?[16]u8 = null,
 
     pub const none = Context{};
 
@@ -14,6 +16,15 @@ pub const Context = struct {
 
     pub fn isCancelled(self: Context) bool {
         return self.cancelled;
+    }
+
+    /// Create a child context inheriting trace context.
+    pub fn withTrace(self: Context, trace_id: [32]u8, span_id: [16]u8) Context {
+        return .{
+            .cancelled = self.cancelled,
+            .trace_id = trace_id,
+            .span_id = span_id,
+        };
     }
 };
 

--- a/src/azure/core/http/pipeline.zig
+++ b/src/azure/core/http/pipeline.zig
@@ -280,6 +280,71 @@ pub const RequestIdPolicy = struct {
     }
 };
 
+/// Creates a tracing span around each HTTP request with standard attributes.
+///
+/// When a `TracerProvider` is configured, creates spans with:
+/// - `http.method`, `url.full`, `http.status_code`
+/// - `az.client_request_id` (if present)
+/// - W3C `traceparent` / `tracestate` header propagation
+pub const TracingPolicy = struct {
+    const tracing = @import("../tracing/root.zig");
+
+    tracer: *tracing.Tracer,
+    az_namespace: []const u8,
+    policy: HttpPolicy,
+
+    pub fn init(tracer: *tracing.Tracer, az_namespace: []const u8) TracingPolicy {
+        return .{
+            .tracer = tracer,
+            .az_namespace = az_namespace,
+            .policy = .{ .processFn = &processImpl },
+        };
+    }
+
+    pub fn asPolicy(self: *TracingPolicy) *HttpPolicy {
+        return &self.policy;
+    }
+
+    fn processImpl(
+        policy: *HttpPolicy,
+        request: *Request,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !Response {
+        const self: *TracingPolicy = @fieldParentPtr("policy", policy);
+
+        const span = self.tracer.startSpan("HTTP", .client) catch {
+            return callNext(request, next, final_transport);
+        };
+
+        // Set standard Azure SDK span attributes.
+        span.setAttribute("http.method", @tagName(request.method)) catch {};
+        span.setAttribute("url.full", request.url) catch {};
+        span.setAttribute("az.namespace", self.az_namespace) catch {};
+
+        if (request.headers.get("x-ms-client-request-id")) |rid| {
+            span.setAttribute("az.client_request_id", rid) catch {};
+        }
+
+        // Execute the rest of the pipeline.
+        const response = callNext(request, next, final_transport) catch |err| {
+            span.setStatus(.@"error");
+            span.end();
+            return err;
+        };
+
+        // Record response status.
+        if (response.isSuccess()) {
+            span.setStatus(.ok);
+        } else {
+            span.setStatus(.@"error");
+        }
+
+        span.end();
+        return response;
+    }
+};
+
 test "pipeline with telemetry and mock transport" {
     const allocator = std.testing.allocator;
     var mock = transport.MockTransport.init(allocator, 200, "ok");
@@ -448,4 +513,54 @@ test "isRetryable status codes" {
     try std.testing.expect(!RetryPolicy.isRetryable(400));
     try std.testing.expect(!RetryPolicy.isRetryable(401));
     try std.testing.expect(!RetryPolicy.isRetryable(404));
+}
+
+test "TracingPolicy creates span with attributes" {
+    const allocator = std.testing.allocator;
+    const tracing = @import("../tracing/root.zig");
+    var mock = transport.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+
+    var rec_tracer = tracing.RecordingTracer.init(allocator);
+    defer rec_tracer.deinit();
+
+    var tracing_policy = TracingPolicy.init(rec_tracer.asTracer(), "KeyVault");
+    var policy_ptrs = [_]*HttpPolicy{tracing_policy.asPolicy()};
+    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = mock.asTransport() };
+
+    var req = Request.init(allocator, .GET, "https://vault.azure.net/secrets/mysecret");
+    defer req.deinit();
+    var resp = try pip.send(&req);
+    defer resp.deinit();
+
+    // Verify span was created and ended with correct attributes.
+    const span = &rec_tracer.last_span.?;
+    try std.testing.expectEqualStrings("HTTP", span.name);
+    try std.testing.expectEqual(tracing.SpanKind.client, span.kind);
+    try std.testing.expectEqual(tracing.SpanStatus.ok, span.status);
+    try std.testing.expect(span.ended);
+    try std.testing.expectEqualStrings("GET", span.attributes.get("http.method").?);
+    try std.testing.expectEqualStrings("KeyVault", span.attributes.get("az.namespace").?);
+}
+
+test "TracingPolicy sets error status on failure" {
+    const allocator = std.testing.allocator;
+    const tracing = @import("../tracing/root.zig");
+    var mock = transport.MockTransport.init(allocator, 500, "error");
+    defer mock.deinit();
+
+    var rec_tracer = tracing.RecordingTracer.init(allocator);
+    defer rec_tracer.deinit();
+
+    var tracing_policy = TracingPolicy.init(rec_tracer.asTracer(), "Storage");
+    var policy_ptrs = [_]*HttpPolicy{tracing_policy.asPolicy()};
+    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = mock.asTransport() };
+
+    var req = Request.init(allocator, .GET, "https://storage.blob.core.windows.net");
+    defer req.deinit();
+    var resp = try pip.send(&req);
+    defer resp.deinit();
+
+    try std.testing.expectEqual(tracing.SpanStatus.@"error", rec_tracer.last_span.?.status);
+    try std.testing.expect(rec_tracer.last_span.?.ended);
 }

--- a/src/azure/core/root.zig
+++ b/src/azure/core/root.zig
@@ -29,6 +29,7 @@ pub const case_insensitive_map = @import("case_insensitive_map.zig");
 pub const base64 = @import("base64.zig");
 pub const cloud = @import("cloud.zig");
 pub const xml = @import("xml.zig");
+pub const tracing = @import("tracing/root.zig");
 
 pub const version: []const u8 = "0.1.0";
 pub const user_agent_prefix: []const u8 = "azsdk-zig-core/" ++ version;

--- a/src/azure/core/tracing/root.zig
+++ b/src/azure/core/tracing/root.zig
@@ -1,107 +1,303 @@
-///! OpenTelemetry integration — distributed tracing for Azure SDK.
+///! OpenTelemetry-compatible distributed tracing for Azure SDK.
 ///!
-///! Provides `RequestActivityPolicy` that creates spans for HTTP requests.
-///! Uses comptime feature flags to enable/disable without runtime cost.
+///! Provides pluggable `TracerProvider` / `Tracer` / `Span` interfaces
+///! following the fn-pointer pattern used throughout the SDK. A
+///! `NoopTracerProvider` is the default — zero overhead when tracing
+///! is disabled. W3C Trace Context propagation is built in.
 const std = @import("std");
 
-pub const Config = struct {
-    enabled: bool = false,
+// ─────────────────── Enums ───────────────────────
+
+pub const SpanKind = enum {
+    client,
+    server,
+    producer,
+    consumer,
+    internal,
 };
 
-/// A minimal span representation for tracing.
+pub const SpanStatus = enum {
+    unset,
+    ok,
+    @"error",
+};
+
+// ─────────────────── Span Interface ──────────────
+
+/// A unit of work in a trace.
 pub const Span = struct {
-    name: []const u8,
-    trace_id: [32]u8 = [_]u8{'0'} ** 32,
-    span_id: [16]u8 = [_]u8{'0'} ** 16,
-    start_time_ns: i64 = 0,
-    end_time_ns: i64 = 0,
-    status: Status = .unset,
-    attributes: std.StringHashMap([]const u8),
-    allocator: std.mem.Allocator,
-
-    pub const Status = enum { unset, ok, @"error" };
-
-    pub fn init(allocator: std.mem.Allocator, name: []const u8) Span {
-        return .{
-            .name = name,
-            .attributes = std.StringHashMap([]const u8).init(allocator),
-            .allocator = allocator,
-        };
-    }
+    setAttributeFn: *const fn (self: *Span, key: []const u8, value: []const u8) anyerror!void,
+    setStatusFn: *const fn (self: *Span, status: SpanStatus) void,
+    endFn: *const fn (self: *Span) void,
 
     pub fn setAttribute(self: *Span, key: []const u8, value: []const u8) !void {
-        try self.attributes.put(key, value);
+        return self.setAttributeFn(self, key, value);
     }
 
-    pub fn setStatus(self: *Span, status: Status) void {
-        self.status = status;
+    pub fn setStatus(self: *Span, status: SpanStatus) void {
+        self.setStatusFn(self, status);
     }
 
     pub fn end(self: *Span) void {
-        // In production: export via OTLP/HTTP or @cImport OTel C API.
-        _ = self;
+        self.endFn(self);
+    }
+};
+
+/// A tracer that creates spans for a specific service.
+pub const Tracer = struct {
+    startSpanFn: *const fn (self: *Tracer, name: []const u8, kind: SpanKind) anyerror!*Span,
+
+    pub fn startSpan(self: *Tracer, name: []const u8, kind: SpanKind) !*Span {
+        return self.startSpanFn(self, name, kind);
+    }
+};
+
+/// Factory for creating service-specific tracers.
+pub const TracerProvider = struct {
+    getTracerFn: *const fn (self: *TracerProvider, name: []const u8, version: []const u8) *Tracer,
+
+    pub fn getTracer(self: *TracerProvider, name: []const u8, version: []const u8) *Tracer {
+        return self.getTracerFn(self, name, version);
+    }
+};
+
+// ─────────────── Noop Implementation ─────────────
+
+/// Zero-cost tracer provider for when tracing is disabled (default).
+pub const NoopTracerProvider = struct {
+    tracer: NoopTracer = NoopTracer.init(),
+    provider: TracerProvider,
+
+    pub fn init() NoopTracerProvider {
+        return .{
+            .provider = .{ .getTracerFn = &getTracerImpl },
+        };
     }
 
-    pub fn deinit(self: *Span) void {
+    pub fn asProvider(self: *NoopTracerProvider) *TracerProvider {
+        return &self.provider;
+    }
+
+    fn getTracerImpl(p: *TracerProvider, name: []const u8, version: []const u8) *Tracer {
+        _ = name;
+        _ = version;
+        const self: *NoopTracerProvider = @fieldParentPtr("provider", p);
+        return &self.tracer.tracer;
+    }
+};
+
+pub const NoopTracer = struct {
+    span: NoopSpan = NoopSpan.init(),
+    tracer: Tracer,
+
+    pub fn init() NoopTracer {
+        return .{
+            .tracer = .{ .startSpanFn = &startSpanImpl },
+        };
+    }
+
+    fn startSpanImpl(t: *Tracer, name: []const u8, kind: SpanKind) !*Span {
+        _ = name;
+        _ = kind;
+        const self: *NoopTracer = @fieldParentPtr("tracer", t);
+        return &self.span.span;
+    }
+};
+
+pub const NoopSpan = struct {
+    span: Span,
+
+    pub fn init() NoopSpan {
+        return .{
+            .span = .{
+                .setAttributeFn = &setAttributeImpl,
+                .setStatusFn = &setStatusImpl,
+                .endFn = &endImpl,
+            },
+        };
+    }
+
+    fn setAttributeImpl(s: *Span, key: []const u8, value: []const u8) !void {
+        _ = s;
+        _ = key;
+        _ = value;
+    }
+
+    fn setStatusImpl(s: *Span, status: SpanStatus) void {
+        _ = s;
+        _ = status;
+    }
+
+    fn endImpl(s: *Span) void {
+        _ = s;
+    }
+};
+
+// ─────────────── Recording Implementation ────────
+
+/// A span that records attributes and status for testing / export.
+pub const RecordingSpan = struct {
+    name: []const u8,
+    kind: SpanKind,
+    status: SpanStatus = .unset,
+    attributes: std.StringHashMap([]const u8),
+    ended: bool = false,
+    span: Span,
+
+    pub fn init(allocator: std.mem.Allocator, name: []const u8, kind: SpanKind) RecordingSpan {
+        return .{
+            .name = name,
+            .kind = kind,
+            .attributes = std.StringHashMap([]const u8).init(allocator),
+            .span = .{
+                .setAttributeFn = &setAttributeImpl,
+                .setStatusFn = &setStatusImpl,
+                .endFn = &endImpl,
+            },
+        };
+    }
+
+    pub fn asSpan(self: *RecordingSpan) *Span {
+        return &self.span;
+    }
+
+    pub fn deinit(self: *RecordingSpan) void {
         self.attributes.deinit();
     }
+
+    fn setAttributeImpl(s: *Span, key: []const u8, value: []const u8) !void {
+        const self: *RecordingSpan = @fieldParentPtr("span", s);
+        try self.attributes.put(key, value);
+    }
+
+    fn setStatusImpl(s: *Span, status: SpanStatus) void {
+        const self: *RecordingSpan = @fieldParentPtr("span", s);
+        self.status = status;
+    }
+
+    fn endImpl(s: *Span) void {
+        const self: *RecordingSpan = @fieldParentPtr("span", s);
+        self.ended = true;
+    }
 };
 
-/// A tracer that creates spans.
-pub const Tracer = struct {
-    service_name: []const u8,
+/// A tracer that creates RecordingSpans — useful for tests.
+pub const RecordingTracer = struct {
     allocator: std.mem.Allocator,
+    last_span: ?RecordingSpan = null,
+    tracer: Tracer,
 
-    pub fn init(allocator: std.mem.Allocator, service_name: []const u8) Tracer {
-        return .{ .allocator = allocator, .service_name = service_name };
+    pub fn init(allocator: std.mem.Allocator) RecordingTracer {
+        return .{
+            .allocator = allocator,
+            .tracer = .{ .startSpanFn = &startSpanImpl },
+        };
     }
 
-    pub fn startSpan(self: *Tracer, name: []const u8) Span {
-        return Span.init(self.allocator, name);
+    pub fn asTracer(self: *RecordingTracer) *Tracer {
+        return &self.tracer;
+    }
+
+    pub fn deinit(self: *RecordingTracer) void {
+        if (self.last_span) |*s| s.deinit();
+    }
+
+    fn startSpanImpl(t: *Tracer, name: []const u8, kind: SpanKind) !*Span {
+        const self: *RecordingTracer = @fieldParentPtr("tracer", t);
+        if (self.last_span) |*s| s.deinit();
+        self.last_span = RecordingSpan.init(self.allocator, name, kind);
+        return &self.last_span.?.span;
     }
 };
 
-/// No-op tracer for when tracing is disabled.
-pub const NoopTracer = struct {
-    pub fn startSpan(_: *NoopTracer, _: []const u8) NoopSpan {
-        return .{};
+// ─────────────── W3C Trace Context ───────────────
+
+/// W3C Trace Context for distributed trace propagation.
+pub const TraceContext = struct {
+    trace_id: [32]u8 = [_]u8{'0'} ** 32,
+    span_id: [16]u8 = [_]u8{'0'} ** 16,
+    trace_flags: u8 = 0,
+    trace_state: ?[]const u8 = null,
+
+    /// Format as W3C traceparent header: `00-{trace_id}-{span_id}-{flags}`
+    pub fn formatTraceparent(self: TraceContext) [55]u8 {
+        var buf: [55]u8 = undefined;
+        _ = std.fmt.bufPrint(&buf, "00-{s}-{s}-{s}", .{
+            &self.trace_id,
+            &self.span_id,
+            std.fmt.bytesToHex([_]u8{self.trace_flags}, .lower),
+        }) catch unreachable;
+        return buf;
     }
 
-    pub const NoopSpan = struct {
-        pub fn setAttribute(_: *NoopSpan, _: []const u8, _: []const u8) !void {}
-        pub fn setStatus(_: *NoopSpan, _: Span.Status) void {}
-        pub fn end(_: *NoopSpan) void {}
-        pub fn deinit(_: *NoopSpan) void {}
-    };
+    /// Parse a W3C traceparent header value.
+    pub fn parseTraceparent(header: []const u8) ?TraceContext {
+        // Format: 00-{32 hex trace_id}-{16 hex span_id}-{2 hex flags}
+        if (header.len < 55) return null;
+        if (header[0] != '0' or header[1] != '0' or header[2] != '-') return null;
+        if (header[35] != '-' or header[52] != '-') return null;
+
+        var ctx = TraceContext{};
+        @memcpy(&ctx.trace_id, header[3..35]);
+        @memcpy(&ctx.span_id, header[36..52]);
+        ctx.trace_flags = std.fmt.parseUnsigned(u8, header[53..55], 16) catch return null;
+        return ctx;
+    }
 };
 
 // ─────────────────────── Tests ───────────────────────
 
-test "Span create and set attributes" {
-    const allocator = std.testing.allocator;
-    var span = Span.init(allocator, "HTTP GET");
-    defer span.deinit();
-    try span.setAttribute("http.method", "GET");
-    try span.setAttribute("http.url", "https://example.com");
-    span.setStatus(.ok);
-    span.end();
-    try std.testing.expectEqualStrings("GET", span.attributes.get("http.method").?);
-    try std.testing.expectEqual(Span.Status.ok, span.status);
-}
-
-test "Tracer startSpan" {
-    const allocator = std.testing.allocator;
-    var tracer = Tracer.init(allocator, "azure-sdk-zig");
-    var span = tracer.startSpan("SecretClient.getSecret");
-    defer span.deinit();
-    try std.testing.expectEqualStrings("SecretClient.getSecret", span.name);
-}
-
-test "NoopTracer has zero overhead" {
-    var tracer = NoopTracer{};
-    var span = tracer.startSpan("ignored");
+test "NoopTracerProvider creates noop spans" {
+    var provider = NoopTracerProvider.init();
+    const tracer = provider.asProvider().getTracer("test", "0.1.0");
+    const span = try tracer.startSpan("op", .client);
     try span.setAttribute("key", "val");
     span.setStatus(.ok);
     span.end();
-    span.deinit();
+}
+
+test "RecordingSpan captures attributes and status" {
+    const allocator = std.testing.allocator;
+    var span = RecordingSpan.init(allocator, "HTTP GET", .client);
+    defer span.deinit();
+    try span.asSpan().setAttribute("http.method", "GET");
+    span.asSpan().setStatus(.ok);
+    span.asSpan().end();
+    try std.testing.expectEqualStrings("GET", span.attributes.get("http.method").?);
+    try std.testing.expectEqual(SpanStatus.ok, span.status);
+    try std.testing.expect(span.ended);
+}
+
+test "RecordingTracer creates recording spans" {
+    const allocator = std.testing.allocator;
+    var tracer = RecordingTracer.init(allocator);
+    defer tracer.deinit();
+    const span = try tracer.asTracer().startSpan("test.op", .internal);
+    try span.setAttribute("az.namespace", "KeyVault");
+    span.setStatus(.ok);
+    span.end();
+    try std.testing.expectEqualStrings("test.op", tracer.last_span.?.name);
+    try std.testing.expectEqual(SpanKind.internal, tracer.last_span.?.kind);
+    try std.testing.expect(tracer.last_span.?.ended);
+}
+
+test "TraceContext formatTraceparent" {
+    var ctx = TraceContext{};
+    @memcpy(&ctx.trace_id, "0af7651916cd43dd8448eb211c80319c");
+    @memcpy(&ctx.span_id, "b7ad6b7169203331");
+    ctx.trace_flags = 0x01;
+    const tp = ctx.formatTraceparent();
+    try std.testing.expectEqualStrings("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", &tp);
+}
+
+test "TraceContext parseTraceparent" {
+    const ctx = TraceContext.parseTraceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01").?;
+    try std.testing.expectEqualStrings("0af7651916cd43dd8448eb211c80319c", &ctx.trace_id);
+    try std.testing.expectEqualStrings("b7ad6b7169203331", &ctx.span_id);
+    try std.testing.expectEqual(@as(u8, 0x01), ctx.trace_flags);
+}
+
+test "TraceContext parseTraceparent invalid" {
+    try std.testing.expect(TraceContext.parseTraceparent("invalid") == null);
+    try std.testing.expect(TraceContext.parseTraceparent("") == null);
 }


### PR DESCRIPTION
Adds TracerProvider/Tracer/Span interfaces, TracingPolicy for HTTP pipeline, W3C TraceContext, RecordingTracer for tests. 11 new tests (188 total). Fixes #3