### PR TITLE
Trigger CI on main branch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -2,19 +2,9 @@ name: Zig SDK
 
 on:
   push:
-    branches: [zig]
-    paths:
-      - 'src/**'
-      - 'build.zig'
-      - 'build.zig.zon'
-      - '.github/workflows/zig.yml'
+    branches: [main]
   pull_request:
-    branches: [zig]
-    paths:
-      - 'src/**'
-      - 'build.zig'
-      - 'build.zig.zon'
-      - '.github/workflows/zig.yml'
+    branches: [main]
 
 jobs:
   test:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .xml = .{
             .url = "git+https://github.com/ctaggart/zig-xml.git#c72ff9efbf1c4588ebd3c0d489576ec2dc0b36bb",
-            .hash = "xml-0.2.0-ZTbP3yI6AgB9Rpd2hQrueO63ib0Bm6mQiL_WB1t7JAmP",
+            .hash = "xml-0.2.0-ZTbP3yI6AgCDqW2awXya1aSKFJzPrXTRGYWGmoMj1mDG",
         },
         .uamqp = .{
             .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",


### PR DESCRIPTION
The workflow previously only triggered on the `zig` branch (which no longer exists), so CI wasn't running on PRs to `main`.

This PR:
- Updates push and pull_request triggers from `zig` -> `main`
- Drops the path filters so required status checks always run on PRs (path filters cause checks to be skipped, which leaves required checks stuck in "pending" and blocks merges)

Once merged, branch protection on `main` will require the matrix jobs (`test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`) to pass before any PR can be merged.