### PR TITLE
Finish Zig 0.16 migration: indexOf->find + fix std.time.timestamp

### DIFF
--- a/src/azure/attestation/root.zig
+++ b/src/azure/attestation/root.zig
@@ -139,5 +139,5 @@ test "AttestationClient attestSgxEnclave" {
     try std.testing.expectEqualStrings("eyJhbGciOiJSUzI1NiJ9.attestation-token", result.token.?);
     try std.testing.expectEqual(false, result.is_debuggable.?);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "attest/SgxEnclave?api-version=") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "attest/SgxEnclave?api-version=") != null);
 }

--- a/src/azure/core/http/pipeline.zig
+++ b/src/azure/core/http/pipeline.zig
@@ -10,6 +10,10 @@ fn nanoTimestamp() i128 {
     return std.Io.Timestamp.now(threaded.io(), .real).toNanoseconds();
 }
 
+fn unixTimestampSeconds() i64 {
+    return @intCast(@divTrunc(nanoTimestamp(), std.time.ns_per_s));
+}
+
 fn sleepMs(ms: u64) void {
     var threaded: std.Io.Threaded = .init_single_threaded;
     threaded.io().sleep(.fromMilliseconds(@intCast(ms)), .real) catch {};
@@ -234,7 +238,7 @@ pub const BearerTokenAuthPolicy = struct {
         final_transport: *HttpTransport,
     ) !Response {
         const self: *BearerTokenAuthPolicy = @fieldParentPtr("policy", policy);
-        const now = std.time.timestamp();
+        const now = unixTimestampSeconds();
         const refresh_buffer: i64 = 300; // 5 minutes before expiry
 
         // Use cached token if still valid.
@@ -430,6 +434,42 @@ test "RequestIdPolicy injects x-ms-client-request-id" {
     // UUID format: 8-4-4-4-12 = 36 chars.
     try std.testing.expectEqual(@as(usize, 36), request_id.len);
     try std.testing.expectEqual(@as(u8, '-'), request_id[8]);
+}
+
+test "BearerTokenAuthPolicy injects Authorization header" {
+    const allocator = std.testing.allocator;
+    const creds = @import("../credentials/token.zig");
+
+    const Stub = struct {
+        fn getTokenFn(
+            _: *creds.TokenCredential,
+            _: creds.TokenRequestContext,
+            _: @import("../context.zig").Context,
+        ) anyerror!creds.AccessToken {
+            const token = try allocator.dupe(u8, "stub-token");
+            return .{ .token = token, .expires_on = unixTimestampSeconds() + 3600 };
+        }
+    };
+    var credential = creds.TokenCredential{ .getTokenFn = &Stub.getTokenFn };
+
+    var mock = transport.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    var auth = BearerTokenAuthPolicy.init(
+        allocator,
+        &credential,
+        &.{"https://vault.azure.net/.default"},
+    );
+    defer auth.deinit();
+    var policy_ptrs = [_]*HttpPolicy{auth.asPolicy()};
+    var pipeline_inst = HttpPipeline{
+        .policies = &policy_ptrs,
+        .transport_impl = mock.asTransport(),
+    };
+    var req = Request.init(allocator, .GET, "https://example.com");
+    defer req.deinit();
+    var resp = try pipeline_inst.send(&req);
+    defer resp.deinit();
+    try std.testing.expectEqualStrings("Bearer stub-token", req.headers.get("Authorization").?);
 }
 
 test "RetryPolicy passes through 200 without retry" {

--- a/src/azure/core/lro.zig
+++ b/src/azure/core/lro.zig
@@ -601,7 +601,7 @@ test "Poller azure-async-operation with final GET" {
 
     try std.testing.expectEqual(OperationStatus.succeeded, result.status);
     // The result body should be from the final GET, not the poll.
-    try std.testing.expect(std.mem.indexOf(u8, result.raw_body, "my-resource") != null);
+    try std.testing.expect(std.mem.find(u8, result.raw_body, "my-resource") != null);
 }
 
 test "Poller single poll" {

--- a/src/azure/core/testing/root.zig
+++ b/src/azure/core/testing/root.zig
@@ -306,7 +306,7 @@ test "RecordingTransport captures exchanges" {
     const exchanges = recorder.getExchanges();
     try std.testing.expectEqual(@as(usize, 1), exchanges.len);
     try std.testing.expectEqual(core.http.Method.GET, exchanges[0].request_method);
-    try std.testing.expect(std.mem.indexOf(u8, exchanges[0].request_url, "secrets/s1") != null);
+    try std.testing.expect(std.mem.find(u8, exchanges[0].request_url, "secrets/s1") != null);
 }
 
 test "RecordingTransport toJson" {
@@ -327,9 +327,9 @@ test "RecordingTransport toJson" {
     defer allocator.free(json);
 
     // Verify JSON structure.
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"method\":\"POST\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"status\":201") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "example.com/items") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"method\":\"POST\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"status\":201") != null);
+    try std.testing.expect(std.mem.find(u8, json, "example.com/items") != null);
 }
 
 test "isSensitiveHeader" {

--- a/src/azure/data/appconfiguration/root.zig
+++ b/src/azure/data/appconfiguration/root.zig
@@ -275,7 +275,7 @@ test "ConfigurationClient getSetting" {
     try std.testing.expectEqualStrings("mykey", setting.key);
     try std.testing.expectEqualStrings("myvalue", setting.value.?);
     try std.testing.expectEqualStrings("prod", setting.label.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "kv/mykey?label=prod") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "kv/mykey?label=prod") != null);
 }
 
 test "ConfigurationClient setSetting and listSettings" {

--- a/src/azure/data/cosmos/root.zig
+++ b/src/azure/data/cosmos/root.zig
@@ -467,10 +467,10 @@ fn parseQueryResult(allocator: std.mem.Allocator, body: []const u8) !QueryResult
     errdefer docs.deinit(allocator);
 
     // Simple extraction: find each document object in the Documents array.
-    const docs_start = std.mem.indexOf(u8, body, "\"Documents\":[") orelse
+    const docs_start = std.mem.find(u8, body, "\"Documents\":[") orelse
         return .{ .documents = &.{} };
     const array_start = docs_start + "\"Documents\":[".len;
-    const array_end = std.mem.indexOfScalarPos(u8, body, array_start, ']') orelse
+    const array_end = std.mem.findScalarPos(u8, body, array_start, ']') orelse
         return .{ .documents = &.{} };
     const array_content = body[array_start..array_end];
 
@@ -499,8 +499,8 @@ fn parseQueryResult(allocator: std.mem.Allocator, body: []const u8) !QueryResult
 }
 
 fn parseJsonString(body: []const u8, prefix: []const u8) ?[]const u8 {
-    const start = (std.mem.indexOf(u8, body, prefix) orelse return null) + prefix.len;
-    const end = std.mem.indexOfScalarPos(u8, body, start, '"') orelse return null;
+    const start = (std.mem.find(u8, body, prefix) orelse return null) + prefix.len;
+    const end = std.mem.findScalarPos(u8, body, start, '"') orelse return null;
     return body[start..end];
 }
 
@@ -511,9 +511,9 @@ fn parseIdList(allocator: std.mem.Allocator, body: []const u8, comptime T: type)
 
     const id_key = "\"id\":\"";
     var pos: usize = 0;
-    while (std.mem.indexOfPos(u8, body, pos, id_key)) |start| {
+    while (std.mem.findPos(u8, body, pos, id_key)) |start| {
         const val_start = start + id_key.len;
-        const val_end = std.mem.indexOfScalarPos(u8, body, val_start, '"') orelse break;
+        const val_end = std.mem.findScalarPos(u8, body, val_start, '"') orelse break;
         const id = try allocator.dupe(u8, body[val_start..val_end]);
         try result.append(allocator, .{ .id = id });
         pos = val_end + 1;
@@ -609,7 +609,7 @@ test "DatabaseClient createContainer" {
     var db = client.database("mydb");
     const ctr = try db.createContainer(allocator, "myctr", "/pk");
     try std.testing.expectEqualStrings("myctr", ctr.id);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/dbs/mydb/colls") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/dbs/mydb/colls") != null);
 }
 
 test "DatabaseClient listContainers" {
@@ -660,7 +660,7 @@ test "ContainerClient readItem" {
     var ctr = db.container("myctr");
     const body = try ctr.readItem(allocator, "item1", "[\"pk1\"]");
     defer allocator.free(body);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"name\":\"test\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"name\":\"test\"") != null);
 }
 
 test "ContainerClient upsertItem" {
@@ -709,7 +709,7 @@ test "ContainerClient queryItems" {
         allocator.free(result.documents);
     }
     try std.testing.expectEqual(@as(usize, 2), result.documents.len);
-    try std.testing.expect(std.mem.indexOf(u8, result.documents[0], "\"id\":\"a\"") != null);
+    try std.testing.expect(std.mem.find(u8, result.documents[0], "\"id\":\"a\"") != null);
 }
 
 test "ContainerClient readItem 404" {

--- a/src/azure/data/tables/root.zig
+++ b/src/azure/data/tables/root.zig
@@ -210,5 +210,5 @@ test "TableClient getEntity builds correct URL" {
     var resp = try tc.getEntity(allocator, "pk1", "rk1");
     defer resp.deinit();
     try std.testing.expectEqual(@as(u16, 200), resp.status_code);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "mytable(PartitionKey='pk1',RowKey='rk1')") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mytable(PartitionKey='pk1',RowKey='rk1')") != null);
 }

--- a/src/azure/identity/client_assertion.zig
+++ b/src/azure/identity/client_assertion.zig
@@ -156,6 +156,6 @@ test "ClientAssertionCredential getToken" {
 
     try std.testing.expectEqualStrings("assertion-token", token.token);
     // Verify the request was sent to the correct token endpoint.
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "tenant-1/oauth2/v2.0/token") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "tenant-1/oauth2/v2.0/token") != null);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
 }

--- a/src/azure/identity/managed_identity.zig
+++ b/src/azure/identity/managed_identity.zig
@@ -102,7 +102,7 @@ test "ManagedIdentityCredential" {
     try std.testing.expectEqualStrings("msi-token", token.token);
     try std.testing.expectEqual(core.http.Method.GET, mock.last_method.?);
     // Verify URL contains resource without /.default.
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "resource=https://vault.azure.net") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "resource=https://vault.azure.net") != null);
 }
 
 test "ManagedIdentityCredential with client_id" {
@@ -119,5 +119,5 @@ test "ManagedIdentityCredential with client_id" {
     );
     defer allocator.free(token.token);
     try std.testing.expectEqualStrings("msi-ua", token.token);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "client_id=user-assigned-id") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "client_id=user-assigned-id") != null);
 }

--- a/src/azure/keyvault/administration/root.zig
+++ b/src/azure/keyvault/administration/root.zig
@@ -315,7 +315,7 @@ test "BackupClient beginBackup" {
 
     try std.testing.expectEqualStrings("backup-op-001", op_id);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/backup?api-version=") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/backup?api-version=") != null);
 }
 
 test "SettingsClient getSetting" {
@@ -342,5 +342,5 @@ test "SettingsClient getSetting" {
     defer allocator.free(value);
 
     try std.testing.expectEqualStrings("true", value);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "settings/AllowKeyManagementOperationsThroughARM") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "settings/AllowKeyManagementOperationsThroughARM") != null);
 }

--- a/src/azure/keyvault/certificates/root.zig
+++ b/src/azure/keyvault/certificates/root.zig
@@ -260,5 +260,5 @@ test "CertificateClient getCertificate" {
     try std.testing.expectEqualStrings("mycert", cert.name);
     try std.testing.expectEqual(true, cert.properties.enabled.?);
     try std.testing.expectEqual(@as(i64, 1800000000), cert.properties.expires_on.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "certificates/mycert?api-version=") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "certificates/mycert?api-version=") != null);
 }

--- a/src/azure/keyvault/keys/root.zig
+++ b/src/azure/keyvault/keys/root.zig
@@ -360,7 +360,7 @@ test "KeyClient createKey and getKey" {
     try std.testing.expectEqualStrings("mykey", key.name);
     try std.testing.expectEqualStrings("RSA", key.key_type.?);
     try std.testing.expectEqual(true, key.properties.enabled.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "keys/mykey/create?api-version=") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "keys/mykey/create?api-version=") != null);
 }
 
 test "CryptographyClient encrypt" {
@@ -389,5 +389,5 @@ test "CryptographyClient encrypt" {
     defer allocator.free(result);
 
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "keys/mykey/v1/encrypt") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "keys/mykey/v1/encrypt") != null);
 }

--- a/src/azure/keyvault/secrets/root.zig
+++ b/src/azure/keyvault/secrets/root.zig
@@ -313,7 +313,7 @@ fn parseSecretListPage(allocator: std.mem.Allocator, body: []const u8) !core.pag
                 if (id_val == .string) {
                     // Extract name from ID: https://.../secrets/{name}
                     const id_str = id_val.string;
-                    if (std.mem.lastIndexOfScalar(u8, id_str, '/')) |slash| {
+                    if (std.mem.findScalarLast(u8, id_str, '/')) |slash| {
                         names[i] = try allocator.dupe(u8, id_str[slash + 1 ..]);
                         continue;
                     }
@@ -357,7 +357,7 @@ test "SecretClient getSecret" {
     try std.testing.expectEqualStrings("mysecret", secret.name);
     try std.testing.expectEqualStrings("my-secret-value", secret.value.?);
     try std.testing.expectEqual(true, secret.properties.enabled.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "secrets/mysecret?api-version=") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "secrets/mysecret?api-version=") != null);
 }
 
 test "SecretClient setSecret" {

--- a/src/azure/kusto/common.zig
+++ b/src/azure/kusto/common.zig
@@ -49,7 +49,7 @@ pub const ConnectionProperties = struct {
     /// Get the data management (ingest) URL by prepending `ingest-` to the hostname.
     pub fn getIngestUrl(self: ConnectionProperties, allocator: std.mem.Allocator) ![]u8 {
         // https://cluster.region.kusto.windows.net → https://ingest-cluster.region.kusto.windows.net
-        if (std.mem.indexOf(u8, self.cluster_url, "://")) |scheme_end| {
+        if (std.mem.find(u8, self.cluster_url, "://")) |scheme_end| {
             const scheme = self.cluster_url[0 .. scheme_end + 3];
             const host = self.cluster_url[scheme_end + 3 ..];
             return std.fmt.allocPrint(allocator, "{s}ingest-{s}", .{ scheme, host });

--- a/src/azure/kusto/data/root.zig
+++ b/src/azure/kusto/data/root.zig
@@ -141,9 +141,9 @@ fn parseResponseDataSet(allocator: std.mem.Allocator, body: []const u8) !KustoRe
 
     // Find DataTable frames by searching for "TableName"
     var pos: usize = 0;
-    while (std.mem.indexOfPos(u8, body, pos, "\"TableName\":\"")) |tn_start| {
+    while (std.mem.findPos(u8, body, pos, "\"TableName\":\"")) |tn_start| {
         const name_start = tn_start + "\"TableName\":\"".len;
-        const name_end = std.mem.indexOfScalarPos(u8, body, name_start, '"') orelse break;
+        const name_end = std.mem.findScalarPos(u8, body, name_start, '"') orelse break;
         const table_name = try allocator.dupe(u8, body[name_start..name_end]);
 
         // Parse columns from this table frame
@@ -151,22 +151,22 @@ fn parseResponseDataSet(allocator: std.mem.Allocator, body: []const u8) !KustoRe
         errdefer columns.deinit(allocator);
 
         const col_search_start = name_end;
-        const col_section_end = std.mem.indexOfPos(u8, body, col_search_start, "\"Rows\"") orelse body.len;
+        const col_section_end = std.mem.findPos(u8, body, col_search_start, "\"Rows\"") orelse body.len;
 
         var col_pos = col_search_start;
         while (col_pos < col_section_end) {
-            const cn_idx = std.mem.indexOfPos(u8, body, col_pos, "\"ColumnName\":\"") orelse break;
+            const cn_idx = std.mem.findPos(u8, body, col_pos, "\"ColumnName\":\"") orelse break;
             if (cn_idx >= col_section_end) break;
             const cn_start = cn_idx + "\"ColumnName\":\"".len;
-            const cn_end = std.mem.indexOfScalarPos(u8, body, cn_start, '"') orelse break;
+            const cn_end = std.mem.findScalarPos(u8, body, cn_start, '"') orelse break;
             const col_name = try allocator.dupe(u8, body[cn_start..cn_end]);
 
             // Find ColumnType
             var col_type: []const u8 = "string";
-            if (std.mem.indexOfPos(u8, body, cn_end, "\"ColumnType\":\"")) |ct_idx| {
+            if (std.mem.findPos(u8, body, cn_end, "\"ColumnType\":\"")) |ct_idx| {
                 if (ct_idx < col_section_end) {
                     const ct_start = ct_idx + "\"ColumnType\":\"".len;
-                    const ct_end = std.mem.indexOfScalarPos(u8, body, ct_start, '"') orelse ct_start;
+                    const ct_end = std.mem.findScalarPos(u8, body, ct_start, '"') orelse ct_start;
                     col_type = try allocator.dupe(u8, body[ct_start..ct_end]);
                 }
             }
@@ -181,7 +181,7 @@ fn parseResponseDataSet(allocator: std.mem.Allocator, body: []const u8) !KustoRe
         var rows = std.ArrayList(KustoResultRow).empty;
         errdefer rows.deinit(allocator);
 
-        if (std.mem.indexOfPos(u8, body, name_end, "\"Rows\":[")) |rows_start| {
+        if (std.mem.findPos(u8, body, name_end, "\"Rows\":[")) |rows_start| {
             const array_start = rows_start + "\"Rows\":[".len;
             // Find matching close bracket
             var depth: u32 = 1;
@@ -292,7 +292,7 @@ test "KustoClient executeQuery" {
         allocator.free(result.tables);
     }
 
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v2/rest/query") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v2/rest/query") != null);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
 
     const primary = result.primaryTable().?;
@@ -332,7 +332,7 @@ test "KustoClient executeMgmt" {
         allocator.free(result.tables);
     }
 
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
     const table = result.tables[0];
     try std.testing.expectEqualStrings("TestDB", table.rows[0].values[0]);
 }
@@ -346,7 +346,7 @@ test "KustoClient execute auto-routes to mgmt" {
     var client = KustoClient.init(conn, mock.asTransport(), .{});
 
     _ = try client.execute(allocator, "db", ".show databases");
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
 }
 
 test "KustoClient execute auto-routes to query" {
@@ -358,7 +358,7 @@ test "KustoClient execute auto-routes to query" {
     var client = KustoClient.init(conn, mock.asTransport(), .{});
 
     _ = try client.execute(allocator, "db", "StormEvents | count");
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v2/rest/query") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v2/rest/query") != null);
 }
 
 test "KustoClient query failure returns error" {

--- a/src/azure/kusto/ingest/root.zig
+++ b/src/azure/kusto/ingest/root.zig
@@ -217,8 +217,8 @@ test "StreamingIngestClient ingestFromSlice" {
 
     const result = try client.ingestFromSlice(allocator, "TestDB", "Logs", "{\"ts\":\"2024-01-01\"}\n", .{ .format = .json });
     try std.testing.expectEqual(IngestionStatus.success, result.status);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v1/rest/ingest/TestDB/Logs") != null);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "streamFormat=Json") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/ingest/TestDB/Logs") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "streamFormat=Json") != null);
 }
 
 test "StreamingIngestClient with mapping name" {
@@ -234,7 +234,7 @@ test "StreamingIngestClient with mapping name" {
         .mapping_name = "MyMapping",
     });
     try std.testing.expectEqual(IngestionStatus.success, result.status);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "mappingName=MyMapping") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mappingName=MyMapping") != null);
 }
 
 test "StreamingIngestClient failure" {
@@ -267,7 +267,7 @@ test "QueuedIngestClient ingestFromBlob" {
     }, "https://storage.blob.core.windows.net/container/blob.json");
 
     try std.testing.expectEqual(IngestionStatus.queued, result.status);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "ingest-mycluster") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "ingest-mycluster") != null);
 }
 
 test "ManagedIngestClient ingestFromSlice success" {

--- a/src/azure/messaging/common.zig
+++ b/src/azure/messaging/common.zig
@@ -22,7 +22,7 @@ pub const ConnectionStringProperties = struct {
             const trimmed = std.mem.trim(u8, part, " ");
             if (trimmed.len == 0) continue;
 
-            if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
+            if (std.mem.findScalar(u8, trimmed, '=')) |eq_pos| {
                 const k = trimmed[0..eq_pos];
                 const v = trimmed[eq_pos + 1 ..];
 
@@ -51,7 +51,7 @@ pub const ConnectionStringProperties = struct {
     }
 
     fn extractHost(endpoint: []const u8) ?[]const u8 {
-        const after_scheme = if (std.mem.indexOf(u8, endpoint, "://")) |pos|
+        const after_scheme = if (std.mem.find(u8, endpoint, "://")) |pos|
             endpoint[pos + 3 ..]
         else
             endpoint;

--- a/src/azure/messaging/eventhubs/checkpoint_store.zig
+++ b/src/azure/messaging/eventhubs/checkpoint_store.zig
@@ -194,8 +194,8 @@ pub fn serializeOwnership(allocator: std.mem.Allocator, own: eventhubs.Partition
 /// Extract "ownerId" value from a JSON body like {"ownerId":"xyz"}.
 fn parseOwnerField(body: []const u8) ?[]const u8 {
     const key = "\"ownerId\":\"";
-    const start = (std.mem.indexOf(u8, body, key) orelse return null) + key.len;
-    const end = std.mem.indexOfScalarPos(u8, body, start, '"') orelse return null;
+    const start = (std.mem.find(u8, body, key) orelse return null) + key.len;
+    const end = std.mem.findScalarPos(u8, body, start, '"') orelse return null;
     return body[start..end];
 }
 
@@ -206,7 +206,7 @@ fn parseCheckpointFields(body: []const u8, cp: *eventhubs.Checkpoint) void {
 }
 
 fn parseJsonInt(body: []const u8, key: []const u8) ?i64 {
-    const start = (std.mem.indexOf(u8, body, key) orelse return null) + key.len;
+    const start = (std.mem.find(u8, body, key) orelse return null) + key.len;
     var end = start;
     while (end < body.len and (body[end] == '-' or (body[end] >= '0' and body[end] <= '9'))) : (end += 1) {}
     if (start == end) return null;
@@ -315,5 +315,5 @@ test "BlobCheckpointStore updateCheckpoint" {
     });
 
     // Verify the upload went to the correct path.
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "ns.servicebus.windows.net/hub/$Default/checkpoint/0") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "ns.servicebus.windows.net/hub/$Default/checkpoint/0") != null);
 }

--- a/src/azure/messaging/servicebus/root.zig
+++ b/src/azure/messaging/servicebus/root.zig
@@ -995,7 +995,7 @@ test "AdministrationClient createQueue" {
     var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
     var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
     try admin.createQueue(allocator, "testqueue");
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "testqueue") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "testqueue") != null);
     try std.testing.expectEqual(core.http.Method.PUT, mock.last_method.?);
 }
 
@@ -1050,5 +1050,5 @@ test "AdministrationClient createSubscription" {
     var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
     var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
     try admin.createSubscription(allocator, "mytopic", "mysub");
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "mytopic/subscriptions/mysub") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mytopic/subscriptions/mysub") != null);
 }

--- a/src/azure/storage/blobs/root.zig
+++ b/src/azure/storage/blobs/root.zig
@@ -337,7 +337,7 @@ test "BlobContainerClient create and listBlobs" {
     );
 
     try container.create(allocator);
-    try std.testing.expect(std.mem.indexOf(u8, mock_create.last_url.?, "mycontainer?restype=container") != null);
+    try std.testing.expect(std.mem.find(u8, mock_create.last_url.?, "mycontainer?restype=container") != null);
 
     // Switch to list mock
     var mock_list = core.http.MockTransport.init(allocator, 200, list_body);
@@ -381,7 +381,7 @@ test "BlobClient download and upload" {
 
     try client.upload(allocator, "hello world", "text/plain");
     try std.testing.expectEqual(core.http.Method.PUT, mock_upload.last_method.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock_upload.last_url.?, "mycontainer/myblob.txt") != null);
+    try std.testing.expect(std.mem.find(u8, mock_upload.last_url.?, "mycontainer/myblob.txt") != null);
 
     // Switch to download mock
     var mock_dl = core.http.MockTransport.init(allocator, 200, "hello world");

--- a/src/azure/storage/common/root.zig
+++ b/src/azure/storage/common/root.zig
@@ -68,9 +68,9 @@ pub const StorageSharedKeyCredential = struct {
 fn extractResource(url: []const u8, account_name: []const u8) []const u8 {
     // Find the path after the host.
     _ = account_name;
-    if (std.mem.indexOf(u8, url, "://")) |schema_end| {
+    if (std.mem.find(u8, url, "://")) |schema_end| {
         const after_schema = url[schema_end + 3 ..];
-        if (std.mem.indexOfScalar(u8, after_schema, '/')) |slash| {
+        if (std.mem.findScalar(u8, after_schema, '/')) |slash| {
             return after_schema[slash..];
         }
     }
@@ -173,8 +173,8 @@ test "SasBuilder sign produces HMAC signature" {
     const qs = try sas.sign(allocator, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
     defer allocator.free(qs);
     // Must contain sig= with a base64 value.
-    try std.testing.expect(std.mem.indexOf(u8, qs, "&sig=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, qs, "sp=rl") != null);
+    try std.testing.expect(std.mem.find(u8, qs, "&sig=") != null);
+    try std.testing.expect(std.mem.find(u8, qs, "sp=rl") != null);
 }
 
 test "SasBuilder toQueryString unsigned" {
@@ -185,8 +185,8 @@ test "SasBuilder toQueryString unsigned" {
     };
     const qs = try sas.toQueryString(allocator);
     defer allocator.free(qs);
-    try std.testing.expect(std.mem.indexOf(u8, qs, "sp=rl") != null);
-    try std.testing.expect(std.mem.indexOf(u8, qs, "se=2026-12-31T23:59:59Z") != null);
+    try std.testing.expect(std.mem.find(u8, qs, "sp=rl") != null);
+    try std.testing.expect(std.mem.find(u8, qs, "se=2026-12-31T23:59:59Z") != null);
 }
 
 test "contentMd5" {

--- a/src/azure/storage/files/datalake/root.zig
+++ b/src/azure/storage/files/datalake/root.zig
@@ -224,7 +224,7 @@ test "DataLakeFileClient create append flush and read" {
     );
 
     try fs_client.create(allocator);
-    try std.testing.expect(std.mem.indexOf(u8, mock_create.last_url.?, "myfilesystem?resource=filesystem") != null);
+    try std.testing.expect(std.mem.find(u8, mock_create.last_url.?, "myfilesystem?resource=filesystem") != null);
 
     var file = fs_client.getFileClient("data/myfile.csv");
 
@@ -233,14 +233,14 @@ test "DataLakeFileClient create append flush and read" {
     defer mock_file.deinit();
     file.pipeline = .{ .policies = &.{}, .transport_impl = mock_file.asTransport() };
     try file.create(allocator);
-    try std.testing.expect(std.mem.indexOf(u8, mock_file.last_url.?, "data/myfile.csv?resource=file") != null);
+    try std.testing.expect(std.mem.find(u8, mock_file.last_url.?, "data/myfile.csv?resource=file") != null);
 
     // Append data
     var mock_append = core.http.MockTransport.init(allocator, 202, "");
     defer mock_append.deinit();
     file.pipeline = .{ .policies = &.{}, .transport_impl = mock_append.asTransport() };
     try file.append(allocator, "col1,col2\na,b\n", 0);
-    try std.testing.expect(std.mem.indexOf(u8, mock_append.last_url.?, "action=append&position=0") != null);
+    try std.testing.expect(std.mem.find(u8, mock_append.last_url.?, "action=append&position=0") != null);
 
     // Read
     var mock_read = core.http.MockTransport.init(allocator, 200, "col1,col2\na,b\n");

--- a/src/azure/storage/files/shares/root.zig
+++ b/src/azure/storage/files/shares/root.zig
@@ -270,7 +270,7 @@ test "ShareFileClient create and download" {
     );
 
     try share.create(allocator);
-    try std.testing.expect(std.mem.indexOf(u8, mock_create.last_url.?, "myshare?restype=share") != null);
+    try std.testing.expect(std.mem.find(u8, mock_create.last_url.?, "myshare?restype=share") != null);
 
     // Create directory and file
     var dir = share.getDirectoryClient("mydir");

--- a/src/azure/storage/queues/root.zig
+++ b/src/azure/storage/queues/root.zig
@@ -272,7 +272,7 @@ test "QueueClient sendMessage" {
 
     try client.sendMessage(allocator, "Hello Queue!");
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
-    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "myqueue/messages") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "myqueue/messages") != null);
 }
 
 test "QueueClient receiveMessages" {


### PR DESCRIPTION
Follow-up to the earlier 0.16 migration commit (5e4b9f1e4), which left two things on the table per the [Zig 0.16 release notes](https://ziglang.org/download/0.16.0/release-notes.html):

### 1. `std.mem.indexOf*` -> `find*` rename
Per [mem: introduce cut functions; rename "index of" to "find"](https://ziglang.org/download/0.16.0/release-notes.html#mem-introduce-cut-functions-rename-index-of-to-find), the canonical names are now:

| Before                       | After                       |
|------------------------------|-----------------------------|
| `std.mem.indexOf`            | `std.mem.find`              |
| `std.mem.indexOfScalar`      | `std.mem.findScalar`        |
| `std.mem.indexOfScalarPos`   | `std.mem.findScalarPos`     |
| `std.mem.indexOfPos`         | `std.mem.findPos`           |
| `std.mem.lastIndexOfScalar`  | `std.mem.findScalarLast`    |

The old names still work as deprecated aliases (`pub const indexOf = find;` in `std/mem.zig`), but this PR moves the codebase to the canonical names. 23 source files updated.

### 2. Fix `std.time.timestamp()` call in `BearerTokenAuthPolicy`
`std.time.timestamp()` was **removed** in 0.16. `BearerTokenAuthPolicy.processImpl` still called it (line 237 of `pipeline.zig`). The build did not catch this because `BearerTokenAuthPolicy` is not yet wired into any service client, so the function was never analyzed.

- Added a local `unixTimestampSeconds()` helper backed by `std.Io.Timestamp.now(...).toNanoseconds()` (the 0.16 equivalent).
- Added a `"BearerTokenAuthPolicy injects Authorization header"` test that exercises the full policy through a mock transport. The test count goes from 220 -> 221, and the policy now gets analyzed at test compile time, so future regressions of this kind will be caught.

### Verification
```
zig fmt --check src/ build.zig    # passes
zig build                          # passes
zig build test --summary all       # 221/221 tests pass
```