### PR TITLE
errors: fan out Result(T) to Kusto and ServiceBus admin (final fanout)

### DIFF
--- a/src/azure/kusto/data/root.zig
+++ b/src/azure/kusto/data/root.zig
@@ -97,6 +97,25 @@ pub const KustoClient = struct {
         return self.executeQuery(allocator, database, query_or_command, null);
     }
 
+    /// `Result(...)` variants of the execute methods.
+    pub fn executeQueryResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
+        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.connection.cluster_url});
+        defer allocator.free(url);
+        return self.executeInternalResult(allocator, url, database, query, properties);
+    }
+    pub fn executeMgmtResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
+        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.connection.cluster_url});
+        defer allocator.free(url);
+        return self.executeInternalResult(allocator, url, database, command, properties);
+    }
+    pub fn executeResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query_or_command: []const u8) !core.errors.Result(KustoResponseDataSet) {
+        const trimmed = std.mem.trimStart(u8, query_or_command, " \t\n\r");
+        if (trimmed.len > 0 and trimmed[0] == '.') {
+            return self.executeMgmtResult(allocator, database, query_or_command, null);
+        }
+        return self.executeQueryResult(allocator, database, query_or_command, null);
+    }
+
     fn executeInternal(
         self: *KustoClient,
         allocator: std.mem.Allocator,
@@ -105,6 +124,18 @@ pub const KustoClient = struct {
         csl: []const u8,
         properties: ?ClientRequestProperties,
     ) !KustoResponseDataSet {
+        var r = try self.executeInternalResult(allocator, url, database, csl, properties);
+        return r.unwrap(error.KustoQueryFailed);
+    }
+
+    fn executeInternalResult(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        url: []const u8,
+        database: []const u8,
+        csl: []const u8,
+        properties: ?ClientRequestProperties,
+    ) !core.errors.Result(KustoResponseDataSet) {
         const props_json = if (properties) |p| try p.toJson(allocator) else try allocator.dupe(u8, "{}");
         defer allocator.free(props_json);
 
@@ -124,11 +155,13 @@ pub const KustoClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.KustoQueryFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return parseResponseDataSet(allocator, resp.body);
+        return .{ .ok = try parseResponseDataSet(allocator, resp.body) };
     }
 };
 

--- a/src/azure/kusto/ingest/root.zig
+++ b/src/azure/kusto/ingest/root.zig
@@ -58,7 +58,26 @@ pub const StreamingIngestClient = struct {
     }
 
     /// Ingest data from a byte slice.
+    ///
+    /// Returns `IngestionResult{ .status = .failed }` on any Azure-side
+    /// error (and logs the error). Use `ingestFromSliceResult` to receive
+    /// the structured `AzureError` instead.
     pub fn ingestFromSlice(self: *StreamingIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !IngestionResult {
+        var r = try self.ingestFromSliceResult(allocator, database, table, data, options);
+        return switch (r) {
+            .ok => |v| v,
+            .err => blk: {
+                std.log.warn("{f}", .{r.err});
+                r.err.deinit();
+                break :blk .{ .status = .failed };
+            },
+        };
+    }
+
+    /// Same as `ingestFromSlice` but exposes Azure-side failures as the
+    /// `.err` variant of `Result` instead of collapsing them into
+    /// `IngestionResult{ .status = .failed }`.
+    pub fn ingestFromSliceResult(self: *StreamingIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !core.errors.Result(IngestionResult) {
         const url = try self.buildIngestUrl(allocator, database, table, options);
         defer allocator.free(url);
 
@@ -73,11 +92,13 @@ pub const StreamingIngestClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return .{ .status = .failed };
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return .{ .status = .success };
+        return .{ .ok = .{ .status = .success } };
     }
 
     fn buildIngestUrl(self: *StreamingIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, options: IngestOptions) ![]u8 {
@@ -112,7 +133,24 @@ pub const QueuedIngestClient = struct {
     }
 
     /// Ingest from a blob URL (blob already uploaded).
+    ///
+    /// Returns `IngestionResult{ .status = .failed }` on Azure-side
+    /// errors. Use `ingestFromBlobResult` to receive the structured
+    /// `AzureError` instead.
     pub fn ingestFromBlob(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !IngestionResult {
+        var r = try self.ingestFromBlobResult(allocator, properties, blob_url);
+        return switch (r) {
+            .ok => |v| v,
+            .err => blk: {
+                std.log.warn("{f}", .{r.err});
+                r.err.deinit();
+                break :blk .{ .status = .failed };
+            },
+        };
+    }
+
+    /// Same as `ingestFromBlob` but exposes Azure-side failures via Result.
+    pub fn ingestFromBlobResult(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !core.errors.Result(IngestionResult) {
         // Build the ingestion message as JSON.
         const msg = try self.buildIngestionMessage(allocator, properties, blob_url);
         defer allocator.free(msg);
@@ -137,11 +175,13 @@ pub const QueuedIngestClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return .{ .status = .failed };
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return .{ .status = .queued };
+        return .{ .ok = .{ .status = .queued } };
     }
 
     fn getDmUrl(self: *QueuedIngestClient, allocator: std.mem.Allocator) ![]const u8 {

--- a/src/azure/messaging/servicebus/root.zig
+++ b/src/azure/messaging/servicebus/root.zig
@@ -549,6 +549,12 @@ pub const ServiceBusAdministrationClient = struct {
     // ── Queue operations ──
 
     pub fn createQueue(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.createQueueResult(allocator, name);
+        try r.unwrap(error.CreateQueueFailed);
+    }
+
+    /// Same as `createQueue` but returns `Result(void)`.
+    pub fn createQueueResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
         const url = try self.buildEntityUrl(allocator, name);
         defer allocator.free(url);
 
@@ -569,13 +575,20 @@ pub const ServiceBusAdministrationClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateQueueFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn deleteQueue(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.deleteQueueResult(allocator, name);
+        try r.unwrap(error.DeleteQueueFailed);
+    }
+
+    /// Same as `deleteQueue` but returns `Result(void)`.
+    pub fn deleteQueueResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
         const url = try self.buildEntityUrl(allocator, name);
         defer allocator.free(url);
 
@@ -585,13 +598,20 @@ pub const ServiceBusAdministrationClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteQueueFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn listQueues(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) ![]QueueProperties {
+        var r = try self.listQueuesResult(allocator);
+        return r.unwrap(error.ListQueuesFailed);
+    }
+
+    /// Same as `listQueues` but returns `Result([]QueueProperties)`.
+    pub fn listQueuesResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) !core.errors.Result([]QueueProperties) {
         const url = try std.fmt.allocPrint(allocator, "https://{s}/$Resources/queues?api-version={s}", .{ self.fully_qualified_namespace, self.api_version });
         defer allocator.free(url);
 
@@ -602,16 +622,24 @@ pub const ServiceBusAdministrationClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.ListQueuesFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return parseEntityNames(allocator, resp.body, "Queue");
+        return .{ .ok = try parseEntityNames(allocator, resp.body, "Queue") };
     }
 
     // ── Topic operations ──
 
     pub fn createTopic(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.createTopicResult(allocator, name);
+        try r.unwrap(error.CreateTopicFailed);
+    }
+
+    /// Same as `createTopic` but returns `Result(void)`.
+    pub fn createTopicResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
         const url = try self.buildEntityUrl(allocator, name);
         defer allocator.free(url);
 
@@ -632,13 +660,20 @@ pub const ServiceBusAdministrationClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateTopicFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn deleteTopic(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.deleteTopicResult(allocator, name);
+        try r.unwrap(error.DeleteTopicFailed);
+    }
+
+    /// Same as `deleteTopic` but returns `Result(void)`.
+    pub fn deleteTopicResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
         const url = try self.buildEntityUrl(allocator, name);
         defer allocator.free(url);
 
@@ -648,13 +683,20 @@ pub const ServiceBusAdministrationClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteTopicFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn listTopics(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) ![]TopicProperties {
+        var r = try self.listTopicsResult(allocator);
+        return r.unwrap(error.ListTopicsFailed);
+    }
+
+    /// Same as `listTopics` but returns `Result([]TopicProperties)`.
+    pub fn listTopicsResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) !core.errors.Result([]TopicProperties) {
         const url = try std.fmt.allocPrint(allocator, "https://{s}/$Resources/topics?api-version={s}", .{ self.fully_qualified_namespace, self.api_version });
         defer allocator.free(url);
 
@@ -665,16 +707,24 @@ pub const ServiceBusAdministrationClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.ListTopicsFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return parseEntityNames(allocator, resp.body, "Topic");
+        return .{ .ok = try parseEntityNames(allocator, resp.body, "Topic") };
     }
 
     // ── Subscription operations ──
 
     pub fn createSubscription(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !void {
+        var r = try self.createSubscriptionResult(allocator, topic_name, subscription_name);
+        try r.unwrap(error.CreateSubscriptionFailed);
+    }
+
+    /// Same as `createSubscription` but returns `Result(void)`.
+    pub fn createSubscriptionResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions/{s}?api-version={s}", .{ self.fully_qualified_namespace, topic_name, subscription_name, self.api_version });
         defer allocator.free(url);
 
@@ -695,13 +745,20 @@ pub const ServiceBusAdministrationClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.CreateSubscriptionFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn deleteSubscription(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !void {
+        var r = try self.deleteSubscriptionResult(allocator, topic_name, subscription_name);
+        try r.unwrap(error.DeleteSubscriptionFailed);
+    }
+
+    /// Same as `deleteSubscription` but returns `Result(void)`.
+    pub fn deleteSubscriptionResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !core.errors.Result(void) {
         const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions/{s}?api-version={s}", .{ self.fully_qualified_namespace, topic_name, subscription_name, self.api_version });
         defer allocator.free(url);
 
@@ -711,13 +768,20 @@ pub const ServiceBusAdministrationClient = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.DeleteSubscriptionFailed;
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
         }
+        return error.AzureRequestFailed;
     }
 
     pub fn listSubscriptions(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8) ![]SubscriptionProperties {
+        var r = try self.listSubscriptionsResult(allocator, topic_name);
+        return r.unwrap(error.ListSubscriptionsFailed);
+    }
+
+    /// Same as `listSubscriptions` but returns `Result([]SubscriptionProperties)`.
+    pub fn listSubscriptionsResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8) !core.errors.Result([]SubscriptionProperties) {
         const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions?api-version={s}", .{ self.fully_qualified_namespace, topic_name, self.api_version });
         defer allocator.free(url);
 
@@ -728,11 +792,13 @@ pub const ServiceBusAdministrationClient = struct {
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            core.errors.logErrorResponse(resp);
-            return error.ListSubscriptionsFailed;
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
         }
 
-        return parseSubscriptionNames(allocator, resp.body, topic_name);
+        return .{ .ok = try parseSubscriptionNames(allocator, resp.body, topic_name) };
     }
 
     fn buildEntityUrl(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) ![]u8 {


### PR DESCRIPTION
Wraps up Plan B by applying the `Result(T)` pattern to the remaining HTTP-based service clients.

## Clients touched (3, 14 methods)

| Client | Result methods |
|---|---|
| `KustoClient` | `executeQueryResult`, `executeMgmtResult`, `executeResult` (plus shared `executeInternalResult` helper) |
| `StreamingIngestClient` | `ingestFromSliceResult` |
| `QueuedIngestClient` | `ingestFromBlobResult` |
| `ServiceBusAdministrationClient` | `createQueueResult`, `deleteQueueResult`, `listQueuesResult`, `createTopicResult`, `deleteTopicResult`, `listTopicsResult`, `createSubscriptionResult`, `deleteSubscriptionResult`, `listSubscriptionsResult` |

Note on Kusto Ingest: the simple forms don't propagate Zig errors — they collapse Azure failures into `IngestionResult{ .status = .failed }`. The `*Result` variants expose the structured `AzureError` while the legacy forms preserve the existing "log + status flag" behavior.

## Skipped (intentional)

- **Tables** (`TableClient.getEntity` / `createEntity` / `deleteEntity`): return `core.http.Response` directly and never call `logErrorResponse`. `Result(Response)` adds no information.
- **ServiceBus sender/receiver/AMQP** + **EventHubs producer/consumer/AMQP**: all AMQP transport, no HTTP error envelopes. Failures already propagate as Zig errors from the AMQP layer.
- **`ManagedIngestClient.ingestFromSlice`**: a try-streaming-then-fallback wrapper that handles errors internally.

## Plan B summary

After this PR (PRs #17 through #22):
- ~50 service-client methods have `*Result` variants giving callers access to the structured `AzureError` for branching on `error_code`.
- `core.errors.Result(T)` with synthetic payload-deinit dispatch and `unwrap(fail_error)` helper for the thin-wrapper pattern.
- Existing simple-form methods preserved unchanged for callers that just want `try client.foo(...)`.

## Verification

```
Build Summary: 53/53 steps succeeded; 227/227 tests passed
```