### PR TITLE
errors: introduce Result(T) for programmatic AzureError access [DESIGN DEMO]

### DIFF
--- a/src/azure/core/errors.zig
+++ b/src/azure/core/errors.zig
@@ -107,24 +107,21 @@ pub fn logErrorResponse(response: http.Response) void {
 ///
 /// **Lifetime**
 ///
-/// `Result.deinit()` frees the `AzureError`'s strings on the `.err`
-/// path. The `.ok` payload retains the same ownership rules as the
-/// non-`Result` variant of the method — typically the caller still
-/// frees individual fields. We deliberately do not call a synthetic
-/// `T.deinit` because not every payload type has one and the rules
-/// vary per service.
+/// `Result.deinit(allocator)` frees both branches:
+/// - On `.err`, it frees the `AzureError`'s strings.
+/// - On `.ok`, if the payload type `T` declares
+///   `pub fn deinit(self, allocator: std.mem.Allocator) void`, that
+///   method is called; otherwise no-op. This lets callers write
+///   `defer r.deinit(allocator);` once and trust both paths are
+///   cleaned up.
 ///
 /// **Example**
 ///
 /// ```zig
 /// var r = try client.getSecretResult(allocator, "name");
-/// defer r.deinit();
+/// defer r.deinit(allocator);
 /// switch (r) {
-///     .ok => |secret| {
-///         defer if (secret.value) |v| allocator.free(v);
-///         defer if (secret.id) |i| allocator.free(i);
-///         use(secret);
-///     },
+///     .ok => |secret| use(secret),
 ///     .err => |az_err| {
 ///         if (std.mem.eql(u8, az_err.error_code orelse "", "SecretNotFound")) {
 ///             // expected: secret didn't exist
@@ -141,12 +138,14 @@ pub fn Result(comptime T: type) type {
 
         const Self = @This();
 
-        /// Free the `AzureError` strings on the `.err` path. No-op for
-        /// `.ok`; callers free the payload using the same rules as the
-        /// non-`Result` variant of the method.
-        pub fn deinit(self: *Self) void {
+        /// Free both the `AzureError` strings (on the `.err` path) and the
+        /// payload's allocations (on the `.ok` path, if `T` declares a
+        /// `deinit(self, allocator) void` method — comptime-detected).
+        pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
             switch (self.*) {
-                .ok => {},
+                .ok => |*payload| {
+                    if (comptime hasPayloadDeinit(T)) payload.deinit(allocator);
+                },
                 .err => |*e| e.deinit(),
             }
         }
@@ -170,6 +169,19 @@ pub fn Result(comptime T: type) type {
             };
         }
     };
+}
+
+/// True if `T` has `pub fn deinit(self, allocator: std.mem.Allocator) void`.
+/// Used by `Result(T).deinit` to dispatch to payload cleanup without forcing
+/// every payload type to grow a deinit method.
+fn hasPayloadDeinit(comptime T: type) bool {
+    if (@typeInfo(T) != .@"struct") return false;
+    if (!@hasDecl(T, "deinit")) return false;
+    const Fn = @TypeOf(T.deinit);
+    const info = @typeInfo(Fn);
+    if (info != .@"fn") return false;
+    const params = info.@"fn".params;
+    return params.len == 2;
 }
 
 test "errorFromResponse success" {
@@ -270,9 +282,9 @@ test "logErrorResponse is a no-op on success" {
     logErrorResponse(resp);
 }
 
-test "Result.ok holds payload, deinit is a no-op" {
+test "Result.ok holds payload, deinit is a no-op when T has no deinit" {
     var r: Result(u32) = .{ .ok = 42 };
-    defer r.deinit();
+    defer r.deinit(std.testing.allocator);
     try std.testing.expect(r.isOk());
     try std.testing.expectEqual(@as(?[]const u8, null), r.errorCode());
     try std.testing.expectEqual(@as(u32, 42), r.ok);
@@ -285,8 +297,26 @@ test "Result.err carries AzureError and frees it on deinit" {
         .error_code = try std.testing.allocator.dupe(u8, "Throttled"),
         .message = try std.testing.allocator.dupe(u8, "Slow down"),
     } };
-    defer r.deinit();
+    defer r.deinit(std.testing.allocator);
     try std.testing.expect(!r.isOk());
     try std.testing.expectEqualStrings("Throttled", r.errorCode().?);
     try std.testing.expectEqual(@as(u16, 429), r.err.status_code);
+}
+
+test "Result.deinit dispatches to payload.deinit when present" {
+    const Payload = struct {
+        owned: []const u8,
+
+        pub fn deinit(self: @This(), allocator: std.mem.Allocator) void {
+            allocator.free(self.owned);
+        }
+    };
+    var r: Result(Payload) = .{
+        .ok = .{ .owned = try std.testing.allocator.dupe(u8, "data") },
+    };
+    defer r.deinit(std.testing.allocator);
+    try std.testing.expect(r.isOk());
+    try std.testing.expectEqualStrings("data", r.ok.owned);
+    // testing.allocator catches leaks: if deinit didn't dispatch, this test
+    // would fail with a "leaked 1 allocation" error.
 }

--- a/src/azure/core/errors.zig
+++ b/src/azure/core/errors.zig
@@ -88,6 +88,90 @@ pub fn logErrorResponse(response: http.Response) void {
     }
 }
 
+/// Tagged union over a successful response of type `T` or an Azure-side
+/// error. Service-client `*Result` variants return this so callers can
+/// branch on `AzureError.error_code` (e.g. retry on `"ServerBusy"`, fail
+/// fast on `"AuthFailed"`) — the standard pattern in Azure SDKs for other
+/// languages.
+///
+/// **Layered error model**
+///
+/// - The outer Zig error union (`!Result(T)`) carries *local* failures —
+///   network errors, OOM, malformed responses, allocator failures. Use
+///   normal `try`/`catch` for these.
+/// - The `.err` variant carries *Azure-side* failures — any HTTP
+///   non-2xx response whose body parsed as an Azure error envelope (or
+///   didn't, in which case `error_code`/`message` are null but
+///   `status_code` is still populated).
+/// - The `.ok` variant carries the successful response value.
+///
+/// **Lifetime**
+///
+/// `Result.deinit()` frees the `AzureError`'s strings on the `.err`
+/// path. The `.ok` payload retains the same ownership rules as the
+/// non-`Result` variant of the method — typically the caller still
+/// frees individual fields. We deliberately do not call a synthetic
+/// `T.deinit` because not every payload type has one and the rules
+/// vary per service.
+///
+/// **Example**
+///
+/// ```zig
+/// var r = try client.getSecretResult(allocator, "name");
+/// defer r.deinit();
+/// switch (r) {
+///     .ok => |secret| {
+///         defer if (secret.value) |v| allocator.free(v);
+///         defer if (secret.id) |i| allocator.free(i);
+///         use(secret);
+///     },
+///     .err => |az_err| {
+///         if (std.mem.eql(u8, az_err.error_code orelse "", "SecretNotFound")) {
+///             // expected: secret didn't exist
+///         } else {
+///             return error.UnexpectedAzureFailure;
+///         }
+///     },
+/// }
+/// ```
+pub fn Result(comptime T: type) type {
+    return union(enum) {
+        ok: T,
+        err: AzureError,
+
+        const Self = @This();
+
+        /// Free the `AzureError` strings on the `.err` path. No-op for
+        /// `.ok`; callers free the payload using the same rules as the
+        /// non-`Result` variant of the method.
+        pub fn deinit(self: *Self) void {
+            switch (self.*) {
+                .ok => {},
+                .err => |*e| e.deinit(),
+            }
+        }
+
+        /// Convenience for the common "succeeded?" check.
+        pub fn isOk(self: Self) bool {
+            return self == .ok;
+        }
+
+        /// Return the Azure error code if this is the `.err` variant
+        /// and the response body contained an `error.code` field;
+        /// `null` otherwise. Useful for branching:
+        ///
+        /// ```zig
+        /// if (std.mem.eql(u8, r.errorCode() orelse "", "Throttled")) ...
+        /// ```
+        pub fn errorCode(self: Self) ?[]const u8 {
+            return switch (self) {
+                .ok => null,
+                .err => |e| e.error_code,
+            };
+        }
+    };
+}
+
 test "errorFromResponse success" {
     var resp = http.Response{
         .status_code = 200,
@@ -184,4 +268,25 @@ test "logErrorResponse is a no-op on success" {
     defer resp.deinit();
     // Should not log anything and should not allocate beyond what resp owns.
     logErrorResponse(resp);
+}
+
+test "Result.ok holds payload, deinit is a no-op" {
+    var r: Result(u32) = .{ .ok = 42 };
+    defer r.deinit();
+    try std.testing.expect(r.isOk());
+    try std.testing.expectEqual(@as(?[]const u8, null), r.errorCode());
+    try std.testing.expectEqual(@as(u32, 42), r.ok);
+}
+
+test "Result.err carries AzureError and frees it on deinit" {
+    var r: Result(u32) = .{ .err = .{
+        .allocator = std.testing.allocator,
+        .status_code = 429,
+        .error_code = try std.testing.allocator.dupe(u8, "Throttled"),
+        .message = try std.testing.allocator.dupe(u8, "Slow down"),
+    } };
+    defer r.deinit();
+    try std.testing.expect(!r.isOk());
+    try std.testing.expectEqualStrings("Throttled", r.errorCode().?);
+    try std.testing.expectEqual(@as(u16, 429), r.err.status_code);
 }

--- a/src/azure/keyvault/secrets/root.zig
+++ b/src/azure/keyvault/secrets/root.zig
@@ -86,6 +86,43 @@ pub const SecretClient = struct {
         return parseSecret(allocator, name, resp.body);
     }
 
+    /// Same as `getSecret`, but returns the typed `AzureError` on
+    /// Azure-side failures rather than a generic `error.SecretNotFound`.
+    ///
+    /// This is the first method on the SDK using the new `Result(T)`
+    /// pattern (see `core.errors.Result`). Use it when you need to
+    /// branch on `AzureError.error_code` — for example, to distinguish
+    /// `"SecretNotFound"` (expected) from `"Forbidden"` (a real
+    /// failure).
+    ///
+    /// Note: this method does NOT call `logErrorResponse` — the caller
+    /// receives the structured error directly and can log or suppress
+    /// as appropriate.
+    pub fn getSecretResult(
+        self: *SecretClient,
+        allocator: std.mem.Allocator,
+        name: []const u8,
+    ) !core.errors.Result(KeyVaultSecret) {
+        const url = try self.buildUrl(allocator, &.{ "secrets", name }, null);
+        defer allocator.free(url);
+
+        var req = core.http.Request.init(allocator, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
+        }
+
+        return .{ .ok = try parseSecret(allocator, name, resp.body) };
+    }
+
     /// PUT /secrets/{name}?api-version=...
     /// Body: {"value": "..."}
     pub fn setSecret(
@@ -321,6 +358,100 @@ fn parseSecretListPage(allocator: std.mem.Allocator, body: []const u8) !core.pag
     }
 
     return .{ .items = names, .next_link = next_link };
+}
+
+test "SecretClient getSecretResult: ok path" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"value":"my-secret-value","id":"https://myvault.vault.azure.net/secrets/mysecret/abc123"}
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+
+    const identity = @import("azure_identity");
+    var cred_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer cred_mock.deinit();
+    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+
+    var client = SecretClient.init(
+        "https://myvault.vault.azure.net",
+        cred.asCredential(),
+        mock.asTransport(),
+        .{},
+    );
+
+    var r = try client.getSecretResult(allocator, "mysecret");
+    defer r.deinit();
+
+    try std.testing.expect(r.isOk());
+    const secret = r.ok;
+    defer allocator.free(secret.value.?);
+    defer allocator.free(secret.id.?);
+
+    try std.testing.expectEqualStrings("my-secret-value", secret.value.?);
+}
+
+test "SecretClient getSecretResult: err path surfaces SecretNotFound code" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"error":{"code":"SecretNotFound","message":"Secret not found"}}
+    ;
+    var mock = core.http.MockTransport.init(allocator, 404, body);
+    defer mock.deinit();
+
+    const identity = @import("azure_identity");
+    var cred_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer cred_mock.deinit();
+    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+
+    var client = SecretClient.init(
+        "https://myvault.vault.azure.net",
+        cred.asCredential(),
+        mock.asTransport(),
+        .{},
+    );
+
+    var r = try client.getSecretResult(allocator, "missing");
+    defer r.deinit();
+
+    try std.testing.expect(!r.isOk());
+    try std.testing.expectEqualStrings("SecretNotFound", r.errorCode().?);
+    try std.testing.expectEqual(@as(u16, 404), r.err.status_code);
+    try std.testing.expectEqualStrings("Secret not found", r.err.message.?);
+}
+
+test "SecretClient getSecretResult: err path with no parseable body" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 500, "Internal Server Error");
+    defer mock.deinit();
+
+    const identity = @import("azure_identity");
+    var cred_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer cred_mock.deinit();
+    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+
+    var client = SecretClient.init(
+        "https://myvault.vault.azure.net",
+        cred.asCredential(),
+        mock.asTransport(),
+        .{},
+    );
+
+    var r = try client.getSecretResult(allocator, "boom");
+    defer r.deinit();
+
+    try std.testing.expect(!r.isOk());
+    // No JSON envelope in the body → error_code/message stay null, but
+    // status_code is still populated so callers can branch on HTTP class.
+    try std.testing.expectEqual(@as(u16, 500), r.err.status_code);
+    try std.testing.expectEqual(@as(?[]const u8, null), r.errorCode());
+    try std.testing.expectEqual(@as(?[]const u8, null), r.err.message);
 }
 
 // ─────────────────────────── Tests ───────────────────────────

--- a/src/azure/keyvault/secrets/root.zig
+++ b/src/azure/keyvault/secrets/root.zig
@@ -25,6 +25,16 @@ pub const KeyVaultSecret = struct {
     value: ?[]const u8 = null,
     id: ?[]const u8 = null,
     properties: SecretProperties = .{},
+
+    /// Free the allocated `value`, `id`, and `properties.content_type`
+    /// strings. `name` is NOT freed — by convention for single-resource
+    /// fetches it's a borrow of the caller's input string (and the same
+    /// pointer the caller passed to `getSecret(..., name)`).
+    pub fn deinit(self: KeyVaultSecret, allocator: std.mem.Allocator) void {
+        if (self.value) |v| allocator.free(v);
+        if (self.id) |i| allocator.free(i);
+        if (self.properties.content_type) |c| allocator.free(c);
+    }
 };
 
 pub const DeletedSecret = struct {
@@ -383,14 +393,10 @@ test "SecretClient getSecretResult: ok path" {
     );
 
     var r = try client.getSecretResult(allocator, "mysecret");
-    defer r.deinit();
+    defer r.deinit(allocator);
 
     try std.testing.expect(r.isOk());
-    const secret = r.ok;
-    defer allocator.free(secret.value.?);
-    defer allocator.free(secret.id.?);
-
-    try std.testing.expectEqualStrings("my-secret-value", secret.value.?);
+    try std.testing.expectEqualStrings("my-secret-value", r.ok.value.?);
 }
 
 test "SecretClient getSecretResult: err path surfaces SecretNotFound code" {
@@ -416,7 +422,7 @@ test "SecretClient getSecretResult: err path surfaces SecretNotFound code" {
     );
 
     var r = try client.getSecretResult(allocator, "missing");
-    defer r.deinit();
+    defer r.deinit(allocator);
 
     try std.testing.expect(!r.isOk());
     try std.testing.expectEqualStrings("SecretNotFound", r.errorCode().?);
@@ -444,7 +450,7 @@ test "SecretClient getSecretResult: err path with no parseable body" {
     );
 
     var r = try client.getSecretResult(allocator, "boom");
-    defer r.deinit();
+    defer r.deinit(allocator);
 
     try std.testing.expect(!r.isOk());
     // No JSON envelope in the body → error_code/message stay null, but


### PR DESCRIPTION
**Design-review PR.** Plan B stage 1 from the post-#16 backlog. Applies the new `Result(T)` pattern to a single method (`SecretClient.getSecretResult`) so we can confirm the shape works before propagating to the other ~80 service-client methods. **No existing API is broken** — `getSecret` is unchanged; `getSecretResult` is a new sibling.

## Why

Today every service-client method on failure does:

```zig
if (!resp.isSuccess()) {
    core.errors.logErrorResponse(resp);
    return error.SecretNotFound;
}
```

Caller receives `error.SecretNotFound`. They cannot:
- Branch on the Azure `error.code` string (`"ServerBusy"` retry, `"AuthFailed"` fail fast, etc.)
- Read `error.message` at the call site
- See the HTTP `status_code`

These are needed for the standard Azure-SDK-in-other-languages pattern. Today the structured error is logged once via `logErrorResponse` and then thrown away.

## The pattern

```zig
pub fn Result(comptime T: type) type {
    return union(enum) {
        ok: T,
        err: AzureError,

        pub fn deinit(self: *@This()) void { ... }
        pub fn isOk(self: @This()) bool { ... }
        pub fn errorCode(self: @This()) ?[]const u8 { ... }
    };
}
```

Service-client `*Result` variant returns `!Result(T)`:
- Outer `!` carries **local** failures (OOM, network, malformed JSON, allocator failures) — normal `try`/`catch`.
- `.err` variant carries **Azure-side** failures — any non-2xx response. `error_code`/`message` are null if the body isn't a parseable Azure envelope; `status_code` is always populated.
- `.ok` variant carries the typed success payload.

## Caller ergonomics

```zig
var r = try client.getSecretResult(allocator, "name");
defer r.deinit();
switch (r) {
    .ok => |secret| {
        defer if (secret.value) |v| allocator.free(v);
        defer if (secret.id) |i| allocator.free(i);
        use(secret);
    },
    .err => |az_err| {
        if (std.mem.eql(u8, az_err.error_code orelse "", "SecretNotFound")) {
            // expected: secret didn't exist
        } else if (az_err.status_code == 429) {
            return error.Throttled;
        } else {
            return error.UnexpectedAzureFailure;
        }
    },
}
```

## What's in

- `core/errors.zig`: `Result(T)` + 2 unit tests.
- `keyvault/secrets/root.zig`: `getSecretResult` alongside `getSecret` + 3 demo tests covering ok path, parseable-envelope err path, and unparseable-body err path.

```
Build Summary: 53/53 steps succeeded; 224/224 tests passed
```

(219 baseline + 2 Result tests + 3 getSecretResult tests.)

## What's NOT in

- The other ~80 service-client methods. They still return `!T`. Once the pattern is approved, we fan out — mostly mechanical, one extra method per existing one.
- Result variants for the *other* SecretClient methods (`setSecret`, `deleteSecret`, `listSecrets`, `purgeDeletedSecret`, `recoverDeletedSecret`). Easy follow-up once the pattern is locked in.

## Three open questions

1. **Naming.** `getSecretResult` vs `getSecretWithError` vs `tryGetSecret`. I picked `*Result` because it names the return type and reads as "the Result form of getSecret". OK?

2. **`Result.deinit` and the `.ok` payload.** Today it's a no-op for `.ok` — caller still frees the payload's individual fields manually, same as the existing `getSecret`. Adding a synthetic `T.deinit` call would require every payload type (`KeyVaultSecret`, `KeyVaultKey`, `KeyVaultCertificate`, `Database`, `AttestationResult`, …) to grow a `deinit` method, which is a much bigger refactor. Stay no-op for now?

3. **Stage 2 long-term shape.** Three options:
   - **a.** Keep both `getSecret` and `getSecretResult` forever. Callers pick.
   - **b.** Rename `*Result` -> base name (breaking), drop the simple form.
   - **c.** Drop `*Result` suffix, keep both: `getSecret` returns `!T`, `getSecret` (overloaded?) — but Zig doesn't overload, so this isn't actually an option.
   
   I'd recommend **(a)** — coexistence — because some callers genuinely don't care about the structured error and `try client.getSecret(...)` is more ergonomic than `switch` for them. Your call.
