### PR TITLE
codegen: emit `--display-name` for human-readable package label

### DIFF
--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -25,6 +25,16 @@ pub const EmitOptions = struct {
     /// Optional override of the package name. Defaults to
     /// `code_model.package_name`.
     package_name: ?[]const u8 = null,
+    /// Optional human-readable label used in `README.md`'s H1 and the
+    /// top-of-file doc comment in `src/root.zig`. Defaults to whatever
+    /// `package_name` resolves to.
+    ///
+    /// In practice operators set this to the dash-cased package label
+    /// (e.g. `arm-avs`, `keyvault-secrets`) so the docs read naturally
+    /// while Zig module identifiers stay snake_case. Source: stripped
+    /// from the `js:` field in `codegen/tspconfigs.yaml`
+    /// (e.g. `@azure/arm-avs` → `arm-avs`).
+    display_name: ?[]const u8 = null,
     /// Commit SHA of the `azure-sdk-for-zig` main branch that the
     /// generated `build.zig.zon` should pin `azure_core` to. May be
     /// null during local development; in that case the generated
@@ -50,9 +60,10 @@ pub fn emit(
     try out_dir.createDirPath(io, "src");
 
     const pkg_name = opts.package_name orelse model.package_name;
+    const display_name = opts.display_name orelse pkg_name;
 
     {
-        const s = try renderRoot(allocator, model);
+        const s = try renderRoot(allocator, model, display_name);
         defer allocator.free(s);
         try writeFile(allocator, io, out_dir, "src/root.zig", s, opts.run_zig_fmt);
     }
@@ -82,7 +93,7 @@ pub fn emit(
         try writeFile(allocator, io, out_dir, "build.zig.zon", s, opts.run_zig_fmt);
     }
     {
-        const s = try renderReadme(allocator, pkg_name, model);
+        const s = try renderReadme(allocator, display_name, model);
         defer allocator.free(s);
         try writeFile(allocator, io, out_dir, "README.md", s, opts.run_zig_fmt);
     }
@@ -135,7 +146,7 @@ fn maybeFormat(
 
 // ─── root.zig ─────────────────────────────────────────────────────────
 
-fn renderRoot(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
+fn renderRoot(allocator: std.mem.Allocator, model: cm.CodeModel, display_name: []const u8) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
     const w = &aw.writer;
@@ -149,7 +160,7 @@ fn renderRoot(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         \\pub const models = @import("models.zig");
         \\pub const enums = @import("enums.zig");
         \\
-    , .{ .name = model.package_name });
+    , .{ .name = display_name });
 
     for (model.clients) |c| {
         try w.print("pub const {s} = clients.{s};\n", .{ c.name, c.name });
@@ -531,7 +542,7 @@ fn computeFingerprint(pkg_name: []const u8) u64 {
     return (@as(u64, crc) << 32) | @as(u32, @truncate(wy));
 }
 
-fn renderReadme(allocator: std.mem.Allocator, pkg_name: []const u8, model: cm.CodeModel) ![]u8 {
+fn renderReadme(allocator: std.mem.Allocator, display_name: []const u8, model: cm.CodeModel) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
     const w = &aw.writer;
@@ -547,7 +558,7 @@ fn renderReadme(allocator: std.mem.Allocator, pkg_name: []const u8, model: cm.Co
         \\
         \\## Clients
         \\
-    , .{ .name = pkg_name });
+    , .{ .name = display_name });
     for (model.clients) |c| {
         try w.print("- `{s}`\n", .{c.name});
     }
@@ -583,4 +594,40 @@ fn renderFieldType(
         return try std.fmt.allocPrint(allocator, "?{s}", .{inner});
     }
     return try types.renderType(allocator, t, scope);
+}
+
+// ─── tests ────────────────────────────────────────────────────────────
+
+test "display_name surfaces in root.zig + README, not build.zig" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const model: cm.CodeModel = .{
+        .package_name = "arm_avs",
+        .package_version = "0.1.0",
+        .target_kind = "arm",
+        .service_kind = "default",
+    };
+
+    const root = try renderRoot(alloc, model, "arm-avs");
+    defer alloc.free(root);
+    try testing.expect(std.mem.indexOf(u8, root, "//! arm-avs — generated") != null);
+    try testing.expect(std.mem.indexOf(u8, root, "arm_avs") == null);
+
+    const readme = try renderReadme(alloc, "arm-avs", model);
+    defer alloc.free(readme);
+    try testing.expect(std.mem.indexOf(u8, readme, "# arm-avs\n") != null);
+    try testing.expect(std.mem.indexOf(u8, readme, "arm_avs") == null);
+
+    // build.zig and build.zig.zon stay on the snake-cased package name —
+    // Zig module identifiers (and `addModule` keys) must be snake_case.
+    const build_zig = try renderBuildZig(alloc, "arm_avs");
+    defer alloc.free(build_zig);
+    try testing.expect(std.mem.indexOf(u8, build_zig, "\"arm_avs\"") != null);
+    try testing.expect(std.mem.indexOf(u8, build_zig, "arm-avs") == null);
+
+    const zon = try renderBuildZigZon(alloc, "arm_avs", "0.1.0", null);
+    defer alloc.free(zon);
+    try testing.expect(std.mem.indexOf(u8, zon, ".name = .arm_avs") != null);
+    try testing.expect(std.mem.indexOf(u8, zon, "arm-avs") == null);
 }

--- a/codegen/cli/src/main.zig
+++ b/codegen/cli/src/main.zig
@@ -15,8 +15,8 @@
 //!
 //! Architecture summary:
 //!   * `main` parses argv (positional: spec-dir, out-dir; flag:
-//!     --package-name, --package-version, --azure-core-commit,
-//!     --no-fmt).
+//!     --package-name, --package-version, --display-name,
+//!     --azure-core-commit, --no-fmt).
 //!   * Calls `tcgc.compile(/spec, emitter-options-json)` via the
 //!     hand-rolled canonical-ABI binding in `tcgc_import.zig`.
 //!   * Parses the JSON code model via `codemodel.zig` (std.json).
@@ -44,6 +44,7 @@ const usage =
     \\Usage:
     \\  codegen-cli <spec-dir> <out-dir>
     \\              [--package-name <name>] [--package-version <ver>]
+    \\              [--display-name <label>]
     \\              [--azure-core-commit <sha>] [--no-fmt]
     \\
 ;
@@ -60,6 +61,7 @@ pub fn main(init: std.process.Init) !u8 {
     var out_dir: ?[]const u8 = null;
     var package_name: ?[]const u8 = null;
     var package_version: ?[]const u8 = null;
+    var display_name: ?[]const u8 = null;
     var azure_core_commit: ?[]const u8 = null;
     var run_fmt = true;
 
@@ -68,6 +70,8 @@ pub fn main(init: std.process.Init) !u8 {
             package_name = it.next() orelse return die("--package-name requires a value");
         } else if (std.mem.eql(u8, a, "--package-version")) {
             package_version = it.next() orelse return die("--package-version requires a value");
+        } else if (std.mem.eql(u8, a, "--display-name")) {
+            display_name = it.next() orelse return die("--display-name requires a value");
         } else if (std.mem.eql(u8, a, "--azure-core-commit")) {
             azure_core_commit = it.next() orelse return die("--azure-core-commit requires a value");
         } else if (std.mem.eql(u8, a, "--no-fmt")) {
@@ -121,6 +125,10 @@ pub fn main(init: std.process.Init) !u8 {
     var ver_buf: ?[]u8 = null;
     defer if (ver_buf) |b| allocator.free(b);
     if (package_version) |v| ver_buf = try allocator.dupe(u8, v);
+
+    var display_buf: ?[]u8 = null;
+    defer if (display_buf) |b| allocator.free(b);
+    if (display_name) |d| display_buf = try allocator.dupe(u8, d);
 
     var commit_buf: ?[]u8 = null;
     defer if (commit_buf) |b| allocator.free(b);
@@ -191,6 +199,7 @@ pub fn main(init: std.process.Init) !u8 {
 
     try emit.emit(allocator, io, out_dir_handle, parsed.value, .{
         .package_name = pkg_buf,
+        .display_name = display_buf,
         .azure_core_commit = commit_buf,
         .run_zig_fmt = run_fmt,
     });

--- a/codegen/scripts/sync.sh
+++ b/codegen/scripts/sync.sh
@@ -90,10 +90,25 @@ spec = None
 js = zig = None
 out = []
 
+def display_from_js(js_value: str, zig_value: str) -> str:
+    """Strip a leading @scope/ from `js` to get the dash-cased label
+    (e.g. `@azure/arm-avs` → `arm-avs`). Falls back to the snake-cased
+    `zig` value when `js` is empty (data-plane Foundry packages, etc.)
+    so the emitter still gets a non-empty display name.
+    """
+    if not js_value:
+        return zig_value
+    if js_value.startswith("@"):
+        slash = js_value.find("/")
+        if slash >= 0:
+            return js_value[slash + 1:]
+    return js_value
+
 def flush():
     if spec and zig:
         spec_dir = os.path.dirname(spec)
-        out.append(f"{zig}\t{spec_dir}")
+        display = display_from_js(js or "", zig)
+        out.append(f"{zig}\t{spec_dir}\t{display}")
 
 for raw in text.splitlines():
     line = raw.rstrip()
@@ -130,12 +145,31 @@ lookup_spec_dir() {
     printf '%s' "$entry"
 }
 
+lookup_display_name() {
+    local pkg="$1"
+    local entry
+    entry="$(printf '%s\n' "$SPEC_INDEX" | awk -F'\t' -v p="$pkg" '$1==p {print $3; exit}')"
+    if [[ -z "$entry" ]]; then
+        # Shouldn't happen if lookup_spec_dir already succeeded, but be
+        # defensive: fall back to the snake-cased package name.
+        printf '%s' "$pkg"
+        return
+    fi
+    printf '%s' "$entry"
+}
+
 # ── per-file sync policy ───────────────────────────────────────────
 #
-# `src/models.zig` is the only file the emitter currently owns end-
-# to-end across both ARM and data-plane packages today. Other files
-# get the SKIP-and-warn treatment unless --force is passed.
-SAFE_FILES=("src/models.zig")
+# `src/models.zig`, `src/root.zig`, and `README.md` are emitter-owned
+# end-to-end today: models.zig because the emitter is the source of
+# truth for the resource/enum shapes, and root.zig + README.md because
+# the emitter honors the dash-cased `--display-name` we derive from
+# `tspconfigs.yaml#js` and writes the same label operators used to set
+# by hand. Other emitter-touched files still drift from operator
+# tweaks (sub-clients in clients.zig, dash-cased addModule keys in
+# build.zig.zon, .env in .gitignore, …) so they get the SKIP-and-warn
+# treatment unless --force is passed.
+SAFE_FILES=("src/models.zig" "src/root.zig" "README.md")
 MANAGED_FILES=(
     "src/root.zig"
     "src/clients.zig"
@@ -185,9 +219,12 @@ for pkg in "${PKGS[@]}"; do
     out_tmp="$TMPROOT/$pkg"
     mkdir -p "$out_tmp"
 
+    display="$(lookup_display_name "$pkg")"
+
     echo "  spec: $spec_rel"
+    echo "  display: $display"
     echo "  regen: $out_tmp"
-    if ! "$RUN_SH" "$spec_dir" "$out_tmp" --package-name "$pkg" >"$TMPROOT/$pkg.log" 2>&1; then
+    if ! "$RUN_SH" "$spec_dir" "$out_tmp" --package-name "$pkg" --display-name "$display" >"$TMPROOT/$pkg.log" 2>&1; then
         echo "  ERROR: emitter failed; see $TMPROOT/$pkg.log"
         tail -20 "$TMPROOT/$pkg.log" | sed 's/^/    /'
         EXIT_CODE=1


### PR DESCRIPTION
Closes #26.

Operators have been hand-editing `src/root.zig` doc comments and `README.md` H1s to the dash-cased label (`arm-avs`, `keyvault-secrets`) while the emitter writes the snake-cased `package_name`. `codegen/scripts/sync.sh` listed both files as `MANAGED_FILES` and SKIPped them on regen — they couldn't land in the tracked tree automatically.

## Plumbing

`EmitOptions.display_name: ?[]const u8` — defaults to `package_name`. New CLI flag `--display-name <label>` in `codegen/cli`. Applied in exactly two render functions:

| Render fn          | After                                         |
|--------------------|-----------------------------------------------|
| `renderRoot`       | `//! arm-avs — generated from TypeSpec.`      |
| `renderReadme`     | `# arm-avs`                                   |
| `renderBuildZig`   | `b.addModule("arm_avs", …)` — **unchanged**   |
| `renderBuildZigZon`| `.name = .arm_avs` — **unchanged**            |

Rationale: Zig `addModule` keys and `.zon` `.name` identifiers conventionally use snake_case. Matches the existing `arm_avs/build.zig` precedent. Avoids cascading renames in `rest/*/examples/` `@import(…)` call sites.

Unit test in `emit.zig` asserts the split.

## sync.sh

Embedded python parser now captures the `js:` field. Display name derived from `js` by stripping the leading `@<scope>/` (`@azure/arm-avs` → `arm-avs`); falls back to the snake-cased `zig:` value when `js` is empty (data-plane Foundry packages, etc.).

`src/root.zig` and `README.md` move from `MANAGED_FILES`-only to `SAFE_FILES` — the emitter now honors the operator label.

## Verification

```text
$ bash codegen/scripts/sync.sh arm_avs keyvault_secrets
── arm_avs ──────────────────────────────────────
  spec: specification/vmware/resource-manager/Microsoft.AVS/AVS
  display: arm-avs
  …
  SKIP src/clients.zig (operator-managed; pass --force to overwrite)
  SKIP build.zig         (operator-managed; pass --force to overwrite)
  SKIP build.zig.zon     (operator-managed; pass --force to overwrite)
  SKIP .gitignore        (operator-managed; pass --force to overwrite)
  → 0 copied, 4 skipped
── keyvault_secrets ──────────────────────────────────────
  spec: specification/keyvault/data-plane/Secrets
  display: keyvault-secrets
  …
  → 0 copied, 4 skipped
```

`src/root.zig` and `README.md` are no longer in the skip list — both files contain the dash form and match the regen output exactly.

- `cd codegen/cli && zig build test` — green (new unit test passes).
- `zig build test` (top-level) — exit 0.
- `zig fmt --check sdk/ build.zig codegen/cli/ codegen/tspconfigs/ rest/arm_avs/{src,build.zig,examples}` — clean.
- `cd rest/arm_avs && zig build list-private-clouds` against the live AVS RP — table renders cleanly.

## Out of scope

- The remaining `MANAGED_FILES` skip entries (`src/clients.zig`, `build.zig`, `build.zig.zon`, `src/enums.zig`, `.gitignore`) need separate emitter completeness work — tracked in #27.
- `keyvault_secrets/build.zig` currently hand-edits the addModule key to `"keyvault-secrets"`. The emitter writes `"keyvault_secrets"` (snake) but this PR keeps build.zig as MANAGED, so today's behavior is unchanged. Whenever someone runs `sync.sh --force keyvault_secrets`, the drift will be reverted; downstream `@import("keyvault-secrets")` call sites will need to switch to `@import("keyvault_secrets")` at that point.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
