### PR TITLE
errors: fan out Result(T) to Storage Files (Shares + DataLake)

### DIFF
--- a/src/azure/storage/files/datalake/root.zig
+++ b/src/azure/storage/files/datalake/root.zig
@@ -31,6 +31,12 @@ pub const DataLakeFileSystemClient = struct {
 
     /// PUT /filesystem?resource=filesystem
     pub fn create(self: *DataLakeFileSystemClient, allocator: std.mem.Allocator) !void {
+        var r = try self.createResult(allocator);
+        try r.unwrap(error.CreateFileSystemFailed);
+    }
+
+    /// Same as `create` but returns `Result(void)`.
+    pub fn createResult(self: *DataLakeFileSystemClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}?resource=filesystem",
@@ -44,14 +50,21 @@ pub const DataLakeFileSystemClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateFileSystemFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// DELETE /filesystem?resource=filesystem
     pub fn deleteFileSystem(self: *DataLakeFileSystemClient, allocator: std.mem.Allocator) !void {
+        var r = try self.deleteFileSystemResult(allocator);
+        try r.unwrap(error.DeleteFileSystemFailed);
+    }
+
+    /// Same as `deleteFileSystem` but returns `Result(void)`.
+    pub fn deleteFileSystemResult(self: *DataLakeFileSystemClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}?resource=filesystem",
@@ -65,10 +78,11 @@ pub const DataLakeFileSystemClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteFileSystemFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn getFileClient(self: *DataLakeFileSystemClient, file_path: []const u8) DataLakeFileClient {
@@ -93,6 +107,12 @@ pub const DataLakeFileClient = struct {
 
     /// PUT /filesystem/path?resource=file
     pub fn create(self: *DataLakeFileClient, allocator: std.mem.Allocator) !void {
+        var r = try self.createResult(allocator);
+        try r.unwrap(error.CreateFileFailed);
+    }
+
+    /// Same as `create` but returns `Result(void)`.
+    pub fn createResult(self: *DataLakeFileClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}?resource=file",
@@ -106,14 +126,21 @@ pub const DataLakeFileClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateFileFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// PATCH /filesystem/path?action=append&position={pos}
     pub fn append(self: *DataLakeFileClient, allocator: std.mem.Allocator, data: []const u8, position: u64) !void {
+        var r = try self.appendResult(allocator, data, position);
+        try r.unwrap(error.AppendFailed);
+    }
+
+    /// Same as `append` but returns `Result(void)`.
+    pub fn appendResult(self: *DataLakeFileClient, allocator: std.mem.Allocator, data: []const u8, position: u64) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}?action=append&position={d}",
@@ -129,14 +156,21 @@ pub const DataLakeFileClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.AppendFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// PATCH /filesystem/path?action=flush&position={pos}
     pub fn flush(self: *DataLakeFileClient, allocator: std.mem.Allocator, position: u64) !void {
+        var r = try self.flushResult(allocator, position);
+        try r.unwrap(error.FlushFailed);
+    }
+
+    /// Same as `flush` but returns `Result(void)`.
+    pub fn flushResult(self: *DataLakeFileClient, allocator: std.mem.Allocator, position: u64) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}?action=flush&position={d}",
@@ -150,14 +184,21 @@ pub const DataLakeFileClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.FlushFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// GET /filesystem/path
     pub fn read(self: *DataLakeFileClient, allocator: std.mem.Allocator) ![]const u8 {
+        var r = try self.readResult(allocator);
+        return r.unwrap(error.ReadFailed);
+    }
+
+    /// Same as `read` but returns `Result([]const u8)`.
+    pub fn readResult(self: *DataLakeFileClient, allocator: std.mem.Allocator) !core.errors.Result([]const u8) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}",
@@ -172,15 +213,23 @@ pub const DataLakeFileClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.ReadFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return allocator.dupe(u8, resp.body);
+        return .{ .ok = try allocator.dupe(u8, resp.body) };
     }
 
     /// DELETE /filesystem/path
     pub fn deleteFile(self: *DataLakeFileClient, allocator: std.mem.Allocator) !void {
+        var r = try self.deleteFileResult(allocator);
+        try r.unwrap(error.DeleteFileFailed);
+    }
+
+    /// Same as `deleteFile` but returns `Result(void)`.
+    pub fn deleteFileResult(self: *DataLakeFileClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}",
@@ -194,10 +243,11 @@ pub const DataLakeFileClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteFileFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 };
 

--- a/src/azure/storage/files/shares/root.zig
+++ b/src/azure/storage/files/shares/root.zig
@@ -31,6 +31,12 @@ pub const ShareClient = struct {
 
     /// PUT /share?restype=share
     pub fn create(self: *ShareClient, allocator: std.mem.Allocator) !void {
+        var r = try self.createResult(allocator);
+        try r.unwrap(error.CreateShareFailed);
+    }
+
+    /// Same as `create` but returns `Result(void)`.
+    pub fn createResult(self: *ShareClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}?restype=share",
@@ -44,14 +50,21 @@ pub const ShareClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateShareFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// DELETE /share?restype=share
     pub fn deleteShare(self: *ShareClient, allocator: std.mem.Allocator) !void {
+        var r = try self.deleteShareResult(allocator);
+        try r.unwrap(error.DeleteShareFailed);
+    }
+
+    /// Same as `deleteShare` but returns `Result(void)`.
+    pub fn deleteShareResult(self: *ShareClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}?restype=share",
@@ -65,10 +78,11 @@ pub const ShareClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteShareFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn getDirectoryClient(self: *ShareClient, directory_name: []const u8) ShareDirectoryClient {
@@ -93,6 +107,12 @@ pub const ShareDirectoryClient = struct {
 
     /// PUT /share/directory?restype=directory
     pub fn create(self: *ShareDirectoryClient, allocator: std.mem.Allocator) !void {
+        var r = try self.createResult(allocator);
+        try r.unwrap(error.CreateDirectoryFailed);
+    }
+
+    /// Same as `create` but returns `Result(void)`.
+    pub fn createResult(self: *ShareDirectoryClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}?restype=directory",
@@ -107,14 +127,21 @@ pub const ShareDirectoryClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateDirectoryFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// DELETE /share/directory?restype=directory
     pub fn deleteDirectory(self: *ShareDirectoryClient, allocator: std.mem.Allocator) !void {
+        var r = try self.deleteDirectoryResult(allocator);
+        try r.unwrap(error.DeleteDirectoryFailed);
+    }
+
+    /// Same as `deleteDirectory` but returns `Result(void)`.
+    pub fn deleteDirectoryResult(self: *ShareDirectoryClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}?restype=directory",
@@ -128,10 +155,11 @@ pub const ShareDirectoryClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteDirectoryFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn getFileClient(self: *ShareDirectoryClient, file_name: []const u8) ShareFileClient {
@@ -158,6 +186,12 @@ pub const ShareFileClient = struct {
 
     /// PUT /share/dir/file (create with x-ms-type: file and x-ms-content-length)
     pub fn create(self: *ShareFileClient, allocator: std.mem.Allocator, content_length: u64) !void {
+        var r = try self.createResult(allocator, content_length);
+        try r.unwrap(error.CreateFileFailed);
+    }
+
+    /// Same as `create` but returns `Result(void)`.
+    pub fn createResult(self: *ShareFileClient, allocator: std.mem.Allocator, content_length: u64) !core.errors.Result(void) {
         const url = try self.buildFileUrl(allocator);
         defer allocator.free(url);
 
@@ -172,14 +206,21 @@ pub const ShareFileClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateFileFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// PUT /share/dir/file?comp=range
     pub fn upload(self: *ShareFileClient, allocator: std.mem.Allocator, data: []const u8) !void {
+        var r = try self.uploadResult(allocator, data);
+        try r.unwrap(error.UploadFailed);
+    }
+
+    /// Same as `upload` but returns `Result(void)`.
+    pub fn uploadResult(self: *ShareFileClient, allocator: std.mem.Allocator, data: []const u8) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}/{s}?comp=range",
@@ -196,14 +237,21 @@ pub const ShareFileClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.UploadFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     /// GET /share/dir/file
     pub fn download(self: *ShareFileClient, allocator: std.mem.Allocator) ![]const u8 {
+        var r = try self.downloadResult(allocator);
+        return r.unwrap(error.DownloadFailed);
+    }
+
+    /// Same as `download` but returns `Result([]const u8)`.
+    pub fn downloadResult(self: *ShareFileClient, allocator: std.mem.Allocator) !core.errors.Result([]const u8) {
         const url = try self.buildFileUrl(allocator);
         defer allocator.free(url);
 
@@ -214,15 +262,23 @@ pub const ShareFileClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DownloadFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return allocator.dupe(u8, resp.body);
+        return .{ .ok = try allocator.dupe(u8, resp.body) };
     }
 
     /// DELETE /share/dir/file
     pub fn deleteFile(self: *ShareFileClient, allocator: std.mem.Allocator) !void {
+        var r = try self.deleteFileResult(allocator);
+        try r.unwrap(error.DeleteFileFailed);
+    }
+
+    /// Same as `deleteFile` but returns `Result(void)`.
+    pub fn deleteFileResult(self: *ShareFileClient, allocator: std.mem.Allocator) !core.errors.Result(void) {
         const url = try self.buildFileUrl(allocator);
         defer allocator.free(url);
 
@@ -232,10 +288,11 @@ pub const ShareFileClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteFileFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     fn buildFileUrl(self: *ShareFileClient, allocator: std.mem.Allocator) ![]u8 {


### PR DESCRIPTION
Same pattern as #19, applied to the file-share and DataLake clients.

## Clients touched (5, 15 methods)

| Client | Methods |
|---|---|
| `ShareClient` | `create`, `deleteShare` |
| `ShareDirectoryClient` | `create`, `deleteDirectory` |
| `ShareFileClient` | `create`, `upload`, `download`, `deleteFile` |
| `DataLakeFileSystemClient` | `create`, `deleteFileSystem` |
| `DataLakeFileClient` | `create`, `append`, `flush`, `read`, `deleteFile` |

Each gets a `*Result` sibling using `core.errors.Result(T)`. The simple forms become 2-line wrappers calling `r.unwrap(error.X)`. No payload deinit needed — all returns are either `void` or `[]const u8`.

## Verification

```
Build Summary: 53/53 steps succeeded; 227/227 tests passed
```

## Still to come

- Data: Tables, Cosmos, AppConfig.
- Attestation.
- Kusto: Data + Ingest.
- Messaging: ServiceBus + EventHubs.