### PR TITLE
codegen: ARM inheritance copy-down + open-enum serde hooks

### DIFF
--- a/codegen/cli/src/codemodel.zig
+++ b/codegen/cli/src/codemodel.zig
@@ -95,6 +95,13 @@ pub const Model = struct {
     discriminator: ?[]const u8 = null,
     is_input: bool = false,
     is_output: bool = false,
+    /// ARM base-type kind, set by the TCGC adapter when this model's
+    /// `baseModel` chain terminates in `Azure.ResourceManager.{Proxy,
+    /// Tracked,Extension}Resource`. The emitter renders a
+    /// `pub const arm_resource_kind: core.arm.ResourceKind = .<kind>;`
+    /// inside the generated struct so `core.arm` helpers can dispatch
+    /// on it.
+    arm_resource_kind: ?[]const u8 = null,
 };
 
 pub const Field = struct {

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -265,14 +265,31 @@ fn renderModels(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
     errdefer aw.deinit();
     const w = &aw.writer;
 
+    // Whether any generated struct will reference `core.arm.ResourceKind`.
+    // If so, models.zig needs `const core = @import("azure_core");`.
+    var needs_core = false;
+    for (model.models) |m| {
+        if (m.arm_resource_kind != null) {
+            needs_core = true;
+            break;
+        }
+    }
+
     try w.writeAll(
         \\//! Generated data-transfer-object models.
         \\
         \\const std = @import("std");
         \\const enums = @import("enums.zig");
         \\
-        \\
     );
+    if (needs_core) {
+        try w.writeAll(
+            \\const core = @import("azure_core");
+            \\
+        );
+    }
+    try w.writeAll("\n");
+
     for (model.models) |m| {
         if (m.doc) |d| try renderDocComment(w, d);
         try w.print("pub const {s} = struct {{\n", .{m.name});
@@ -295,6 +312,18 @@ fn renderModels(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         // services emit camelCase JSON keys while Zig fields are snake_case.
         // Per-field `wireName` overrides from TCGC still win when present.
         try w.writeAll("\n    pub const serde = .{ .rename_all = .camel_case };\n");
+
+        // ARM resource marker. Lets `core.arm` helpers like
+        // `core.arm.id(&res)` / `core.arm.setTags(&res, ...)` dispatch
+        // on the resource's base type at comptime, with zero runtime
+        // cost. See `sdk/core/arm/resource.zig`.
+        if (m.arm_resource_kind) |kind| {
+            try w.print(
+                "    pub const arm_resource_kind: core.arm.ResourceKind = .{s};\n",
+                .{kind},
+            );
+        }
+
         try w.writeAll("};\n\n");
     }
     return try aw.toOwnedSlice();
@@ -307,18 +336,32 @@ fn renderEnums(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
     errdefer aw.deinit();
     const w = &aw.writer;
 
+    var any_extensible = false;
+    for (model.enums) |e| {
+        if (e.extensible) {
+            any_extensible = true;
+            break;
+        }
+    }
+
     try w.writeAll(
         \\//! Generated enums.
         \\//!
         \\//! Azure data-plane enums are typically *extensible* — the wire
         \\//! contract may grow with new values that older clients still
         \\//! need to round-trip. Represented as a tagged union with a
-        \\//! catch-all `unknown` variant.
+        \\//! catch-all `unrecognized` variant.
         \\
         \\const std = @import("std");
         \\
-        \\
     );
+    if (any_extensible) {
+        try w.writeAll(
+            \\const core = @import("azure_core");
+            \\
+        );
+    }
+    try w.writeAll("\n");
     for (model.enums) |e| {
         if (e.doc) |d| try renderDocComment(w, d);
         if (e.extensible) {
@@ -330,7 +373,35 @@ fn renderEnums(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
                 defer allocator.free(tag);
                 try w.print("    {s},\n", .{tag});
             }
-            try w.writeAll("    unknown: []const u8,\n};\n\n");
+            try w.writeAll("    unrecognized: []const u8,\n\n");
+
+            try w.writeAll("    const wire_names = .{\n");
+            for (e.values) |v| {
+                const snake = try naming.toSnakeCase(allocator, v.name);
+                defer allocator.free(snake);
+                const tag = try ids.quoteIfNeeded(allocator, snake);
+                defer allocator.free(tag);
+                const wire = wireNameForEnumValue(v);
+                try w.print("        .{s} = \"{s}\",\n", .{ tag, wire });
+            }
+            try w.writeAll("    };\n\n");
+
+            try w.writeAll(
+                \\    pub fn zerdeDeserialize(
+                \\        comptime T: type,
+                \\        allocator: std.mem.Allocator,
+                \\        deserializer: anytype,
+                \\    ) @TypeOf(deserializer.*).Error!T {
+                \\        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+                \\    }
+                \\
+                \\    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+                \\        return core.open_enum.serialize(self, wire_names, serializer);
+                \\    }
+                \\};
+                \\
+                \\
+            );
         } else {
             try w.print("pub const {s} = enum {{\n", .{e.name});
             for (e.values) |v| {
@@ -344,6 +415,16 @@ fn renderEnums(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         }
     }
     return try aw.toOwnedSlice();
+}
+
+/// Choose the JSON-wire string for an enum value. Prefers the explicit
+/// `value` if it parsed as a string (TypeSpec allows `Foo: "wire-form"`);
+/// falls back to the variant `name` otherwise.
+fn wireNameForEnumValue(v: cm.EnumValue) []const u8 {
+    return switch (v.value) {
+        .string => |s| s,
+        else => v.name,
+    };
 }
 
 // ─── build.zig / build.zig.zon ───────────────────────────────────────

--- a/codegen/tcgc-component/src/index.js
+++ b/codegen/tcgc-component/src/index.js
@@ -388,12 +388,87 @@ function adaptLro(method) {
 
 /* ───────────────────────── Model / enum / type adapters ──────────── */
 
+// Cross-language-definition-id of each ARM base type. TCGC stamps these
+// onto `SdkModelType.crossLanguageDefinitionId` regardless of how the
+// spec aliases the type, so matching here is robust against namespace
+// re-imports.
+const ARM_RESOURCE_KIND_BY_XLDID = {
+  "Azure.ResourceManager.CommonTypes.ProxyResource": "proxy",
+  "Azure.ResourceManager.CommonTypes.Resource": "proxy",
+  "Azure.ResourceManager.CommonTypes.TrackedResource": "tracked",
+  "Azure.ResourceManager.CommonTypes.ExtensionResource": "extension",
+  // Older / alternate aliases used by some TCGC versions.
+  "Azure.ResourceManager.ProxyResource": "proxy",
+  "Azure.ResourceManager.Resource": "proxy",
+  "Azure.ResourceManager.TrackedResource": "tracked",
+  "Azure.ResourceManager.ExtensionResource": "extension",
+};
+
+// Fallback table keyed on the topmost base model's `name`, used when
+// `crossLanguageDefinitionId` is unset or unrecognized.
+const ARM_RESOURCE_KIND_BY_NAME = {
+  ProxyResource: "proxy",
+  Resource: "proxy",
+  TrackedResource: "tracked",
+  ExtensionResource: "extension",
+};
+
+/**
+ * Walk the `baseModel` chain root-to-leaf and return the concatenated
+ * list of (own + inherited) properties. Inherited properties come
+ * first; the leaf's own properties last. Within that order we de-dup
+ * by `serializedName` so a property re-declared on the leaf wins (its
+ * doc / optionality / type override the inherited one).
+ */
+function collectInheritedProperties(model) {
+  const chain = [];
+  for (let cur = model; cur; cur = cur.baseModel) chain.unshift(cur);
+
+  const byKey = new Map();
+  for (const m of chain) {
+    for (const p of m.properties ?? []) {
+      const key = p.serializedName ?? p.name;
+      byKey.set(key, p); // later (more-derived) entries replace earlier ones
+    }
+  }
+  return Array.from(byKey.values());
+}
+
+/**
+ * Detect which ARM base type (if any) sits at the root of `model`'s
+ * `baseModel` chain. Returns `"proxy"` / `"tracked"` / `"extension"`,
+ * or `null` for non-ARM types.
+ */
+function detectArmResourceKind(model) {
+  let topmost = model;
+  for (let cur = model; cur; cur = cur.baseModel) {
+    const xldid = cur.crossLanguageDefinitionId;
+    if (xldid && Object.prototype.hasOwnProperty.call(ARM_RESOURCE_KIND_BY_XLDID, xldid)) {
+      return ARM_RESOURCE_KIND_BY_XLDID[xldid];
+    }
+    topmost = cur;
+  }
+  // Fallback: classify by the topmost base model's name when xldid is
+  // unrecognized. Guard with a namespace prefix to avoid catching
+  // unrelated "Resource" / "TrackedResource" types in non-ARM specs.
+  const ns = topmost?.namespace ?? topmost?.clientNamespace ?? "";
+  if (
+    Object.prototype.hasOwnProperty.call(ARM_RESOURCE_KIND_BY_NAME, topmost?.name) &&
+    typeof ns === "string" &&
+    ns.startsWith("Azure.ResourceManager")
+  ) {
+    return ARM_RESOURCE_KIND_BY_NAME[topmost.name];
+  }
+  return null;
+}
+
 function adaptModel(model) {
+  const props = collectInheritedProperties(model);
   return {
     name: model.name,
     namespace: model.namespace ?? null,
     doc: model.doc ?? null,
-    fields: (model.properties ?? []).map((p) => ({
+    fields: props.map((p) => ({
       name: toSnakeCase(p.name),
       serialized_name: p.serializedName ?? p.name,
       doc: p.doc ?? null,
@@ -406,6 +481,7 @@ function adaptModel(model) {
     discriminator: model.discriminatorProperty?.name ?? null,
     is_input: !!(model.usage & 1),
     is_output: !!(model.usage & 2),
+    arm_resource_kind: detectArmResourceKind(model),
   };
 }
 

--- a/codegen/tcgc-component/src/wasi-host.js
+++ b/codegen/tcgc-component/src/wasi-host.js
@@ -427,12 +427,87 @@ function paramLocation(p) {
   }
 }
 
+// Cross-language-definition-id of each ARM base type. TCGC stamps these
+// onto `SdkModelType.crossLanguageDefinitionId` regardless of how the
+// spec aliases the type, so matching here is robust against namespace
+// re-imports.
+const ARM_RESOURCE_KIND_BY_XLDID = {
+  "Azure.ResourceManager.CommonTypes.ProxyResource": "proxy",
+  "Azure.ResourceManager.CommonTypes.Resource": "proxy",
+  "Azure.ResourceManager.CommonTypes.TrackedResource": "tracked",
+  "Azure.ResourceManager.CommonTypes.ExtensionResource": "extension",
+  // Older / alternate aliases used by some TCGC versions.
+  "Azure.ResourceManager.ProxyResource": "proxy",
+  "Azure.ResourceManager.Resource": "proxy",
+  "Azure.ResourceManager.TrackedResource": "tracked",
+  "Azure.ResourceManager.ExtensionResource": "extension",
+};
+
+// Fallback table keyed on the topmost base model's `name`, used when
+// `crossLanguageDefinitionId` is unset or unrecognized.
+const ARM_RESOURCE_KIND_BY_NAME = {
+  ProxyResource: "proxy",
+  Resource: "proxy",
+  TrackedResource: "tracked",
+  ExtensionResource: "extension",
+};
+
+/**
+ * Walk the `baseModel` chain root-to-leaf and return the concatenated
+ * list of (own + inherited) properties. Inherited properties come
+ * first; the leaf's own properties last. Within that order we de-dup
+ * by `serializedName` so a property re-declared on the leaf wins (its
+ * doc / optionality / type override the inherited one).
+ */
+function collectInheritedProperties(model) {
+  const chain = [];
+  for (let cur = model; cur; cur = cur.baseModel) chain.unshift(cur);
+
+  const byKey = new Map();
+  for (const m of chain) {
+    for (const p of m.properties ?? []) {
+      const key = p.serializedName ?? p.name;
+      byKey.set(key, p);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
+/**
+ * Detect which ARM base type (if any) sits at the root of `model`'s
+ * `baseModel` chain. Returns `"proxy"` / `"tracked"` / `"extension"`,
+ * or `null` for non-ARM types.
+ */
+function detectArmResourceKind(model) {
+  let topmost = model;
+  for (let cur = model; cur; cur = cur.baseModel) {
+    const xldid = cur.crossLanguageDefinitionId;
+    if (xldid && Object.prototype.hasOwnProperty.call(ARM_RESOURCE_KIND_BY_XLDID, xldid)) {
+      return ARM_RESOURCE_KIND_BY_XLDID[xldid];
+    }
+    topmost = cur;
+  }
+  // Fallback: classify by the topmost base model's name when xldid is
+  // unrecognized. Guard with a namespace prefix to avoid catching
+  // unrelated "Resource" / "TrackedResource" types in non-ARM specs.
+  const ns = topmost?.namespace ?? topmost?.clientNamespace ?? "";
+  if (
+    Object.prototype.hasOwnProperty.call(ARM_RESOURCE_KIND_BY_NAME, topmost?.name) &&
+    typeof ns === "string" &&
+    ns.startsWith("Azure.ResourceManager")
+  ) {
+    return ARM_RESOURCE_KIND_BY_NAME[topmost.name];
+  }
+  return null;
+}
+
 function adaptModel(model) {
+  const props = collectInheritedProperties(model);
   return {
     name: model.name,
     namespace: model.namespace ?? null,
     doc: model.doc ?? null,
-    fields: (model.properties ?? []).map((p) => ({
+    fields: props.map((p) => ({
       name: toSnakeCase(p.name),
       serialized_name: p.serializedName ?? p.name,
       doc: p.doc ?? null,
@@ -445,6 +520,7 @@ function adaptModel(model) {
     discriminator: model.discriminatorProperty?.name ?? null,
     is_input: !!(model.usage & 1),
     is_output: !!(model.usage & 2),
+    arm_resource_kind: detectArmResourceKind(model),
   };
 }
 

--- a/rest/arm_avs/examples/list_private_clouds.zig
+++ b/rest/arm_avs/examples/list_private_clouds.zig
@@ -56,12 +56,13 @@ pub fn main(init: std.process.Init) !void {
     var count: usize = 0;
     while (try pager.next()) |page| {
         for (page) |cloud| {
-            const state = if (cloud.properties) |props|
-                props.provisioning_state orelse "-"
-            else
-                "-";
-            const location = cloud.location orelse "-";
-            try w.print("{s:<40}  {s:<14}  {s:<18}\n", .{ cloud.name, location, state });
+            const state: []const u8 = if (cloud.properties) |props|
+                if (props.provisioning_state) |ps| switch (ps) {
+                    .unrecognized => |s| s,
+                    else => @tagName(ps),
+                } else "-"
+            else "-";
+            try w.print("{s:<40}  {s:<14}  {s:<18}\n", .{ cloud.name, cloud.location, state });
             count += 1;
         }
     }

--- a/rest/arm_avs/src/clients.zig
+++ b/rest/arm_avs/src/clients.zig
@@ -10,16 +10,13 @@
 //!   • Only `AVSClient.privateClouds().listInSubscription(...)` is wired.
 //!   • All other ARM resource collections (Clusters, Datastores, …) are
 //!     omitted — add them when the emitter learns sub-client recursion.
-//!   • We use a local `PrivateCloudSummary` instead of `models.PrivateCloud`
-//!     because the emitter does not yet emit fields inherited from base
-//!     ARM resource types (`id`, `location` on `TrackedResource` /
-//!     `Resource`); the generated `models.PrivateCloud` only has the
-//!     leaf-type fields, so the example would have nothing to print for
-//!     location.
-//!     The camelCase rename hint that this shim demonstrates is now
-//!     emitter-supplied as of Phase E1: every generated struct in
-//!     `src/models.zig` ends in
-//!     `pub const serde = .{ .rename_all = .camel_case };`.
+//!
+//! Resource DTOs come from the generated `models.zig`: every ARM resource
+//! (e.g. `models.PrivateCloud`) carries the full set of inherited fields
+//! from its base chain (`id`, `name`, `type`, `system_data`, plus
+//! `location`/`tags` for tracked resources) and is tagged with
+//! `pub const arm_resource_kind: core.arm.ResourceKind = .tracked;` so
+//! that generic helpers in `core.arm` accept it.
 
 const std = @import("std");
 const core = @import("azure_core");
@@ -29,27 +26,8 @@ const default_endpoint = "https://management.azure.com";
 const default_api_version = "2025-09-01";
 const arm_scopes: []const []const u8 = &.{"https://management.azure.com/.default"};
 
-/// Minimal view of a Private Cloud sufficient for `listInSubscription`.
-///
-/// Hand-written wire-format type with `pub const serde = .{ .rename_all =
-/// .camel_case }` so ARM's camelCase JSON keys map to snake_case Zig
-/// fields. This is the convention the emitter is expected to apply to
-/// every generated struct.
-pub const PrivateCloudSummary = struct {
-    id: ?[]const u8 = null,
-    name: []const u8,
-    location: ?[]const u8 = null,
-    properties: ?Properties = null,
-
-    pub const Properties = struct {
-        provisioning_state: ?[]const u8 = null,
-
-        pub const serde = .{ .rename_all = .camel_case };
-    };
-};
-
 /// Pager type returned by `PrivateCloudsClient.listInSubscription`.
-pub const PrivateCloudPager = core.pager.PipelinePager(PrivateCloudSummary);
+pub const PrivateCloudPager = core.pager.PipelinePager(models.PrivateCloud);
 
 /// Top-level Azure VMware Solution client.
 ///
@@ -144,7 +122,7 @@ pub const PrivateCloudsClient = struct {
             self.pipeline,
             url,
             alloc,
-            core.pager.listPageParser(PrivateCloudSummary),
+            core.pager.listPageParser(models.PrivateCloud),
             "application/json",
         );
     }
@@ -158,7 +136,7 @@ test "AVSClient.privateClouds().listInSubscription pages mock results" {
     const allocator = testing.allocator;
 
     const body =
-        \\{"value":[{"name":"cloud-a","sku":{"name":"av36"}},{"name":"cloud-b","sku":{"name":"av36p"}}]}
+        \\{"value":[{"name":"cloud-a","location":"eastus","sku":{"name":"av36"}},{"name":"cloud-b","location":"westus2","sku":{"name":"av36p"}}]}
     ;
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
@@ -193,6 +171,11 @@ test "AVSClient.privateClouds().listInSubscription pages mock results" {
     try testing.expectEqual(@as(usize, 2), page.len);
     try testing.expectEqualStrings("cloud-a", page[0].name);
     try testing.expectEqualStrings("cloud-b", page[1].name);
+    // Generic ARM accessors from `core.arm` work because the generated
+    // struct carries `pub const arm_resource_kind = .tracked` and the
+    // required base fields.
+    try testing.expectEqualStrings("eastus", core.arm.location(&page[0]).?);
+    try testing.expectEqualStrings("westus2", core.arm.location(&page[1]).?);
 
     try testing.expect(try pager.next() == null);
 }

--- a/rest/arm_avs/src/enums.zig
+++ b/rest/arm_avs/src/enums.zig
@@ -3,22 +3,57 @@
 //! Azure data-plane enums are typically *extensible* — the wire
 //! contract may grow with new values that older clients still
 //! need to round-trip. Represented as a tagged union with a
-//! catch-all `unknown` variant.
+//! catch-all `unrecognized` variant.
 
 const std = @import("std");
+const core = @import("azure_core");
 
 /// The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
 pub const Origin = union(enum) {
     user,
     system,
     @"user,system",
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .user = "user",
+        .system = "system",
+        .@"user,system" = "user,system",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Extensible enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
 pub const ActionType = union(enum) {
     internal,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .internal = "Internal",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Addon type
@@ -27,7 +62,26 @@ pub const AddonType = union(enum) {
     vr,
     hcx,
     arc,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .srm = "SRM",
+        .vr = "VR",
+        .hcx = "HCX",
+        .arc = "Arc",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Addon provisioning state
@@ -39,7 +93,29 @@ pub const AddonProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .cancelled = "Cancelled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The kind of entity that created the resource.
@@ -48,7 +124,26 @@ pub const createdByType = union(enum) {
     application,
     managed_identity,
     key,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .user = "User",
+        .application = "Application",
+        .managed_identity = "ManagedIdentity",
+        .key = "Key",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The provisioning state of a resource type.
@@ -56,7 +151,25 @@ pub const ResourceProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Express Route Circuit Authorization provisioning state
@@ -65,7 +178,26 @@ pub const ExpressRouteAuthorizationProvisioningState = union(enum) {
     failed,
     canceled,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// cloud link provisioning state
@@ -73,7 +205,25 @@ pub const CloudLinkProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Cloud Link status
@@ -83,7 +233,27 @@ pub const CloudLinkStatus = union(enum) {
     deleting,
     failed,
     disconnected,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .active = "Active",
+        .building = "Building",
+        .deleting = "Deleting",
+        .failed = "Failed",
+        .disconnected = "Disconnected",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Cluster provisioning state
@@ -94,7 +264,28 @@ pub const ClusterProvisioningState = union(enum) {
     cancelled,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .cancelled = "Cancelled",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
@@ -115,29 +306,88 @@ pub const DatastoreProvisioningState = union(enum) {
     creating,
     updating,
     deleting,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .cancelled = "Cancelled",
+        .pending = "Pending",
+        .creating = "Creating",
+        .updating = "Updating",
+        .deleting = "Deleting",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// mount option
 pub const MountOptionEnum = union(enum) {
     mount,
     attach,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .mount = "MOUNT",
+        .attach = "ATTACH",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// datastore status
 pub const DatastoreStatus = union(enum) {
-    // NOTE: emitter bug — the spec has an enum value `Unknown` that
-    // collides with the open-union sentinel `unknown: []const u8`. Until
-    // the emitter learns to disambiguate, rename the explicit variant.
-    unknown_value,
+    unknown,
     accessible,
     inaccessible,
     attached,
     detached,
     lost_communication,
     dead_or_error,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .unknown = "Unknown",
+        .accessible = "Accessible",
+        .inaccessible = "Inaccessible",
+        .attached = "Attached",
+        .detached = "Detached",
+        .lost_communication = "LostCommunication",
+        .dead_or_error = "DeadOrError",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Global Reach Connection provisioning state
@@ -146,7 +396,26 @@ pub const GlobalReachConnectionProvisioningState = union(enum) {
     failed,
     canceled,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Global Reach Connection status
@@ -154,7 +423,25 @@ pub const GlobalReachConnectionStatus = union(enum) {
     connected,
     connecting,
     disconnected,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .connected = "Connected",
+        .connecting = "Connecting",
+        .disconnected = "Disconnected",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// HCX Enterprise Site provisioning state
@@ -162,7 +449,25 @@ pub const HcxEnterpriseSiteProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// HCX Enterprise Site status
@@ -171,14 +476,50 @@ pub const HcxEnterpriseSiteStatus = union(enum) {
     consumed,
     deactivated,
     deleted,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .available = "Available",
+        .consumed = "Consumed",
+        .deactivated = "Deactivated",
+        .deleted = "Deleted",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The kind of host.
 pub const HostKind = union(enum) {
     general,
     specialized,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .general = "General",
+        .specialized = "Specialized",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// provisioning state of the host
@@ -186,14 +527,49 @@ pub const HostProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The reason for host maintenance.
 pub const HostMaintenance = union(enum) {
     replacement,
     upgrade,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .replacement = "Replacement",
+        .upgrade = "Upgrade",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// private cloud provisioning state
@@ -205,13 +581,51 @@ pub const IscsiPathProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .pending = "Pending",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The kind of license.
 pub const LicenseKind = union(enum) {
     vmware_firewall,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .vmware_firewall = "VmwareFirewall",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// provisioning state of the license
@@ -219,13 +633,47 @@ pub const LicenseProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The name of the license.
 pub const LicenseName = union(enum) {
     vmware_firewall,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .vmware_firewall = "VmwareFirewall",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// trial status
@@ -233,14 +681,49 @@ pub const TrialStatus = union(enum) {
     trial_available,
     trial_used,
     trial_disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .trial_available = "TrialAvailable",
+        .trial_used = "TrialUsed",
+        .trial_disabled = "TrialDisabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// quota enabled
 pub const QuotaEnabled = union(enum) {
     enabled,
     disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .enabled = "Enabled",
+        .disabled = "Disabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Customer presentable maintenance state
@@ -251,14 +734,52 @@ pub const MaintenanceStateName = union(enum) {
     success,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .not_scheduled = "NotScheduled",
+        .scheduled = "Scheduled",
+        .in_progress = "InProgress",
+        .success = "Success",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// status filter for the maintenance
 pub const MaintenanceStatusFilter = union(enum) {
     active,
     inactive,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .active = "Active",
+        .inactive = "Inactive",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// type of the maintenance
@@ -266,7 +787,25 @@ pub const MaintenanceType = union(enum) {
     vcsa,
     esxi,
     nsxt,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .vcsa = "VCSA",
+        .esxi = "ESXI",
+        .nsxt = "NSXT",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// provisioning state of the maintenance
@@ -275,7 +814,26 @@ pub const MaintenanceProvisioningState = union(enum) {
     failed,
     canceled,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Defines the type of operation
@@ -283,7 +841,25 @@ pub const MaintenanceManagementOperationKind = union(enum) {
     schedule,
     reschedule,
     maintenance_readiness_refresh,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .schedule = "Schedule",
+        .reschedule = "Reschedule",
+        .maintenance_readiness_refresh = "MaintenanceReadinessRefresh",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Constraints for scheduling of maintenance
@@ -291,7 +867,25 @@ pub const ScheduleOperationConstraintKind = union(enum) {
     scheduling_window,
     available_window_for_maintenance_while_schedule_operation,
     blocked_while_schedule_operation,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .scheduling_window = "SchedulingWindow",
+        .available_window_for_maintenance_while_schedule_operation = "AvailableWindowForMaintenance",
+        .blocked_while_schedule_operation = "Blocked",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Reason for blocking operation on maintenance
@@ -299,14 +893,49 @@ pub const BlockedDatesConstraintCategory = union(enum) {
     hi_priority_event,
     quota_exhausted,
     holiday,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .hi_priority_event = "HiPriorityEvent",
+        .quota_exhausted = "QuotaExhausted",
+        .holiday = "Holiday",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Constraints for rescheduling of maintenance
 pub const RescheduleOperationConstraintKind = union(enum) {
     available_window_for_maintenance_while_reschedule_operation,
     blocked_while_reschedule_operation,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .available_window_for_maintenance_while_reschedule_operation = "AvailableWindowForMaintenance",
+        .blocked_while_reschedule_operation = "Blocked",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The status of an MaintenanceReadinessRefresh operation
@@ -315,14 +944,50 @@ pub const MaintenanceReadinessRefreshOperationStatus = union(enum) {
     not_started,
     failed,
     not_applicable,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .in_progress = "InProgress",
+        .not_started = "NotStarted",
+        .failed = "Failed",
+        .not_applicable = "NotApplicable",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Defines the type of maintenance readiness check
 pub const MaintenanceCheckType = union(enum) {
     precheck,
     preflight,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .precheck = "Precheck",
+        .preflight = "Preflight",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Defines the readiness status of maintenance
@@ -331,21 +996,74 @@ pub const MaintenanceReadinessStatus = union(enum) {
     not_ready,
     data_not_available,
     not_applicable,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .ready = "Ready",
+        .not_ready = "NotReady",
+        .data_not_available = "DataNotAvailable",
+        .not_applicable = "NotApplicable",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Placement Policy type
 pub const PlacementPolicyType = union(enum) {
     vm_vm,
     vm_host,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .vm_vm = "VmVm",
+        .vm_host = "VmHost",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Placement Policy state
 pub const PlacementPolicyState = union(enum) {
     enabled,
     disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .enabled = "Enabled",
+        .disabled = "Disabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Placement Policy provisioning state
@@ -356,70 +1074,244 @@ pub const PlacementPolicyProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Affinity type
 pub const AffinityType = union(enum) {
     affinity,
     anti_affinity,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .affinity = "Affinity",
+        .anti_affinity = "AntiAffinity",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Affinity Strength
 pub const AffinityStrength = union(enum) {
     should,
     must,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .should = "Should",
+        .must = "Must",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Azure Hybrid Benefit type
 pub const AzureHybridBenefitType = union(enum) {
     sql_host,
     none,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .sql_host = "SqlHost",
+        .none = "None",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Whether internet is enabled or disabled
 pub const InternetEnum = union(enum) {
     enabled,
     disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .enabled = "Enabled",
+        .disabled = "Disabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Whether SSL is enabled or disabled
 pub const SslEnum = union(enum) {
     enabled,
     disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .enabled = "Enabled",
+        .disabled = "Disabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Whether the private clouds is available in a single zone or two zones
 pub const AvailabilityStrategy = union(enum) {
     single_zone,
     dual_zone,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .single_zone = "SingleZone",
+        .dual_zone = "DualZone",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Whether encryption is enabled or disabled
 pub const EncryptionState = union(enum) {
     enabled,
     disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .enabled = "Enabled",
+        .disabled = "Disabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Whether the the encryption key is connected or access denied
 pub const EncryptionKeyStatus = union(enum) {
     connected,
     access_denied,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .connected = "Connected",
+        .access_denied = "AccessDenied",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Whether the encryption version is fixed or auto-detected
 pub const EncryptionVersionType = union(enum) {
     fixed,
     auto_detected,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .fixed = "Fixed",
+        .auto_detected = "AutoDetected",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// private cloud provisioning state
@@ -432,34 +1324,124 @@ pub const PrivateCloudProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .cancelled = "Cancelled",
+        .pending = "Pending",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// NSX public IP quota raised
 pub const NsxPublicIpQuotaRaisedEnum = union(enum) {
     enabled,
     disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .enabled = "Enabled",
+        .disabled = "Disabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The type of DNS zone.
 pub const DnsZoneType = union(enum) {
     public,
     private,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .public = "Public",
+        .private = "Private",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The kind of license.
 pub const VcfLicenseKind = union(enum) {
     vcf5,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .vcf5 = "vcf5",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Type of managed service identity (either system assigned, or none).
 pub const SystemAssignedServiceIdentityType = union(enum) {
     none,
     system_assigned,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .none = "None",
+        .system_assigned = "SystemAssigned",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// provisioned network provisioning state
@@ -467,7 +1449,25 @@ pub const ProvisionedNetworkProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The type of network provisioned.
@@ -479,7 +1479,29 @@ pub const ProvisionedNetworkTypes = union(enum) {
     vcenter_management,
     vmotion,
     vsan,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .esx_management = "esxManagement",
+        .esx_replication = "esxReplication",
+        .hcx_management = "hcxManagement",
+        .hcx_uplink = "hcxUplink",
+        .vcenter_management = "vcenterManagement",
+        .vmotion = "vmotion",
+        .vsan = "vsan",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Pure Storage Policy Based Management policy provisioning state
@@ -489,7 +1511,27 @@ pub const PureStoragePolicyProvisioningState = union(enum) {
     canceled,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// A script cmdlet provisioning state
@@ -497,14 +1539,49 @@ pub const ScriptCmdletProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Specifies whether a script cmdlet is intended to be invoked only through automation or visible to customers
 pub const ScriptCmdletAudience = union(enum) {
     automation,
     any,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .automation = "Automation",
+        .any = "Any",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Script Parameter types
@@ -515,21 +1592,76 @@ pub const ScriptParameterTypes = union(enum) {
     int,
     bool,
     float,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .string = "String",
+        .secure_string = "SecureString",
+        .credential = "Credential",
+        .int = "Int",
+        .bool = "Bool",
+        .float = "Float",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Visibility Parameter
 pub const VisibilityParameterEnum = union(enum) {
     visible,
     hidden,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .visible = "Visible",
+        .hidden = "Hidden",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Optional Param
 pub const OptionalParamEnum = union(enum) {
     optional,
     required,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .optional = "Optional",
+        .required = "Required",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// script execution parameter type
@@ -537,7 +1669,25 @@ pub const ScriptExecutionParameterType = union(enum) {
     value,
     secure_value,
     credential,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .value = "Value",
+        .secure_value = "SecureValue",
+        .credential = "Credential",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Script Execution provisioning state
@@ -550,7 +1700,30 @@ pub const ScriptExecutionProvisioningState = union(enum) {
     cancelling,
     cancelled,
     deleting,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .pending = "Pending",
+        .running = "Running",
+        .cancelling = "Cancelling",
+        .cancelled = "Cancelled",
+        .deleting = "Deleting",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Script Output Stream type
@@ -559,7 +1732,26 @@ pub const ScriptOutputStreamType = union(enum) {
     warning,
     output,
     @"error",
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .information = "Information",
+        .warning = "Warning",
+        .output = "Output",
+        .@"error" = "Error",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Script Package provisioning state
@@ -567,28 +1759,97 @@ pub const ScriptPackageProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Describes the type of resource the SKU applies to.
 pub const ResourceSkuResourceType = union(enum) {
     private_clouds,
     @"private_clouds/clusters",
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .private_clouds = "privateClouds",
+        .@"private_clouds/clusters" = "privateClouds/clusters",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Describes the kind of SKU restrictions that can exist
 pub const ResourceSkuRestrictionsType = union(enum) {
     location,
     zone,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .location = "Location",
+        .zone = "Zone",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Describes the reason for SKU restriction.
 pub const ResourceSkuRestrictionsReasonCode = union(enum) {
     quota_id,
     not_available_for_subscription,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .quota_id = "QuotaId",
+        .not_available_for_subscription = "NotAvailableForSubscription",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Virtual Machine provisioning state
@@ -596,14 +1857,49 @@ pub const VirtualMachineProvisioningState = union(enum) {
     succeeded,
     failed,
     canceled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Virtual Machine Restrict Movement state
 pub const VirtualMachineRestrictMovementState = union(enum) {
     enabled,
     disabled,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .enabled = "Enabled",
+        .disabled = "Disabled",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// base Workload Network provisioning state
@@ -614,14 +1910,52 @@ pub const WorkloadNetworkProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Type of DHCP: SERVER or RELAY.
 pub const DhcpTypeEnum = union(enum) {
     server,
     relay,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .server = "SERVER",
+        .relay = "RELAY",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Workload Network DHCP provisioning state
@@ -632,7 +1966,28 @@ pub const WorkloadNetworkDhcpProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// DNS service log level
@@ -642,14 +1997,51 @@ pub const DnsServiceLogLevelEnum = union(enum) {
     warning,
     @"error",
     fatal,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .debug = "DEBUG",
+        .info = "INFO",
+        .warning = "WARNING",
+        .@"error" = "ERROR",
+        .fatal = "FATAL",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// DNS service status
 pub const DnsServiceStatusEnum = union(enum) {
     success,
     failure,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .success = "SUCCESS",
+        .failure = "FAILURE",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Workload Network DNS Service provisioning state
@@ -660,7 +2052,28 @@ pub const WorkloadNetworkDnsServiceProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Workload Network DNS Zone provisioning state
@@ -671,7 +2084,28 @@ pub const WorkloadNetworkDnsZoneProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Port Mirroring Direction
@@ -679,14 +2113,49 @@ pub const PortMirroringDirectionEnum = union(enum) {
     ingress,
     egress,
     bidirectional,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .ingress = "INGRESS",
+        .egress = "EGRESS",
+        .bidirectional = "BIDIRECTIONAL",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Port Mirroring status
 pub const PortMirroringStatusEnum = union(enum) {
     success,
     failure,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .success = "SUCCESS",
+        .failure = "FAILURE",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Workload Network Port Mirroring provisioning state
@@ -697,7 +2166,28 @@ pub const WorkloadNetworkPortMirroringProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Workload Network Public IP provisioning state
@@ -708,14 +2198,52 @@ pub const WorkloadNetworkPublicIPProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Segment status
 pub const SegmentStatusEnum = union(enum) {
     success,
     failure,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .success = "SUCCESS",
+        .failure = "FAILURE",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Workload Network Segment provisioning state
@@ -726,7 +2254,28 @@ pub const WorkloadNetworkSegmentProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// VM type
@@ -734,14 +2283,49 @@ pub const VMTypeEnum = union(enum) {
     regular,
     edge,
     service,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .regular = "REGULAR",
+        .edge = "EDGE",
+        .service = "SERVICE",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// VM group status
 pub const VMGroupStatusEnum = union(enum) {
     success,
     failure,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .success = "SUCCESS",
+        .failure = "FAILURE",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Workload Network VM Group provisioning state
@@ -752,7 +2336,28 @@ pub const WorkloadNetworkVMGroupProvisioningState = union(enum) {
     building,
     deleting,
     updating,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .succeeded = "Succeeded",
+        .failed = "Failed",
+        .canceled = "Canceled",
+        .building = "Building",
+        .deleting = "Deleting",
+        .updating = "Updating",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// Azure VMware Solution API versions.

--- a/rest/arm_avs/src/models.zig
+++ b/rest/arm_avs/src/models.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const enums = @import("enums.zig");
+const core = @import("azure_core");
 
 /// A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get the next set of results.
 pub const OperationListResult = struct {
@@ -89,12 +90,19 @@ pub const AddonList = struct {
 
 /// An addon resource
 pub const Addon = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?AddonProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the addon.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?AddonProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of an addon
@@ -109,30 +117,36 @@ pub const AddonProperties = struct {
 
 /// The properties of a Site Recovery Manager (SRM) addon
 pub const AddonSrmProperties = struct {
-    /// The Site Recovery Manager (SRM) license
-    license_key: ?[]const u8 = null,
     /// The type of private cloud addon
     addon_type: []const u8,
+    /// The state of the addon provisioning
+    provisioning_state: ?enums.AddonProvisioningState = null,
+    /// The Site Recovery Manager (SRM) license
+    license_key: ?[]const u8 = null,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
 
 /// The properties of a vSphere Replication (VR) addon
 pub const AddonVrProperties = struct {
-    /// The vSphere Replication Server (VRS) count
-    vrs_count: i32,
     /// The type of private cloud addon
     addon_type: []const u8,
+    /// The state of the addon provisioning
+    provisioning_state: ?enums.AddonProvisioningState = null,
+    /// The vSphere Replication Server (VRS) count
+    vrs_count: i32,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
 
 /// The properties of an HCX addon
 pub const AddonHcxProperties = struct {
-    /// The HCX offer, example VMware MaaS Cloud Provider (Enterprise)
-    offer: []const u8,
     /// The type of private cloud addon
     addon_type: []const u8,
+    /// The state of the addon provisioning
+    provisioning_state: ?enums.AddonProvisioningState = null,
+    /// The HCX offer, example VMware MaaS Cloud Provider (Enterprise)
+    offer: []const u8,
     /// HCX management network.
     management_network: ?[]const u8 = null,
     /// HCX uplink network
@@ -143,10 +157,12 @@ pub const AddonHcxProperties = struct {
 
 /// The properties of an Arc addon
 pub const AddonArcProperties = struct {
-    /// The VMware vCenter resource ID
-    v_center: ?[]const u8 = null,
     /// The type of private cloud addon
     addon_type: []const u8,
+    /// The state of the addon provisioning
+    provisioning_state: ?enums.AddonProvisioningState = null,
+    /// The VMware vCenter resource ID
+    v_center: ?[]const u8 = null,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
@@ -202,12 +218,19 @@ pub const ExpressRouteAuthorizationList = struct {
 
 /// ExpressRoute Circuit Authorization
 pub const ExpressRouteAuthorization = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?ExpressRouteAuthorizationProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the ExpressRoute Circuit Authorization
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?ExpressRouteAuthorizationProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of an ExpressRoute Circuit Authorization resource
@@ -236,12 +259,19 @@ pub const CloudLinkList = struct {
 
 /// A cloud link resource
 pub const CloudLink = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?CloudLinkProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the cloud link.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?CloudLinkProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a cloud link.
@@ -268,14 +298,21 @@ pub const ClusterList = struct {
 
 /// A cluster resource
 pub const Cluster = struct {
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
+    /// Name of the cluster
+    name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
     /// The resource-specific properties for this resource.
     properties: ?ClusterProperties = null,
     /// The SKU (Stock Keeping Unit) assigned to this resource.
     sku: Sku,
-    /// Name of the cluster
-    name: []const u8,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a cluster
@@ -360,12 +397,19 @@ pub const DatastoreList = struct {
 
 /// A datastore resource
 pub const Datastore = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?DatastoreProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the datastore
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?DatastoreProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a datastore
@@ -439,12 +483,19 @@ pub const GlobalReachConnectionList = struct {
 
 /// A global reach connection resource
 pub const GlobalReachConnection = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?GlobalReachConnectionProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the global reach connection
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?GlobalReachConnectionProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a global reach connection
@@ -481,12 +532,19 @@ pub const HcxEnterpriseSiteList = struct {
 
 /// An HCX Enterprise Site resource
 pub const HcxEnterpriseSite = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?HcxEnterpriseSiteProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the HCX Enterprise Site
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?HcxEnterpriseSiteProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of an HCX Enterprise Site
@@ -513,16 +571,23 @@ pub const HostListResult = struct {
 
 /// A host resource
 pub const Host = struct {
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
+    /// The host identifier.
+    name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
     /// The resource-specific properties for this resource.
     properties: ?HostProperties = null,
     /// The availability zones.
     zones: ?[]const []const u8 = null,
     /// The SKU (Stock Keeping Unit) assigned to this resource.
     sku: ?Sku = null,
-    /// The host identifier.
-    name: []const u8,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a host.
@@ -548,6 +613,17 @@ pub const HostProperties = struct {
 pub const GeneralHostProperties = struct {
     /// The kind of host.
     kind: []const u8,
+    /// The state of the host provisioning.
+    provisioning_state: ?enums.HostProvisioningState = null,
+    /// Display name of the host in VMware vCenter.
+    display_name: ?[]const u8 = null,
+    /// vCenter managed object reference ID of the host.
+    mo_ref_id: ?[]const u8 = null,
+    /// Fully qualified domain name of the host.
+    fqdn: ?[]const u8 = null,
+    /// If provided, the host is in maintenance. The value is the reason for maintenance.
+    maintenance: ?enums.HostMaintenance = null,
+    fault_domain: ?[]const u8 = null,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
@@ -556,6 +632,17 @@ pub const GeneralHostProperties = struct {
 pub const SpecializedHostProperties = struct {
     /// The kind of host is specialized.
     kind: []const u8,
+    /// The state of the host provisioning.
+    provisioning_state: ?enums.HostProvisioningState = null,
+    /// Display name of the host in VMware vCenter.
+    display_name: ?[]const u8 = null,
+    /// vCenter managed object reference ID of the host.
+    mo_ref_id: ?[]const u8 = null,
+    /// Fully qualified domain name of the host.
+    fqdn: ?[]const u8 = null,
+    /// If provided, the host is in maintenance. The value is the reason for maintenance.
+    maintenance: ?enums.HostMaintenance = null,
+    fault_domain: ?[]const u8 = null,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
@@ -572,12 +659,19 @@ pub const IscsiPathListResult = struct {
 
 /// An iSCSI path resource
 pub const IscsiPath = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?IscsiPathProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the iSCSI path resource
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?IscsiPathProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of an iSCSI path resource
@@ -602,12 +696,19 @@ pub const LicenseListResult = struct {
 
 /// A license resource
 pub const License = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?LicenseProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the license.
     name: enums.LicenseName,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?LicenseProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a license
@@ -624,6 +725,8 @@ pub const LicenseProperties = struct {
 pub const VmwareFirewallLicenseProperties = struct {
     /// License kind
     kind: []const u8,
+    /// The state of the license provisioning
+    provisioning_state: ?enums.LicenseProvisioningState = null,
     /// License key
     license_key: ?[]const u8 = null,
     /// Number of cores included in the license, measured per hour
@@ -682,12 +785,19 @@ pub const MaintenanceListResult = struct {
 
 /// A cluster resource
 pub const Maintenance = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?MaintenanceProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the maintenance
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?MaintenanceProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// properties of a maintenance
@@ -960,12 +1070,19 @@ pub const PlacementPoliciesList = struct {
 
 /// A vSphere Distributed Resource Scheduler (DRS) placement policy
 pub const PlacementPolicy = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?PlacementPolicyProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the placement policy.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?PlacementPolicyProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Abstract placement policy properties
@@ -984,18 +1101,32 @@ pub const PlacementPolicyProperties = struct {
 
 /// VM-VM placement policy properties
 pub const VmPlacementPolicyProperties = struct {
+    /// placement policy type
+    type: []const u8,
+    /// Whether the placement policy is enabled or disabled
+    state: ?enums.PlacementPolicyState = null,
+    /// Display name of the placement policy
+    display_name: ?[]const u8 = null,
+    /// The provisioning state
+    provisioning_state: ?enums.PlacementPolicyProvisioningState = null,
     /// Virtual machine members list
     vm_members: []const []const u8,
     /// placement policy affinity type
     affinity_type: enums.AffinityType,
-    /// placement policy type
-    type: []const u8,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
 
 /// VM-Host placement policy properties
 pub const VmHostPlacementPolicyProperties = struct {
+    /// placement policy type
+    type: []const u8,
+    /// Whether the placement policy is enabled or disabled
+    state: ?enums.PlacementPolicyState = null,
+    /// Display name of the placement policy
+    display_name: ?[]const u8 = null,
+    /// The provisioning state
+    provisioning_state: ?enums.PlacementPolicyProvisioningState = null,
     /// Virtual machine members list
     vm_members: []const []const u8,
     /// Host members list
@@ -1006,8 +1137,6 @@ pub const VmHostPlacementPolicyProperties = struct {
     affinity_strength: ?enums.AffinityStrength = null,
     /// placement policy azure hybrid benefit opt-in type
     azure_hybrid_benefit_type: ?enums.AzureHybridBenefitType = null,
-    /// placement policy type
-    type: []const u8,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
@@ -1048,6 +1177,18 @@ pub const PrivateCloudList = struct {
 
 /// A private cloud resource
 pub const PrivateCloud = struct {
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
+    /// Name of the private cloud
+    name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// Resource tags.
+    tags: ?std.json.ArrayHashMap([]const u8) = null,
+    /// The geo-location where the resource lives
+    location: []const u8,
     /// The resource-specific properties for this resource.
     properties: ?PrivateCloudProperties = null,
     /// The SKU (Stock Keeping Unit) assigned to this resource.
@@ -1056,10 +1197,9 @@ pub const PrivateCloud = struct {
     identity: ?SystemAssignedServiceIdentity = null,
     /// The availability zones.
     zones: ?[]const []const u8 = null,
-    /// Name of the private cloud
-    name: []const u8,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .tracked;
 };
 
 /// The properties of a private cloud resource
@@ -1251,6 +1391,8 @@ pub const VcfLicense = struct {
 pub const Vcf5License = struct {
     /// License kind
     kind: []const u8,
+    /// The state of the license provisioning
+    provisioning_state: ?enums.LicenseProvisioningState = null,
     /// License key
     license_key: ?[]const u8 = null,
     /// Number of cores included in the license
@@ -1342,12 +1484,19 @@ pub const ProvisionedNetworkListResult = struct {
 
 /// A provisioned network resource
 pub const ProvisionedNetwork = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?ProvisionedNetworkProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the cloud link.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?ProvisionedNetworkProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a provisioned network.
@@ -1374,12 +1523,19 @@ pub const PureStoragePolicyListResult = struct {
 
 /// An instance describing a Pure Storage Policy Based Management policy
 pub const PureStoragePolicy = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?PureStoragePolicyProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the storage policy.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?PureStoragePolicyProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Properties of a Pure Storage Policy Based Management policy
@@ -1406,12 +1562,19 @@ pub const ScriptCmdletsList = struct {
 
 /// A cmdlet available for script execution
 pub const ScriptCmdlet = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?ScriptCmdletProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the script cmdlet.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?ScriptCmdletProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Properties of a pre-canned script
@@ -1460,12 +1623,19 @@ pub const ScriptExecutionsList = struct {
 
 /// An instance of a script executed by a user - custom or AVS
 pub const ScriptExecution = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?ScriptExecutionProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the script cmdlet.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?ScriptExecutionProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Properties of a user-invoked script
@@ -1518,32 +1688,38 @@ pub const ScriptExecutionParameter = struct {
 
 /// a plain text value execution parameter
 pub const ScriptSecureStringExecutionParameter = struct {
-    /// A secure value for the passed parameter, not to be stored in logs
-    secure_value: ?[]const u8 = null,
     /// The type of execution parameter
     type: []const u8,
+    /// The parameter name
+    name: []const u8,
+    /// A secure value for the passed parameter, not to be stored in logs
+    secure_value: ?[]const u8 = null,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
 
 /// a plain text value execution parameter
 pub const ScriptStringExecutionParameter = struct {
-    /// The value for the passed parameter
-    value: ?[]const u8 = null,
     /// The type of execution parameter
     type: []const u8,
+    /// The parameter name
+    name: []const u8,
+    /// The value for the passed parameter
+    value: ?[]const u8 = null,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
 
 /// a powershell credential object
 pub const PSCredentialExecutionParameter = struct {
+    /// The type of execution parameter
+    type: []const u8,
+    /// The parameter name
+    name: []const u8,
     /// username for login
     username: ?[]const u8 = null,
     /// password for login
     password: ?[]const u8 = null,
-    /// The type of execution parameter
-    type: []const u8,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
@@ -1564,12 +1740,19 @@ pub const ScriptPackagesList = struct {
 
 /// Script Package resources available for execution
 pub const ScriptPackage = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?ScriptPackageProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the script package.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?ScriptPackageProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Properties of a Script Package subresource
@@ -1690,12 +1873,19 @@ pub const VirtualMachinesList = struct {
 
 /// Virtual Machine
 pub const VirtualMachine = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?VirtualMachineProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// ID of the virtual machine.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?VirtualMachineProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Virtual Machine Properties
@@ -1724,12 +1914,19 @@ pub const VirtualMachineRestrictMovement = struct {
 
 /// Workload Network
 pub const WorkloadNetwork = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// Name of the global reach connection
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// The properties of a workload network
@@ -1762,12 +1959,19 @@ pub const WorkloadNetworkDhcpList = struct {
 
 /// NSX DHCP
 pub const WorkloadNetworkDhcp = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkDhcpEntity = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// The ID of the DHCP configuration
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkDhcpEntity = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Base class for WorkloadNetworkDhcpServer and WorkloadNetworkDhcpRelay to
@@ -1789,22 +1993,38 @@ pub const WorkloadNetworkDhcpEntity = struct {
 
 /// NSX DHCP Server
 pub const WorkloadNetworkDhcpServer = struct {
+    /// Type of DHCP: SERVER or RELAY.
+    dhcp_type: []const u8,
+    /// Display name of the DHCP entity.
+    display_name: ?[]const u8 = null,
+    /// NSX Segments consuming DHCP.
+    segments: ?[]const []const u8 = null,
+    /// The provisioning state
+    provisioning_state: ?enums.WorkloadNetworkDhcpProvisioningState = null,
+    /// NSX revision number.
+    revision: ?i64 = null,
     /// DHCP Server Address.
     server_address: ?[]const u8 = null,
     /// DHCP Server Lease Time.
     lease_time: ?i64 = null,
-    /// Type of DHCP: SERVER or RELAY.
-    dhcp_type: []const u8,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
 
 /// NSX DHCP Relay
 pub const WorkloadNetworkDhcpRelay = struct {
-    /// DHCP Relay Addresses. Max 3.
-    server_addresses: ?[]const []const u8 = null,
     /// Type of DHCP: SERVER or RELAY.
     dhcp_type: []const u8,
+    /// Display name of the DHCP entity.
+    display_name: ?[]const u8 = null,
+    /// NSX Segments consuming DHCP.
+    segments: ?[]const []const u8 = null,
+    /// The provisioning state
+    provisioning_state: ?enums.WorkloadNetworkDhcpProvisioningState = null,
+    /// NSX revision number.
+    revision: ?i64 = null,
+    /// DHCP Relay Addresses. Max 3.
+    server_addresses: ?[]const []const u8 = null,
 
     pub const serde = .{ .rename_all = .camel_case };
 };
@@ -1821,12 +2041,19 @@ pub const WorkloadNetworkDnsServicesList = struct {
 
 /// NSX DNS Service
 pub const WorkloadNetworkDnsService = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkDnsServiceProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// ID of the DNS service.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkDnsServiceProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// NSX DNS Service Properties
@@ -1863,12 +2090,19 @@ pub const WorkloadNetworkDnsZonesList = struct {
 
 /// NSX DNS Zone
 pub const WorkloadNetworkDnsZone = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkDnsZoneProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// ID of the DNS zone.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkDnsZoneProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// NSX DNS Zone Properties
@@ -1903,12 +2137,19 @@ pub const WorkloadNetworkGatewayList = struct {
 
 /// NSX Gateway.
 pub const WorkloadNetworkGateway = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkGatewayProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// The ID of the NSX Gateway
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkGatewayProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// Properties of a NSX Gateway.
@@ -1935,12 +2176,19 @@ pub const WorkloadNetworkPortMirroringList = struct {
 
 /// NSX Port Mirroring
 pub const WorkloadNetworkPortMirroring = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkPortMirroringProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// ID of the NSX port mirroring profile.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkPortMirroringProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// NSX Port Mirroring Properties
@@ -1975,12 +2223,19 @@ pub const WorkloadNetworkPublicIPsList = struct {
 
 /// NSX Public IP Block
 pub const WorkloadNetworkPublicIP = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkPublicIPProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// ID of the DNS zone.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkPublicIPProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// NSX Public IP Block Properties
@@ -2009,12 +2264,19 @@ pub const WorkloadNetworkSegmentsList = struct {
 
 /// NSX Segment
 pub const WorkloadNetworkSegment = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkSegmentProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// The ID of the NSX Segment
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkSegmentProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// NSX Segment Properties
@@ -2067,12 +2329,19 @@ pub const WorkloadNetworkVirtualMachinesList = struct {
 
 /// NSX Virtual Machine
 pub const WorkloadNetworkVirtualMachine = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkVirtualMachineProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// ID of the virtual machine.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkVirtualMachineProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// NSX Virtual Machine Properties
@@ -2099,12 +2368,19 @@ pub const WorkloadNetworkVMGroupsList = struct {
 
 /// NSX VM Group
 pub const WorkloadNetworkVMGroup = struct {
-    /// The resource-specific properties for this resource.
-    properties: ?WorkloadNetworkVMGroupProperties = null,
+    /// Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+    id: ?[]const u8 = null,
     /// ID of the VM group.
     name: []const u8,
+    /// The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
+    type: ?[]const u8 = null,
+    /// Azure Resource Manager metadata containing createdBy and modifiedBy information.
+    system_data: ?SystemData = null,
+    /// The resource-specific properties for this resource.
+    properties: ?WorkloadNetworkVMGroupProperties = null,
 
     pub const serde = .{ .rename_all = .camel_case };
+    pub const arm_resource_kind: core.arm.ResourceKind = .proxy;
 };
 
 /// NSX VM Group Properties

--- a/sdk/core/arm/resource.zig
+++ b/sdk/core/arm/resource.zig
@@ -1,0 +1,149 @@
+//! ARM (Azure Resource Manager) resource concept.
+//!
+//! Zig has no struct inheritance, so generated ARM models use the
+//! "copy-down" strategy: every leaf resource struct redeclares the
+//! fields it inherits from `Resource` / `TrackedResource` /
+//! `ExtensionResource`. To still allow generic helpers like "get the id
+//! of any resource" or "set tags on any tracked resource", each
+//! generated resource struct declares
+//!
+//!     pub const arm_resource_kind: core.arm.ResourceKind = .tracked;
+//!
+//! and the helpers in this file dispatch on that marker plus comptime
+//! `@hasField` checks. The pattern is the same flavor of comptime
+//! parametricity used by `core.pager.Pager(T)`, but without runtime fn
+//! pointers — accessors are monomorphized per concrete `T` and compile
+//! down to plain field loads.
+
+const std = @import("std");
+
+/// Which ARM base type a generated resource derives from.
+///
+/// The set mirrors the base types in `Azure.ResourceManager`:
+///
+/// * `proxy`     — `ProxyResource` (id/name/type/systemData only)
+/// * `tracked`   — `TrackedResource` (proxy + location/tags)
+/// * `extension` — `ExtensionResource` (proxy + extends parent scope)
+///
+/// Resources that don't fit (rare; usually pre-ARM data-plane shapes)
+/// simply omit the `arm_resource_kind` decl.
+pub const ResourceKind = enum { proxy, tracked, extension };
+
+fn requireFields(comptime T: type, comptime fields: []const []const u8) void {
+    comptime {
+        for (fields) |f| {
+            if (!@hasField(T, f))
+                @compileError(@typeName(T) ++ " is not an ARM resource: missing field '" ++ f ++ "'");
+        }
+    }
+}
+
+/// Comptime contract check: `T` carries the four ARM identity fields
+/// (`id`, `name`, `type`, `system_data`).
+///
+/// Note: `type` is not a reserved Zig keyword, so the emitter uses it
+/// as a bare field name (matching what TCGC produces from its
+/// `serializedName`).
+pub fn assertResource(comptime T: type) void {
+    comptime {
+        if (!@hasDecl(T, "arm_resource_kind"))
+            @compileError(@typeName(T) ++ " is not an ARM resource (no arm_resource_kind decl)");
+        requireFields(T, &.{ "id", "name", "type", "system_data" });
+    }
+}
+
+/// Comptime contract check: `T` is a TrackedResource — Resource plus
+/// `location` and `tags`.
+pub fn assertTrackedResource(comptime T: type) void {
+    comptime {
+        assertResource(T);
+        if (T.arm_resource_kind != .tracked)
+            @compileError(@typeName(T) ++ " is not a TrackedResource (arm_resource_kind != .tracked)");
+        requireFields(T, &.{ "location", "tags" });
+    }
+}
+
+/// Get the ARM resource id of any resource.
+pub fn id(res: anytype) ?[]const u8 {
+    assertResource(@TypeOf(res.*));
+    return res.id;
+}
+
+/// Get the ARM resource name of any resource.
+pub fn name(res: anytype) ?[]const u8 {
+    assertResource(@TypeOf(res.*));
+    return res.name;
+}
+
+/// Get the ARM resource type (e.g. `Microsoft.AVS/privateClouds`).
+pub fn typeName(res: anytype) ?[]const u8 {
+    assertResource(@TypeOf(res.*));
+    return res.type;
+}
+
+/// Get the ARM region of any TrackedResource.
+pub fn location(res: anytype) ?[]const u8 {
+    assertTrackedResource(@TypeOf(res.*));
+    return res.location;
+}
+
+/// Replace the tags map on any TrackedResource.
+pub fn setTags(res: anytype, tags: anytype) void {
+    assertTrackedResource(@TypeOf(res.*));
+    res.tags = tags;
+}
+
+// ─────────────────────────── Tests ───────────────────────────
+
+const testing = std.testing;
+
+const FakeTracked = struct {
+    id: ?[]const u8 = null,
+    name: ?[]const u8 = null,
+    type: ?[]const u8 = null,
+    system_data: ?u8 = null,
+    location: ?[]const u8 = null,
+    tags: ?u8 = null,
+    extra: u32 = 0,
+
+    pub const arm_resource_kind: ResourceKind = .tracked;
+};
+
+const FakeProxy = struct {
+    id: ?[]const u8 = null,
+    name: ?[]const u8 = null,
+    type: ?[]const u8 = null,
+    system_data: ?u8 = null,
+
+    pub const arm_resource_kind: ResourceKind = .proxy;
+};
+
+test "Resource accessors compile and read the marked fields" {
+    var r = FakeTracked{
+        .id = "/subscriptions/s/resources/r",
+        .name = "r",
+        .type = "Microsoft.AVS/privateClouds",
+        .location = "westus",
+    };
+    try testing.expectEqualStrings("/subscriptions/s/resources/r", id(&r).?);
+    try testing.expectEqualStrings("r", name(&r).?);
+    try testing.expectEqualStrings("Microsoft.AVS/privateClouds", typeName(&r).?);
+    try testing.expectEqualStrings("westus", location(&r).?);
+
+    setTags(&r, @as(?u8, 42));
+    try testing.expectEqual(@as(?u8, 42), r.tags);
+}
+
+test "Resource accessors work on a proxy resource (no location)" {
+    var r = FakeProxy{ .id = "/p/q", .name = "q" };
+    try testing.expectEqualStrings("/p/q", id(&r).?);
+    try testing.expectEqualStrings("q", name(&r).?);
+    // location(&r) would be a compile error: FakeProxy is not a TrackedResource.
+}
+
+test "assertResource/assertTrackedResource accept the matching kinds" {
+    assertResource(FakeProxy);
+    assertResource(FakeTracked);
+    assertTrackedResource(FakeTracked);
+    // assertTrackedResource(FakeProxy) would be a compile error.
+}

--- a/sdk/core/open_enum.zig
+++ b/sdk/core/open_enum.zig
@@ -1,0 +1,125 @@
+//! Helpers for "open" (extensible) Azure string-valued enums.
+//!
+//! Open enums are generated as
+//!
+//!     pub const Foo = union(enum) {
+//!         known_one,
+//!         known_two,
+//!         unrecognized: []const u8,
+//!         ...
+//!     };
+//!
+//! so wire values not listed in `wire_names` round-trip through the
+//! catch-all `unrecognized` variant. The default serde `union(enum)`
+//! deserializer refuses such unknown strings with
+//! `error.UnexpectedToken`; the generated emitter therefore wires
+//! each open enum to the helpers below via `zerdeDeserialize` /
+//! `zerdeSerialize` hooks.
+//!
+//! Each open enum supplies a compile-time `wire_names` mapping from
+//! the Zig variant identifier to the JSON wire string, e.g.
+//!
+//!     const wire_names = .{ .single_zone = "SingleZone", ... };
+//!
+//! The variant `unrecognized` is implicit and does not need a mapping.
+//! Picking `unrecognized` (rather than `unknown`) avoids colliding
+//! with TypeSpec specs that themselves declare an `Unknown` enum
+//! literal — e.g. `DatastoreStatus { Unknown, Accessible, ... }`.
+
+const std = @import("std");
+
+/// Deserialize an open-enum union from a JSON string. Returns the
+/// matching void variant, or `.unrecognized = "<raw>"` for values not
+/// listed in `wire_names` (the raw string is allocator-owned by the
+/// caller).
+pub fn deserialize(
+    comptime T: type,
+    comptime wire_names: anytype,
+    allocator: std.mem.Allocator,
+    deserializer: anytype,
+) @TypeOf(deserializer.*).Error!T {
+    const s = try deserializer.deserializeString(allocator);
+    inline for (comptime std.meta.fields(@TypeOf(wire_names))) |f| {
+        const wire: []const u8 = @field(wire_names, f.name);
+        if (std.mem.eql(u8, s, wire)) {
+            allocator.free(s);
+            return @unionInit(T, f.name, {});
+        }
+    }
+    return @unionInit(T, "unrecognized", s);
+}
+
+/// Serialize an open-enum union as a JSON string. Known void variants
+/// use their `wire_names` mapping; `unrecognized` writes its inner
+/// string verbatim.
+pub fn serialize(value: anytype, comptime wire_names: anytype, serializer: anytype) !void {
+    const T = @TypeOf(value);
+    const Tag = std.meta.Tag(T);
+    inline for (comptime std.meta.fields(T)) |field| {
+        if (@as(Tag, value) == @field(Tag, field.name)) {
+            if (comptime std.mem.eql(u8, field.name, "unrecognized")) {
+                return serializer.serializeString(@field(value, "unrecognized"));
+            }
+            const wire: []const u8 = @field(wire_names, field.name);
+            return serializer.serializeString(wire);
+        }
+    }
+    unreachable;
+}
+
+// ─────────────────────────── Tests ───────────────────────────
+
+const testing = std.testing;
+
+const Sample = union(enum) {
+    one,
+    two,
+    unrecognized: []const u8,
+
+    const wire_names = .{ .one = "One", .two = "Two" };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return serialize(self, wire_names, serializer);
+    }
+};
+
+test "open enum: known variant deserializes via wire name" {
+    const serde = @import("serde");
+    const out = try serde.json.fromSlice(Sample, testing.allocator, "\"One\"");
+    try testing.expectEqual(Sample.one, out);
+}
+
+test "open enum: unrecognized variant captures raw string" {
+    const serde = @import("serde");
+    const out = try serde.json.fromSlice(Sample, testing.allocator, "\"Floomp\"");
+    defer switch (out) {
+        .unrecognized => |s| testing.allocator.free(s),
+        else => {},
+    };
+    switch (out) {
+        .unrecognized => |s| try testing.expectEqualStrings("Floomp", s),
+        else => return error.ExpectedUnrecognized,
+    }
+}
+
+test "open enum: known variant serializes to wire name" {
+    const serde = @import("serde");
+    const out = try serde.json.toSlice(testing.allocator, Sample{ .two = {} });
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("\"Two\"", out);
+}
+
+test "open enum: unrecognized variant serializes its inner string" {
+    const serde = @import("serde");
+    const out = try serde.json.toSlice(testing.allocator, Sample{ .unrecognized = "Floomp" });
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("\"Floomp\"", out);
+}

--- a/sdk/core/root.zig
+++ b/sdk/core/root.zig
@@ -30,6 +30,8 @@ pub const base64 = @import("base64.zig");
 pub const cloud = @import("cloud.zig");
 pub const tracing = @import("tracing/root.zig");
 pub const dotenv = @import("dotenv.zig");
+pub const arm = @import("arm/resource.zig");
+pub const open_enum = @import("open_enum.zig");
 
 pub const version: []const u8 = "0.1.0";
 pub const user_agent_prefix: []const u8 = "azsdk-zig-core/" ++ version;


### PR DESCRIPTION
Closes #25 — ARM models were missing every field contributed by the base chain (`id`, `name`, `type`, `system_data`, `location`, `tags`), forcing every example to hand-roll a summary shim.

Closes #24 — open-union enums collided whenever the spec declared its own `Unknown` literal (e.g. `DatastoreStatus { Unknown, … }`) with the emitter-appended catch-all variant.

Live `zig build list-private-clouds` against the AVS RP now renders 100+ private clouds with id / location / provisioning state populated.

## Approach

| Layer | Strategy |
|---|---|
| Models on the wire | **Copy-down inheritance** — leaf structs are flat, matching the JSON shape used by Go / JS SDKs. |
| ARM contract in Zig | **Comptime concept** (Pager-style) — `core.arm.{assertResource,assertTrackedResource}` + anytype accessors monomorphize per leaf, zero runtime cost. |
| Open enums | Generic helpers in `core.open_enum` invoked via per-enum `zerdeDeserialize` / `zerdeSerialize` hooks; each enum carries a compile-time `wire_names` table. |
| Open-enum catch-all | Renamed `unknown` → `unrecognized` (Zig-side concept, never on the wire) to avoid clashes with TypeSpec specs that declare `Unknown`. |

The design rationale and trade-off table (Go vs .NET vs Python vs Rust vs JS vs Zig options) was posted on #25.

## Changes

**TCGC adapter** (`codegen/tcgc-component/src/{wasi-host.js,index.js}`)
- `adaptModel` now walks `baseModel` root→leaf, dedups by `serializedName` (leaf wins), and copies inherited properties onto the leaf.
- Stamps each ARM resource with `arm_resource_kind` via `crossLanguageDefinitionId` (`Azure.ResourceManager.CommonTypes.{Tracked,Proxy,Extension}Resource`) with a name + namespace fallback.

**Emitter** (`codegen/cli/src/{codemodel.zig,emit.zig}`)
- `Model.arm_resource_kind: ?[]const u8` plumbing.
- `renderModels` emits `pub const arm_resource_kind: core.arm.ResourceKind = .<kind>;` per ARM struct.
- `renderEnums` emits a `wire_names` decl + `zerdeDeserialize`/`zerdeSerialize` trampolines for every extensible enum, and a top-level `const core = @import("azure_core");` when any extensible enum exists.

**Core SDK** (`sdk/core/`)
- `sdk/core/arm/resource.zig` — `ResourceKind` enum + comptime `assertResource`/`assertTrackedResource` + anytype `id`/`name`/`typeName`/`location`/`setTags` accessors.
- `sdk/core/open_enum.zig` — shared `deserialize`/`serialize` used by generated extensible enums.
- `sdk/core/root.zig` — exports `arm` and `open_enum`.

**arm_avs**
- `clients.zig` drops the `PrivateCloudSummary` shim — `PrivateCloudPager = PipelinePager(models.PrivateCloud)`. Mock test exercises `core.arm.location(&page[0])`.
- `examples/list_private_clouds.zig` switches on `enums.PrivateCloudProvisioningState` with `.unrecognized => |s| break :blk s`.
- `src/models.zig` and `src/enums.zig` are regenerated.

## Verification

- `zig build test` — exit 0.
- `zig fmt --check sdk/ build.zig rest/arm_avs/ codegen/cli/` — clean.
- `cd rest/arm_avs && zig build list-private-clouds` against live AVS RP — prints full table.

## Follow-up

#27 tracks emitting ARM sub-clients + operation bodies so the hand-written shim header in `rest/arm_avs/src/clients.zig` can finally disappear.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
