### PR TITLE
docs: refresh README; remove last page_allocator leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Pure Zig implementation of Azure service clients with **zero C dependencies**.
 
-**40 source files · ~6,800 lines · 106 tests · Zig 0.15.2+**
+**53 source files · 219 tests · Zig 0.16+**
 
 ## Quick Start
 
@@ -33,11 +33,11 @@ const secret = try client.getSecret(allocator, "my-secret");
 
 ## Build & Test
 
-Requires [Zig 0.15.2](https://ziglang.org/download/) or later.
+Requires [Zig 0.16.0](https://ziglang.org/download/) or later.
 
 ```bash
 zig build           # compile SDK + example
-zig build test      # run all 106 tests
+zig build test      # run all 219 tests
 zig build run       # run the example app
 ```
 
@@ -73,9 +73,9 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 | `credentials.CachedTokenCredential` | In-memory token cache with TTL |
 | `base64` | Base64 + HMAC-SHA256, SHA-256, MD5 helpers |
 | `url` | URL parsing, percent-encode/decode (RFC 3986) |
-| `xml` | XML pull-parser helpers (via zig-xml) |
-| `errors` | Azure error JSON parsing |
+| `errors` | Azure error envelope parsing + `logErrorResponse` |
 | `lro` | Long-running operation poller (poll until Succeeded/Failed) |
+| `pager` | Generic paged-result iterator (`PipelinePager`) |
 
 ### Identity (`azure_identity`)
 
@@ -104,8 +104,13 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 | `azure_keyvault_admin` | `BackupClient`, `SettingsClient` |
 | `azure_data_tables` | `TableClient`, `TableServiceClient` |
 | `azure_data_appconfiguration` | `ConfigurationClient` |
+| `azure_data_cosmos` | `CosmosClient`, `DatabaseClient`, `ContainerClient` |
 | `azure_attestation` | `AttestationClient` |
 | `azure_messaging_eventhubs` | `ProducerClient`, `ConsumerClient` |
+| `azure_messaging_eventhubs_checkpointstore_blob` | Blob-backed checkpoint store |
+| `azure_messaging_servicebus` | `ServiceBusSenderClient`, `ServiceBusReceiverClient`, `ServiceBusAdministrationClient` |
+| `azure_kusto_data` | `KustoClient` (queries + management) |
+| `azure_kusto_ingest` | `StreamingIngestClient`, `QueuedIngestClient`, `ManagedIngestClient` |
 
 ### Infrastructure
 
@@ -122,8 +127,8 @@ The SDK uses only the Zig standard library plus two small Zig packages:
 
 | Purpose | Package |
 |---------|---------|
-| HTTP, TLS, JSON, crypto, compression | `std` (Zig standard library) |
-| XML parsing | [zig-xml](https://github.com/cataggar/zig-xml) |
+| HTTP, TLS, crypto, compression | `std` (Zig standard library) |
+| Typed JSON + XML (de)serialization | [serde.zig](https://github.com/cataggar/serde.zig) |
 | AMQP 1.0 protocol | [azure-uamqp-zig](https://github.com/cataggar/azure-uamqp-zig) |
 
 ## Using as a Dependency
@@ -157,9 +162,8 @@ replacing every C/C++ dependency with Zig standard library equivalents:
 |----------------|-----------------|
 | libcurl / WinHTTP | `std.http.Client` |
 | OpenSSL | `std.crypto.tls`, `std.crypto.hash`, `std.crypto.auth.hmac` |
-| libxml2 | zig-xml |
+| nlohmann/json + libxml2 | [serde.zig](https://github.com/cataggar/serde.zig) (typed schemas) |
 | azure-uamqp-c | azure-uamqp-zig |
-| nlohmann/json | `std.json` |
 | CMake + vcpkg | `build.zig` |
 | Google Test | `std.testing` |
 

--- a/src/azure/core/lro.zig
+++ b/src/azure/core/lro.zig
@@ -134,8 +134,8 @@ pub const Poller = struct {
         // Parse initial status from the response body (may already be terminal).
         const initial_status = switch (strategy) {
             .location => statusFromHttpCode(initial_response.status_code),
-            .provisioning_state => parseProvisioningState(initial_response.body),
-            else => parseStatus(initial_response.body),
+            .provisioning_state => parseProvisioningState(allocator, initial_response.body),
+            else => parseStatus(allocator, initial_response.body),
         };
 
         return .{
@@ -168,8 +168,8 @@ pub const Poller = struct {
         // Extract status based on strategy.
         self.status = switch (self.strategy) {
             .location => statusFromHttpCode(resp.status_code),
-            .provisioning_state => parseProvisioningState(resp.body),
-            else => parseStatus(resp.body),
+            .provisioning_state => parseProvisioningState(self.allocator, resp.body),
+            else => parseStatus(self.allocator, resp.body),
         };
 
         // Replace cached body.
@@ -270,12 +270,12 @@ fn detectStrategy(response: http.Response) !PollingStrategy {
 
 // ─────────────────── Status Parsing ────────────────────────
 
-fn parseStatus(body: []const u8) OperationStatus {
+fn parseStatus(allocator: std.mem.Allocator, body: []const u8) OperationStatus {
     const StatusSchema = struct {
         status: ?[]const u8 = null,
     };
 
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
     const parsed = serde.json.fromSlice(StatusSchema, arena.allocator(), body) catch return .in_progress;
@@ -283,7 +283,7 @@ fn parseStatus(body: []const u8) OperationStatus {
     return .in_progress;
 }
 
-fn parseProvisioningState(body: []const u8) OperationStatus {
+fn parseProvisioningState(allocator: std.mem.Allocator, body: []const u8) OperationStatus {
     const PropsSchema = struct {
         provisioningState: ?[]const u8 = null,
     };
@@ -293,7 +293,7 @@ fn parseProvisioningState(body: []const u8) OperationStatus {
         provisioningState: ?[]const u8 = null,
     };
 
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
     const parsed = serde.json.fromSlice(ProvisioningSchema, arena.allocator(), body) catch return .in_progress;
@@ -359,7 +359,7 @@ pub fn pollUntilDone(
         }
 
         // Parse status from response body.
-        const status = parseStatus(resp.body);
+        const status = parseStatus(resp.allocator, resp.body);
         if (status.isTerminal()) {
             return .{
                 .status = status,
@@ -669,17 +669,17 @@ test "Poller auto-detect fails without headers" {
 }
 
 test "parseProvisioningState" {
-    try std.testing.expectEqual(OperationStatus.succeeded, parseProvisioningState(
+    try std.testing.expectEqual(OperationStatus.succeeded, parseProvisioningState(std.testing.allocator,
         \\{"properties":{"provisioningState":"Succeeded"}}
     ));
-    try std.testing.expectEqual(OperationStatus.in_progress, parseProvisioningState(
+    try std.testing.expectEqual(OperationStatus.in_progress, parseProvisioningState(std.testing.allocator,
         \\{"properties":{"provisioningState":"Creating"}}
     ));
-    try std.testing.expectEqual(OperationStatus.failed, parseProvisioningState(
+    try std.testing.expectEqual(OperationStatus.failed, parseProvisioningState(std.testing.allocator,
         \\{"properties":{"provisioningState":"Failed"}}
     ));
     // Top-level fallback.
-    try std.testing.expectEqual(OperationStatus.succeeded, parseProvisioningState(
+    try std.testing.expectEqual(OperationStatus.succeeded, parseProvisioningState(std.testing.allocator,
         \\{"provisioningState":"Succeeded"}
     ));
 }

--- a/src/azure/data/cosmos/root.zig
+++ b/src/azure/data/cosmos/root.zig
@@ -33,6 +33,16 @@ pub const Database = struct {
     rid: ?[]const u8 = null,
     self_link: ?[]const u8 = null,
     etag: ?[]const u8 = null,
+
+    /// Free any strings duped into `allocator` by parseDatabaseResponse /
+    /// parseDatabaseList. `id` is duped for list results; not for
+    /// single-resource fetches (where it's a borrow of the caller's input).
+    pub fn deinit(self: Database, allocator: std.mem.Allocator, owns_id: bool) void {
+        if (owns_id) allocator.free(self.id);
+        if (self.rid) |s| allocator.free(s);
+        if (self.self_link) |s| allocator.free(s);
+        if (self.etag) |s| allocator.free(s);
+    }
 };
 
 pub const ContainerProperties = struct {
@@ -41,6 +51,13 @@ pub const ContainerProperties = struct {
     rid: ?[]const u8 = null,
     self_link: ?[]const u8 = null,
     etag: ?[]const u8 = null,
+
+    pub fn deinit(self: ContainerProperties, allocator: std.mem.Allocator, owns_id: bool) void {
+        if (owns_id) allocator.free(self.id);
+        if (self.rid) |s| allocator.free(s);
+        if (self.self_link) |s| allocator.free(s);
+        if (self.etag) |s| allocator.free(s);
+    }
 };
 
 pub const CosmosItem = struct {
@@ -120,7 +137,7 @@ pub const CosmosClient = struct {
             return error.CreateDatabaseFailed;
         }
 
-        return parseDatabaseResponse(database_id, resp.body);
+        return parseDatabaseResponse(allocator, database_id, resp.body);
     }
 
     /// Delete a database.
@@ -273,7 +290,7 @@ pub const DatabaseClient = struct {
             return error.GetContainerFailed;
         }
 
-        return parseContainerResponse(container_id, resp.body);
+        return parseContainerResponse(allocator, container_id, resp.body);
     }
 
     fn setCommonHeaders(self: *DatabaseClient, req: *core.http.Request) !void {
@@ -445,13 +462,13 @@ const ResourceMetaSchema = struct {
     _etag: ?[]const u8 = null,
 };
 
-fn parseDatabaseResponse(id: []const u8, body: []const u8) Database {
+fn parseDatabaseResponse(allocator: std.mem.Allocator, id: []const u8, body: []const u8) Database {
     var db = Database{ .id = id };
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     if (serde.json.fromSlice(ResourceMetaSchema, arena.allocator(), body)) |parsed| {
-        if (parsed._rid) |s| db.rid = dupeStaticLeak(s);
-        if (parsed._etag) |s| db.etag = dupeStaticLeak(s);
+        if (parsed._rid) |s| db.rid = allocator.dupe(u8, s) catch null;
+        if (parsed._etag) |s| db.etag = allocator.dupe(u8, s) catch null;
     } else |_| {}
     return db;
 }
@@ -486,13 +503,13 @@ fn parseDatabaseList(allocator: std.mem.Allocator, body: []const u8) ![]Database
     return result[0..n];
 }
 
-fn parseContainerResponse(id: []const u8, body: []const u8) ContainerProperties {
+fn parseContainerResponse(allocator: std.mem.Allocator, id: []const u8, body: []const u8) ContainerProperties {
     var props = ContainerProperties{ .id = id };
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     if (serde.json.fromSlice(ResourceMetaSchema, arena.allocator(), body)) |parsed| {
-        if (parsed._rid) |s| props.rid = dupeStaticLeak(s);
-        if (parsed._etag) |s| props.etag = dupeStaticLeak(s);
+        if (parsed._rid) |s| props.rid = allocator.dupe(u8, s) catch null;
+        if (parsed._etag) |s| props.etag = allocator.dupe(u8, s) catch null;
     } else |_| {}
     return props;
 }
@@ -561,25 +578,17 @@ fn parseQueryResult(allocator: std.mem.Allocator, body: []const u8) !QueryResult
     }
 
     // Use serde for the simple `_continuation` field on the top-level envelope.
-    var meta_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var meta_arena = std.heap.ArenaAllocator.init(allocator);
     defer meta_arena.deinit();
     var continuation: ?[]const u8 = null;
     if (serde.json.fromSlice(QueryResultMetaSchema, meta_arena.allocator(), body)) |meta| {
-        if (meta._continuation) |s| continuation = dupeStaticLeak(s);
+        if (meta._continuation) |s| continuation = try allocator.dupe(u8, s);
     } else |_| {}
 
     return .{
         .documents = try docs.toOwnedSlice(allocator),
         .continuation_token = continuation,
     };
-}
-
-/// Helper: dupe a string into page_allocator. The resulting slice lives forever.
-/// Used for fields on result structs that don't carry an allocator, matching
-/// the original substring-borrow lifetime (which lived for the request's
-/// response body — effectively forever for short-lived programs).
-fn dupeStaticLeak(s: []const u8) []const u8 {
-    return std.heap.page_allocator.dupe(u8, s) catch s;
 }
 
 // ─────────────────────── Tests ───────────────────────
@@ -613,6 +622,7 @@ test "CosmosClient createDatabase" {
     defer mock.deinit();
     var client = createTestClient(&mock);
     const db = try client.createDatabase(allocator, "testdb");
+    defer db.deinit(allocator, false);
     try std.testing.expectEqualStrings("testdb", db.id);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
     try std.testing.expect(std.mem.endsWith(u8, mock.last_url.?, "/dbs"));
@@ -668,6 +678,8 @@ test "DatabaseClient createContainer" {
     var client = createTestClient(&mock);
     var db = client.database("mydb");
     const ctr = try db.createContainer(allocator, "myctr", "/pk");
+    // createContainer assembles the struct locally from the inputs — no
+    // allocations to free.
     try std.testing.expectEqualStrings("myctr", ctr.id);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/dbs/mydb/colls") != null);
 }

--- a/src/azure/messaging/eventhubs/checkpoint_store.zig
+++ b/src/azure/messaging/eventhubs/checkpoint_store.zig
@@ -149,7 +149,7 @@ pub const BlobCheckpointStore = struct {
                 .consumer_group = consumer_group,
                 .partition_id = partition_id,
             };
-            parseCheckpointFields(body, &cp);
+            parseCheckpointFields(allocator, body, &cp);
             try result.append(allocator, cp);
         }
 
@@ -203,12 +203,12 @@ fn parseOwnerField(allocator: std.mem.Allocator, body: []const u8) ?[]const u8 {
 }
 
 /// Parse offset and sequenceNumber from checkpoint JSON into the struct.
-fn parseCheckpointFields(body: []const u8, cp: *eventhubs.Checkpoint) void {
+fn parseCheckpointFields(allocator: std.mem.Allocator, body: []const u8, cp: *eventhubs.Checkpoint) void {
     const Schema = struct {
         offset: ?i64 = null,
         sequenceNumber: ?i64 = null,
     };
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const parsed = serde.json.fromSlice(Schema, arena.allocator(), body) catch return;
     cp.offset = parsed.offset;
@@ -282,7 +282,7 @@ test "parseCheckpointFields" {
         .consumer_group = "cg",
         .partition_id = "0",
     };
-    parseCheckpointFields("{\"offset\":100,\"sequenceNumber\":42}", &cp);
+    parseCheckpointFields(std.testing.allocator, "{\"offset\":100,\"sequenceNumber\":42}", &cp);
     try std.testing.expectEqual(@as(i64, 100), cp.offset.?);
     try std.testing.expectEqual(@as(i64, 42), cp.sequence_number.?);
 }


### PR DESCRIPTION
## Two follow-ups from the discussion of "what's next after the serde migration".

### Thread 1: README refresh

Front door was stale. Before vs after:

| Section | Before | After |
|---|---|---|
| Stats line | `40 source files · ~6,800 lines · 106 tests · Zig 0.15.2+` | `53 source files · 219 tests · Zig 0.16+` |
| Build & Test | `Zig 0.15.2 or later`, `run all 106 tests` | `Zig 0.16.0 or later`, `run all 219 tests` |
| `azure_core` module list | included an `xml` row (deleted in #15), missing `pager` | `xml` removed, `pager` added, `errors` description updated |
| Service SDKs table | missed Cosmos, Service Bus, ServiceBus admin, Kusto data, Kusto ingest, EH checkpoint store | all added |
| Dependencies table | `JSON` listed under `std`, separate `XML parsing` row pointing at `zig-xml` | `Typed JSON + XML (de)serialization` row pointing at `serde.zig`; `zig-xml` row gone |
| C++ porting comparison | separate `libxml2 -> zig-xml` and `nlohmann/json -> std.json` rows | one row: `libxml2 + nlohmann/json -> serde.zig (typed schemas)` |

### Thread 2: Remove last `std.heap.page_allocator` leaks

Seven remaining sites that didn't get an allocator parameter during the serde migration (PR #15). Each parses JSON into an arena rooted at `page_allocator` and never frees — so every call leaks ~hundreds of bytes for the life of the process. Pre-existing, but the serde migration was the moment to catch it.

| File | Function | Change |
|---|---|---|
| `core/lro.zig` | `parseStatus(body)` | `parseStatus(allocator, body)` |
| `core/lro.zig` | `parseProvisioningState(body)` | `parseProvisioningState(allocator, body)` |
| `data/cosmos/root.zig` | `parseDatabaseResponse(id, body)` | `parseDatabaseResponse(allocator, id, body)` |
| `data/cosmos/root.zig` | `parseContainerResponse(id, body)` | `parseContainerResponse(allocator, id, body)` |
| `data/cosmos/root.zig` | `parseQueryResult` meta arena | uses caller's `allocator` |
| `data/cosmos/root.zig` | `dupeStaticLeak` helper | **deleted** |
| `messaging/eventhubs/checkpoint_store.zig` | `parseCheckpointFields(body, *cp)` | `parseCheckpointFields(allocator, body, *cp)` |

`Database` and `ContainerProperties` gain a `deinit(allocator, owns_id)` method so the caller can free the duped `_rid` / `_etag` strings. `owns_id` distinguishes single-resource fetches (where `id` is a borrow of the caller's input, e.g. `"testdb"`) from list results (where `id` is allocated and must be freed) — same convention `errors.AzureError.deinit` uses.

### Verification

```
$ grep -rn 'std.heap.page_allocator' --include='*.zig' src/
$ # empty
$ zig fmt --check src/ build.zig
$ zig build && zig build test --summary all
Build Summary: 53/53 steps succeeded; 219/219 tests passed
```

No new tests; the test allocator inside `CosmosClient createDatabase` would have caught the leak once `page_allocator` was removed, and did — that's how I caught the missing `deinit` call in the test (now fixed in the commit).
