### PR TITLE
errors: Result.unwrap helper + fan out Result(T) to Storage Blobs/Queues

### DIFF
--- a/src/azure/core/errors.zig
+++ b/src/azure/core/errors.zig
@@ -168,6 +168,28 @@ pub fn Result(comptime T: type) type {
                 .err => |e| e.error_code,
             };
         }
+
+        /// Convert this Result into the corresponding Zig error union:
+        /// returns the `.ok` payload on success, or logs+deinits the
+        /// `AzureError` and returns `fail_error` on Azure-side failure.
+        ///
+        /// Designed for the thin-wrapper pattern: a simple-form method
+        /// like `getSecret(...) !KeyVaultSecret` calls the matching
+        /// `getSecretResult` and then `return r.unwrap(error.X);`. Two
+        /// lines instead of an explicit switch.
+        ///
+        /// Note: this consumes the `AzureError` strings via `deinit`,
+        /// so callers cannot use `r` again afterward.
+        pub fn unwrap(self: *Self, fail_error: anyerror) anyerror!T {
+            switch (self.*) {
+                .ok => |v| return v,
+                .err => |*e| {
+                    std.log.warn("{f}", .{e.*});
+                    e.deinit();
+                    return fail_error;
+                },
+            }
+        }
     };
 }
 
@@ -319,4 +341,23 @@ test "Result.deinit dispatches to payload.deinit when present" {
     try std.testing.expectEqualStrings("data", r.ok.owned);
     // testing.allocator catches leaks: if deinit didn't dispatch, this test
     // would fail with a "leaked 1 allocation" error.
+}
+
+test "Result.unwrap: .ok returns the value" {
+    var r: Result(u32) = .{ .ok = 99 };
+    const v = try r.unwrap(error.UnusedFail);
+    try std.testing.expectEqual(@as(u32, 99), v);
+}
+
+test "Result.unwrap: .err deinits and returns supplied error" {
+    var r: Result(u32) = .{ .err = .{
+        .allocator = std.testing.allocator,
+        .status_code = 403,
+        .error_code = try std.testing.allocator.dupe(u8, "Forbidden"),
+        .message = try std.testing.allocator.dupe(u8, "Access denied"),
+    } };
+    const got = r.unwrap(error.SecretNotFound);
+    try std.testing.expectError(error.SecretNotFound, got);
+    // unwrap deinits the AzureError on the .err path; testing.allocator
+    // would flag a leak here if it didn't.
 }

--- a/src/azure/keyvault/administration/root.zig
+++ b/src/azure/keyvault/administration/root.zig
@@ -42,16 +42,8 @@ pub const BackupClient = struct {
         storage_uri: []const u8,
         sas_token: []const u8,
     ) ![]const u8 {
-        const r = try self.beginBackupResult(allocator, storage_uri, sas_token);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.BeginBackupFailed;
-            },
-        };
+        var r = try self.beginBackupResult(allocator, storage_uri, sas_token);
+        return r.unwrap(error.BeginBackupFailed);
     }
 
     /// Same as `beginBackup` but returns `Result([]const u8)`.
@@ -101,16 +93,8 @@ pub const BackupClient = struct {
         backup_uri: []const u8,
         sas_token: []const u8,
     ) ![]const u8 {
-        const r = try self.beginRestoreResult(allocator, backup_uri, sas_token);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.BeginRestoreFailed;
-            },
-        };
+        var r = try self.beginRestoreResult(allocator, backup_uri, sas_token);
+        return r.unwrap(error.BeginRestoreFailed);
     }
 
     /// Same as `beginRestore` but returns `Result([]const u8)`.
@@ -198,16 +182,8 @@ pub const SettingsClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) ![]const u8 {
-        const r = try self.getSettingResult(allocator, name);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.GetSettingFailed;
-            },
-        };
+        var r = try self.getSettingResult(allocator, name);
+        return r.unwrap(error.GetSettingFailed);
     }
 
     /// Same as `getSetting` but returns `Result([]const u8)`.
@@ -247,16 +223,8 @@ pub const SettingsClient = struct {
         name: []const u8,
         value: []const u8,
     ) !void {
-        const r = try self.updateSettingResult(allocator, name, value);
-        switch (r) {
-            .ok => {},
-            .err => {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                return error.UpdateSettingFailed;
-            },
-        }
+        var r = try self.updateSettingResult(allocator, name, value);
+        try r.unwrap(error.UpdateSettingFailed);
     }
 
     /// Same as `updateSetting` but returns `Result(void)`.

--- a/src/azure/keyvault/certificates/root.zig
+++ b/src/azure/keyvault/certificates/root.zig
@@ -56,16 +56,8 @@ pub const CertificateClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !KeyVaultCertificate {
-        const r = try self.getCertificateResult(allocator, name);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.CertificateNotFound;
-            },
-        };
+        var r = try self.getCertificateResult(allocator, name);
+        return r.unwrap(error.CertificateNotFound);
     }
 
     /// Same as `getCertificate` but returns `Result(KeyVaultCertificate)`.
@@ -102,16 +94,8 @@ pub const CertificateClient = struct {
         subject: []const u8,
         issuer: []const u8,
     ) !KeyVaultCertificate {
-        const r = try self.createCertificateResult(allocator, name, subject, issuer);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.CreateCertificateFailed;
-            },
-        };
+        var r = try self.createCertificateResult(allocator, name, subject, issuer);
+        return r.unwrap(error.CreateCertificateFailed);
     }
 
     /// Same as `createCertificate` but returns `Result(KeyVaultCertificate)`.
@@ -157,16 +141,8 @@ pub const CertificateClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !void {
-        const r = try self.deleteCertificateResult(allocator, name);
-        switch (r) {
-            .ok => {},
-            .err => {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                return error.DeleteCertificateFailed;
-            },
-        }
+        var r = try self.deleteCertificateResult(allocator, name);
+        try r.unwrap(error.DeleteCertificateFailed);
     }
 
     /// Same as `deleteCertificate` but returns `Result(void)`.

--- a/src/azure/keyvault/keys/root.zig
+++ b/src/azure/keyvault/keys/root.zig
@@ -61,16 +61,8 @@ pub const KeyClient = struct {
         name: []const u8,
         key_type: []const u8,
     ) !KeyVaultKey {
-        const r = try self.createKeyResult(allocator, name, key_type);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.CreateKeyFailed;
-            },
-        };
+        var r = try self.createKeyResult(allocator, name, key_type);
+        return r.unwrap(error.CreateKeyFailed);
     }
 
     /// Same as `createKey` but returns `Result(KeyVaultKey)`.
@@ -111,16 +103,8 @@ pub const KeyClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !KeyVaultKey {
-        const r = try self.getKeyResult(allocator, name);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.KeyNotFound;
-            },
-        };
+        var r = try self.getKeyResult(allocator, name);
+        return r.unwrap(error.KeyNotFound);
     }
 
     /// Same as `getKey` but returns `Result(KeyVaultKey)`.
@@ -155,16 +139,8 @@ pub const KeyClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !void {
-        const r = try self.deleteKeyResult(allocator, name);
-        switch (r) {
-            .ok => {},
-            .err => {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                return error.DeleteKeyFailed;
-            },
-        }
+        var r = try self.deleteKeyResult(allocator, name);
+        try r.unwrap(error.DeleteKeyFailed);
     }
 
     /// Same as `deleteKey` but returns `Result(void)`.
@@ -309,16 +285,8 @@ pub const CryptographyClient = struct {
         algorithm: []const u8,
         value: []const u8,
     ) ![]const u8 {
-        const r = try self.cryptoOperationResult(allocator, operation, algorithm, value);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.CryptoOperationFailed;
-            },
-        };
+        var r = try self.cryptoOperationResult(allocator, operation, algorithm, value);
+        return r.unwrap(error.CryptoOperationFailed);
     }
 
     fn cryptoOperationResult(

--- a/src/azure/keyvault/secrets/root.zig
+++ b/src/azure/keyvault/secrets/root.zig
@@ -83,16 +83,8 @@ pub const SecretClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !KeyVaultSecret {
-        const r = try self.getSecretResult(allocator, name);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.SecretNotFound;
-            },
-        };
+        var r = try self.getSecretResult(allocator, name);
+        return r.unwrap(error.SecretNotFound);
     }
 
     /// Same as `getSecret`, but returns the typed `AzureError` on
@@ -138,16 +130,8 @@ pub const SecretClient = struct {
         name: []const u8,
         value: []const u8,
     ) !KeyVaultSecret {
-        const r = try self.setSecretResult(allocator, name, value);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.SetSecretFailed;
-            },
-        };
+        var r = try self.setSecretResult(allocator, name, value);
+        return r.unwrap(error.SetSecretFailed);
     }
 
     /// Same as `setSecret` but returns `Result(KeyVaultSecret)`.
@@ -188,16 +172,8 @@ pub const SecretClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !DeletedSecret {
-        const r = try self.deleteSecretResult(allocator, name);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.DeleteSecretFailed;
-            },
-        };
+        var r = try self.deleteSecretResult(allocator, name);
+        return r.unwrap(error.DeleteSecretFailed);
     }
 
     /// Same as `deleteSecret` but returns `Result(DeletedSecret)`.
@@ -232,16 +208,8 @@ pub const SecretClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !void {
-        const r = try self.purgeDeletedSecretResult(allocator, name);
-        switch (r) {
-            .ok => {},
-            .err => {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                return error.PurgeFailed;
-            },
-        }
+        var r = try self.purgeDeletedSecretResult(allocator, name);
+        try r.unwrap(error.PurgeFailed);
     }
 
     /// Same as `purgeDeletedSecret` but returns `Result(void)`.
@@ -274,16 +242,8 @@ pub const SecretClient = struct {
         allocator: std.mem.Allocator,
         name: []const u8,
     ) !KeyVaultSecret {
-        const r = try self.recoverDeletedSecretResult(allocator, name);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                var e = r.err;
-                defer e.deinit();
-                std.log.warn("{f}", .{e});
-                break :blk error.RecoverFailed;
-            },
-        };
+        var r = try self.recoverDeletedSecretResult(allocator, name);
+        return r.unwrap(error.RecoverFailed);
     }
 
     /// Same as `recoverDeletedSecret` but returns `Result(KeyVaultSecret)`.

--- a/src/azure/storage/blobs/root.zig
+++ b/src/azure/storage/blobs/root.zig
@@ -8,6 +8,12 @@ pub const BlobProperties = struct {
     content_length: ?u64 = null,
     etag: ?[]const u8 = null,
     last_modified: ?[]const u8 = null,
+
+    pub fn deinit(self: BlobProperties, allocator: std.mem.Allocator) void {
+        if (self.content_type) |c| allocator.free(c);
+        if (self.etag) |e| allocator.free(e);
+        if (self.last_modified) |lm| allocator.free(lm);
+    }
 };
 
 pub const BlobItem = struct {
@@ -45,6 +51,12 @@ pub const BlobContainerClient = struct {
 
     /// PUT /container?restype=container
     pub fn create(self: *BlobContainerClient, allocator: std.mem.Allocator) !void {
+        var r = try self.createResult(allocator);
+        try r.unwrap(error.CreateContainerFailed);
+    }
+
+    /// Same as `create` but returns `Result(void)`.
+    pub fn createResult(self: *BlobContainerClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}?restype=container",
@@ -58,14 +70,21 @@ pub const BlobContainerClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateContainerFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// DELETE /container?restype=container
     pub fn deleteContainer(self: *BlobContainerClient, allocator: std.mem.Allocator) !void {
+        var r = try self.deleteContainerResult(allocator);
+        try r.unwrap(error.DeleteContainerFailed);
+    }
+
+    /// Same as `deleteContainer` but returns `Result(void)`.
+    pub fn deleteContainerResult(self: *BlobContainerClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}?restype=container",
@@ -79,10 +98,11 @@ pub const BlobContainerClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteContainerFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// GET /container?restype=container&comp=list
@@ -162,6 +182,12 @@ pub const BlobClient = struct {
 
     /// GET /container/blob
     pub fn download(self: *BlobClient, allocator: std.mem.Allocator) ![]const u8 {
+        var r = try self.downloadResult(allocator);
+        return r.unwrap(error.DownloadFailed);
+    }
+
+    /// Same as `download` but returns `Result([]const u8)`.
+    pub fn downloadResult(self: *BlobClient, allocator: std.mem.Allocator) !core.errors.Result([]const u8) {
         const url = try self.buildBlobUrl(allocator);
         defer allocator.free(url);
 
@@ -172,15 +198,23 @@ pub const BlobClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DownloadFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return allocator.dupe(u8, resp.body);
+        return .{ .ok = try allocator.dupe(u8, resp.body) };
     }
 
     /// PUT /container/blob
     pub fn upload(self: *BlobClient, allocator: std.mem.Allocator, data: []const u8, content_type: []const u8) !void {
+        var r = try self.uploadResult(allocator, data, content_type);
+        try r.unwrap(error.UploadFailed);
+    }
+
+    /// Same as `upload` but returns `Result(void)`.
+    pub fn uploadResult(self: *BlobClient, allocator: std.mem.Allocator, data: []const u8, content_type: []const u8) !core.errors.Result(void) {
         const url = try self.buildBlobUrl(allocator);
         defer allocator.free(url);
 
@@ -193,14 +227,21 @@ pub const BlobClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.UploadFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// PUT /container/blob with conditional headers and ETag response.
     pub fn uploadConditional(self: *BlobClient, allocator: std.mem.Allocator, data: []const u8, options: UploadBlobOptions) !UploadBlobResult {
+        var r = try self.uploadConditionalResult(allocator, data, options);
+        return r.unwrap(error.UploadFailed);
+    }
+
+    /// Same as `uploadConditional` but returns `Result(UploadBlobResult)`.
+    pub fn uploadConditionalResult(self: *BlobClient, allocator: std.mem.Allocator, data: []const u8, options: UploadBlobOptions) !core.errors.Result(UploadBlobResult) {
         const url = try self.buildBlobUrl(allocator);
         defer allocator.free(url);
 
@@ -208,28 +249,32 @@ pub const BlobClient = struct {
         defer req.deinit();
         try req.setHeader("Content-Type", options.content_type);
         try req.setHeader("x-ms-blob-type", "BlockBlob");
-        if (options.if_match) |etag| {
-            try req.setHeader("If-Match", etag);
-        }
-        if (options.if_none_match) |etag| {
-            try req.setHeader("If-None-Match", etag);
-        }
+        if (options.if_match) |etag| try req.setHeader("If-Match", etag);
+        if (options.if_none_match) |etag| try req.setHeader("If-None-Match", etag);
         req.body = data;
 
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.UploadFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
         const etag = if (resp.headers.get("ETag")) |e| try allocator.dupe(u8, e) else null;
-        return .{ .etag = etag };
+        return .{ .ok = .{ .etag = etag } };
     }
 
     /// DELETE /container/blob
     pub fn deleteBlob(self: *BlobClient, allocator: std.mem.Allocator) !void {
+        var r = try self.deleteBlobResult(allocator);
+        try r.unwrap(error.DeleteBlobFailed);
+    }
+
+    /// Same as `deleteBlob` but returns `Result(void)`.
+    pub fn deleteBlobResult(self: *BlobClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try self.buildBlobUrl(allocator);
         defer allocator.free(url);
 
@@ -239,14 +284,21 @@ pub const BlobClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteBlobFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// HEAD /container/blob
     pub fn getProperties(self: *BlobClient, allocator: std.mem.Allocator) !BlobProperties {
+        var r = try self.getPropertiesResult(allocator);
+        return r.unwrap(error.GetPropertiesFailed);
+    }
+
+    /// Same as `getProperties` but returns `Result(BlobProperties)`.
+    pub fn getPropertiesResult(self: *BlobClient, allocator: std.mem.Allocator) !core.errors.Result(BlobProperties) {
         const url = try self.buildBlobUrl(allocator);
         defer allocator.free(url);
 
@@ -257,14 +309,16 @@ pub const BlobClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.GetPropertiesFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return .{
+        return .{ .ok = .{
             .etag = if (resp.headers.get("ETag")) |e| try allocator.dupe(u8, e) else null,
             .last_modified = if (resp.headers.get("Last-Modified")) |lm| try allocator.dupe(u8, lm) else null,
-        };
+        } };
     }
 
     fn buildBlobUrl(self: *BlobClient, allocator: std.mem.Allocator) ![]u8 {

--- a/src/azure/storage/queues/root.zig
+++ b/src/azure/storage/queues/root.zig
@@ -40,6 +40,12 @@ pub const QueueClient = struct {
 
     /// POST /queue/messages
     pub fn sendMessage(self: *QueueClient, allocator: std.mem.Allocator, message_text: []const u8) !void {
+        var r = try self.sendMessageResult(allocator, message_text);
+        try r.unwrap(error.SendMessageFailed);
+    }
+
+    /// Same as `sendMessage` but returns `Result(void)`.
+    pub fn sendMessageResult(self: *QueueClient, allocator: std.mem.Allocator, message_text: []const u8) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/messages",
@@ -62,14 +68,21 @@ pub const QueueClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.SendMessageFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// GET /queue/messages
     pub fn receiveMessages(self: *QueueClient, allocator: std.mem.Allocator) ![]QueueMessage {
+        var r = try self.receiveMessagesResult(allocator);
+        return r.unwrap(error.ReceiveMessagesFailed);
+    }
+
+    /// Same as `receiveMessages` but returns `Result([]QueueMessage)`.
+    pub fn receiveMessagesResult(self: *QueueClient, allocator: std.mem.Allocator) !core.errors.Result([]QueueMessage) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/messages",
@@ -84,15 +97,23 @@ pub const QueueClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.ReceiveMessagesFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return parseMessages(allocator, resp.body);
+        return .{ .ok = try parseMessages(allocator, resp.body) };
     }
 
     /// DELETE /queue/messages/{messageId}?popreceipt={popReceipt}
     pub fn deleteMessage(self: *QueueClient, allocator: std.mem.Allocator, message_id: []const u8, pop_receipt: []const u8) !void {
+        var r = try self.deleteMessageResult(allocator, message_id, pop_receipt);
+        try r.unwrap(error.DeleteMessageFailed);
+    }
+
+    /// Same as `deleteMessage` but returns `Result(void)`.
+    pub fn deleteMessageResult(self: *QueueClient, allocator: std.mem.Allocator, message_id: []const u8, pop_receipt: []const u8) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/messages/{s}?popreceipt={s}",
@@ -106,14 +127,21 @@ pub const QueueClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteMessageFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// GET /queue/messages?peekonly=true
     pub fn peekMessages(self: *QueueClient, allocator: std.mem.Allocator) ![]QueueMessage {
+        var r = try self.peekMessagesResult(allocator);
+        return r.unwrap(error.PeekMessagesFailed);
+    }
+
+    /// Same as `peekMessages` but returns `Result([]QueueMessage)`.
+    pub fn peekMessagesResult(self: *QueueClient, allocator: std.mem.Allocator) !core.errors.Result([]QueueMessage) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/messages?peekonly=true",
@@ -128,11 +156,13 @@ pub const QueueClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.PeekMessagesFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return parseMessages(allocator, resp.body);
+        return .{ .ok = try parseMessages(allocator, resp.body) };
     }
 };
 
@@ -161,6 +191,12 @@ pub const QueueServiceClient = struct {
 
     /// PUT /queue?comp=metadata (create queue)
     pub fn createQueue(self: *QueueServiceClient, allocator: std.mem.Allocator, queue_name: []const u8) !void {
+        var r = try self.createQueueResult(allocator, queue_name);
+        try r.unwrap(error.CreateQueueFailed);
+    }
+
+    /// Same as `createQueue` but returns `Result(void)`.
+    pub fn createQueueResult(self: *QueueServiceClient, allocator: std.mem.Allocator, queue_name: []const u8) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}",
@@ -174,14 +210,21 @@ pub const QueueServiceClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateQueueFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// DELETE /queue
     pub fn deleteQueue(self: *QueueServiceClient, allocator: std.mem.Allocator, queue_name: []const u8) !void {
+        var r = try self.deleteQueueResult(allocator, queue_name);
+        try r.unwrap(error.DeleteQueueFailed);
+    }
+
+    /// Same as `deleteQueue` but returns `Result(void)`.
+    pub fn deleteQueueResult(self: *QueueServiceClient, allocator: std.mem.Allocator, queue_name: []const u8) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}",
@@ -195,10 +238,11 @@ pub const QueueServiceClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteQueueFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn getQueueClient(self: *QueueServiceClient, queue_name: []const u8) QueueClient {


### PR DESCRIPTION
Three threads in one PR — continues the Result(T) fanout that started in #17/#18.

## Thread 1: `Result.unwrap` helper

The thin-wrapper pattern landed in #18 was 10 lines per method:

```zig
pub fn getSecret(...) !KeyVaultSecret {
    const r = try self.getSecretResult(allocator, name);
    return switch (r) {
        .ok => |v| v,
        .err => blk: {
            var e = r.err;
            defer e.deinit();
            std.log.warn("{f}", .{e});
            break :blk error.SecretNotFound;
        },
    };
}
```

Now it's 2 lines:

```zig
pub fn getSecret(...) !KeyVaultSecret {
    var r = try self.getSecretResult(allocator, name);
    return r.unwrap(error.SecretNotFound);
}
```

`Result.unwrap(fail_error)` returns the `.ok` payload on success, or logs+deinits the AzureError and returns `fail_error` on Azure-side failure. Two new tests cover both paths.

## Thread 2: Refactor existing KV wrappers

All 16 thin wrappers from #18 (across SecretClient, KeyClient, CryptographyClient, CertificateClient, BackupClient, SettingsClient) now use `unwrap`. Behavior is identical — the consolidation is purely syntactic.

## Thread 3: Fan out to Storage Blobs and Queues

12 new `*Result` variants:

| Client | Result variants |
|---|---|
| `BlobContainerClient` | `createResult`, `deleteContainerResult` |
| `BlobClient` | `downloadResult`, `uploadResult`, `uploadConditionalResult`, `deleteBlobResult`, `getPropertiesResult` |
| `QueueClient` | `sendMessageResult`, `receiveMessagesResult`, `deleteMessageResult`, `peekMessagesResult` |
| `QueueServiceClient` | `createQueueResult`, `deleteQueueResult` |

`BlobProperties` gains `pub fn deinit(allocator)` so `Result(BlobProperties)` cleans up automatically via the synthetic dispatch.

## Verification

```
$ zig fmt --check src/ build.zig
$ zig build && zig build test --summary all
Build Summary: 53/53 steps succeeded; 227/227 tests passed
```

225 → 227 (+2 for `Result.unwrap` ok/err paths).

## Still to come

- Storage Files (Shares + DataLake): same pattern, 13 methods.
- Data: Tables, Cosmos, AppConfig.
- Attestation.
- Kusto: Data + Ingest.
- Messaging: ServiceBus + EventHubs.
