### PR TITLE
chore(arm_avs): zig fmt list_private_clouds example

### DIFF
--- a/rest/arm_avs/examples/list_private_clouds.zig
+++ b/rest/arm_avs/examples/list_private_clouds.zig
@@ -61,7 +61,8 @@ pub fn main(init: std.process.Init) !void {
                     .unrecognized => |s| s,
                     else => @tagName(ps),
                 } else "-"
-            else "-";
+            else
+                "-";
             try w.print("{s:<40}  {s:<14}  {s:<18}\n", .{ cloud.name, cloud.location, state });
             count += 1;
         }


### PR DESCRIPTION
Pre-existing fmt drift in `rest/arm_avs/examples/list_private_clouds.zig` — the trailing `else "-"` on the same line as the closing brace. `zig fmt` wants it on its own line.

```diff
                 } else "-"
-            else "-";
+            else
+                "-";
```

`zig fmt --check rest/arm_avs/examples/list_private_clouds.zig` now passes; `cd rest/arm_avs && zig build` still green.

Out of scope of #26 / PR #30, hence a separate small PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
