### PR TITLE
codegen: emit ARM sub-clients and operation bodies (#27)

### DIFF
--- a/codegen/cli/src/codemodel.zig
+++ b/codegen/cli/src/codemodel.zig
@@ -23,11 +23,31 @@ pub const Client = struct {
     name: []const u8,
     namespace: ?[]const u8 = null,
     doc: ?[]const u8 = null,
-    parameters: []ClientParameter = &.{},
+    /// True for the top-level client of a service. The emitter renders
+    /// `init()`/`deinit()`/auth on the root only; sub-clients borrow the
+    /// pipeline by value via accessor methods.
+    is_root: bool = true,
+    parent_name: ?[]const u8 = null,
+    /// Typed client-level state propagated through the sub-client tree
+    /// (e.g. ARM's `subscription_id`). The emitter places each entry as
+    /// a struct field on every client in the family, and as a required
+    /// field on the root's `InitOptions`.
+    init_parameters: []InitParameter = &.{},
+    /// Default api-version string read from TCGC's `apiVersion`
+    /// `clientDefaultValue`. Used to populate `InitOptions.api_version`.
+    api_version_default: ?[]const u8 = null,
     endpoint: Endpoint,
     methods: []Method = &.{},
     sub_clients: []SubClient = &.{},
     credential_scopes: [][]const u8 = &.{},
+};
+
+pub const InitParameter = struct {
+    name: []const u8,
+    serialized_name: []const u8,
+    doc: ?[]const u8 = null,
+    param_type: TypeRef,
+    optional: bool = false,
 };
 
 pub const Endpoint = struct {
@@ -35,38 +55,65 @@ pub const Endpoint = struct {
     default_value: ?[]const u8 = null,
 };
 
-pub const ClientParameter = struct {
-    name: []const u8,
-    doc: ?[]const u8 = null,
-    param_type: TypeRef,
-    optional: bool = false,
-};
-
 pub const SubClient = struct {
-    name: []const u8,
-    accessor_name: []const u8,
+    accessor_camel: []const u8,
+    accessor_snake: []const u8,
     client_name: []const u8,
 };
 
 pub const Method = struct {
     name: []const u8,
+    name_camel: []const u8,
     doc: ?[]const u8 = null,
     http_method: []const u8,
     path: []const u8,
-    parameters: []MethodParameter = &.{},
+    /// User-facing method parameters in declaration order (after the
+    /// implicit `self` and `allocator`). Client-level params
+    /// (`subscription_id`, `api_version`, `endpoint`) and constants
+    /// (`Accept`, `Content-Type`) are absent here — they're sourced
+    /// from the client struct or hard-coded.
+    user_parameters: []UserParameter = &.{},
+    /// Path placeholders resolved to either a client-state field or a
+    /// user parameter.
+    path_parameters: []WireParameter = &.{},
+    /// Query-string keys; ordered as TCGC surfaces them.
+    query_parameters: []WireParameter = &.{},
+    /// HTTP request headers; constants are emitted unconditionally.
+    header_parameters: []WireParameter = &.{},
+    /// Body to serialize; null for verbs without a payload.
+    body_parameter: ?BodyParameter = null,
     response: MethodResponse,
     paging: ?Paging = null,
     long_running: ?LongRunning = null,
     kind: []const u8 = "basic",
 };
 
-pub const MethodParameter = struct {
+pub const UserParameter = struct {
     name: []const u8,
-    serialized_name: []const u8,
-    location: []const u8,
+    method_name: []const u8,
     doc: ?[]const u8 = null,
     param_type: TypeRef,
     optional: bool = false,
+};
+
+pub const WireParameter = struct {
+    wire_name: []const u8,
+    source: WireSource,
+    optional: bool = false,
+};
+
+pub const WireSource = struct {
+    /// "client" | "user" | "constant"
+    kind: []const u8,
+    /// snake_case identifier for "client"/"user" sources.
+    name: ?[]const u8 = null,
+    /// Constant literal for "constant" sources.
+    value: ?[]const u8 = null,
+};
+
+pub const BodyParameter = struct {
+    user_param_name: []const u8,
+    content_type: []const u8,
 };
 
 pub const MethodResponse = struct {
@@ -79,6 +126,12 @@ pub const Paging = struct {
     next_link_segments: []?[]const u8 = &.{},
     next_link_verb: ?[]const u8 = null,
     next_link_operation: ?[]const u8 = null,
+    /// Marker set by the JS adapter when the response is the standard
+    /// `{ "value": [T, ...], "nextLink": "..." }` ARM envelope. The
+    /// emitter uses `core.pager.listPageParser(T)` in that case.
+    envelope: ?[]const u8 = null,
+    /// The element type T for envelope=`value_next_link`. Null otherwise.
+    item_type: ?TypeRef = null,
 };
 
 pub const LongRunning = struct {

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -97,6 +97,30 @@ pub fn emit(
         defer allocator.free(s);
         try writeFile(allocator, io, out_dir, "README.md", s, opts.run_zig_fmt);
     }
+    // Operator-owned test file. The emitter writes a stub the first
+    // time a package is generated; on subsequent regenerations the
+    // sync helper marks it as operator-managed (SKIP-and-warn) so
+    // operator-added tests are preserved.
+    try writeFile(
+        allocator,
+        io,
+        out_dir,
+        "src/clients_test.zig",
+        \\//! Tests for the generated `clients.zig`.
+        \\//!
+        \\//! Kept in a separate file so the emitter can overwrite
+        \\//! `clients.zig` without losing test coverage. Wired into the
+        \\//! package's test step via `root.zig`.
+        \\//!
+        \\//! This file is **operator-owned**: `codegen/scripts/sync.sh`
+        \\//! marks it as operator-managed and never overwrites an
+        \\//! existing copy. Add tests freely.
+        \\
+        \\const std = @import("std");
+        \\
+    ,
+        opts.run_zig_fmt,
+    );
     try writeFile(allocator, io, out_dir, ".gitignore", "zig-cache/\nzig-out/\n.zig-cache/\n", opts.run_zig_fmt);
 }
 
@@ -162,9 +186,25 @@ fn renderRoot(allocator: std.mem.Allocator, model: cm.CodeModel, display_name: [
         \\
     , .{ .name = display_name });
 
+    // Only re-export root clients; sub-clients are reachable through
+    // accessor methods on their parent.
     for (model.clients) |c| {
+        if (!c.is_root) continue;
         try w.print("pub const {s} = clients.{s};\n", .{ c.name, c.name });
     }
+
+    // Pull in an operator-owned test file (if it exists) so package
+    // tests stay reachable from `zig build test` across regenerations.
+    // The file itself is hand-written and never overwritten by the
+    // emitter; if it does not exist, the build will fail loudly — drop
+    // the import or land a `clients_test.zig` in `src/`.
+    try w.writeAll(
+        \\
+        \\test {
+        \\    _ = @import("clients_test.zig");
+        \\}
+        \\
+    );
     return try aw.toOwnedSlice();
 }
 
@@ -179,12 +219,21 @@ fn renderClients(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         \\//! Generated service clients.
         \\
         \\const std = @import("std");
+        \\const serde = @import("serde");
         \\const core = @import("azure_core");
         \\const models = @import("models.zig");
         \\const enums = @import("enums.zig");
         \\
         \\
     );
+
+    // Per-family constants (endpoint default, api-version default, auth
+    // scopes) emitted next to the root client so callers can override
+    // them via `InitOptions`.
+    for (model.clients) |c| {
+        if (!c.is_root) continue;
+        try renderRootConstants(w, c);
+    }
 
     for (model.clients) |c| {
         try renderClient(allocator, w, c);
@@ -193,80 +242,457 @@ fn renderClients(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
     return try aw.toOwnedSlice();
 }
 
+fn renderRootConstants(w: *std.Io.Writer, c: cm.Client) !void {
+    if (c.endpoint.default_value) |ep| {
+        try w.print("const default_endpoint = \"{s}\";\n", .{ep});
+    }
+    if (c.api_version_default) |ver| {
+        try w.print("const default_api_version = \"{s}\";\n", .{ver});
+    }
+    try w.writeAll("const auth_scopes: []const []const u8 = &.{");
+    for (c.credential_scopes, 0..) |s, i| {
+        if (i != 0) try w.writeAll(", ");
+        try w.print("\"{s}\"", .{s});
+    }
+    try w.writeAll("};\n\n");
+}
+
 fn renderClient(allocator: std.mem.Allocator, w: *std.Io.Writer, c: cm.Client) !void {
     if (c.doc) |d| try renderDocComment(w, d);
     try w.print("pub const {s} = struct {{\n", .{c.name});
+
+    // Common state — present on root *and* sub-clients so the
+    // accessor on the root can splat-assign in one literal.
     try w.writeAll(
-        \\    allocator: std.mem.Allocator,
-        \\    pipeline: core.pipeline.HttpPipeline,
         \\    endpoint: []const u8,
+        \\    api_version: []const u8,
+        \\    pipeline: core.pipeline.HttpPipeline,
         \\
     );
+    for (c.init_parameters) |p| {
+        const id = try ids.quoteIfNeeded(allocator, p.name);
+        defer allocator.free(id);
+        const ty = try renderFieldType(allocator, p.param_type, p.optional, .clients);
+        defer allocator.free(ty);
+        try w.print("    {s}: {s},\n", .{ id, ty });
+    }
 
-    try w.print(
-        \\
-        \\    pub fn init(
-        \\        allocator: std.mem.Allocator,
-        \\        endpoint: []const u8,
-        \\        credential: core.credentials.TokenCredential,
-        \\        transport: core.http.Transport,
-        \\        options: ClientOptions,
-        \\    ) {s} {{
-        \\        _ = options;
-        \\        _ = credential;
-        \\        return .{{
-        \\            .allocator = allocator,
-        \\            .endpoint = endpoint,
-        \\            .pipeline = core.pipeline.HttpPipeline.init(allocator, transport),
-        \\        }};
-        \\    }}
-        \\
-        \\    pub const ClientOptions = struct {{}};
-        \\
-    , .{c.name});
+    if (c.is_root) {
+        // Root-only: own the bearer-token policy + policy_ptrs slice
+        // and expose `init()`/`deinit()`.
+        try w.writeAll(
+            \\    allocator: std.mem.Allocator,
+            \\    auth_policy: *core.pipeline.BearerTokenAuthPolicy,
+            \\    policy_ptrs: []*core.pipeline.HttpPolicy,
+            \\
+        );
+        try renderRootInit(allocator, w, c);
+        try renderRootDeinit(w);
+    }
+
+    for (c.sub_clients) |sc| {
+        try renderSubClientAccessor(w, c, sc);
+    }
 
     for (c.methods) |m| {
-        try renderMethod(allocator, w, m);
+        try renderMethod(allocator, w, c, m);
     }
 
     try w.writeAll("};\n");
 }
 
-fn renderMethod(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method) !void {
-    if (m.doc) |d| try renderDocComment(w, d);
-    const camel = try naming.toCamelCase(allocator, m.name);
-    defer allocator.free(camel);
-
-    try w.print("    pub fn {s}(self: *@This()", .{camel});
-    for (m.parameters) |p| {
-        if (std.mem.eql(u8, p.location, "endpoint") or
-            std.mem.eql(u8, p.location, "credential")) continue;
+fn renderRootInit(allocator: std.mem.Allocator, w: *std.Io.Writer, c: cm.Client) !void {
+    try w.writeAll(
+        \\
+        \\    pub const InitOptions = struct {
+        \\
+    );
+    for (c.init_parameters) |p| {
+        const id = try ids.quoteIfNeeded(allocator, p.name);
+        defer allocator.free(id);
         const ty = try renderFieldType(allocator, p.param_type, p.optional, .clients);
         defer allocator.free(ty);
-        const id = try ids.quoteIfNeeded(allocator, p.name);
-        defer allocator.free(id);
-        try w.print(", {s}: {s}", .{ id, ty });
-    }
-    if (m.response.response_type) |rt| {
-        const ret = try types.renderType(allocator, rt, .clients);
-        defer allocator.free(ret);
-        try w.print(") !{s} {{\n", .{ret});
-    } else {
-        try w.writeAll(") !void {\n");
-    }
-    try w.writeAll("        _ = self;\n");
-    for (m.parameters) |p| {
-        if (std.mem.eql(u8, p.location, "endpoint") or
-            std.mem.eql(u8, p.location, "credential")) continue;
-        const id = try ids.quoteIfNeeded(allocator, p.name);
-        defer allocator.free(id);
-        try w.print("        _ = {s};\n", .{id});
+        try w.print("        {s}: {s},\n", .{ id, ty });
     }
     try w.writeAll(
-        \\        return error.NotImplemented;
+        \\        credential: *core.credentials.TokenCredential,
+        \\        transport: *core.http.HttpTransport,
+        \\
+    );
+    if (c.endpoint.default_value != null) {
+        try w.writeAll("        endpoint: []const u8 = default_endpoint,\n");
+    } else {
+        try w.writeAll("        endpoint: []const u8,\n");
+    }
+    if (c.api_version_default != null) {
+        try w.writeAll("        api_version: []const u8 = default_api_version,\n");
+    } else {
+        try w.writeAll("        api_version: []const u8,\n");
+    }
+    try w.writeAll(
+        \\    };
+        \\
+        \\
+    );
+
+    try w.print(
+        \\    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !{s} {{
+        \\        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
+        \\        errdefer allocator.destroy(auth_policy);
+        \\        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
+        \\            allocator,
+        \\            options.credential,
+        \\            auth_scopes,
+        \\        );
+        \\
+        \\        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
+        \\        errdefer allocator.free(policy_ptrs);
+        \\        policy_ptrs[0] = auth_policy.asPolicy();
+        \\
+        \\        return .{{
+        \\            .allocator = allocator,
+        \\            .endpoint = options.endpoint,
+        \\            .api_version = options.api_version,
+        \\            .auth_policy = auth_policy,
+        \\            .policy_ptrs = policy_ptrs,
+        \\            .pipeline = .{{
+        \\                .policies = policy_ptrs,
+        \\                .transport_impl = options.transport,
+        \\            }},
+        \\
+    , .{c.name});
+    for (c.init_parameters) |p| {
+        const id = try ids.quoteIfNeeded(allocator, p.name);
+        defer allocator.free(id);
+        try w.print("            .{s} = options.{s},\n", .{ id, id });
+    }
+    try w.writeAll(
+        \\        };
         \\    }
         \\
     );
+}
+
+fn renderRootDeinit(w: *std.Io.Writer) !void {
+    try w.writeAll(
+        \\
+        \\    pub fn deinit(self: *@This()) void {
+        \\        self.auth_policy.deinit();
+        \\        self.allocator.destroy(self.auth_policy);
+        \\        self.allocator.free(self.policy_ptrs);
+        \\    }
+        \\
+    );
+}
+
+fn renderSubClientAccessor(w: *std.Io.Writer, parent: cm.Client, sc: cm.SubClient) !void {
+    try w.print(
+        \\
+        \\    pub fn {[acc]s}(self: *@This()) {[name]s} {{
+        \\        return .{{
+        \\            .endpoint = self.endpoint,
+        \\            .api_version = self.api_version,
+        \\            .pipeline = self.pipeline,
+        \\
+    , .{ .acc = sc.accessor_camel, .name = sc.client_name });
+    for (parent.init_parameters) |p| {
+        try w.print("            .{s} = self.{s},\n", .{ p.name, p.name });
+    }
+    try w.writeAll(
+        \\        };
+        \\    }
+        \\
+    );
+}
+
+// ─── method bodies ────────────────────────────────────────────────────
+
+fn renderMethod(allocator: std.mem.Allocator, w: *std.Io.Writer, c: cm.Client, m: cm.Method) !void {
+    if (m.doc) |d| try renderDocComment(w, d);
+
+    // Return type depends on method kind.
+    const ReturnKind = enum { void_op, value_op, list_op, lro_op };
+    const ret_kind: ReturnKind = if (m.long_running != null)
+        .lro_op
+    else if (std.mem.eql(u8, m.kind, "paging") or std.mem.eql(u8, m.kind, "lropaging"))
+        .list_op
+    else if (m.response.response_type == null)
+        .void_op
+    else
+        .value_op;
+
+    const ret_str = try renderReturnType(allocator, m, ret_kind);
+    defer allocator.free(ret_str);
+
+    // Signature: `pub fn <name>(self: *@This(), alloc: std.mem.Allocator, <user params>) !<ret> {`
+    try w.print("\n    pub fn {s}(self: *@This(), alloc: std.mem.Allocator", .{m.name_camel});
+    for (m.user_parameters) |p| {
+        const id = try ids.quoteIfNeeded(allocator, p.name);
+        defer allocator.free(id);
+        const ty = try renderFieldType(allocator, p.param_type, p.optional, .clients);
+        defer allocator.free(ty);
+        try w.print(", {s}: {s}", .{ id, ty });
+    }
+    try w.print(") !{s} {{\n", .{ret_str});
+
+    // URL build (path + query) — shared by every kind.
+    try renderUrlBuild(allocator, w, m);
+
+    switch (ret_kind) {
+        .list_op => try renderListBody(allocator, w, m),
+        .void_op => try renderVoidBody(allocator, w, c, m),
+        .value_op => try renderValueBody(allocator, w, c, m),
+        .lro_op => try renderLroBody(allocator, w, c, m),
+    }
+
+    try w.writeAll("    }\n");
+}
+
+fn renderReturnType(allocator: std.mem.Allocator, m: cm.Method, kind: anytype) ![]u8 {
+    return switch (kind) {
+        .void_op => try allocator.dupe(u8, "void"),
+        .value_op => blk: {
+            const t = m.response.response_type.?;
+            const ty = try types.renderType(allocator, t, .clients);
+            break :blk ty;
+        },
+        .list_op => blk: {
+            // Item type from paging metadata when the envelope is the
+            // standard `{ value, nextLink }` shape; otherwise fall back
+            // to the response type (already an array).
+            const item_type_ref: ?cm.TypeRef = if (m.paging) |p| p.item_type else null;
+            if (item_type_ref) |it| {
+                const ty = try types.renderType(allocator, it, .clients);
+                defer allocator.free(ty);
+                break :blk try std.fmt.allocPrint(allocator, "core.pager.PipelinePager({s})", .{ty});
+            }
+            // No item_type? Fall back to the response type's element.
+            if (m.response.response_type) |t| {
+                const ty = try types.renderType(allocator, t, .clients);
+                defer allocator.free(ty);
+                // ty is `[]const X`. Strip the prefix to get X.
+                const prefix = "[]const ";
+                if (std.mem.startsWith(u8, ty, prefix)) {
+                    const elem = ty[prefix.len..];
+                    break :blk try std.fmt.allocPrint(allocator, "core.pager.PipelinePager({s})", .{elem});
+                }
+                break :blk try std.fmt.allocPrint(allocator, "core.pager.PipelinePager({s})", .{ty});
+            }
+            break :blk try allocator.dupe(u8, "core.pager.PipelinePager(std.json.Value)");
+        },
+        .lro_op => blk: {
+            const final = if (m.long_running) |l| l.final_response_type else null;
+            if (final) |t| {
+                const ty = try types.renderType(allocator, t, .clients);
+                defer allocator.free(ty);
+                break :blk try std.fmt.allocPrint(allocator, "core.lro.TypedPoller({s})", .{ty});
+            }
+            break :blk try allocator.dupe(u8, "core.lro.TypedPoller(void)");
+        },
+    };
+}
+
+/// Render the `const url = try std.fmt.allocPrint(...)` block. Path
+/// placeholders are substituted by walking the operation path
+/// character-by-character and replacing `{<wire_name>}` runs with
+/// `{s}`, then collecting the corresponding value-expression for the
+/// argument tuple.
+fn renderUrlBuild(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method) !void {
+    var fmt_buf: std.ArrayList(u8) = .empty;
+    defer fmt_buf.deinit(allocator);
+    var args_buf: std.ArrayList(u8) = .empty;
+    defer args_buf.deinit(allocator);
+
+    // Endpoint first.
+    try fmt_buf.appendSlice(allocator, "{s}");
+    try args_buf.appendSlice(allocator, "self.endpoint");
+
+    // Walk the path, substituting placeholders.
+    var i: usize = 0;
+    const path = m.path;
+    while (i < path.len) {
+        if (path[i] == '{') {
+            const close = std.mem.indexOfScalarPos(u8, path, i + 1, '}') orelse break;
+            const wire_name = path[i + 1 .. close];
+            try fmt_buf.appendSlice(allocator, "{s}");
+            const expr = try valueExpression(allocator, m.path_parameters, wire_name);
+            defer allocator.free(expr);
+            try args_buf.appendSlice(allocator, ", ");
+            try args_buf.appendSlice(allocator, expr);
+            i = close + 1;
+        } else {
+            try fmt_buf.append(allocator, path[i]);
+            i += 1;
+        }
+    }
+
+    // Query string. Required first, then optional ones with conditional
+    // concatenation (out of scope here — AVS has none).
+    if (m.query_parameters.len > 0) {
+        try fmt_buf.append(allocator, '?');
+        for (m.query_parameters, 0..) |qp, idx| {
+            if (idx != 0) try fmt_buf.append(allocator, '&');
+            try fmt_buf.print(allocator, "{s}={{s}}", .{qp.wire_name});
+            const expr = try sourceExpression(allocator, qp.source);
+            defer allocator.free(expr);
+            try args_buf.appendSlice(allocator, ", ");
+            try args_buf.appendSlice(allocator, expr);
+        }
+    }
+
+    try w.print(
+        \\        const url = try std.fmt.allocPrint(alloc, "{s}", .{{ {s} }});
+        \\        defer alloc.free(url);
+        \\
+    , .{ fmt_buf.items, args_buf.items });
+}
+
+fn valueExpression(allocator: std.mem.Allocator, params: []cm.WireParameter, wire_name: []const u8) ![]u8 {
+    for (params) |p| {
+        if (std.mem.eql(u8, p.wire_name, wire_name)) {
+            return sourceExpression(allocator, p.source);
+        }
+    }
+    // Fallback to the placeholder name as-is (snake-cased) — keeps the
+    // file compiling so the reviewer can spot the missing wire mapping.
+    return try std.fmt.allocPrint(allocator, "\"<missing:{s}>\"", .{wire_name});
+}
+
+fn sourceExpression(allocator: std.mem.Allocator, src: cm.WireSource) ![]u8 {
+    if (std.mem.eql(u8, src.kind, "constant")) {
+        return try std.fmt.allocPrint(allocator, "\"{s}\"", .{src.value orelse ""});
+    }
+    if (std.mem.eql(u8, src.kind, "client")) {
+        return try std.fmt.allocPrint(allocator, "self.{s}", .{src.name orelse "<missing>"});
+    }
+    // user
+    return try ids.quoteIfNeeded(allocator, src.name orelse "<missing>");
+}
+
+fn renderListBody(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method) !void {
+    // Determine the item type T.
+    const item_type_ref: ?cm.TypeRef = if (m.paging) |p| p.item_type else null;
+    var item_ty: []u8 = undefined;
+    if (item_type_ref) |t| {
+        item_ty = try types.renderType(allocator, t, .clients);
+    } else if (m.response.response_type) |t| {
+        const ty = try types.renderType(allocator, t, .clients);
+        defer allocator.free(ty);
+        const prefix = "[]const ";
+        if (std.mem.startsWith(u8, ty, prefix)) {
+            item_ty = try allocator.dupe(u8, ty[prefix.len..]);
+        } else {
+            item_ty = try allocator.dupe(u8, ty);
+        }
+    } else {
+        item_ty = try allocator.dupe(u8, "std.json.Value");
+    }
+    defer allocator.free(item_ty);
+
+    try w.print(
+        \\        return core.pager.PipelinePager({s}).init(
+        \\            self.pipeline,
+        \\            url,
+        \\            alloc,
+        \\            core.pager.listPageParser({s}),
+        \\            "application/json",
+        \\        );
+        \\
+    , .{ item_ty, item_ty });
+}
+
+fn renderRequestSetup(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method) !void {
+    const verb = try httpVerbZig(allocator, m.http_method);
+    defer allocator.free(verb);
+    try w.print(
+        \\        var req = core.http.Request.init(alloc, .{s}, url);
+        \\        defer req.deinit();
+        \\
+    , .{verb});
+
+    // Render headers — every entry tagged `kind: "constant"` becomes a
+    // `req.setHeader("Name", "value")` line. User-sourced headers are
+    // out of scope for the initial emitter cut (AVS has none).
+    for (m.header_parameters) |hp| {
+        if (std.mem.eql(u8, hp.source.kind, "constant")) {
+            try w.print("        try req.setHeader(\"{s}\", \"{s}\");\n", .{ hp.wire_name, hp.source.value orelse "" });
+        }
+    }
+
+    if (m.body_parameter) |bp| {
+        const id = try ids.quoteIfNeeded(allocator, bp.user_param_name);
+        defer allocator.free(id);
+        try w.print(
+            \\        const body_json = try serde.json.toSlice(alloc, {s});
+            \\        defer alloc.free(body_json);
+            \\        req.body = body_json;
+            \\
+        , .{id});
+    }
+}
+
+fn httpVerbZig(allocator: std.mem.Allocator, http_method: []const u8) ![]u8 {
+    var upper = try allocator.alloc(u8, http_method.len);
+    for (http_method, 0..) |c, i| upper[i] = std.ascii.toUpper(c);
+    return upper;
+}
+
+fn renderVoidBody(allocator: std.mem.Allocator, w: *std.Io.Writer, c: cm.Client, m: cm.Method) !void {
+    try renderRequestSetup(allocator, w, m);
+    try w.print(
+        \\
+        \\        var resp = try self.pipeline.send(&req);
+        \\        defer resp.deinit();
+        \\
+        \\        if (!resp.isSuccess()) {{
+        \\            core.pager.logHttpError("{[client]s}.{[method]s}", resp.status_code, resp.body);
+        \\            return error.AzureRequestFailed;
+        \\        }}
+        \\        return;
+        \\
+    , .{ .client = c.name, .method = m.name_camel });
+}
+
+fn renderValueBody(allocator: std.mem.Allocator, w: *std.Io.Writer, c: cm.Client, m: cm.Method) !void {
+    try renderRequestSetup(allocator, w, m);
+    const ty = try types.renderType(allocator, m.response.response_type.?, .clients);
+    defer allocator.free(ty);
+    try w.print(
+        \\
+        \\        var resp = try self.pipeline.send(&req);
+        \\        defer resp.deinit();
+        \\
+        \\        if (!resp.isSuccess()) {{
+        \\            core.pager.logHttpError("{[client]s}.{[method]s}", resp.status_code, resp.body);
+        \\            return error.AzureRequestFailed;
+        \\        }}
+        \\        return try serde.json.fromSlice({[ty]s}, alloc, resp.body);
+        \\
+    , .{ .client = c.name, .method = m.name_camel, .ty = ty });
+}
+
+fn renderLroBody(allocator: std.mem.Allocator, w: *std.Io.Writer, c: cm.Client, m: cm.Method) !void {
+    try renderRequestSetup(allocator, w, m);
+    const final_ty = if (m.long_running) |l| l.final_response_type else null;
+    var ty_owned: []u8 = undefined;
+    if (final_ty) |t| {
+        ty_owned = try types.renderType(allocator, t, .clients);
+    } else {
+        ty_owned = try allocator.dupe(u8, "void");
+    }
+    defer allocator.free(ty_owned);
+    try w.print(
+        \\
+        \\        var resp = try self.pipeline.send(&req);
+        \\        defer resp.deinit();
+        \\
+        \\        if (!resp.isSuccess()) {{
+        \\            core.pager.logHttpError("{[client]s}.{[method]s}", resp.status_code, resp.body);
+        \\            return error.AzureRequestFailed;
+        \\        }}
+        \\        return try core.lro.TypedPoller({[ty]s}).init(alloc, self.pipeline, resp, url, .{{}});
+        \\
+    , .{ .client = c.name, .method = m.name_camel, .ty = ty_owned });
 }
 
 // ─── models.zig ───────────────────────────────────────────────────────

--- a/codegen/cli/src/main.zig
+++ b/codegen/cli/src/main.zig
@@ -189,12 +189,28 @@ pub fn main(init: std.process.Init) !u8 {
     std.debug.print("got {d} bytes back from tcgc.compile\n", .{json.len});
 
     // ── Deserialize and emit ─────────────────────────────────────────
-    var parsed = try std.json.parseFromSlice(
-        cm.CodeModel,
-        allocator,
-        json,
-        .{ .ignore_unknown_fields = true },
-    );
+    var parsed = blk: {
+        var diag: std.json.Diagnostics = .{};
+        var scanner = std.json.Scanner.initCompleteInput(allocator, json);
+        defer scanner.deinit();
+        scanner.enableDiagnostics(&diag);
+        const r = std.json.parseFromTokenSource(
+            cm.CodeModel,
+            allocator,
+            &scanner,
+            .{ .ignore_unknown_fields = true },
+        ) catch |e| {
+            const off: usize = @intCast(diag.getByteOffset());
+            const lo = if (off > 200) off - 200 else 0;
+            const hi = @min(json.len, off + 200);
+            std.debug.print(
+                "JSON parse failure: {s} (line {d} col {d} byte {d})\nnear:\n{s}\n",
+                .{ @errorName(e), diag.getLine(), diag.getColumn(), off, json[lo..hi] },
+            );
+            return e;
+        };
+        break :blk r;
+    };
     defer parsed.deinit();
 
     try emit.emit(allocator, io, out_dir_handle, parsed.value, .{

--- a/codegen/scripts/sync.sh
+++ b/codegen/scripts/sync.sh
@@ -160,19 +160,20 @@ lookup_display_name() {
 
 # ── per-file sync policy ───────────────────────────────────────────
 #
-# `src/models.zig`, `src/root.zig`, and `README.md` are emitter-owned
-# end-to-end today: models.zig because the emitter is the source of
-# truth for the resource/enum shapes, and root.zig + README.md because
-# the emitter honors the dash-cased `--display-name` we derive from
-# `tspconfigs.yaml#js` and writes the same label operators used to set
-# by hand. Other emitter-touched files still drift from operator
-# tweaks (sub-clients in clients.zig, dash-cased addModule keys in
-# build.zig.zon, .env in .gitignore, …) so they get the SKIP-and-warn
-# treatment unless --force is passed.
-SAFE_FILES=("src/models.zig" "src/root.zig" "README.md")
+# `src/models.zig`, `src/root.zig`, `src/clients.zig`, `src/enums.zig`,
+# and `README.md` are emitter-owned end-to-end today: the emitter is the
+# source of truth for the resource/enum shapes and the client tree
+# (root + sub-clients + operation bodies), and it honors the dash-cased
+# `--display-name` we derive from `tspconfigs.yaml#js` so root.zig and
+# README.md no longer drift from operator tweaks. Other emitter-touched
+# files (`build.zig`, `build.zig.zon`, `.gitignore`) still drift
+# (operator-managed module wiring, .env in .gitignore, …) so they get
+# the SKIP-and-warn treatment unless --force is passed.
+SAFE_FILES=("src/models.zig" "src/root.zig" "src/clients.zig" "src/enums.zig" "README.md")
 MANAGED_FILES=(
     "src/root.zig"
     "src/clients.zig"
+    "src/clients_test.zig"
     "src/enums.zig"
     "src/models.zig"
     "build.zig"
@@ -240,7 +241,11 @@ for pkg in "${PKGS[@]}"; do
         if [[ -f "$dst" ]] && cmp -s "$src" "$dst"; then
             continue
         fi
-        if [[ "$FORCE" -eq 1 ]] || is_safe "$f"; then
+        # Seed missing files unconditionally so brand-new operator-owned
+        # files (e.g. `src/clients_test.zig`) don't need `--force` on
+        # first regen. SAFE_FILES are still overwritten when they
+        # differ. Everything else gets the SKIP-and-warn treatment.
+        if [[ ! -f "$dst" ]] || [[ "$FORCE" -eq 1 ]] || is_safe "$f"; then
             mkdir -p "$(dirname "$dst")"
             cp "$src" "$dst"
             echo "  COPY $f"

--- a/codegen/tcgc-component/package.json
+++ b/codegen/tcgc-component/package.json
@@ -11,7 +11,7 @@
     "build": "npm run bundle && jco componentize dist/bundled.js --wit wit/component.wit --world-name codegen --out tcgc.wasm",
     "build:stub": "jco componentize src/stub.js --wit wit/component.wit --world-name codegen --out tcgc-stub.wasm",
     "clean": "rm -rf dist tcgc.wasm tcgc-stub.wasm",
-    "dev": "node src/index.js"
+    "dev": "node src/cli.js"
   },
   "dependencies": {
     "@typespec/compiler": "1.12.0",

--- a/codegen/tcgc-component/src/cli.js
+++ b/codegen/tcgc-component/src/cli.js
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+//
+// CLI entrypoint for the TypeSpec → JSON code-model emitter. Drives
+// the TypeSpec compiler in-process with our package registered as
+// `--emit`, then writes the resulting code model to stdout.
+//
+// Lives in its own file (separate from `src/index.js`) because
+// `node:fs` / `node:path` / `node:url` aren't available inside the
+// wasm bundle that `tcgc-component/scripts/build-component.mjs`
+// produces. The wasm path uses `src/wasi-host.js` instead, which
+// surfaces the spec files through WASI preopens.
+//
+// Usage:
+//
+//   node src/cli.js <project-path> [emitter-options-json]
+
+import {
+  compile as tspCompile,
+  NodeHost,
+  resolvePath,
+} from "@typespec/compiler";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { LIB_NAME, __slot } from "./index.js";
+
+/**
+ * Drives the TypeSpec compiler with this package registered as the
+ * sole emitter and returns the JSON code model.
+ *
+ * @param {string} projectPath path to a directory containing
+ *                             `tspconfig.yaml`, `client.tsp`, or
+ *                             `main.tsp`, or to a `.tsp` file.
+ * @param {string} emitterOptions JSON-encoded options blob.
+ * @returns {Promise<string>} JSON code model.
+ */
+export async function compile(projectPath, emitterOptions) {
+  const options = JSON.parse(emitterOptions || "{}");
+  const staged = stageSpec(projectPath);
+  const mainFile = resolveMainFile(staged);
+
+  __slot.json = null;
+  __slot.error = null;
+
+  const program = await tspCompile(NodeHost, mainFile, {
+    emit: [packageRoot()],
+    options: {
+      [LIB_NAME]: {
+        "package-name": options["package-name"],
+        "package-version": options["package-version"],
+        "target-kind": options["target-kind"] ?? "client",
+        "emitter-output-dir": joinTmp(),
+      },
+    },
+    noEmit: false,
+    warningAsError: false,
+  });
+
+  const compileErrors = program.diagnostics.filter(
+    (d) => d.severity === "error",
+  );
+  if (compileErrors.length > 0) {
+    throw new Error(
+      "TypeSpec compilation failed:\n" +
+        compileErrors.map((d) => `  ${d.code}: ${d.message}`).join("\n"),
+    );
+  }
+  if (__slot.error) throw __slot.error;
+  if (!__slot.json) throw new Error("typespec-zig emitter produced no output");
+  return __slot.json;
+}
+
+function packageRoot() {
+  // src/cli.js → ../
+  const here = fileURLToPath(import.meta.url);
+  return resolvePath(path.dirname(path.dirname(here)));
+}
+
+function joinTmp() {
+  return resolvePath(path.join(packageRoot(), ".typespec-output"));
+}
+
+function resolveMainFile(projectPath) {
+  const abs = path.resolve(projectPath);
+  const stat = fs.statSync(abs);
+  if (stat.isFile()) return resolvePath(abs);
+  for (const candidate of ["client.tsp", "main.tsp"]) {
+    const p = path.join(abs, candidate);
+    if (fs.existsSync(p)) return resolvePath(p);
+  }
+  return resolvePath(abs);
+}
+
+/**
+ * The TypeSpec compiler walks up from the spec file's directory looking
+ * for `node_modules`. Azure specs in `azure-rest-api-specs/` don't have
+ * one, so we stage the spec under our package directory where our
+ * `node_modules` is reachable.
+ */
+function stageSpec(inputPath) {
+  const root = packageRoot();
+  const stagingRoot = path.join(root, ".tsp-staging");
+  fs.rmSync(stagingRoot, { recursive: true, force: true });
+  fs.mkdirSync(stagingRoot, { recursive: true });
+
+  const absInput = path.resolve(inputPath);
+  const inputDir = fs.statSync(absInput).isFile()
+    ? path.dirname(absInput)
+    : absInput;
+  const parentDir = path.dirname(inputDir);
+
+  const stagedParent = path.join(stagingRoot, path.basename(parentDir));
+  fs.mkdirSync(stagedParent, { recursive: true });
+  copyDir(parentDir, stagedParent);
+
+  const rel = path.relative(parentDir, absInput);
+  return rel === "" ? stagedParent : path.join(stagedParent, rel);
+}
+
+function copyDir(src, dst) {
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    const s = path.join(src, entry.name);
+    const d = path.join(dst, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(d, { recursive: true });
+      copyDir(s, d);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(s, d);
+    }
+  }
+}
+
+/* ───────────────────────── CLI ───────────────────────────────────── */
+
+if (
+  typeof process !== "undefined" &&
+  typeof process.argv?.[1] === "string" &&
+  process.argv[1].endsWith("cli.js")
+) {
+  const args = process.argv.slice(2);
+  if (args.length < 1) {
+    console.error(
+      "Usage: node src/cli.js <project-path> [emitter-options-json]",
+    );
+    process.exit(1);
+  }
+  compile(args[0], args[1] || "{}").then(
+    (json) => process.stdout.write(json + "\n"),
+    (err) => {
+      console.error(err?.stack || err);
+      process.exit(1);
+    },
+  );
+}

--- a/codegen/tcgc-component/src/index.js
+++ b/codegen/tcgc-component/src/index.js
@@ -23,20 +23,14 @@
 // (matches @typespec/compiler 1.12.0).
 
 import {
-  compile as tspCompile,
-  NodeHost,
-  resolvePath,
   createTypeSpecLibrary,
   paramMessage,
 } from "@typespec/compiler";
 import { createSdkContext } from "@azure-tools/typespec-client-generator-core";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 
 /* ───────────────────────── Library registration ──────────────────── */
 
-const LIB_NAME = "@azure-tools/typespec-zig";
+export const LIB_NAME = "@azure-tools/typespec-zig";
 
 export const $lib = createTypeSpecLibrary({
   name: LIB_NAME,
@@ -71,7 +65,7 @@ export const { reportDiagnostic } = $lib;
  *
  * @type {{ json: string | null, error: Error | null }}
  */
-const __slot = { json: null, error: null };
+export const __slot = { json: null, error: null };
 
 /* ───────────────────────── TypeSpec `$onEmit` ────────────────────── */
 
@@ -97,12 +91,22 @@ export async function $onEmit(context) {
     }
 
     const opts = context.options ?? {};
+    // Flatten the SdkClient tree (TCGC keeps children nested under
+    // `client.children`). The Zig emitter renders one struct per
+    // entry; the first entry of each contiguous family is the root
+    // (`is_root: true`) and owns init / auth / deinit. Sub-clients
+    // borrow the parent's pipeline + init params and only carry
+    // method bodies.
+    const flatClients = [];
+    for (const top of sdkContext.sdkPackage.clients) {
+      flattenClients(top, /*parent=*/null, flatClients);
+    }
     const codeModel = {
       package_name: opts["package-name"] || "azure_generated",
       package_version: opts["package-version"] || "0.1.0",
       target_kind: opts["target-kind"] || "client",
       service_kind: detectServiceKind(sdkContext),
-      clients: sdkContext.sdkPackage.clients.map(adaptClient),
+      clients: flatClients,
       models: sdkContext.sdkPackage.models.map(adaptModel),
       enums: sdkContext.sdkPackage.enums.map(adaptEnum),
       unions: [],
@@ -110,133 +114,6 @@ export async function $onEmit(context) {
     __slot.json = JSON.stringify(codeModel, null, 2);
   } catch (err) {
     __slot.error = err instanceof Error ? err : new Error(String(err));
-  }
-}
-
-/* ───────────────────────── WIT export: compile() ─────────────────── */
-
-/**
- * Drives the TypeSpec compiler with this package registered as the
- * sole emitter and returns the JSON code model.
- *
- * @param {string} projectPath path to a directory containing
- *                             `tspconfig.yaml`, `client.tsp`, or
- *                             `main.tsp`, or to a `.tsp` file.
- * @param {string} emitterOptions JSON-encoded options blob.
- * @returns {Promise<string>} JSON code model.
- */
-export async function compile(projectPath, emitterOptions) {
-  const options = JSON.parse(emitterOptions || "{}");
-  const staged = stageSpec(projectPath);
-  const mainFile = resolveMainFile(staged);
-
-  __slot.json = null;
-  __slot.error = null;
-
-  const program = await tspCompile(NodeHost, mainFile, {
-    emit: [packageRoot()],
-    options: {
-      [LIB_NAME]: {
-        "package-name": options["package-name"],
-        "package-version": options["package-version"],
-        "target-kind": options["target-kind"] ?? "client",
-        "emitter-output-dir": joinTmp(),
-      },
-    },
-    noEmit: false,
-    warningAsError: false,
-  });
-
-  const compileErrors = program.diagnostics.filter(
-    (d) => d.severity === "error",
-  );
-  if (compileErrors.length > 0) {
-    throw new Error(
-      "TypeSpec compilation failed:\n" +
-        compileErrors.map((d) => `  ${d.code}: ${d.message}`).join("\n"),
-    );
-  }
-  if (__slot.error) throw __slot.error;
-  if (!__slot.json) throw new Error("typespec-zig emitter produced no output");
-  return __slot.json;
-}
-
-/* ───────────────────────── Helpers ───────────────────────────────── */
-
-function packageRoot() {
-  // src/index.js → ../
-  const here = fileURLToPath(import.meta.url);
-  return resolvePath(path.dirname(path.dirname(here)));
-}
-
-function joinTmp() {
-  // The TypeSpec compiler insists on an emitter-output-dir even when we
-  // don't write any files. Use the package's own tmp area; we'll clean
-  // it up implicitly on next invocation.
-  return resolvePath(path.join(packageRoot(), ".typespec-output"));
-}
-
-function resolveMainFile(projectPath) {
-  const abs = path.resolve(projectPath);
-  const stat = fs.statSync(abs);
-  if (stat.isFile()) return resolvePath(abs);
-  for (const candidate of ["client.tsp", "main.tsp"]) {
-    const p = path.join(abs, candidate);
-    if (fs.existsSync(p)) return resolvePath(p);
-  }
-  return resolvePath(abs);
-}
-
-/**
- * The TypeSpec compiler walks up from the spec file's directory looking
- * for `node_modules`. Azure specs in `azure-rest-api-specs/` don't have
- * one, so we stage the spec under our package directory where our
- * `node_modules` is reachable.
- *
- * For specs that pull in sibling directories via tspconfig
- * `additionalDirectories`, this layout is extended later. For
- * self-contained specs (e.g. keyvault data-plane), copying the spec
- * directory itself is enough.
- *
- * @param {string} inputPath
- * @returns {string} path to the staged equivalent of `inputPath`.
- */
-function stageSpec(inputPath) {
-  const root = packageRoot();
-  const stagingRoot = path.join(root, ".tsp-staging");
-  fs.rmSync(stagingRoot, { recursive: true, force: true });
-  fs.mkdirSync(stagingRoot, { recursive: true });
-
-  // For initial bring-up: stage the spec's parent directory so sibling
-  // dirs referenced by `tspconfig.additionalDirectories` or relative
-  // imports (`../Foo.Shared`) are reachable. Specs that reach further
-  // (ARM `../../common-types/...`) still need an extended staging
-  // strategy — tracked as a follow-up.
-  const absInput = path.resolve(inputPath);
-  const inputDir = fs.statSync(absInput).isFile()
-    ? path.dirname(absInput)
-    : absInput;
-  const parentDir = path.dirname(inputDir);
-
-  const stagedParent = path.join(stagingRoot, path.basename(parentDir));
-  fs.mkdirSync(stagedParent, { recursive: true });
-  copyDir(parentDir, stagedParent);
-
-  const rel = path.relative(parentDir, absInput);
-  return rel === "" ? stagedParent : path.join(stagedParent, rel);
-}
-
-function copyDir(src, dst) {
-  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
-    if (entry.name === "node_modules" || entry.name === ".git") continue;
-    const s = path.join(src, entry.name);
-    const d = path.join(dst, entry.name);
-    if (entry.isDirectory()) {
-      fs.mkdirSync(d, { recursive: true });
-      copyDir(s, d);
-    } else if (entry.isFile()) {
-      fs.copyFileSync(s, d);
-    }
   }
 }
 
@@ -254,69 +131,163 @@ function detectServiceKind(sdkContext) {
 
 /* ───────────────────────── Client / method adapters ──────────────── */
 
-function adaptClient(client) {
+/** Recursively walk a TCGC client tree and adapt each node. */
+function flattenClients(client, parent, out) {
+  out.push(adaptClient(client, parent));
+  for (const child of client.children ?? []) {
+    flattenClients(child, client, out);
+  }
+}
+
+function adaptClient(client, parent) {
+  const isRoot = !parent;
+  const initParams = adaptInitParameters(client.clientInitialization);
   return {
     name: client.name,
     namespace: client.namespace ?? null,
     doc: client.doc ?? null,
-    parameters: adaptClientParams(client.clientInitialization),
-    endpoint: adaptClientEndpoint(client.clientInitialization),
+    is_root: isRoot,
+    parent_name: parent ? parent.name : null,
+    /** Propagated client-level state stored on every (root + sub-)
+     *  client struct (e.g. `subscription_id`). */
+    init_parameters: initParams.propagated,
+    /** Default api-version string (`@@clientInitialization apiVersion`
+     *  default). Used to populate `InitOptions.api_version`. */
+    api_version_default: initParams.api_version_default,
+    endpoint: initParams.endpoint,
     methods: (client.methods ?? [])
       .filter((m) => m.kind !== "clientaccessor")
-      .map(adaptMethod),
+      .map((m) => adaptMethod(m, initParams.client_param_names)),
     sub_clients: (client.children ?? []).map((child) => ({
-      name: toSnakeCase(child.name),
-      accessor_name: `get${child.name}`,
+      /** camelCase accessor: `Microsoft.AVS.PrivateClouds` →
+       *  `privateClouds`. The previous shape (`getPrivateClouds`) was
+       *  wrong for the Zig emitter. */
+      accessor_camel: toCamelCase(child.name),
+      /** snake_case fallback if a future emitter needs it. */
+      accessor_snake: toSnakeCase(child.name),
       client_name: child.name,
     })),
     credential_scopes: defaultCredentialScopes(client),
   };
 }
 
-function adaptClientEndpoint(init) {
-  const ep = init?.parameters?.find((p) => p.kind === "endpoint");
-  if (!ep) return { name: "endpoint", default_value: null };
-  return {
-    name: toSnakeCase(ep.name),
-    default_value:
-      ep.type?.templateArguments?.[0]?.defaultValue ??
-      ep.clientDefaultValue ??
-      null,
-  };
-}
-
-function adaptClientParams(init) {
-  const params = [];
-  for (const p of init?.parameters ?? []) {
-    if (p.kind === "credential" || p.kind === "endpoint") continue;
-    if (p.isApiVersionParam) continue;
-    params.push({
-      name: toSnakeCase(p.name),
+/**
+ * Walk a `SdkClientInitializationType.parameters` array and partition
+ * it into:
+ *   - `endpoint`         : the endpoint param (always present)
+ *   - `api_version_default` : default value if a method-typed
+ *                          `apiVersion` parameter is present
+ *   - `propagated`       : typed init knobs (e.g. `subscription_id`)
+ *                          that we surface as required fields on the
+ *                          root `InitOptions` and store on every
+ *                          sub-client struct
+ *   - `client_param_names`: a set of snake_cased names of all
+ *                          client-level params (`subscription_id`,
+ *                          `endpoint`, `api_version`). The method
+ *                          adapter uses this set to decide whether a
+ *                          path/query parameter is sourced from
+ *                          `self.<name>` instead of a user argument.
+ */
+function adaptInitParameters(init) {
+  const params = init?.parameters ?? [];
+  const propagated = [];
+  let endpointParam = null;
+  let apiVersionDefault = null;
+  const clientParamNames = new Set();
+  for (const p of params) {
+    if (p.kind === "endpoint") {
+      endpointParam = p;
+      clientParamNames.add("endpoint");
+      continue;
+    }
+    if (p.kind === "credential") continue;
+    if (p.isApiVersionParam) {
+      if (typeof p.clientDefaultValue === "string") apiVersionDefault = p.clientDefaultValue;
+      clientParamNames.add("api_version");
+      continue;
+    }
+    // Remaining: typed init knobs (kind === "method"). For ARM, that's
+    // `subscriptionId`. Surface as a required required field unless
+    // marked optional.
+    const snake = toSnakeCase(p.name);
+    clientParamNames.add(snake);
+    propagated.push({
+      name: snake,
+      serialized_name: p.serializedName ?? p.name,
       doc: p.doc ?? null,
       param_type: adaptType(p.type),
       optional: !!p.optional,
     });
   }
-  return params;
+  return {
+    endpoint: adaptEndpointFromParam(endpointParam),
+    api_version_default: apiVersionDefault,
+    propagated,
+    client_param_names: clientParamNames,
+  };
+}
+
+function adaptEndpointFromParam(ep) {
+  if (!ep) return { name: "endpoint", default_value: null };
+  return {
+    name: toSnakeCase(ep.name),
+    default_value:
+      ep.type?.templateArguments?.[0]?.clientDefaultValue ??
+      ep.clientDefaultValue ??
+      null,
+  };
 }
 
 function defaultCredentialScopes(client) {
-  const isArm = (client.clientInitialization?.parameters ?? []).some(
+  // Look up the credential param on this client (or any ancestor) and
+  // pick the first scope value the OAuth2 flow declares.
+  let cur = client;
+  while (cur) {
+    for (const p of cur.clientInitialization?.parameters ?? []) {
+      if (p.kind !== "credential") continue;
+      const flows = p.type?.scheme?.flows ?? [];
+      const scopes = [];
+      for (const f of flows) {
+        for (const s of f.scopes ?? []) {
+          if (s.value) scopes.push(s.value);
+        }
+      }
+      if (scopes.length > 0) return Array.from(new Set(scopes));
+    }
+    cur = cur.parent;
+  }
+  // Fallback: ARM scope if a `subscriptionId` parameter is present,
+  // else the data-plane wildcard.
+  const hasSub = (client.clientInitialization?.parameters ?? []).some(
     (p) => p.name === "subscriptionId",
   );
-  return isArm
+  return hasSub
     ? ["https://management.azure.com/.default"]
     : ["{endpoint}/.default"];
 }
 
-function adaptMethod(method) {
+function adaptMethod(method, clientParamNames) {
   const op = method.operation ?? {};
+  const user = adaptUserParameters(method.parameters ?? [], clientParamNames);
+  const wire = adaptWireParameters(op, clientParamNames, user.byMethodName);
   return {
     name: toSnakeCase(method.name),
+    name_camel: toCamelCase(method.name),
     doc: method.doc ?? null,
     http_method: (op.verb ?? "get").toLowerCase(),
     path: op.path ?? "",
-    parameters: (method.parameters ?? []).map(adaptMethodParameter),
+    /** User-facing args. Snake-cased name + type; the emitter renders
+     *  these as method parameters in order. */
+    user_parameters: user.list,
+    /** Resolved path placeholders: `{ wire_name, source: {kind, name} }`. */
+    path_parameters: wire.path,
+    /** Query string keys: `{ wire_name, source, optional }`. */
+    query_parameters: wire.query,
+    /** Static + sourced headers. The emitter always sets the ones with
+     *  `source.kind === "constant"`. */
+    header_parameters: wire.header,
+    /** Body to serialize; null for no-body operations. */
+    body_parameter: wire.body,
     response: adaptMethodResponse(method.response),
     paging: adaptPaging(method),
     long_running: adaptLro(method),
@@ -324,36 +295,129 @@ function adaptMethod(method) {
   };
 }
 
-function adaptMethodParameter(p) {
-  return {
-    name: toSnakeCase(p.name),
-    serialized_name: p.serializedName ?? p.name,
-    location: paramLocation(p),
-    doc: p.doc ?? null,
-    param_type: adaptType(p.type),
-    optional: !!p.optional,
-  };
+/**
+ * Extract the user-facing parameter list from a method. Filter out:
+ *   - `accept` / `contentType` (constants emitted by the wire layer)
+ *   - client-level parameters (`subscriptionId`, `apiVersion`,
+ *     `endpoint`) — those are stored on the client struct
+ *
+ * Returns `{ list, byMethodName }`. `list` keeps spec declaration
+ * order so the generated function signature matches the spec.
+ * `byMethodName` is a `Map<string, UserParam>` keyed by the *raw*
+ * TCGC name (camelCase) used by `methodParameterSegments` lookups.
+ */
+function adaptUserParameters(params, clientParamNames) {
+  const list = [];
+  const byMethodName = new Map();
+  for (const p of params) {
+    const snake = toSnakeCase(p.name);
+    if (clientParamNames.has(snake)) continue;
+    if (p.isApiVersionParam) continue;
+    if (p.type?.kind === "constant") continue;
+    // Anything else is a real user-facing arg.
+    const out = {
+      name: snake,
+      method_name: p.name,
+      doc: p.doc ?? null,
+      param_type: adaptType(p.type),
+      optional: !!p.optional,
+    };
+    list.push(out);
+    byMethodName.set(p.name, out);
+  }
+  return { list, byMethodName };
 }
 
-function paramLocation(p) {
-  switch (p.kind) {
-    case "path":
-      return "path";
-    case "query":
-      return "query";
-    case "header":
-      return "header";
-    case "cookie":
-      return "cookie";
-    case "body":
-      return "body";
-    case "endpoint":
-      return "endpoint";
-    case "credential":
-      return "credential";
-    default:
-      return "method";
+/**
+ * Walk `operation.parameters` + `operation.bodyParam` and tag each
+ * HTTP-layer parameter with how to source its value at runtime:
+ *
+ *   - `{ kind: "client", name: "subscription_id" }`
+ *   - `{ kind: "user",   name: "resource_group_name" }`
+ *   - `{ kind: "constant", value: "application/json" }`
+ *
+ * Returns `{ path, query, header, body }`.
+ */
+function adaptWireParameters(op, clientParamNames, userByMethodName) {
+  const path = [];
+  const query = [];
+  const header = [];
+  let body = null;
+
+  function sourceFor(p) {
+    // 1. Sourced from the client struct? (subscription_id, etc.)
+    if (p.onClient) {
+      const snake = toSnakeCase(p.name);
+      if (p.isApiVersionParam) {
+        return { kind: "client", name: "api_version" };
+      }
+      if (clientParamNames.has(snake)) {
+        return { kind: "client", name: snake };
+      }
+    }
+    // 2. Constant from a TypeSpec literal (e.g. `Accept: "application/json"`).
+    if (p.type?.kind === "constant") {
+      return { kind: "constant", value: String(p.type.value ?? "") };
+    }
+    // 3. Sourced from a user-facing method parameter via the
+    //    correspondence chain. Prefer `methodParameterSegments` over
+    //    the deprecated `correspondingMethodParams`.
+    const segs = p.methodParameterSegments?.[0] ?? p.correspondingMethodParams ?? [];
+    for (const seg of segs) {
+      const user = userByMethodName.get(seg.name);
+      if (user) return { kind: "user", name: user.name };
+    }
+    // 4. Last-resort fallback to a constant value if the param has a
+    //    `clientDefaultValue` (e.g. `accept` is sometimes modeled as a
+    //    method param with a constant type that we already filtered).
+    if (typeof p.clientDefaultValue !== "undefined") {
+      return { kind: "constant", value: String(p.clientDefaultValue) };
+    }
+    return { kind: "user", name: toSnakeCase(p.name) };
   }
+
+  for (const p of op.parameters ?? []) {
+    const src = sourceFor(p);
+    const entry = {
+      wire_name: p.serializedName ?? p.name,
+      source: src,
+      optional: !!p.optional,
+    };
+    switch (p.kind) {
+      case "path":
+        path.push(entry);
+        break;
+      case "query":
+        query.push(entry);
+        break;
+      case "header":
+        header.push(entry);
+        break;
+      // We intentionally drop "cookie" — no Azure API uses it.
+    }
+  }
+
+  if (op.bodyParam) {
+    const bp = op.bodyParam;
+    const segs = bp.methodParameterSegments?.[0] ?? bp.correspondingMethodParams ?? [];
+    let userName = null;
+    for (const seg of segs) {
+      const user = userByMethodName.get(seg.name);
+      if (user) {
+        userName = user.name;
+        break;
+      }
+    }
+    body = {
+      user_param_name: userName ?? toSnakeCase(bp.name),
+      content_type:
+        bp.defaultContentType ??
+        (bp.contentTypes && bp.contentTypes[0]) ??
+        "application/json",
+    };
+  }
+
+  return { path, query, header, body };
 }
 
 function adaptMethodResponse(resp) {
@@ -367,22 +431,56 @@ function adaptMethodResponse(resp) {
 function adaptPaging(method) {
   if (method.kind !== "paging" && method.kind !== "lropaging") return null;
   const meta = method.pagingMetadata ?? {};
+  const items = meta.pageItemsSegments ?? [];
+  // For the standard `{ "value": [T, ...], "nextLink": "..." }` ARM
+  // envelope, surface the *item* type (T) so the Zig emitter can hand
+  // it to `core.pager.listPageParser(T)` directly.
+  let item_type = null;
+  if (items.length === 1) {
+    const leaf = items[0];
+    if (leaf.type?.kind === "array" && leaf.type.valueType) {
+      item_type = adaptType(leaf.type.valueType);
+    }
+  }
   return {
-    items_segments: (meta.pageItemsSegments ?? []).map((s) => s.name ?? null),
+    items_segments: items.map((s) => s.name ?? null),
     next_link_segments: (meta.nextLinkSegments ?? []).map((s) => s.name ?? null),
     next_link_verb: meta.nextLinkVerb ?? null,
     next_link_operation: meta.nextLinkOperation?.name ?? null,
+    /** Standard ARM-style page envelope marker. The emitter falls back
+     *  to a hand-rolled parse if this isn't set. */
+    envelope:
+      items.length === 1 &&
+      items[0].name === "value" &&
+      (meta.nextLinkSegments ?? []).length === 1 &&
+      meta.nextLinkSegments[0].name === "nextLink"
+        ? "value_next_link"
+        : null,
+    item_type,
   };
 }
 
 function adaptLro(method) {
   if (method.kind !== "lro" && method.kind !== "lropaging") return null;
   const meta = method.lroMetadata ?? {};
+  // For the typed final result we prefer the operation's own response
+  // model (e.g. `PrivateCloud` for `privateClouds.update`) over the
+  // polling envelope (`ArmOperationStatusResourceProvisioningState`
+  // and similar). TCGC's `finalResult` / `envelopeResult` reflect the
+  // *polling protocol* output, not the user-visible result. Falling
+  // back to `method.response.type` matches every ARM LRO we've
+  // surveyed.
+  let result_type = null;
+  if (method.response?.type) {
+    result_type = adaptType(method.response.type);
+  } else if (meta.finalResult && typeof meta.finalResult !== "string") {
+    result_type = adaptType(meta.finalResult);
+  } else if (meta.envelopeResult) {
+    result_type = adaptType(meta.envelopeResult);
+  }
   return {
     final_state_via: meta.finalStateVia ?? null,
-    final_response_type: meta.finalResponse?.envelopeResult
-      ? adaptType(meta.finalResponse.envelopeResult)
-      : null,
+    final_response_type: result_type,
   };
 }
 
@@ -565,25 +663,10 @@ function toSnakeCase(str) {
     .replace(/^_/, "");
 }
 
-/* ───────────────────────── CLI shim ──────────────────────────────── */
-
-if (
-  typeof process !== "undefined" &&
-  typeof process.argv?.[1] === "string" &&
-  process.argv[1].endsWith("index.js")
-) {
-  const args = process.argv.slice(2);
-  if (args.length < 1) {
-    console.error(
-      "Usage: node src/index.js <project-path> [emitter-options-json]",
-    );
-    process.exit(1);
-  }
-  compile(args[0], args[1] || "{}").then(
-    (json) => process.stdout.write(json + "\n"),
-    (err) => {
-      console.error(err?.stack || err);
-      process.exit(1);
-    },
-  );
+/** Lower-camel-case: keeps existing camelCase as-is, lowercases the
+ *  first character. `PrivateClouds` → `privateClouds`. */
+function toCamelCase(str) {
+  const s = String(str);
+  if (!s) return s;
+  return s.charAt(0).toLowerCase() + s.slice(1);
 }

--- a/codegen/tcgc-component/src/wasi-host.js
+++ b/codegen/tcgc-component/src/wasi-host.js
@@ -23,12 +23,10 @@
 
 import {
   compile as tspCompile,
-  createTypeSpecLibrary,
-  paramMessage,
   resolvePath,
 } from "@typespec/compiler";
-import { createSdkContext } from "@azure-tools/typespec-client-generator-core";
 import { virtualFsSources, jsImports } from "../dist/wasi-entry.generated.js";
+import { $lib, $onEmit, LIB_NAME, __slot } from "./index.js";
 
 // ─────────────────────────────────────────────────────────────────
 //
@@ -47,38 +45,17 @@ import { virtualFsSources, jsImports } from "../dist/wasi-entry.generated.js";
 // FIRST (populating both maps), THEN this file runs (consuming them).
 // To make that work the entry file uses static imports rather than
 // re-imports through the package main.
+//
+// All TypeSpec→JSON adaptation logic — `$lib`, `$onEmit`, every
+// `adapt*` helper — lives in `./index.js`. This file is purely the
+// WASI host that registers `index.js` as the emitter and surfaces
+// the resulting JSON model. Keep adaptation OUT of this file so the
+// CLI shim (`node src/index.js …`) and the in-component path stay
+// byte-for-byte identical.
 
-// ── TypeSpec library registration ──────────────────────────────────
-
-const LIB_NAME = "@azure-tools/typespec-zig";
-
-export const $lib = createTypeSpecLibrary({
-  name: LIB_NAME,
-  diagnostics: {
-    "internal-error": {
-      severity: "error",
-      messages: {
-        default: paramMessage`typespec-zig encountered an internal error: ${"message"}`,
-      },
-    },
-  },
-  emitter: {
-    options: {
-      type: "object",
-      additionalProperties: true,
-      properties: {},
-      required: [],
-    },
-  },
-});
-
-/* eslint-disable-next-line @typescript-eslint/unbound-method */
-export const { reportDiagnostic } = $lib;
+export { $lib };
 
 // ── WasiHost CompilerHost implementation ───────────────────────────
-
-// Captured by $onEmit, returned by compile(). One per `compile()` call.
-const __slot = { json: null, error: null };
 
 function makeHost() {
   // In-memory layer combining baked-in stdlib (`virtualFsSources`)
@@ -186,38 +163,6 @@ function makeFsError(p, code) {
   return err;
 }
 
-// ── TypeSpec emitter — captures the SdkPackage as JSON ─────────────
-
-export async function $onEmit(context) {
-  try {
-    const sdkContext = await createSdkContext(context, LIB_NAME, {
-      disableUsageAccessPropagationToBase: true,
-    });
-    context.program.reportDiagnostics(sdkContext.diagnostics);
-    const errors = sdkContext.diagnostics.filter((d) => d.severity === "error");
-    if (errors.length > 0) {
-      throw new Error(
-        "TCGC reported errors:\n" +
-          errors.map((d) => `  ${d.code}: ${d.message}`).join("\n"),
-      );
-    }
-    const opts = context.options ?? {};
-    const codeModel = {
-      package_name: opts["package-name"] || "azure_generated",
-      package_version: opts["package-version"] || "0.1.0",
-      target_kind: opts["target-kind"] || "client",
-      service_kind: detectServiceKind(sdkContext),
-      clients: sdkContext.sdkPackage.clients.map(adaptClient),
-      models: sdkContext.sdkPackage.models.map(adaptModel),
-      enums: sdkContext.sdkPackage.enums.map(adaptEnum),
-      unions: [],
-    };
-    __slot.json = JSON.stringify(codeModel);
-  } catch (err) {
-    __slot.error = err instanceof Error ? err : new Error(String(err));
-  }
-}
-
 // ── WIT export: tcgc.compile ───────────────────────────────────────
 
 export const tcgc = {
@@ -321,253 +266,6 @@ async function resolveMainFile(host, projectPath) {
   return resolvePath(projectPath);
 }
 
-// ── Adapters — keep in sync with src/index.js (Node-bridge version) ─
-
-function detectServiceKind(sdkContext) {
-  if (sdkContext.arm === true) return "azure-arm";
-  for (const c of sdkContext.sdkPackage.clients) {
-    for (const p of c.clientInitialization?.parameters ?? []) {
-      if (p.name === "subscriptionId") return "azure-arm";
-    }
-  }
-  return "azure-dataplane";
-}
-
-function adaptClient(client) {
-  return {
-    name: client.name,
-    namespace: client.namespace ?? null,
-    doc: client.doc ?? null,
-    parameters: adaptClientParams(client.clientInitialization),
-    endpoint: adaptClientEndpoint(client.clientInitialization),
-    methods: (client.methods ?? [])
-      .filter((m) => m.kind !== "clientaccessor")
-      .map(adaptMethod),
-    sub_clients: (client.children ?? []).map((child) => ({
-      name: toSnakeCase(child.name),
-      accessor_name: `get${child.name}`,
-      client_name: child.name,
-    })),
-    credential_scopes: defaultCredentialScopes(client),
-  };
-}
-
-function adaptClientEndpoint(init) {
-  const ep = init?.parameters?.find((p) => p.kind === "endpoint");
-  if (!ep) return { name: "endpoint", default_value: null };
-  return {
-    name: toSnakeCase(ep.name),
-    default_value:
-      ep.type?.templateArguments?.[0]?.defaultValue ??
-      ep.clientDefaultValue ??
-      null,
-  };
-}
-
-function adaptClientParams(init) {
-  const params = [];
-  for (const p of init?.parameters ?? []) {
-    if (p.kind === "credential" || p.kind === "endpoint") continue;
-    if (p.isApiVersionParam) continue;
-    params.push({
-      name: toSnakeCase(p.name),
-      doc: p.doc ?? null,
-      param_type: adaptType(p.type),
-      optional: !!p.optional,
-    });
-  }
-  return params;
-}
-
-function defaultCredentialScopes(client) {
-  const isArm = (client.clientInitialization?.parameters ?? []).some(
-    (p) => p.name === "subscriptionId",
-  );
-  return isArm
-    ? ["https://management.azure.com/.default"]
-    : ["{endpoint}/.default"];
-}
-
-function adaptMethod(method) {
-  const op = method.operation ?? {};
-  return {
-    name: toSnakeCase(method.name),
-    doc: method.doc ?? null,
-    http_method: (op.verb ?? "get").toLowerCase(),
-    path: op.path ?? "",
-    parameters: (method.parameters ?? []).map(adaptMethodParameter),
-    response: { response_type: method.response?.type ? adaptType(method.response.type) : null, status_codes: [] },
-    paging: null,
-    long_running: null,
-    kind: method.kind ?? "basic",
-  };
-}
-
-function adaptMethodParameter(p) {
-  return {
-    name: toSnakeCase(p.name),
-    serialized_name: p.serializedName ?? p.name,
-    location: paramLocation(p),
-    doc: p.doc ?? null,
-    param_type: adaptType(p.type),
-    optional: !!p.optional,
-  };
-}
-
-function paramLocation(p) {
-  switch (p.kind) {
-    case "path": return "path";
-    case "query": return "query";
-    case "header": return "header";
-    case "cookie": return "cookie";
-    case "body": return "body";
-    case "endpoint": return "endpoint";
-    case "credential": return "credential";
-    default: return "method";
-  }
-}
-
-// Cross-language-definition-id of each ARM base type. TCGC stamps these
-// onto `SdkModelType.crossLanguageDefinitionId` regardless of how the
-// spec aliases the type, so matching here is robust against namespace
-// re-imports.
-const ARM_RESOURCE_KIND_BY_XLDID = {
-  "Azure.ResourceManager.CommonTypes.ProxyResource": "proxy",
-  "Azure.ResourceManager.CommonTypes.Resource": "proxy",
-  "Azure.ResourceManager.CommonTypes.TrackedResource": "tracked",
-  "Azure.ResourceManager.CommonTypes.ExtensionResource": "extension",
-  // Older / alternate aliases used by some TCGC versions.
-  "Azure.ResourceManager.ProxyResource": "proxy",
-  "Azure.ResourceManager.Resource": "proxy",
-  "Azure.ResourceManager.TrackedResource": "tracked",
-  "Azure.ResourceManager.ExtensionResource": "extension",
-};
-
-// Fallback table keyed on the topmost base model's `name`, used when
-// `crossLanguageDefinitionId` is unset or unrecognized.
-const ARM_RESOURCE_KIND_BY_NAME = {
-  ProxyResource: "proxy",
-  Resource: "proxy",
-  TrackedResource: "tracked",
-  ExtensionResource: "extension",
-};
-
-/**
- * Walk the `baseModel` chain root-to-leaf and return the concatenated
- * list of (own + inherited) properties. Inherited properties come
- * first; the leaf's own properties last. Within that order we de-dup
- * by `serializedName` so a property re-declared on the leaf wins (its
- * doc / optionality / type override the inherited one).
- */
-function collectInheritedProperties(model) {
-  const chain = [];
-  for (let cur = model; cur; cur = cur.baseModel) chain.unshift(cur);
-
-  const byKey = new Map();
-  for (const m of chain) {
-    for (const p of m.properties ?? []) {
-      const key = p.serializedName ?? p.name;
-      byKey.set(key, p);
-    }
-  }
-  return Array.from(byKey.values());
-}
-
-/**
- * Detect which ARM base type (if any) sits at the root of `model`'s
- * `baseModel` chain. Returns `"proxy"` / `"tracked"` / `"extension"`,
- * or `null` for non-ARM types.
- */
-function detectArmResourceKind(model) {
-  let topmost = model;
-  for (let cur = model; cur; cur = cur.baseModel) {
-    const xldid = cur.crossLanguageDefinitionId;
-    if (xldid && Object.prototype.hasOwnProperty.call(ARM_RESOURCE_KIND_BY_XLDID, xldid)) {
-      return ARM_RESOURCE_KIND_BY_XLDID[xldid];
-    }
-    topmost = cur;
-  }
-  // Fallback: classify by the topmost base model's name when xldid is
-  // unrecognized. Guard with a namespace prefix to avoid catching
-  // unrelated "Resource" / "TrackedResource" types in non-ARM specs.
-  const ns = topmost?.namespace ?? topmost?.clientNamespace ?? "";
-  if (
-    Object.prototype.hasOwnProperty.call(ARM_RESOURCE_KIND_BY_NAME, topmost?.name) &&
-    typeof ns === "string" &&
-    ns.startsWith("Azure.ResourceManager")
-  ) {
-    return ARM_RESOURCE_KIND_BY_NAME[topmost.name];
-  }
-  return null;
-}
-
-function adaptModel(model) {
-  const props = collectInheritedProperties(model);
-  return {
-    name: model.name,
-    namespace: model.namespace ?? null,
-    doc: model.doc ?? null,
-    fields: props.map((p) => ({
-      name: toSnakeCase(p.name),
-      serialized_name: p.serializedName ?? p.name,
-      doc: p.doc ?? null,
-      field_type: adaptType(p.type),
-      optional: !!p.optional,
-      read_only: !!p.readOnly,
-      flatten: !!p.flatten,
-    })),
-    parents: model.baseModel ? [model.baseModel.name] : [],
-    discriminator: model.discriminatorProperty?.name ?? null,
-    is_input: !!(model.usage & 1),
-    is_output: !!(model.usage & 2),
-    arm_resource_kind: detectArmResourceKind(model),
-  };
-}
-
-function adaptEnum(en) {
-  return {
-    name: en.name,
-    namespace: en.namespace ?? null,
-    doc: en.doc ?? null,
-    values: (en.values ?? []).map((v) => ({
-      name: v.name,
-      value: v.value,
-      doc: v.doc ?? null,
-    })),
-    value_type: en.valueType?.kind ?? "string",
-    extensible: en.isFixed === false,
-  };
-}
-
-function adaptType(type) {
-  if (!type) return { kind: "Scalar", value: "unknown" };
-  switch (type.kind) {
-    case "string": return { kind: "Scalar", value: "string" };
-    case "boolean": return { kind: "Scalar", value: "bool" };
-    case "bytes": return { kind: "Scalar", value: "bytes" };
-    case "url": return { kind: "Scalar", value: "url" };
-    case "utcDateTime":
-    case "offsetDateTime":
-      return { kind: "Scalar", value: "datetime" };
-    case "duration": return { kind: "Scalar", value: "duration" };
-    case "model": return { kind: "Model", value: type.name };
-    case "enum": return { kind: "Enum", value: type.name };
-    case "union": return { kind: "Union", value: type.name ?? "anonymous" };
-    case "array": return { kind: "Array", value: adaptType(type.valueType) };
-    case "dict": return { kind: "Map", value: adaptType(type.valueType) };
-    case "nullable": return { kind: "Option", value: adaptType(type.type) };
-    case "constant": return { kind: "Constant", value: String(type.value) };
-    default: return { kind: "Scalar", value: type.kind ?? "unknown" };
-  }
-}
-
-function toSnakeCase(str) {
-  return String(str)
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
-    .replace(/([a-z\d])([A-Z])/g, "$1_$2")
-    .toLowerCase()
-    .replace(/^_/, "");
-}
 
 // Top-level shim so `compile` is also reachable as a named export of
 // the bundle root (jco's "extract exports" stage looks for it).

--- a/rest/arm_avs/README.md
+++ b/rest/arm_avs/README.md
@@ -9,4 +9,28 @@ overwritten on the next regeneration.
 
 ## Clients
 - `AVSClient`
+- `Operations`
+- `Addons`
+- `Authorizations`
+- `CloudLinks`
+- `Clusters`
+- `Datastores`
+- `GlobalReachConnections`
+- `HcxEnterpriseSites`
+- `Hosts`
+- `IscsiPaths`
+- `Licenses`
+- `Locations`
+- `Maintenances`
+- `PlacementPolicies`
+- `PrivateClouds`
+- `ProvisionedNetworks`
+- `PureStoragePolicies`
+- `ScriptCmdlets`
+- `ScriptExecutions`
+- `ScriptPackages`
+- `ServiceComponents`
+- `Skus`
+- `VirtualMachines`
+- `WorkloadNetworks`
 

--- a/rest/arm_avs/build.zig
+++ b/rest/arm_avs/build.zig
@@ -11,11 +11,18 @@ pub fn build(b: *std.Build) void {
     const azure_core_mod = azure_sdk_dep.module("azure_core");
     const azure_identity_mod = azure_sdk_dep.module("azure_identity");
 
+    const serde_dep = b.dependency("serde", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const serde_mod = serde_dep.module("serde");
+
     const lib_mod = b.addModule("arm_avs", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = azure_core_mod },
+            .{ .name = "serde", .module = serde_mod },
         },
     });
 
@@ -26,6 +33,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "azure_core", .module = azure_core_mod },
+                .{ .name = "serde", .module = serde_mod },
             },
         }),
     });
@@ -55,4 +63,26 @@ pub fn build(b: *std.Build) void {
         "List Microsoft.AVS private clouds in $AZURE_SUBSCRIPTION_ID (or argv[1]).",
     );
     example_step.dependOn(&run_example.step);
+
+    // `zig build list-clusters -- <sub-id> <rg> <private-cloud>`
+    const list_clusters_exe = b.addExecutable(.{
+        .name = "list-clusters",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/list_clusters.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "arm_avs", .module = lib_mod },
+                .{ .name = "azure_core", .module = azure_core_mod },
+                .{ .name = "azure_identity", .module = azure_identity_mod },
+            },
+        }),
+    });
+    const run_list_clusters = b.addRunArtifact(list_clusters_exe);
+    if (b.args) |args| run_list_clusters.addArgs(args);
+    const list_clusters_step = b.step(
+        "list-clusters",
+        "List clusters in a private cloud (argv: <sub-id> <rg> <private-cloud>).",
+    );
+    list_clusters_step.dependOn(&run_list_clusters.step);
 }

--- a/rest/arm_avs/build.zig.zon
+++ b/rest/arm_avs/build.zig.zon
@@ -9,6 +9,10 @@
             // repo root.
             .path = "../..",
         },
+        .serde = .{
+            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
+            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+        },
     },
     .paths = .{
         "build.zig",

--- a/rest/arm_avs/examples/list_clusters.zig
+++ b/rest/arm_avs/examples/list_clusters.zig
@@ -1,0 +1,98 @@
+//! List Microsoft.AVS clusters within a private cloud.
+//!
+//! Demonstrates a sub-client (`Clusters`) reached through the root
+//! client (`AVSClient`).
+//!
+//! Usage:
+//!   az login
+//!   zig build list-clusters -- <sub-id> <resource-group> <private-cloud>
+//!   # or set AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP / AZURE_PRIVATE_CLOUD
+//!   # via env or `.env`.
+
+const std = @import("std");
+const core = @import("azure_core");
+const identity = @import("azure_identity");
+const arm_avs = @import("arm_avs");
+
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.gpa;
+
+    var dotenv = core.dotenv.loadFromFileOrEmpty(gpa, init.io, ".env");
+    defer dotenv.deinit();
+
+    const subscription_id, const resource_group, const private_cloud_name =
+        try resolveArgs(init, &dotenv);
+
+    var cli_cred = identity.AzureCliCredential.init(gpa, init.io);
+
+    var http_transport = core.http.StdHttpTransport.init(gpa, init.io);
+
+    var client = try arm_avs.AVSClient.init(gpa, .{
+        .subscription_id = subscription_id,
+        .credential = cli_cred.asCredential(),
+        .transport = http_transport.asTransport(),
+    });
+    defer client.deinit();
+
+    // Pager + per-page items use an arena so we don't have to deep-free
+    // each Cluster's owned strings field-by-field.
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+
+    var clusters = client.clusters();
+    var pager = try clusters.list(arena.allocator(), resource_group, private_cloud_name);
+    defer pager.deinit();
+
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_file = std.Io.File.stdout();
+    var stdout = stdout_file.writer(init.io, &stdout_buf);
+    const w = &stdout.interface;
+    defer w.flush() catch {};
+
+    try w.print("{s:<32}  {s:<10}  {s:<18}\n", .{ "NAME", "SKU", "PROVISIONING_STATE" });
+    try w.splatByteAll('-', 64);
+    try w.writeByte('\n');
+
+    var count: usize = 0;
+    while (try pager.next()) |page| {
+        for (page) |cluster| {
+            const state: []const u8 = if (cluster.properties) |props|
+                if (props.provisioning_state) |ps| switch (ps) {
+                    .unrecognized => |s| s,
+                    else => @tagName(ps),
+                } else "-"
+            else
+                "-";
+            try w.print("{s:<32}  {s:<10}  {s:<18}\n", .{ cluster.name, cluster.sku.name, state });
+            count += 1;
+        }
+    }
+    try w.print("\n{d} cluster(s).\n", .{count});
+}
+
+const Args = struct { []const u8, []const u8, []const u8 };
+
+/// Look up subscription id, resource group, and private cloud name from
+/// (in order): argv, env vars, then `.env` in the cwd.
+fn resolveArgs(init: std.process.Init, dotenv: *const core.dotenv.DotEnv) !Args {
+    var args = init.minimal.args.iterate();
+    _ = args.next(); // argv[0]
+    const arg1 = args.next();
+    const arg2 = args.next();
+    const arg3 = args.next();
+
+    const sub = arg1 orelse
+        init.environ_map.get("AZURE_SUBSCRIPTION_ID") orelse
+        dotenv.get("AZURE_SUBSCRIPTION_ID") orelse
+        return error.MissingAzureSubscriptionId;
+    const rg = arg2 orelse
+        init.environ_map.get("AZURE_RESOURCE_GROUP") orelse
+        dotenv.get("AZURE_RESOURCE_GROUP") orelse
+        return error.MissingAzureResourceGroup;
+    const pc = arg3 orelse
+        init.environ_map.get("AZURE_PRIVATE_CLOUD") orelse
+        dotenv.get("AZURE_PRIVATE_CLOUD") orelse
+        return error.MissingAzurePrivateCloud;
+
+    return .{ sub, rg, pc };
+}

--- a/rest/arm_avs/examples/list_private_clouds.zig
+++ b/rest/arm_avs/examples/list_private_clouds.zig
@@ -61,7 +61,8 @@ pub fn main(init: std.process.Init) !void {
                     .unrecognized => |s| s,
                     else => @tagName(ps),
                 } else "-"
-            else "-";
+            else
+                "-";
             try w.print("{s:<40}  {s:<14}  {s:<18}\n", .{ cloud.name, cloud.location, state });
             count += 1;
         }

--- a/rest/arm_avs/src/clients.zig
+++ b/rest/arm_avs/src/clients.zig
@@ -1,47 +1,24 @@
-//! Service clients for Azure VMware Solution (Microsoft.AVS).
-//!
-//! NOTE: hand-written shim. The TypeSpec → Zig emitter does not yet emit
-//! ARM sub-clients, operation bodies, ARM auth scope, or `subscription_id`
-//! as a required init argument. This file represents the *shape* the
-//! emitter is expected to produce. Until that lands, regenerating the
-//! arm_avs package will overwrite it.
-//!
-//! What's missing vs. a fully generated client tree:
-//!   • Only `AVSClient.privateClouds().listInSubscription(...)` is wired.
-//!   • All other ARM resource collections (Clusters, Datastores, …) are
-//!     omitted — add them when the emitter learns sub-client recursion.
-//!
-//! Resource DTOs come from the generated `models.zig`: every ARM resource
-//! (e.g. `models.PrivateCloud`) carries the full set of inherited fields
-//! from its base chain (`id`, `name`, `type`, `system_data`, plus
-//! `location`/`tags` for tracked resources) and is tagged with
-//! `pub const arm_resource_kind: core.arm.ResourceKind = .tracked;` so
-//! that generic helpers in `core.arm` accept it.
+//! Generated service clients.
 
 const std = @import("std");
+const serde = @import("serde");
 const core = @import("azure_core");
 const models = @import("models.zig");
+const enums = @import("enums.zig");
 
 const default_endpoint = "https://management.azure.com";
 const default_api_version = "2025-09-01";
-const arm_scopes: []const []const u8 = &.{"https://management.azure.com/.default"};
+const auth_scopes: []const []const u8 = &.{"https://management.azure.com/.default"};
 
-/// Pager type returned by `PrivateCloudsClient.listInSubscription`.
-pub const PrivateCloudPager = core.pager.PipelinePager(models.PrivateCloud);
-
-/// Top-level Azure VMware Solution client.
-///
-/// Owns the bearer-token policy + pipeline; sub-clients borrow the
-/// pipeline by value.
+/// Azure VMware Solution API
 pub const AVSClient = struct {
-    allocator: std.mem.Allocator,
-    subscription_id: []const u8,
     endpoint: []const u8,
     api_version: []const u8,
-
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    allocator: std.mem.Allocator,
     auth_policy: *core.pipeline.BearerTokenAuthPolicy,
     policy_ptrs: []*core.pipeline.HttpPolicy,
-    pipeline: core.pipeline.HttpPipeline,
 
     pub const InitOptions = struct {
         subscription_id: []const u8,
@@ -57,7 +34,7 @@ pub const AVSClient = struct {
         auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
             allocator,
             options.credential,
-            arm_scopes,
+            auth_scopes,
         );
 
         const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
@@ -66,7 +43,6 @@ pub const AVSClient = struct {
 
         return .{
             .allocator = allocator,
-            .subscription_id = options.subscription_id,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
             .auth_policy = auth_policy,
@@ -75,50 +51,1243 @@ pub const AVSClient = struct {
                 .policies = policy_ptrs,
                 .transport_impl = options.transport,
             },
+            .subscription_id = options.subscription_id,
         };
     }
 
-    pub fn deinit(self: *AVSClient) void {
+    pub fn deinit(self: *@This()) void {
         self.auth_policy.deinit();
         self.allocator.destroy(self.auth_policy);
         self.allocator.free(self.policy_ptrs);
     }
 
-    /// Sub-client for `Microsoft.AVS/privateClouds` resources.
-    pub fn privateClouds(self: *AVSClient) PrivateCloudsClient {
+    pub fn operations(self: *@This()) Operations {
         return .{
-            .subscription_id = self.subscription_id,
             .endpoint = self.endpoint,
             .api_version = self.api_version,
             .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn addons(self: *@This()) Addons {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn authorizations(self: *@This()) Authorizations {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn cloudLinks(self: *@This()) CloudLinks {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn clusters(self: *@This()) Clusters {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn datastores(self: *@This()) Datastores {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn globalReachConnections(self: *@This()) GlobalReachConnections {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn hcxEnterpriseSites(self: *@This()) HcxEnterpriseSites {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn hosts(self: *@This()) Hosts {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn iscsiPaths(self: *@This()) IscsiPaths {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn licenses(self: *@This()) Licenses {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn locations(self: *@This()) Locations {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn maintenances(self: *@This()) Maintenances {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn placementPolicies(self: *@This()) PlacementPolicies {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn privateClouds(self: *@This()) PrivateClouds {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn provisionedNetworks(self: *@This()) ProvisionedNetworks {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn pureStoragePolicies(self: *@This()) PureStoragePolicies {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn scriptCmdlets(self: *@This()) ScriptCmdlets {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn scriptExecutions(self: *@This()) ScriptExecutions {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn scriptPackages(self: *@This()) ScriptPackages {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn serviceComponents(self: *@This()) ServiceComponents {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn skus(self: *@This()) Skus {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn virtualMachines(self: *@This()) VirtualMachines {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
+        };
+    }
+
+    pub fn workloadNetworks(self: *@This()) WorkloadNetworks {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+            .subscription_id = self.subscription_id,
         };
     }
 };
 
-/// Sub-client for the `Microsoft.AVS/privateClouds` resource collection.
-pub const PrivateCloudsClient = struct {
-    subscription_id: []const u8,
+pub const Operations = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
-
-    /// `GET /subscriptions/{sub}/providers/Microsoft.AVS/privateClouds?api-version=…`
-    ///
-    /// Caller owns the returned pager and the items it yields. The
-    /// returned pager and per-page items are allocated from `alloc`;
-    /// using an arena allocator avoids per-field cleanup.
-    pub fn listInSubscription(
-        self: *PrivateCloudsClient,
-        alloc: std.mem.Allocator,
-    ) !PrivateCloudPager {
-        const url = try std.fmt.allocPrint(
-            alloc,
-            "{s}/subscriptions/{s}/providers/Microsoft.AVS/privateClouds?api-version={s}",
-            .{ self.endpoint, self.subscription_id, self.api_version },
-        );
+    /// List the operations for the provider
+    pub fn list(self: *@This(), alloc: std.mem.Allocator) !core.pager.PipelinePager(models.Operation) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/providers/Microsoft.AVS/operations?api-version={s}", .{ self.endpoint, self.api_version });
         defer alloc.free(url);
+        return core.pager.PipelinePager(models.Operation).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.Operation),
+            "application/json",
+        );
+    }
+};
 
-        return PrivateCloudPager.init(
+pub const Addons = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List Addon resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.Addon) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/addons?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.Addon).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.Addon),
+            "application/json",
+        );
+    }
+    /// Get a Addon
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, addon_name: []const u8) !models.Addon {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/addons/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, addon_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Addons.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Addon, alloc, resp.body);
+    }
+    /// Create a Addon
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, addon_name: []const u8, addon: models.Addon) !core.lro.TypedPoller(models.Addon) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/addons/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, addon_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, addon);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Addons.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.Addon).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a Addon
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, addon_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/addons/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, addon_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Addons.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const Authorizations = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List ExpressRouteAuthorization resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.ExpressRouteAuthorization) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/authorizations?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.ExpressRouteAuthorization).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.ExpressRouteAuthorization),
+            "application/json",
+        );
+    }
+    /// Get a ExpressRouteAuthorization
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, authorization_name: []const u8) !models.ExpressRouteAuthorization {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/authorizations/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, authorization_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Authorizations.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ExpressRouteAuthorization, alloc, resp.body);
+    }
+    /// Create a ExpressRouteAuthorization
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, authorization_name: []const u8, authorization: models.ExpressRouteAuthorization) !core.lro.TypedPoller(models.ExpressRouteAuthorization) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/authorizations/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, authorization_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, authorization);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Authorizations.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ExpressRouteAuthorization).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a ExpressRouteAuthorization
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, authorization_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/authorizations/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, authorization_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Authorizations.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const CloudLinks = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List CloudLink resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.CloudLink) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/cloudLinks?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.CloudLink).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.CloudLink),
+            "application/json",
+        );
+    }
+    /// Get a CloudLink
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cloud_link_name: []const u8) !models.CloudLink {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/cloudLinks/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cloud_link_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("CloudLinks.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.CloudLink, alloc, resp.body);
+    }
+    /// Create a CloudLink
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cloud_link_name: []const u8, cloud_link: models.CloudLink) !core.lro.TypedPoller(models.CloudLink) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/cloudLinks/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cloud_link_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, cloud_link);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("CloudLinks.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.CloudLink).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a CloudLink
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cloud_link_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/cloudLinks/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cloud_link_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("CloudLinks.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const Clusters = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List Cluster resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.Cluster) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.Cluster).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.Cluster),
+            "application/json",
+        );
+    }
+    /// Get a Cluster
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8) !models.Cluster {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Clusters.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Cluster, alloc, resp.body);
+    }
+    /// Create a Cluster
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, cluster: models.Cluster) !core.lro.TypedPoller(models.Cluster) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, cluster);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Clusters.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.Cluster).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a Cluster
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, cluster_update: models.ClusterUpdate) !core.lro.TypedPoller(models.Cluster) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, cluster_update);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Clusters.update", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.Cluster).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a Cluster
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Clusters.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List hosts by zone in a cluster
+    pub fn listZones(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8) !models.ClusterZoneList {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/listZones?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Clusters.listZones", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ClusterZoneList, alloc, resp.body);
+    }
+};
+
+pub const Datastores = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List Datastore resources by Cluster
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8) !core.pager.PipelinePager(models.Datastore) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/datastores?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.Datastore).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.Datastore),
+            "application/json",
+        );
+    }
+    /// Get a Datastore
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, datastore_name: []const u8) !models.Datastore {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/datastores/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, datastore_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Datastores.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Datastore, alloc, resp.body);
+    }
+    /// Create a Datastore
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, datastore_name: []const u8, datastore: models.Datastore) !core.lro.TypedPoller(models.Datastore) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/datastores/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, datastore_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, datastore);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Datastores.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.Datastore).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a Datastore
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, datastore_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/datastores/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, datastore_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Datastores.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const GlobalReachConnections = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List GlobalReachConnection resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.GlobalReachConnection) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/globalReachConnections?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.GlobalReachConnection).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.GlobalReachConnection),
+            "application/json",
+        );
+    }
+    /// Get a GlobalReachConnection
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, global_reach_connection_name: []const u8) !models.GlobalReachConnection {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/globalReachConnections/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, global_reach_connection_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("GlobalReachConnections.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.GlobalReachConnection, alloc, resp.body);
+    }
+    /// Create a GlobalReachConnection
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, global_reach_connection_name: []const u8, global_reach_connection: models.GlobalReachConnection) !core.lro.TypedPoller(models.GlobalReachConnection) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/globalReachConnections/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, global_reach_connection_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, global_reach_connection);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("GlobalReachConnections.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.GlobalReachConnection).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a GlobalReachConnection
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, global_reach_connection_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/globalReachConnections/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, global_reach_connection_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("GlobalReachConnections.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const HcxEnterpriseSites = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List HcxEnterpriseSite resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.HcxEnterpriseSite) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/hcxEnterpriseSites?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.HcxEnterpriseSite).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.HcxEnterpriseSite),
+            "application/json",
+        );
+    }
+    /// Get a HcxEnterpriseSite
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, hcx_enterprise_site_name: []const u8) !models.HcxEnterpriseSite {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/hcxEnterpriseSites/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, hcx_enterprise_site_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("HcxEnterpriseSites.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.HcxEnterpriseSite, alloc, resp.body);
+    }
+    /// Create a HcxEnterpriseSite
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, hcx_enterprise_site_name: []const u8, hcx_enterprise_site: models.HcxEnterpriseSite) !models.HcxEnterpriseSite {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/hcxEnterpriseSites/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, hcx_enterprise_site_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, hcx_enterprise_site);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("HcxEnterpriseSites.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.HcxEnterpriseSite, alloc, resp.body);
+    }
+    /// Delete a HcxEnterpriseSite
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, hcx_enterprise_site_name: []const u8) !void {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/hcxEnterpriseSites/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, hcx_enterprise_site_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("HcxEnterpriseSites.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return;
+    }
+};
+
+pub const Hosts = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List Host resources by Cluster
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8) !core.pager.PipelinePager(models.Host) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/hosts?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.Host).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.Host),
+            "application/json",
+        );
+    }
+    /// Get a Host
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, host_id: []const u8) !models.Host {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/hosts/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, host_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Hosts.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Host, alloc, resp.body);
+    }
+};
+
+pub const IscsiPaths = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List IscsiPath resources by PrivateCloud
+    pub fn listByPrivateCloud(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.IscsiPath) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/iscsiPaths?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.IscsiPath).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.IscsiPath),
+            "application/json",
+        );
+    }
+    /// Get a IscsiPath
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !models.IscsiPath {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/iscsiPaths/default?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("IscsiPaths.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.IscsiPath, alloc, resp.body);
+    }
+    /// Create a IscsiPath
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, resource: models.IscsiPath) !core.lro.TypedPoller(models.IscsiPath) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/iscsiPaths/default?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, resource);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("IscsiPaths.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.IscsiPath).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a IscsiPath
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/iscsiPaths/default?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("IscsiPaths.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const Licenses = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List License resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.License) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/licenses?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.License).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.License),
+            "application/json",
+        );
+    }
+    /// Get a License
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, license_name: enums.LicenseName) !models.License {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/licenses/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, license_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Licenses.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.License, alloc, resp.body);
+    }
+    /// Create a License
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, license_name: enums.LicenseName, resource: models.License) !core.lro.TypedPoller(models.License) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/licenses/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, license_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, resource);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Licenses.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.License).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a License
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, license_name: enums.LicenseName) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/licenses/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, license_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Licenses.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Just like ArmResourceActionSync, but with no request body.
+    pub fn getProperties(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, license_name: enums.LicenseName) !models.LicenseProperties {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/licenses/{s}/getProperties?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, license_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Licenses.getProperties", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.LicenseProperties, alloc, resp.body);
+    }
+};
+
+pub const Locations = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// Return trial status for subscription by region
+    pub fn checkTrialAvailability(self: *@This(), alloc: std.mem.Allocator, location: []const u8, sku: ?models.Sku) !models.Trial {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/providers/Microsoft.AVS/locations/{s}/checkTrialAvailability?api-version={s}", .{ self.endpoint, self.subscription_id, location, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, sku);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Locations.checkTrialAvailability", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Trial, alloc, resp.body);
+    }
+    /// Return quota for subscription by region
+    pub fn checkQuotaAvailability(self: *@This(), alloc: std.mem.Allocator, location: []const u8) !models.Quota {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/providers/Microsoft.AVS/locations/{s}/checkQuotaAvailability?api-version={s}", .{ self.endpoint, self.subscription_id, location, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Locations.checkQuotaAvailability", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Quota, alloc, resp.body);
+    }
+};
+
+pub const Maintenances = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List Maintenance resources by subscription ID
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, state_name: ?enums.MaintenanceStateName, status: ?enums.MaintenanceStatusFilter, from: ?[]const u8, to: ?[]const u8) !core.pager.PipelinePager(models.Maintenance) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/maintenances?api-version={s}&stateName={s}&status={s}&from={s}&to={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version, state_name, status, from, to });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.Maintenance).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.Maintenance),
+            "application/json",
+        );
+    }
+    /// Get a Maintenance
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, maintenance_name: []const u8) !models.Maintenance {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/maintenances/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, maintenance_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Maintenances.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Maintenance, alloc, resp.body);
+    }
+    /// Reschedule a maintenance
+    pub fn reschedule(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, maintenance_name: []const u8, body: models.MaintenanceReschedule) !models.Maintenance {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/maintenances/{s}/reschedule?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, maintenance_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, body);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Maintenances.reschedule", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Maintenance, alloc, resp.body);
+    }
+    /// Schedule a maintenance
+    pub fn schedule(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, maintenance_name: []const u8, body: models.MaintenanceSchedule) !models.Maintenance {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/maintenances/{s}/schedule?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, maintenance_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, body);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Maintenances.schedule", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Maintenance, alloc, resp.body);
+    }
+    /// Initiate maintenance readiness checks
+    pub fn initiateChecks(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, maintenance_name: []const u8) !models.Maintenance {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/maintenances/{s}/initiateChecks?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, maintenance_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("Maintenances.initiateChecks", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.Maintenance, alloc, resp.body);
+    }
+};
+
+pub const PlacementPolicies = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List PlacementPolicy resources by Cluster
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8) !core.pager.PipelinePager(models.PlacementPolicy) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/placementPolicies?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.PlacementPolicy).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.PlacementPolicy),
+            "application/json",
+        );
+    }
+    /// Get a PlacementPolicy
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, placement_policy_name: []const u8) !models.PlacementPolicy {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/placementPolicies/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, placement_policy_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PlacementPolicies.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.PlacementPolicy, alloc, resp.body);
+    }
+    /// Create a PlacementPolicy
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, placement_policy_name: []const u8, placement_policy: models.PlacementPolicy) !core.lro.TypedPoller(models.PlacementPolicy) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/placementPolicies/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, placement_policy_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, placement_policy);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PlacementPolicies.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.PlacementPolicy).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a PlacementPolicy
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, placement_policy_name: []const u8, placement_policy_update: models.PlacementPolicyUpdate) !core.lro.TypedPoller(models.PlacementPolicy) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/placementPolicies/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, placement_policy_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, placement_policy_update);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PlacementPolicies.update", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.PlacementPolicy).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a PlacementPolicy
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, placement_policy_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/placementPolicies/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, placement_policy_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PlacementPolicies.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const PrivateClouds = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List PrivateCloud resources by resource group
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8) !core.pager.PipelinePager(models.PrivateCloud) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.PrivateCloud).init(
             self.pipeline,
             url,
             alloc,
@@ -126,56 +1295,1212 @@ pub const PrivateCloudsClient = struct {
             "application/json",
         );
     }
+    /// List PrivateCloud resources by subscription ID
+    pub fn listInSubscription(self: *@This(), alloc: std.mem.Allocator) !core.pager.PipelinePager(models.PrivateCloud) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/providers/Microsoft.AVS/privateClouds?api-version={s}", .{ self.endpoint, self.subscription_id, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.PrivateCloud).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.PrivateCloud),
+            "application/json",
+        );
+    }
+    /// Get a PrivateCloud
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !models.PrivateCloud {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.PrivateCloud, alloc, resp.body);
+    }
+    /// Create a PrivateCloud
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, private_cloud: models.PrivateCloud) !core.lro.TypedPoller(models.PrivateCloud) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, private_cloud);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.PrivateCloud).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a PrivateCloud
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, private_cloud_update: models.PrivateCloudUpdate) !core.lro.TypedPoller(models.PrivateCloud) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, private_cloud_update);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.update", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.PrivateCloud).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a PrivateCloud
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Rotate the vCenter password
+    pub fn rotateVcenterPassword(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/rotateVcenterPassword?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.rotateVcenterPassword", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Rotate the NSX-T Manager password
+    pub fn rotateNsxtPassword(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/rotateNsxtPassword?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.rotateNsxtPassword", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List the admin credentials for the private cloud
+    pub fn listAdminCredentials(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !models.AdminCredentials {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/listAdminCredentials?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.listAdminCredentials", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.AdminCredentials, alloc, resp.body);
+    }
+    /// Get the license for the private cloud
+    pub fn getVcfLicense(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !models.VcfLicense {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/getVcfLicense?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PrivateClouds.getVcfLicense", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.VcfLicense, alloc, resp.body);
+    }
 };
 
-// ─────────────────────────── Tests ───────────────────────────
+pub const ProvisionedNetworks = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List ProvisionedNetwork resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.ProvisionedNetwork) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/provisionedNetworks?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.ProvisionedNetwork).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.ProvisionedNetwork),
+            "application/json",
+        );
+    }
+    /// Get a ProvisionedNetwork
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, provisioned_network_name: []const u8) !models.ProvisionedNetwork {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/provisionedNetworks/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, provisioned_network_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
 
-const testing = std.testing;
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
 
-test "AVSClient.privateClouds().listInSubscription pages mock results" {
-    const allocator = testing.allocator;
-
-    const body =
-        \\{"value":[{"name":"cloud-a","location":"eastus","sku":{"name":"av36"}},{"name":"cloud-b","location":"westus2","sku":{"name":"av36p"}}]}
-    ;
-    var mock = core.http.MockTransport.init(allocator, 200, body);
-    defer mock.deinit();
-
-    const Stub = struct {
-        fn getTokenFn(
-            _: *core.credentials.TokenCredential,
-            _: core.credentials.TokenRequestContext,
-            _: core.context.Context,
-        ) anyerror!core.credentials.AccessToken {
-            const tok = try testing.allocator.dupe(u8, "stub-token");
-            return .{ .token = tok, .expires_on = std.math.maxInt(i64) };
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ProvisionedNetworks.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
         }
-    };
-    var credential = core.credentials.TokenCredential{ .getTokenFn = &Stub.getTokenFn };
+        return try serde.json.fromSlice(models.ProvisionedNetwork, alloc, resp.body);
+    }
+};
 
-    var client = try AVSClient.init(allocator, .{
-        .subscription_id = "00000000-0000-0000-0000-000000000000",
-        .credential = &credential,
-        .transport = mock.asTransport(),
-    });
-    defer client.deinit();
+pub const PureStoragePolicies = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List PureStoragePolicy resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.PureStoragePolicy) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/pureStoragePolicies?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.PureStoragePolicy).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.PureStoragePolicy),
+            "application/json",
+        );
+    }
+    /// Get a PureStoragePolicy
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, storage_policy_name: []const u8) !models.PureStoragePolicy {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/pureStoragePolicies/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, storage_policy_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
 
-    var pcs = client.privateClouds();
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
 
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PureStoragePolicies.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.PureStoragePolicy, alloc, resp.body);
+    }
+    /// Create a PureStoragePolicy
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, storage_policy_name: []const u8, resource: models.PureStoragePolicy) !core.lro.TypedPoller(models.PureStoragePolicy) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/pureStoragePolicies/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, storage_policy_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, resource);
+        defer alloc.free(body_json);
+        req.body = body_json;
 
-    var pager = try pcs.listInSubscription(arena.allocator());
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
 
-    const page = (try pager.next()) orelse return error.ExpectedPage;
-    try testing.expectEqual(@as(usize, 2), page.len);
-    try testing.expectEqualStrings("cloud-a", page[0].name);
-    try testing.expectEqualStrings("cloud-b", page[1].name);
-    // Generic ARM accessors from `core.arm` work because the generated
-    // struct carries `pub const arm_resource_kind = .tracked` and the
-    // required base fields.
-    try testing.expectEqualStrings("eastus", core.arm.location(&page[0]).?);
-    try testing.expectEqualStrings("westus2", core.arm.location(&page[1]).?);
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PureStoragePolicies.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.PureStoragePolicy).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a PureStoragePolicy
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, storage_policy_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/pureStoragePolicies/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, storage_policy_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
 
-    try testing.expect(try pager.next() == null);
-}
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("PureStoragePolicies.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const ScriptCmdlets = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List ScriptCmdlet resources by ScriptPackage
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, script_package_name: []const u8) !core.pager.PipelinePager(models.ScriptCmdlet) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptPackages/{s}/scriptCmdlets?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, script_package_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.ScriptCmdlet).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.ScriptCmdlet),
+            "application/json",
+        );
+    }
+    /// Get a ScriptCmdlet
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, script_package_name: []const u8, script_cmdlet_name: []const u8) !models.ScriptCmdlet {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptPackages/{s}/scriptCmdlets/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, script_package_name, script_cmdlet_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ScriptCmdlets.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ScriptCmdlet, alloc, resp.body);
+    }
+};
+
+pub const ScriptExecutions = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List ScriptExecution resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.ScriptExecution) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptExecutions?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.ScriptExecution).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.ScriptExecution),
+            "application/json",
+        );
+    }
+    /// Get a ScriptExecution
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, script_execution_name: []const u8) !models.ScriptExecution {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptExecutions/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, script_execution_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ScriptExecutions.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ScriptExecution, alloc, resp.body);
+    }
+    /// Create a ScriptExecution
+    pub fn createOrUpdate(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, script_execution_name: []const u8, script_execution: models.ScriptExecution) !core.lro.TypedPoller(models.ScriptExecution) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptExecutions/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, script_execution_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, script_execution);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ScriptExecutions.createOrUpdate", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ScriptExecution).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a ScriptExecution
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, script_execution_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptExecutions/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, script_execution_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ScriptExecutions.delete", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Return the logs for a script execution resource
+    pub fn getExecutionLogs(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, script_execution_name: []const u8, script_output_stream_type: ?[]const enums.ScriptOutputStreamType) !models.ScriptExecution {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptExecutions/{s}/getExecutionLogs?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, script_execution_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, script_output_stream_type);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ScriptExecutions.getExecutionLogs", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ScriptExecution, alloc, resp.body);
+    }
+};
+
+pub const ScriptPackages = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List ScriptPackage resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.ScriptPackage) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptPackages?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.ScriptPackage).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.ScriptPackage),
+            "application/json",
+        );
+    }
+    /// Get a ScriptPackage
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, script_package_name: []const u8) !models.ScriptPackage {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/scriptPackages/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, script_package_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ScriptPackages.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ScriptPackage, alloc, resp.body);
+    }
+};
+
+pub const ServiceComponents = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// Return service component availability
+    pub fn checkAvailability(self: *@This(), alloc: std.mem.Allocator, location: []const u8, service_component_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/providers/Microsoft.AVS/locations/{s}/serviceComponents/{s}/checkAvailability?api-version={s}", .{ self.endpoint, self.subscription_id, location, service_component_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("ServiceComponents.checkAvailability", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const Skus = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// A list of SKUs.
+    pub fn list(self: *@This(), alloc: std.mem.Allocator) !core.pager.PipelinePager(models.ResourceSku) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/providers/Microsoft.AVS/skus?api-version={s}", .{ self.endpoint, self.subscription_id, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.ResourceSku).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.ResourceSku),
+            "application/json",
+        );
+    }
+};
+
+pub const VirtualMachines = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// List VirtualMachine resources by Cluster
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8) !core.pager.PipelinePager(models.VirtualMachine) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/virtualMachines?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.VirtualMachine).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.VirtualMachine),
+            "application/json",
+        );
+    }
+    /// Get a VirtualMachine
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, virtual_machine_id: []const u8) !models.VirtualMachine {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/virtualMachines/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, virtual_machine_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("VirtualMachines.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.VirtualMachine, alloc, resp.body);
+    }
+    /// Enable or disable DRS-driven VM movement restriction
+    pub fn restrictMovement(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, cluster_name: []const u8, virtual_machine_id: []const u8, restrict_movement: models.VirtualMachineRestrictMovement) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/clusters/{s}/virtualMachines/{s}/restrictMovement?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, cluster_name, virtual_machine_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        const body_json = try serde.json.toSlice(alloc, restrict_movement);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("VirtualMachines.restrictMovement", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};
+
+pub const WorkloadNetworks = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    subscription_id: []const u8,
+    /// Get a WorkloadNetwork
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !models.WorkloadNetwork {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.get", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetwork, alloc, resp.body);
+    }
+    /// List WorkloadNetwork resources by PrivateCloud
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetwork) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetwork).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetwork),
+            "application/json",
+        );
+    }
+    /// List WorkloadNetworkDhcp resources by WorkloadNetwork
+    pub fn listDhcp(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkDhcp) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dhcpConfigurations?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkDhcp).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkDhcp),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkDhcp
+    pub fn getDhcp(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, dhcp_id: []const u8, private_cloud_name: []const u8) !models.WorkloadNetworkDhcp {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dhcpConfigurations/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dhcp_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getDhcp", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkDhcp, alloc, resp.body);
+    }
+    /// Create a WorkloadNetworkDhcp
+    pub fn createDhcp(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dhcp_id: []const u8, workload_network_dhcp: models.WorkloadNetworkDhcp) !core.lro.TypedPoller(models.WorkloadNetworkDhcp) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dhcpConfigurations/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dhcp_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_dhcp);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.createDhcp", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkDhcp).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a WorkloadNetworkDhcp
+    pub fn updateDhcp(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dhcp_id: []const u8, workload_network_dhcp: models.WorkloadNetworkDhcp) !core.lro.TypedPoller(models.WorkloadNetworkDhcp) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dhcpConfigurations/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dhcp_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_dhcp);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.updateDhcp", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkDhcp).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a WorkloadNetworkDhcp
+    pub fn deleteDhcp(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dhcp_id: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dhcpConfigurations/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dhcp_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.deleteDhcp", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List WorkloadNetworkDnsService resources by WorkloadNetwork
+    pub fn listDnsServices(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkDnsService) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsServices?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkDnsService).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkDnsService),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkDnsService
+    pub fn getDnsService(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dns_service_id: []const u8) !models.WorkloadNetworkDnsService {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsServices/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_service_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getDnsService", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkDnsService, alloc, resp.body);
+    }
+    /// Create a WorkloadNetworkDnsService
+    pub fn createDnsService(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dns_service_id: []const u8, workload_network_dns_service: models.WorkloadNetworkDnsService) !core.lro.TypedPoller(models.WorkloadNetworkDnsService) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsServices/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_service_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_dns_service);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.createDnsService", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkDnsService).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a WorkloadNetworkDnsService
+    pub fn updateDnsService(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dns_service_id: []const u8, workload_network_dns_service: models.WorkloadNetworkDnsService) !core.lro.TypedPoller(models.WorkloadNetworkDnsService) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsServices/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_service_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_dns_service);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.updateDnsService", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkDnsService).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a WorkloadNetworkDnsService
+    pub fn deleteDnsService(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, dns_service_id: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsServices/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_service_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.deleteDnsService", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List WorkloadNetworkDnsZone resources by WorkloadNetwork
+    pub fn listDnsZones(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkDnsZone) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsZones?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkDnsZone).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkDnsZone),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkDnsZone
+    pub fn getDnsZone(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dns_zone_id: []const u8) !models.WorkloadNetworkDnsZone {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsZones/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_zone_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getDnsZone", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkDnsZone, alloc, resp.body);
+    }
+    /// Create a WorkloadNetworkDnsZone
+    pub fn createDnsZone(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dns_zone_id: []const u8, workload_network_dns_zone: models.WorkloadNetworkDnsZone) !core.lro.TypedPoller(models.WorkloadNetworkDnsZone) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsZones/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_zone_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_dns_zone);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.createDnsZone", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkDnsZone).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a WorkloadNetworkDnsZone
+    pub fn updateDnsZone(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, dns_zone_id: []const u8, workload_network_dns_zone: models.WorkloadNetworkDnsZone) !core.lro.TypedPoller(models.WorkloadNetworkDnsZone) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsZones/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_zone_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_dns_zone);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.updateDnsZone", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkDnsZone).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a WorkloadNetworkDnsZone
+    pub fn deleteDnsZone(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, dns_zone_id: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/dnsZones/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, dns_zone_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.deleteDnsZone", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List WorkloadNetworkGateway resources by WorkloadNetwork
+    pub fn listGateways(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkGateway) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/gateways?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkGateway).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkGateway),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkGateway
+    pub fn getGateway(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, gateway_id: []const u8) !models.WorkloadNetworkGateway {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/gateways/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, gateway_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getGateway", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkGateway, alloc, resp.body);
+    }
+    /// List WorkloadNetworkPortMirroring resources by WorkloadNetwork
+    pub fn listPortMirroring(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkPortMirroring) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/portMirroringProfiles?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkPortMirroring).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkPortMirroring),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkPortMirroring
+    pub fn getPortMirroring(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, port_mirroring_id: []const u8) !models.WorkloadNetworkPortMirroring {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/portMirroringProfiles/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, port_mirroring_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getPortMirroring", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkPortMirroring, alloc, resp.body);
+    }
+    /// Create a WorkloadNetworkPortMirroring
+    pub fn createPortMirroring(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, port_mirroring_id: []const u8, workload_network_port_mirroring: models.WorkloadNetworkPortMirroring) !core.lro.TypedPoller(models.WorkloadNetworkPortMirroring) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/portMirroringProfiles/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, port_mirroring_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_port_mirroring);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.createPortMirroring", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkPortMirroring).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a WorkloadNetworkPortMirroring
+    pub fn updatePortMirroring(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, port_mirroring_id: []const u8, workload_network_port_mirroring: models.WorkloadNetworkPortMirroring) !core.lro.TypedPoller(models.WorkloadNetworkPortMirroring) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/portMirroringProfiles/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, port_mirroring_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_port_mirroring);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.updatePortMirroring", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkPortMirroring).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a WorkloadNetworkPortMirroring
+    pub fn deletePortMirroring(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, port_mirroring_id: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/portMirroringProfiles/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, port_mirroring_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.deletePortMirroring", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List WorkloadNetworkPublicIP resources by WorkloadNetwork
+    pub fn listPublicIPs(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkPublicIP) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/publicIPs?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkPublicIP).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkPublicIP),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkPublicIP
+    pub fn getPublicIP(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, public_ip_id: []const u8) !models.WorkloadNetworkPublicIP {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/publicIPs/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, public_ip_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getPublicIP", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkPublicIP, alloc, resp.body);
+    }
+    /// Create a WorkloadNetworkPublicIP
+    pub fn createPublicIP(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, public_ip_id: []const u8, workload_network_public_ip: models.WorkloadNetworkPublicIP) !core.lro.TypedPoller(models.WorkloadNetworkPublicIP) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/publicIPs/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, public_ip_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_public_ip);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.createPublicIP", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkPublicIP).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a WorkloadNetworkPublicIP
+    pub fn deletePublicIP(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, public_ip_id: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/publicIPs/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, public_ip_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.deletePublicIP", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List WorkloadNetworkSegment resources by WorkloadNetwork
+    pub fn listSegments(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkSegment) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/segments?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkSegment).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkSegment),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkSegment
+    pub fn getSegment(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, segment_id: []const u8) !models.WorkloadNetworkSegment {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/segments/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, segment_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getSegment", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkSegment, alloc, resp.body);
+    }
+    /// Create a WorkloadNetworkSegment
+    pub fn createSegments(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, segment_id: []const u8, workload_network_segment: models.WorkloadNetworkSegment) !core.lro.TypedPoller(models.WorkloadNetworkSegment) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/segments/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, segment_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_segment);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.createSegments", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkSegment).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a WorkloadNetworkSegment
+    pub fn updateSegments(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, segment_id: []const u8, workload_network_segment: models.WorkloadNetworkSegment) !core.lro.TypedPoller(models.WorkloadNetworkSegment) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/segments/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, segment_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_segment);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.updateSegments", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkSegment).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a WorkloadNetworkSegment
+    pub fn deleteSegment(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, segment_id: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/segments/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, segment_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.deleteSegment", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// List WorkloadNetworkVirtualMachine resources by WorkloadNetwork
+    pub fn listVirtualMachines(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkVirtualMachine) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/virtualMachines?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkVirtualMachine).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkVirtualMachine),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkVirtualMachine
+    pub fn getVirtualMachine(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, virtual_machine_id: []const u8) !models.WorkloadNetworkVirtualMachine {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/virtualMachines/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, virtual_machine_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getVirtualMachine", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkVirtualMachine, alloc, resp.body);
+    }
+    /// List WorkloadNetworkVMGroup resources by WorkloadNetwork
+    pub fn listVMGroups(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8) !core.pager.PipelinePager(models.WorkloadNetworkVMGroup) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/vmGroups?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, self.api_version });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.WorkloadNetworkVMGroup).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.WorkloadNetworkVMGroup),
+            "application/json",
+        );
+    }
+    /// Get a WorkloadNetworkVMGroup
+    pub fn getVMGroup(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, vm_group_id: []const u8) !models.WorkloadNetworkVMGroup {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/vmGroups/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, vm_group_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.getVMGroup", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.WorkloadNetworkVMGroup, alloc, resp.body);
+    }
+    /// Create a WorkloadNetworkVMGroup
+    pub fn createVMGroup(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, vm_group_id: []const u8, workload_network_vm_group: models.WorkloadNetworkVMGroup) !core.lro.TypedPoller(models.WorkloadNetworkVMGroup) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/vmGroups/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, vm_group_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_vm_group);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.createVMGroup", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkVMGroup).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Update a WorkloadNetworkVMGroup
+    pub fn updateVMGroup(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, private_cloud_name: []const u8, vm_group_id: []const u8, workload_network_vm_group: models.WorkloadNetworkVMGroup) !core.lro.TypedPoller(models.WorkloadNetworkVMGroup) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/vmGroups/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, vm_group_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, workload_network_vm_group);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.updateVMGroup", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.WorkloadNetworkVMGroup).init(alloc, self.pipeline, resp, url, .{});
+    }
+    /// Delete a WorkloadNetworkVMGroup
+    pub fn deleteVMGroup(self: *@This(), alloc: std.mem.Allocator, resource_group_name: []const u8, vm_group_id: []const u8, private_cloud_name: []const u8) !core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/subscriptions/{s}/resourceGroups/{s}/providers/Microsoft.AVS/privateClouds/{s}/workloadNetworks/default/vmGroups/{s}?api-version={s}", .{ self.endpoint, self.subscription_id, resource_group_name, private_cloud_name, vm_group_id, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("WorkloadNetworks.deleteVMGroup", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try core.lro.TypedPoller(models.ArmOperationStatusResourceProvisioningState).init(alloc, self.pipeline, resp, url, .{});
+    }
+};

--- a/rest/arm_avs/src/clients_test.zig
+++ b/rest/arm_avs/src/clients_test.zig
@@ -1,0 +1,59 @@
+//! Tests for the generated `clients.zig`.
+//!
+//! Kept in a separate file so the emitter can overwrite `clients.zig`
+//! without losing test coverage. Wired into the package's test step via
+//! `root.zig`.
+
+const std = @import("std");
+const testing = std.testing;
+const core = @import("azure_core");
+const clients = @import("clients.zig");
+const models = @import("models.zig");
+
+test "AVSClient.privateClouds().listInSubscription pages mock results" {
+    const allocator = testing.allocator;
+
+    const body =
+        \\{"value":[{"name":"cloud-a","location":"eastus","sku":{"name":"av36"}},{"name":"cloud-b","location":"westus2","sku":{"name":"av36p"}}]}
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+
+    const Stub = struct {
+        fn getTokenFn(
+            _: *core.credentials.TokenCredential,
+            _: core.credentials.TokenRequestContext,
+            _: core.context.Context,
+        ) anyerror!core.credentials.AccessToken {
+            const tok = try testing.allocator.dupe(u8, "stub-token");
+            return .{ .token = tok, .expires_on = std.math.maxInt(i64) };
+        }
+    };
+    var credential = core.credentials.TokenCredential{ .getTokenFn = &Stub.getTokenFn };
+
+    var client = try clients.AVSClient.init(allocator, .{
+        .subscription_id = "00000000-0000-0000-0000-000000000000",
+        .credential = &credential,
+        .transport = mock.asTransport(),
+    });
+    defer client.deinit();
+
+    var pcs = client.privateClouds();
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var pager = try pcs.listInSubscription(arena.allocator());
+
+    const page = (try pager.next()) orelse return error.ExpectedPage;
+    try testing.expectEqual(@as(usize, 2), page.len);
+    try testing.expectEqualStrings("cloud-a", page[0].name);
+    try testing.expectEqualStrings("cloud-b", page[1].name);
+    // Generic ARM accessors from `core.arm` work because the generated
+    // struct carries `pub const arm_resource_kind = .tracked` and the
+    // required base fields.
+    try testing.expectEqualStrings("eastus", core.arm.location(&page[0]).?);
+    try testing.expectEqualStrings("westus2", core.arm.location(&page[1]).?);
+
+    try testing.expect(try pager.next() == null);
+}

--- a/rest/arm_avs/src/root.zig
+++ b/rest/arm_avs/src/root.zig
@@ -6,3 +6,7 @@ const clients = @import("clients.zig");
 pub const models = @import("models.zig");
 pub const enums = @import("enums.zig");
 pub const AVSClient = clients.AVSClient;
+
+test {
+    _ = @import("clients_test.zig");
+}

--- a/rest/keyvault_secrets/src/clients.zig
+++ b/rest/keyvault_secrets/src/clients.zig
@@ -1,123 +1,259 @@
 //! Generated service clients.
 
 const std = @import("std");
+const serde = @import("serde");
 const core = @import("azure_core");
 const models = @import("models.zig");
 const enums = @import("enums.zig");
 
+const default_api_version = "2026-03-01-preview";
+const auth_scopes: []const []const u8 = &.{"https://vault.azure.net/.default"};
+
 /// The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
 pub const KeyVaultClient = struct {
-    allocator: std.mem.Allocator,
-    pipeline: core.pipeline.HttpPipeline,
     endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    allocator: std.mem.Allocator,
+    auth_policy: *core.pipeline.BearerTokenAuthPolicy,
+    policy_ptrs: []*core.pipeline.HttpPolicy,
 
-    pub fn init(
-        allocator: std.mem.Allocator,
+    pub const InitOptions = struct {
+        credential: *core.credentials.TokenCredential,
+        transport: *core.http.HttpTransport,
         endpoint: []const u8,
-        credential: core.credentials.TokenCredential,
-        transport: core.http.Transport,
-        options: ClientOptions,
-    ) KeyVaultClient {
-        _ = options;
-        _ = credential;
+        api_version: []const u8 = default_api_version,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !KeyVaultClient {
+        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
+        errdefer allocator.destroy(auth_policy);
+        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
+            allocator,
+            options.credential,
+            auth_scopes,
+        );
+
+        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
+        errdefer allocator.free(policy_ptrs);
+        policy_ptrs[0] = auth_policy.asPolicy();
+
         return .{
             .allocator = allocator,
-            .endpoint = endpoint,
-            .pipeline = core.pipeline.HttpPipeline.init(allocator, transport),
+            .endpoint = options.endpoint,
+            .api_version = options.api_version,
+            .auth_policy = auth_policy,
+            .policy_ptrs = policy_ptrs,
+            .pipeline = .{
+                .policies = policy_ptrs,
+                .transport_impl = options.transport,
+            },
         };
     }
 
-    pub const ClientOptions = struct {};
+    pub fn deinit(self: *@This()) void {
+        self.auth_policy.deinit();
+        self.allocator.destroy(self.auth_policy);
+        self.allocator.free(self.policy_ptrs);
+    }
     /// The SET operation adds a secret to the Azure Key Vault. If the named secret already exists, Azure Key Vault creates a new version of that secret. This operation requires the secrets/set permission.
-    pub fn setSecret(self: *@This(), secret_name: []const u8, parameters: models.SecretSetParameters, content_type: std.json.Value, accept: std.json.Value) !models.SecretBundle {
-        _ = self;
-        _ = secret_name;
-        _ = parameters;
-        _ = content_type;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn setSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, parameters: models.SecretSetParameters) !models.SecretBundle {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}?api-version={s}", .{ self.endpoint, secret_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, parameters);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.setSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.SecretBundle, alloc, resp.body);
     }
     /// The DELETE operation applies to any secret stored in Azure Key Vault. DELETE cannot be applied to an individual version of a secret. This operation requires the secrets/delete permission.
-    pub fn deleteSecret(self: *@This(), secret_name: []const u8, accept: std.json.Value) !models.DeletedSecretBundle {
-        _ = self;
-        _ = secret_name;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn deleteSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.DeletedSecretBundle {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}?api-version={s}", .{ self.endpoint, secret_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.deleteSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.DeletedSecretBundle, alloc, resp.body);
     }
     /// The UPDATE operation changes specified attributes of an existing stored secret. Attributes that are not specified in the request are left unchanged. The value of a secret itself cannot be changed. This operation requires the secrets/set permission.
-    pub fn updateSecret(self: *@This(), secret_name: []const u8, secret_version: []const u8, parameters: models.SecretUpdateParameters, content_type: std.json.Value, accept: std.json.Value) !models.SecretBundle {
-        _ = self;
-        _ = secret_name;
-        _ = secret_version;
-        _ = parameters;
-        _ = content_type;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn updateSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, secret_version: []const u8, parameters: models.SecretUpdateParameters) !models.SecretBundle {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}/{s}?api-version={s}", .{ self.endpoint, secret_name, secret_version, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, parameters);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.updateSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.SecretBundle, alloc, resp.body);
     }
     /// The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires the secrets/get permission.
-    pub fn getSecret(self: *@This(), secret_name: []const u8, secret_version: []const u8, out_content_type: ?enums.ContentType, accept: std.json.Value) !models.SecretBundle {
-        _ = self;
-        _ = secret_name;
-        _ = secret_version;
-        _ = out_content_type;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn getSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, secret_version: []const u8, out_content_type: ?enums.ContentType) !models.SecretBundle {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}/{s}?api-version={s}&outContentType={s}", .{ self.endpoint, secret_name, secret_version, self.api_version, out_content_type });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.getSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.SecretBundle, alloc, resp.body);
     }
     /// The Get Secrets operation is applicable to the entire vault. However, only the base secret identifier and its attributes are provided in the response. Individual secret versions are not listed in the response. This operation requires the secrets/list permission.
-    pub fn getSecrets(self: *@This(), maxresults: ?i32, accept: std.json.Value) ![]const models.SecretItem {
-        _ = self;
-        _ = maxresults;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn getSecrets(self: *@This(), alloc: std.mem.Allocator, maxresults: ?i32) !core.pager.PipelinePager(models.SecretItem) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets?api-version={s}&maxresults={s}", .{ self.endpoint, self.api_version, maxresults });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.SecretItem).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.SecretItem),
+            "application/json",
+        );
     }
     /// The full secret identifier and attributes are provided in the response. No values are returned for the secrets. This operations requires the secrets/list permission.
-    pub fn getSecretVersions(self: *@This(), secret_name: []const u8, maxresults: ?i32, accept: std.json.Value) ![]const models.SecretItem {
-        _ = self;
-        _ = secret_name;
-        _ = maxresults;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn getSecretVersions(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, maxresults: ?i32) !core.pager.PipelinePager(models.SecretItem) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}/versions?api-version={s}&maxresults={s}", .{ self.endpoint, secret_name, self.api_version, maxresults });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.SecretItem).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.SecretItem),
+            "application/json",
+        );
     }
     /// The Get Deleted Secrets operation returns the secrets that have been deleted for a vault enabled for soft-delete. This operation requires the secrets/list permission.
-    pub fn getDeletedSecrets(self: *@This(), maxresults: ?i32, accept: std.json.Value) ![]const models.DeletedSecretItem {
-        _ = self;
-        _ = maxresults;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn getDeletedSecrets(self: *@This(), alloc: std.mem.Allocator, maxresults: ?i32) !core.pager.PipelinePager(models.DeletedSecretItem) {
+        const url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets?api-version={s}&maxresults={s}", .{ self.endpoint, self.api_version, maxresults });
+        defer alloc.free(url);
+        return core.pager.PipelinePager(models.DeletedSecretItem).init(
+            self.pipeline,
+            url,
+            alloc,
+            core.pager.listPageParser(models.DeletedSecretItem),
+            "application/json",
+        );
     }
     /// The Get Deleted Secret operation returns the specified deleted secret along with its attributes. This operation requires the secrets/get permission.
-    pub fn getDeletedSecret(self: *@This(), secret_name: []const u8, accept: std.json.Value) !models.DeletedSecretBundle {
-        _ = self;
-        _ = secret_name;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn getDeletedSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.DeletedSecretBundle {
+        const url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets/{s}?api-version={s}", .{ self.endpoint, secret_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.getDeletedSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.DeletedSecretBundle, alloc, resp.body);
     }
     /// The purge deleted secret operation removes the secret permanently, without the possibility of recovery. This operation can only be enabled on a soft-delete enabled vault. This operation requires the secrets/purge permission.
-    pub fn purgeDeletedSecret(self: *@This(), secret_name: []const u8) !void {
-        _ = self;
-        _ = secret_name;
-        return error.NotImplemented;
+    pub fn purgeDeletedSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !void {
+        const url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets/{s}?api-version={s}", .{ self.endpoint, secret_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.purgeDeletedSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return;
     }
     /// Recovers the deleted secret in the specified vault. This operation can only be performed on a soft-delete enabled vault. This operation requires the secrets/recover permission.
-    pub fn recoverDeletedSecret(self: *@This(), secret_name: []const u8, accept: std.json.Value) !models.SecretBundle {
-        _ = self;
-        _ = secret_name;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn recoverDeletedSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.SecretBundle {
+        const url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets/{s}/recover?api-version={s}", .{ self.endpoint, secret_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.recoverDeletedSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.SecretBundle, alloc, resp.body);
     }
     /// Requests that a backup of the specified secret be downloaded to the client. All versions of the secret will be downloaded. This operation requires the secrets/backup permission.
-    pub fn backupSecret(self: *@This(), secret_name: []const u8, accept: std.json.Value) !models.BackupSecretResult {
-        _ = self;
-        _ = secret_name;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn backupSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.BackupSecretResult {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}/backup?api-version={s}", .{ self.endpoint, secret_name, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.backupSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.BackupSecretResult, alloc, resp.body);
     }
     /// Restores a backed up secret, and all its versions, to a vault. This operation requires the secrets/restore permission.
-    pub fn restoreSecret(self: *@This(), parameters: models.SecretRestoreParameters, content_type: std.json.Value, accept: std.json.Value) !models.SecretBundle {
-        _ = self;
-        _ = parameters;
-        _ = content_type;
-        _ = accept;
-        return error.NotImplemented;
+    pub fn restoreSecret(self: *@This(), alloc: std.mem.Allocator, parameters: models.SecretRestoreParameters) !models.SecretBundle {
+        const url = try std.fmt.allocPrint(alloc, "{s}/secrets/restore?api-version={s}", .{ self.endpoint, self.api_version });
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        const body_json = try serde.json.toSlice(alloc, parameters);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            core.pager.logHttpError("KeyVaultClient.restoreSecret", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.SecretBundle, alloc, resp.body);
     }
 };

--- a/rest/keyvault_secrets/src/clients_test.zig
+++ b/rest/keyvault_secrets/src/clients_test.zig
@@ -1,0 +1,11 @@
+//! Tests for the generated `clients.zig`.
+//!
+//! Kept in a separate file so the emitter can overwrite
+//! `clients.zig` without losing test coverage. Wired into the
+//! package's test step via `root.zig`.
+//!
+//! This file is **operator-owned**: `codegen/scripts/sync.sh`
+//! marks it as operator-managed and never overwrites an
+//! existing copy. Add tests freely.
+
+const std = @import("std");

--- a/rest/keyvault_secrets/src/enums.zig
+++ b/rest/keyvault_secrets/src/enums.zig
@@ -3,9 +3,10 @@
 //! Azure data-plane enums are typically *extensible* — the wire
 //! contract may grow with new values that older clients still
 //! need to round-trip. Represented as a tagged union with a
-//! catch-all `unknown` variant.
+//! catch-all `unrecognized` variant.
 
 const std = @import("std");
+const core = @import("azure_core");
 
 /// Reflects the deletion recovery level currently in effect for secrets in the current vault. If it contains 'Purgeable', the secret can be permanently deleted by a privileged user; otherwise, only the system can purge the secret, at the end of the retention interval.
 pub const DeletionRecoveryLevel = union(enum) {
@@ -16,14 +17,53 @@ pub const DeletionRecoveryLevel = union(enum) {
     customized_recoverable_purgeable,
     customized_recoverable,
     customized_recoverable_protected_subscription,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .purgeable = "Purgeable",
+        .recoverable_purgeable = "Recoverable+Purgeable",
+        .recoverable = "Recoverable",
+        .recoverable_protected_subscription = "Recoverable+ProtectedSubscription",
+        .customized_recoverable_purgeable = "CustomizedRecoverable+Purgeable",
+        .customized_recoverable = "CustomizedRecoverable",
+        .customized_recoverable_protected_subscription = "CustomizedRecoverable+ProtectedSubscription",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The media type (MIME type).
 pub const ContentType = union(enum) {
     pfx,
     pem,
-    unknown: []const u8,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .pfx = "application/x-pkcs12",
+        .pem = "application/x-pem-file",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
 };
 
 /// The available API versions.

--- a/rest/keyvault_secrets/src/root.zig
+++ b/rest/keyvault_secrets/src/root.zig
@@ -6,3 +6,7 @@ const clients = @import("clients.zig");
 pub const models = @import("models.zig");
 pub const enums = @import("enums.zig");
 pub const KeyVaultClient = clients.KeyVaultClient;
+
+test {
+    _ = @import("clients_test.zig");
+}

--- a/sdk/core/lro.zig
+++ b/sdk/core/lro.zig
@@ -256,6 +256,59 @@ pub const Poller = struct {
     }
 };
 
+// ─────────────────── Typed Poller wrapper ──────────────────
+
+/// Typed convenience wrapper over `Poller`. Used by generated ARM
+/// clients so callers can `await` an LRO and receive the parsed
+/// resource type instead of having to deserialize `PollResult.raw_body`
+/// themselves.
+///
+/// Specialize `T = void` for operations with no body (e.g. ARM DELETE
+/// LROs) — `pollUntilDone` then returns `void` without attempting to
+/// parse the response body.
+pub fn TypedPoller(comptime T: type) type {
+    return struct {
+        inner: Poller,
+
+        const Self = @This();
+
+        pub fn init(
+            allocator: std.mem.Allocator,
+            pipeline: pipeline_mod.HttpPipeline,
+            initial_response: http.Response,
+            original_url: ?[]const u8,
+            options: PollerOptions,
+        ) !Self {
+            return .{ .inner = try Poller.init(allocator, pipeline, initial_response, original_url, options) };
+        }
+
+        /// Single poll step; returns the new status without driving to
+        /// completion. Forwards to the embedded `Poller`.
+        pub fn poll(self: *Self) !OperationStatus {
+            return self.inner.poll();
+        }
+
+        /// Current cached status (does not perform I/O).
+        pub fn getStatus(self: *const Self) OperationStatus {
+            return self.inner.getStatus();
+        }
+
+        /// Drive the LRO to a terminal state and return the parsed `T`.
+        /// `allocator` owns the returned value's heap data; the
+        /// poll-result body is released before this method returns.
+        pub fn pollUntilDone(self: *Self, allocator: std.mem.Allocator) !T {
+            var raw = try self.inner.pollUntilDone();
+            defer raw.deinit();
+            if (T == void) return;
+            return try serde.json.fromSlice(T, allocator, raw.raw_body);
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.inner.deinit();
+        }
+    };
+}
+
 // ─────────────────── Strategy Detection ────────────────────
 
 fn detectStrategy(response: http.Response) !PollingStrategy {


### PR DESCRIPTION
Closes #27.

Replaces the hand-written `rest/arm_avs/src/clients.zig` shim with a fully generated client tree and extends the TypeSpec → Zig emitter to produce ARM-shaped clients end-to-end.

## Emitter

- **Adapter** (`codegen/tcgc-component/src/index.js`) surfaces `is_root`, `init_parameters`, typed user/path/query/header/body parameter buckets, paging envelope (`value_next_link` + `item_type`), and LRO `final_response_type` from `method.response.type`.
- Extracted Node-CLI bits to `codegen/tcgc-component/src/cli.js` so `index.js` stays wasm-bundle-safe; `wasi-host.js` now re-imports the adapter/emitter functions from `index.js` (no more duplicated copy).
- **Zig code model** (`codegen/cli/src/codemodel.zig`) mirrors the new shape via `InitParameter` / `UserParameter` / `WireParameter` / `WireSource` / `BodyParameter` and reshaped `Client`/`Method`/`SubClient`/`Paging`.
- **Zig emitter** (`codegen/cli/src/emit.zig`) generates per-family root constants (`default_endpoint`, `default_api_version`, `auth_scopes`), root client with `BearerTokenAuthPolicy` + `InitOptions`/`init`/`deinit`, sub-client accessors, sub-client structs, and full method bodies:
  - LIST -> `PipelinePager(T)`
  - GET -> typed deserialize
  - PUT/PATCH -> `serde.json.toSlice` body
  - DELETE -> void
  - LRO -> `TypedPoller(T)`
- `sdk/core/lro.zig` grows a `TypedPoller(T)` wrapper (specializes `T == void`).
- `main.zig` parses JSON via `parseFromTokenSource` + `Diagnostics` so future `MissingField` errors show line/col/byte/context.

## Operator-owned tests

- Emitter now writes a stub `src/clients_test.zig` and wires `test { _ = @import("clients_test.zig"); }` into `root.zig` so package tests stay reachable across regenerations.
- `sync.sh` promotes `src/clients.zig` and `src/enums.zig` to `SAFE_FILES`, adds `src/clients_test.zig` to `MANAGED_FILES` (skip-and-warn), and seeds missing files automatically so new packages don't need `--force`.

## arm_avs

- `src/clients.zig` regenerated: `AVSClient` + 24 sub-client accessors + 24 sub-client structs with full LIST/GET/CREATEORUPDATE/UPDATE/DELETE/POST bodies (~2500 lines).
- Preserved the mock-pager test in `src/clients_test.zig`.
- Added `serde` dep to `build.zig{,.zon}`; new `list-clusters` example exercises the `Clusters` sub-client.

## keyvault_secrets

- Regenerated against the new emitter and seeded `clients_test.zig` stub (verifies the emitter changes are package-agnostic).

## Verification

- `zig build test --summary all` -> **242/242 tests pass**.
- `zig fmt --check` clean.
- `codegen/scripts/sync.sh arm_avs` is **idempotent** (0 copies on rerun).

## Follow-ups (filed as separate issues)

- DELETE LRO methods are typed as `TypedPoller(models.ArmOperationStatus...)` instead of `TypedPoller(void)`. Refine `adaptLro` to force `void` for DELETE.
- Optional query params (e.g. `Maintenances.list`) are appended unconditionally to the URL -- compiles, behavior wrong when value is `None`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
