### PR TITLE
codegen: wire serde into generated build.zig + ignore zig-pkg/

### DIFF
--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -1071,11 +1071,18 @@ fn renderBuildZig(allocator: std.mem.Allocator, pkg_name: []const u8) ![]u8 {
         \\    }});
         \\    const azure_core_mod = azure_sdk_dep.module("azure_core");
         \\
+        \\    const serde_dep = b.dependency("serde", .{{
+        \\        .target = target,
+        \\        .optimize = optimize,
+        \\    }});
+        \\    const serde_mod = serde_dep.module("serde");
+        \\
         \\    _ = b.addModule("{[name]s}", .{{
         \\        .root_source_file = b.path("src/root.zig"),
         \\        .target = target,
         \\        .imports = &.{{
         \\            .{{ .name = "azure_core", .module = azure_core_mod }},
+        \\            .{{ .name = "serde", .module = serde_mod }},
         \\        }},
         \\    }});
         \\
@@ -1086,6 +1093,7 @@ fn renderBuildZig(allocator: std.mem.Allocator, pkg_name: []const u8) ![]u8 {
         \\            .optimize = optimize,
         \\            .imports = &.{{
         \\                .{{ .name = "azure_core", .module = azure_core_mod }},
+        \\                .{{ .name = "serde", .module = serde_mod }},
         \\            }},
         \\        }}),
         \\    }});
@@ -1122,6 +1130,14 @@ fn renderBuildZigZon(
         );
     defer allocator.free(azure_sdk_entry);
 
+    const serde_entry =
+        \\        .serde = .{
+        \\            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
+        \\            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+        \\        },
+        \\
+    ;
+
     return std.fmt.allocPrint(allocator,
         \\.{{
         \\    .name = .{[name_id]s},
@@ -1129,7 +1145,7 @@ fn renderBuildZigZon(
         \\    .fingerprint = 0x{[fp]x},
         \\    .minimum_zig_version = "0.16.0",
         \\    .dependencies = .{{
-        \\{[sdk]s}    }},
+        \\{[sdk]s}{[serde]s}    }},
         \\    .paths = .{{
         \\        "build.zig",
         \\        "build.zig.zon",
@@ -1143,6 +1159,7 @@ fn renderBuildZigZon(
         .version = pkg_version,
         .fp = computeFingerprint(pkg_name),
         .sdk = azure_sdk_entry,
+        .serde = serde_entry,
     });
 }
 

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -121,7 +121,7 @@ pub fn emit(
     ,
         opts.run_zig_fmt,
     );
-    try writeFile(allocator, io, out_dir, ".gitignore", "zig-cache/\nzig-out/\n.zig-cache/\n", opts.run_zig_fmt);
+    try writeFile(allocator, io, out_dir, ".gitignore", "zig-cache/\nzig-out/\nzig-pkg/\n.zig-cache/\n", opts.run_zig_fmt);
 }
 
 /// Write `content` to `<out_dir>/<sub_path>`. When `fmt_enabled` is true


### PR DESCRIPTION
Two fixes to the code generator's emitted package scaffolding (`codegen/cli/src/emit.zig`):

## 1. Wire `serde` into the generated `build.zig`

Generated `src/clients.zig` does `@import("serde")` for JSON (de)serialization (used by `get`, `createOrUpdate`, `update`, … — 74 call sites in the AVS client alone), but the emitted `build.zig` only wired `azure_core` into the module. Any serde-using method failed to compile:

```
error: no module named 'serde' available within module 'arm_avs'
const serde = @import("serde");
```

This was latent because list-only examples (e.g. `listInSubscription`) don't touch serde, so Zig's lazy analysis never resolved the import. The emitter now emits a pinned `serde.zig` dependency in `build.zig.zon` and imports the `serde` module into both the package module and its test module, mirroring the operator-managed `rest/<pkg>` layout.

## 2. Ignore `zig-pkg/`

Zig materializes a `zig-pkg/` package-cache dir in the package root during builds; add it to the generated `.gitignore` alongside `zig-out/` and the zig caches.

## Verification

- `zig build test` in `codegen/cli` (emitter unit tests) passes.
- Regenerated `arm_avs` and `keyvault_secrets`; both build + test standalone.
- A consumer project calling serde-using methods (`get`/`createOrUpdate`) now compiles (previously failed).

Generated branches `arm_avs` and `keyvault_secrets` have been updated with the regenerated `build.zig`/`build.zig.zon`.