### PR TITLE
core: @alignCast vtable @fieldParentPtr reconstructions for wasm32

### DIFF
--- a/sdk/core/credentials/token.zig
+++ b/sdk/core/credentials/token.zig
@@ -71,7 +71,7 @@ pub const CachedTokenCredential = struct {
         request_context: TokenRequestContext,
         ctx: context_mod.Context,
     ) anyerror!AccessToken {
-        const self: *CachedTokenCredential = @fieldParentPtr("credential", cred);
+        const self: *CachedTokenCredential = @alignCast(@fieldParentPtr("credential", cred));
         const now = currentTimestamp();
 
         // Return cached token if still valid.

--- a/sdk/core/http/pipeline.zig
+++ b/sdk/core/http/pipeline.zig
@@ -83,7 +83,7 @@ pub const TelemetryPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        const self: *TelemetryPolicy = @fieldParentPtr("policy", policy);
+        const self: *TelemetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
         try request.setHeader("User-Agent", self.user_agent);
         return callNext(request, next, final_transport);
     }
@@ -145,7 +145,7 @@ pub const RetryPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        const self: *RetryPolicy = @fieldParentPtr("policy", policy);
+        const self: *RetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
         var attempt: u32 = 0;
         var prng = std.Random.DefaultPrng.init(@truncate(@as(u128, @bitCast(nanoTimestamp()))));
         while (true) {
@@ -237,7 +237,7 @@ pub const BearerTokenAuthPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        const self: *BearerTokenAuthPolicy = @fieldParentPtr("policy", policy);
+        const self: *BearerTokenAuthPolicy = @alignCast(@fieldParentPtr("policy", policy));
         const now = unixTimestampSeconds();
         const refresh_buffer: i64 = 300; // 5 minutes before expiry
 
@@ -329,7 +329,7 @@ pub const TracingPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        const self: *TracingPolicy = @fieldParentPtr("policy", policy);
+        const self: *TracingPolicy = @alignCast(@fieldParentPtr("policy", policy));
 
         const span = self.tracer.startSpan("HTTP", .client) catch {
             return callNext(request, next, final_transport);

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -107,7 +107,7 @@ pub const StdHttpTransport = struct {
     }
 
     fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *StdHttpTransport = @fieldParentPtr("transport", transport);
+        const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
         const allocator = self.allocator;
 
         var client: std.http.Client = .{ .allocator = allocator, .io = self.io };
@@ -242,7 +242,7 @@ pub const MockTransport = struct {
     }
 
     fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *MockTransport = @fieldParentPtr("transport", transport);
+        const self: *MockTransport = @alignCast(@fieldParentPtr("transport", transport));
         self.last_method = request.method;
         if (self.last_url) |old| self.allocator.free(old);
         self.last_url = try self.allocator.dupe(u8, request.url);
@@ -286,7 +286,7 @@ pub const SequenceMockTransport = struct {
     }
 
     fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *SequenceMockTransport = @fieldParentPtr("transport", transport);
+        const self: *SequenceMockTransport = @alignCast(@fieldParentPtr("transport", transport));
         _ = request;
         const idx = @min(self.call_count, self.responses.len - 1);
         self.call_count += 1;

--- a/sdk/core/pager.zig
+++ b/sdk/core/pager.zig
@@ -110,7 +110,7 @@ pub fn PipelinePager(comptime T: type) type {
         }
 
         fn nextImpl(pager_ptr: *Pager(T)) anyerror!?[]T {
-            const self: *Self = @fieldParentPtr("pager", pager_ptr);
+            const self: *Self = @alignCast(@fieldParentPtr("pager", pager_ptr));
             const url = self.next_url orelse return null;
 
             var req = transport.Request.init(self.allocator, .GET, url);
@@ -138,7 +138,7 @@ pub fn PipelinePager(comptime T: type) type {
         }
 
         fn deinitImpl(pager_ptr: *Pager(T)) void {
-            const self: *Self = @fieldParentPtr("pager", pager_ptr);
+            const self: *Self = @alignCast(@fieldParentPtr("pager", pager_ptr));
             self.deinit();
         }
     };

--- a/sdk/core/testing/root.zig
+++ b/sdk/core/testing/root.zig
@@ -48,7 +48,7 @@ pub const PlaybackTransport = struct {
     }
 
     fn sendImpl(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *PlaybackTransport = @fieldParentPtr("transport", transport);
+        const self: *PlaybackTransport = @alignCast(@fieldParentPtr("transport", transport));
         if (self.index >= self.recordings.len) return error.NoMoreRecordings;
 
         const rec = self.recordings[self.index];
@@ -134,7 +134,7 @@ pub const RecordingTransport = struct {
     }
 
     fn sendImpl(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *RecordingTransport = @fieldParentPtr("transport", transport);
+        const self: *RecordingTransport = @alignCast(@fieldParentPtr("transport", transport));
 
         // Forward to inner transport.
         const resp = try self.inner.send(request);

--- a/sdk/core/tracing/root.zig
+++ b/sdk/core/tracing/root.zig
@@ -81,7 +81,7 @@ pub const NoopTracerProvider = struct {
     fn getTracerImpl(p: *TracerProvider, name: []const u8, version: []const u8) *Tracer {
         _ = name;
         _ = version;
-        const self: *NoopTracerProvider = @fieldParentPtr("provider", p);
+        const self: *NoopTracerProvider = @alignCast(@fieldParentPtr("provider", p));
         return &self.tracer.tracer;
     }
 };
@@ -99,7 +99,7 @@ pub const NoopTracer = struct {
     fn startSpanImpl(t: *Tracer, name: []const u8, kind: SpanKind) !*Span {
         _ = name;
         _ = kind;
-        const self: *NoopTracer = @fieldParentPtr("tracer", t);
+        const self: *NoopTracer = @alignCast(@fieldParentPtr("tracer", t));
         return &self.span.span;
     }
 };
@@ -166,17 +166,17 @@ pub const RecordingSpan = struct {
     }
 
     fn setAttributeImpl(s: *Span, key: []const u8, value: []const u8) !void {
-        const self: *RecordingSpan = @fieldParentPtr("span", s);
+        const self: *RecordingSpan = @alignCast(@fieldParentPtr("span", s));
         try self.attributes.put(key, value);
     }
 
     fn setStatusImpl(s: *Span, status: SpanStatus) void {
-        const self: *RecordingSpan = @fieldParentPtr("span", s);
+        const self: *RecordingSpan = @alignCast(@fieldParentPtr("span", s));
         self.status = status;
     }
 
     fn endImpl(s: *Span) void {
-        const self: *RecordingSpan = @fieldParentPtr("span", s);
+        const self: *RecordingSpan = @alignCast(@fieldParentPtr("span", s));
         self.ended = true;
     }
 };
@@ -203,7 +203,7 @@ pub const RecordingTracer = struct {
     }
 
     fn startSpanImpl(t: *Tracer, name: []const u8, kind: SpanKind) !*Span {
-        const self: *RecordingTracer = @fieldParentPtr("tracer", t);
+        const self: *RecordingTracer = @alignCast(@fieldParentPtr("tracer", t));
         if (self.last_span) |*s| s.deinit();
         self.last_span = RecordingSpan.init(self.allocator, name, kind);
         return &self.last_span.?.span;


### PR DESCRIPTION
## Problem

`azure_core` reconstructs its vtable structs from an embedded interface field
via `@fieldParentPtr` (e.g. `BearerTokenAuthPolicy` from its `HttpPolicy`,
`CachedTokenCredential` from its `TokenCredential`). On 64-bit targets this is
fine because everything is 8-aligned, but on **wasm32** the function-pointer
vtables are 4-aligned while the embedding structs can be 8-aligned (e.g.
`BearerTokenAuthPolicy`/`CachedTokenCredential` have an `i64` expiry field). The
compiler then rejects the reconstruction:

```
error: @fieldParentPtr increases pointer alignment
    const self: *BearerTokenAuthPolicy = @fieldParentPtr("policy", policy);
note: parent pointer type '...BearerTokenAuthPolicy' has alignment '2'
note: struct field 'policy' limits alignment to '...'
note: use @alignCast to assert pointer alignment
```

This blocks building `azure_core` (and any SDK on top of it, e.g. `arm_avs`)
for `wasm32-wasi` — needed to run SDK clients as WebAssembly components (e.g.
the `wasi:http/outgoing-handler` transport in a forthcoming
`examples/arm_avs_wasi`).

## Fix

Wrap every vtable `@fieldParentPtr` reconstruction in `sdk/core` with
`@alignCast`. The assertion is sound — these parents are always allocated at
their natural alignment — and `@alignCast` is a no-op on 64-bit targets, so
existing behavior is unchanged.

## Verification

`zig build test` passes identically before and after (same exit code, same
output). The change is mechanical and uniform: every edit just wraps the
existing `@fieldParentPtr(...)` in `@alignCast(...)`.