### PR TITLE
refactor: move azure_identity into azure_core (remove the module)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,21 +28,11 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    const identity_mod = b.addModule("azure_identity", .{
-        .root_source_file = b.path("sdk/identity/root.zig"),
-        .target = target,
-        .imports = &.{
-            .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "serde", .module = serde_mod },
-        },
-    });
-
     const blobs_mod = b.addModule("azure_storage_blobs", .{
         .root_source_file = b.path("sdk/storage/blobs/root.zig"),
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -61,7 +51,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -71,7 +60,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
         },
     });
 
@@ -80,7 +68,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -90,7 +77,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -100,7 +86,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -110,7 +95,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -165,7 +149,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
         },
     });
 
@@ -174,7 +157,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "azure_kusto_common", .module = kusto_common_mod },
             .{ .name = "serde", .module = serde_mod },
         },
@@ -208,7 +190,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "uamqp", .module = uamqp_mod },
             .{ .name = "azure_messaging_common", .module = messaging_common_mod },
         },
@@ -219,7 +200,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "azure_storage_blobs", .module = blobs_mod },
             .{ .name = "azure_messaging_eventhubs", .module = eventhubs_mod },
             .{ .name = "serde", .module = serde_mod },
@@ -231,7 +211,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
-            .{ .name = "azure_identity", .module = identity_mod },
             .{ .name = "uamqp", .module = uamqp_mod },
             .{ .name = "azure_messaging_common", .module = messaging_common_mod },
             .{ .name = "serde", .module = serde_mod },
@@ -269,20 +248,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
-    const identity_tests = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("sdk/identity/root.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "azure_core", .module = core_mod },
-                .{ .name = "serde", .module = serde_mod },
-            },
-        }),
-    });
-
     const run_core_tests = b.addRunArtifact(core_tests);
-    const run_identity_tests = b.addRunArtifact(identity_tests);
 
     const storage_common_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -304,7 +270,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "azure_core", .module = core_mod },
-                .{ .name = "azure_identity", .module = identity_mod },
                 .{ .name = "serde", .module = serde_mod },
             },
         }),
@@ -318,7 +283,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "azure_core", .module = core_mod },
-                .{ .name = "azure_identity", .module = identity_mod },
             },
         }),
     });
@@ -326,7 +290,6 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run all tests");
     test_step.dependOn(&run_core_tests.step);
-    test_step.dependOn(&run_identity_tests.step);
     test_step.dependOn(&run_storage_common_tests.step);
     test_step.dependOn(&run_kv_secrets_tests.step);
     test_step.dependOn(&run_tables_tests.step);
@@ -352,7 +315,6 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
-                    .{ .name = "azure_identity", .module = identity_mod },
                     .{ .name = "serde", .module = serde_mod },
                 },
             }),
@@ -369,7 +331,6 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
-                    .{ .name = "azure_identity", .module = identity_mod },
                     .{ .name = "uamqp", .module = uamqp_mod },
                     .{ .name = "azure_messaging_common", .module = messaging_common_mod },
                 },
@@ -387,7 +348,6 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
-                    .{ .name = "azure_identity", .module = identity_mod },
                     .{ .name = "azure_storage_blobs", .module = blobs_mod },
                     .{ .name = "azure_messaging_eventhubs", .module = eventhubs_mod },
                     .{ .name = "serde", .module = serde_mod },
@@ -418,7 +378,6 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
-                    .{ .name = "azure_identity", .module = identity_mod },
                     .{ .name = "uamqp", .module = uamqp_mod },
                     .{ .name = "azure_messaging_common", .module = messaging_common_mod },
                     .{ .name = "serde", .module = serde_mod },
@@ -437,7 +396,6 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
-                    .{ .name = "azure_identity", .module = identity_mod },
                 },
             }),
         });
@@ -453,7 +411,6 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
-                    .{ .name = "azure_identity", .module = identity_mod },
                     .{ .name = "azure_kusto_common", .module = kusto_common_mod },
                     .{ .name = "serde", .module = serde_mod },
                 },
@@ -535,7 +492,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "azure_core", .module = core_mod },
-                .{ .name = "azure_identity", .module = identity_mod },
             },
         }),
     });

--- a/rest/arm_avs/build.zig
+++ b/rest/arm_avs/build.zig
@@ -9,7 +9,6 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const azure_core_mod = azure_sdk_dep.module("azure_core");
-    const azure_identity_mod = azure_sdk_dep.module("azure_identity");
 
     const serde_dep = b.dependency("serde", .{
         .target = target,
@@ -52,7 +51,6 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{ .name = "arm_avs", .module = lib_mod },
                 .{ .name = "azure_core", .module = azure_core_mod },
-                .{ .name = "azure_identity", .module = azure_identity_mod },
             },
         }),
     });
@@ -74,7 +72,6 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{ .name = "arm_avs", .module = lib_mod },
                 .{ .name = "azure_core", .module = azure_core_mod },
-                .{ .name = "azure_identity", .module = azure_identity_mod },
             },
         }),
     });

--- a/rest/arm_avs/examples/list_clusters.zig
+++ b/rest/arm_avs/examples/list_clusters.zig
@@ -11,7 +11,7 @@
 
 const std = @import("std");
 const core = @import("azure_core");
-const identity = @import("azure_identity");
+const identity = @import("azure_core").identity;
 const arm_avs = @import("arm_avs");
 
 pub fn main(init: std.process.Init) !void {

--- a/rest/arm_avs/examples/list_private_clouds.zig
+++ b/rest/arm_avs/examples/list_private_clouds.zig
@@ -12,7 +12,7 @@
 
 const std = @import("std");
 const core = @import("azure_core");
-const identity = @import("azure_identity");
+const identity = @import("azure_core").identity;
 const arm_avs = @import("arm_avs");
 
 pub fn main(init: std.process.Init) !void {

--- a/sdk/attestation/root.zig
+++ b/sdk/attestation/root.zig
@@ -153,7 +153,7 @@ test "AttestationClient attestSgxEnclave" {
     );
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/core/identity/azure_cli.zig
+++ b/sdk/core/identity/azure_cli.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 const serde = @import("serde");
 
 const AccessToken = core.credentials.AccessToken;

--- a/sdk/core/identity/azure_developer_cli.zig
+++ b/sdk/core/identity/azure_developer_cli.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 const serde = @import("serde");
 
 const AccessToken = core.credentials.AccessToken;

--- a/sdk/core/identity/azure_pipelines.zig
+++ b/sdk/core/identity/azure_pipelines.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 const serde = @import("serde");
 const client_assertion = @import("client_assertion.zig");
 

--- a/sdk/core/identity/client_assertion.zig
+++ b/sdk/core/identity/client_assertion.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 const serde = @import("serde");
 
 const AccessToken = core.credentials.AccessToken;

--- a/sdk/core/identity/client_certificate.zig
+++ b/sdk/core/identity/client_certificate.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 const client_assertion = @import("client_assertion.zig");
 
 const AccessToken = core.credentials.AccessToken;

--- a/sdk/core/identity/client_secret.zig
+++ b/sdk/core/identity/client_secret.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 const serde = @import("serde");
 
 const AccessToken = core.credentials.AccessToken;

--- a/sdk/core/identity/default_azure_credential.zig
+++ b/sdk/core/identity/default_azure_credential.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 
 const AccessToken = core.credentials.AccessToken;
 const TokenCredential = core.credentials.TokenCredential;

--- a/sdk/core/identity/environment.zig
+++ b/sdk/core/identity/environment.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 
 const AccessToken = core.credentials.AccessToken;
 const TokenCredential = core.credentials.TokenCredential;

--- a/sdk/core/identity/managed_identity.zig
+++ b/sdk/core/identity/managed_identity.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 
 const AccessToken = core.credentials.AccessToken;
 const TokenCredential = core.credentials.TokenCredential;

--- a/sdk/core/identity/root.zig
+++ b/sdk/core/identity/root.zig
@@ -2,7 +2,7 @@
 ///!
 ///! Provides DefaultAzureCredential and individual credential types for
 ///! authenticating with Azure services.
-const core = @import("azure_core");
+const core = @import("../root.zig");
 
 pub const TokenCredential = core.credentials.TokenCredential;
 pub const AccessToken = core.credentials.AccessToken;

--- a/sdk/core/identity/workload_identity.zig
+++ b/sdk/core/identity/workload_identity.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const core = @import("azure_core");
+const core = @import("../root.zig");
 
 const AccessToken = core.credentials.AccessToken;
 const TokenCredential = core.credentials.TokenCredential;

--- a/sdk/core/root.zig
+++ b/sdk/core/root.zig
@@ -16,6 +16,7 @@ pub const http = @import("http/transport.zig");
 pub const pipeline = @import("http/pipeline.zig");
 pub const decompression = @import("http/decompression.zig");
 pub const credentials = @import("credentials/token.zig");
+pub const identity = @import("identity/root.zig");
 pub const context = @import("context.zig");
 pub const url = @import("url.zig");
 pub const uuid = @import("uuid.zig");

--- a/sdk/data/appconfiguration/root.zig
+++ b/sdk/data/appconfiguration/root.zig
@@ -299,7 +299,7 @@ test "ConfigurationClient getSetting" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -332,7 +332,7 @@ test "ConfigurationClient setSetting and listSettings" {
     );
     defer mock_set.deinit();
 
-    const identity2 = @import("azure_identity");
+    const identity2 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/data/cosmos/root.zig
+++ b/sdk/data/cosmos/root.zig
@@ -698,7 +698,7 @@ test "ConsistencyLevel toString" {
 }
 
 fn createTestClient(mock: *core.http.MockTransport) CosmosClient {
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     // Use a stack-allocated mock for credential — not actually called in tests.
     var cred_mock = core.http.MockTransport.init(mock.allocator, 200,
         \\{"access_token":"t","expires_in":3600}
@@ -901,7 +901,7 @@ test "CosmosClient with consistency level" {
         \\{"Databases":[],"_count":0}
     );
     defer mock.deinit();
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/data/tables/root.zig
+++ b/sdk/data/tables/root.zig
@@ -193,7 +193,7 @@ test "TableClient getEntity builds correct URL" {
     var mock = core.http.MockTransport.init(allocator, 200, "{}");
     defer mock.deinit();
 
-    const client_secret = @import("azure_identity").client_secret;
+    const client_secret = @import("azure_core").identity.client_secret;
     var inner_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/keyvault/administration/root.zig
+++ b/sdk/keyvault/administration/root.zig
@@ -343,7 +343,7 @@ test "BackupClient beginBackup" {
     );
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -372,7 +372,7 @@ test "SettingsClient getSetting" {
     );
     defer mock.deinit();
 
-    const identity2 = @import("azure_identity");
+    const identity2 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/keyvault/certificates/root.zig
+++ b/sdk/keyvault/certificates/root.zig
@@ -285,7 +285,7 @@ test "CertificateClient getCertificate" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/keyvault/keys/root.zig
+++ b/sdk/keyvault/keys/root.zig
@@ -416,7 +416,7 @@ test "KeyClient createKey and getKey" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -447,7 +447,7 @@ test "CryptographyClient encrypt" {
     );
     defer mock.deinit();
 
-    const identity2 = @import("azure_identity");
+    const identity2 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/keyvault/secrets/root.zig
+++ b/sdk/keyvault/secrets/root.zig
@@ -420,7 +420,7 @@ test "SecretClient getSecretResult: ok path" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -449,7 +449,7 @@ test "SecretClient getSecretResult: err path surfaces SecretNotFound code" {
     var mock = core.http.MockTransport.init(allocator, 404, body);
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -477,7 +477,7 @@ test "SecretClient getSecretResult: err path with no parseable body" {
     var mock = core.http.MockTransport.init(allocator, 500, "Internal Server Error");
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -512,7 +512,7 @@ test "SecretClient getSecret" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -543,7 +543,7 @@ test "SecretClient setSecret" {
     );
     defer mock.deinit();
 
-    const identity2 = @import("azure_identity");
+    const identity2 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -573,7 +573,7 @@ test "SecretClient getSecret 404" {
     var mock = core.http.MockTransport.init(allocator, 404, body);
     defer mock.deinit();
 
-    const identity3 = @import("azure_identity");
+    const identity3 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -598,7 +598,7 @@ test "SecretClient setSecret failure" {
     );
     defer mock.deinit();
 
-    const identity4 = @import("azure_identity");
+    const identity4 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -624,7 +624,7 @@ test "SecretClient listSecrets" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity5 = @import("azure_identity");
+    const identity5 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/kusto/common.zig
+++ b/sdk/kusto/common.zig
@@ -139,7 +139,7 @@ test "KustoConnectionStringBuilder build" {
 }
 
 test "KustoConnectionStringBuilder withTokenCredential" {
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     const allocator = std.testing.allocator;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}

--- a/sdk/messaging/eventhubs/checkpoint_store.zig
+++ b/sdk/messaging/eventhubs/checkpoint_store.zig
@@ -292,7 +292,7 @@ test "BlobCheckpointStore updateCheckpoint" {
     var mock = core.http.MockTransport.init(allocator, 201, "");
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/messaging/eventhubs/root.zig
+++ b/sdk/messaging/eventhubs/root.zig
@@ -550,7 +550,7 @@ test "EventPosition fromEnqueuedTime" {
 
 test "ProducerClient createBatch" {
     const allocator = std.testing.allocator;
-    const cred_mod = @import("azure_identity").client_secret;
+    const cred_mod = @import("azure_core").identity.client_secret;
     var mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -568,7 +568,7 @@ test "ProducerClient createBatch" {
 
 test "ProducerClient sendBatch" {
     const allocator = std.testing.allocator;
-    const cred_mod = @import("azure_identity").client_secret;
+    const cred_mod = @import("azure_core").identity.client_secret;
     var mock_http = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -593,7 +593,7 @@ test "ProducerClient sendBatch" {
 
 test "ProducerClient sendBatch empty returns error" {
     const allocator = std.testing.allocator;
-    const cred_mod = @import("azure_identity").client_secret;
+    const cred_mod = @import("azure_core").identity.client_secret;
     var mock_http = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -614,7 +614,7 @@ test "ProducerClient sendBatch empty returns error" {
 
 test "ProducerClient getEventHubProperties" {
     const allocator = std.testing.allocator;
-    const cred_mod = @import("azure_identity").client_secret;
+    const cred_mod = @import("azure_core").identity.client_secret;
     var mock_http = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -634,7 +634,7 @@ test "ProducerClient getEventHubProperties" {
 
 test "ConsumerClient receiveEvents" {
     const allocator = std.testing.allocator;
-    const cred_mod = @import("azure_identity").client_secret;
+    const cred_mod = @import("azure_core").identity.client_secret;
     var mock_http = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/messaging/servicebus/root.zig
+++ b/sdk/messaging/servicebus/root.zig
@@ -1073,7 +1073,7 @@ test "AdministrationClient createQueue" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
     defer mock.deinit();
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -1089,7 +1089,7 @@ test "AdministrationClient deleteQueue" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, "");
     defer mock.deinit();
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -1107,7 +1107,7 @@ test "AdministrationClient listQueues" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -1128,7 +1128,7 @@ test "AdministrationClient createSubscription" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
     defer mock.deinit();
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/storage/blobs/root.zig
+++ b/sdk/storage/blobs/root.zig
@@ -389,7 +389,7 @@ test "BlobContainerClient create and listBlobs" {
     var mock_create = core.http.MockTransport.init(allocator, 201, "");
     defer mock_create.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -431,7 +431,7 @@ test "BlobClient download and upload" {
     var mock_upload = core.http.MockTransport.init(allocator, 201, "");
     defer mock_upload.deinit();
 
-    const identity2 = @import("azure_identity");
+    const identity2 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -469,7 +469,7 @@ test "BlobClient uploadConditional with etag" {
     };
     defer mock.deinit();
 
-    const identity_uc = @import("azure_identity");
+    const identity_uc = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -502,7 +502,7 @@ test "BlobClient getProperties with etag" {
     };
     defer mock.deinit();
 
-    const identity_gp = @import("azure_identity");
+    const identity_gp = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -534,7 +534,7 @@ test "BlobClient download 404" {
     );
     defer mock.deinit();
 
-    const identity3 = @import("azure_identity");
+    const identity3 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/storage/files/datalake/root.zig
+++ b/sdk/storage/files/datalake/root.zig
@@ -258,7 +258,7 @@ test "DataLakeFileClient create append flush and read" {
     var mock_create = core.http.MockTransport.init(allocator, 201, "");
     defer mock_create.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/storage/files/shares/root.zig
+++ b/sdk/storage/files/shares/root.zig
@@ -311,7 +311,7 @@ test "ShareFileClient create and download" {
     var mock_create = core.http.MockTransport.init(allocator, 201, "");
     defer mock_create.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );

--- a/sdk/storage/queues/root.zig
+++ b/sdk/storage/queues/root.zig
@@ -292,7 +292,7 @@ test "QueueClient sendMessage" {
     var mock = core.http.MockTransport.init(allocator, 201, "");
     defer mock.deinit();
 
-    const identity = @import("azure_identity");
+    const identity = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );
@@ -320,7 +320,7 @@ test "QueueClient receiveMessages" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity2 = @import("azure_identity");
+    const identity2 = @import("azure_core").identity;
     var cred_mock = core.http.MockTransport.init(allocator, 200,
         \\{"access_token":"t","expires_in":3600}
     );


### PR DESCRIPTION
## Summary

Moves the concrete credential implementations from the `azure_identity` module into `azure_core` (exposed as `core.identity`) and **removes the `azure_identity` module entirely**. All consumers now reach the credentials via `@import("azure_core").identity`.

This is the same consolidation the **.NET SDK** did — the `Azure.Identity` types were moved into `Azure.Core` (1.53.0+) where they physically live in `sdk/core/Azure.Core/src/Identity/` — but **without the type-forwarding facade**. .NET kept `Azure.Identity` as a shim only to survive assembly type-resolution conflicts (`CS0433`); Zig has no such problem, so no shim is needed.

The `TokenCredential` / `AccessToken` abstraction already lived in `azure_core`; this brings the implementations alongside it.

## Why this makes sense for the Zig SDK

- **Lazy type resolution removes the bloat objection.** Per the Zig devlog (2026-03-10), the compiler now defers resolving type fields/namespaces, and combined with Zig's long-standing declaration-level lazy analysis, a consumer that touches only `core.credentials.TokenCredential` never analyzes or codegens the heavy credential implementations (CLI subprocess, IMDS, cert parsing). The compile-time/binary "keep them separate" argument does not apply in Zig.
- **Zero new dependencies for core.** The credential implementations import only `std`, `serde`, and `azure_core` — all of which `azure_core` already has. Contrast Rust's `azure_identity` (openssl, async-trait, tokio/process) and Python's (MSAL): those ecosystems split for real transitive-dependency weight that Zig does not incur here.
- **Single package.** The multi-package / separate-release rationale that drives the split in the Rust/Go/Python/JS SDKs is moot here — it is one Zig package.
- **Direct access, like .NET 1.53+.** `DefaultAzureCredential` and friends are now reachable directly from `azure_core` as `core.identity.*`.

## Changes

- `sdk/identity/*.zig` (implementations) -> `sdk/core/identity/*.zig`; their `@import("azure_core")` became relative `@import("../root.zig")`.
- `sdk/core/root.zig` exposes `pub const identity = @import("identity/root.zig")`.
- Removed the `azure_identity` module and its test target from `build.zig`, and dropped it from every consuming module's imports (-44 lines).
- Migrated ~40 `@import("azure_identity")` call sites across keyvault, storage, messaging, kusto, data, and attestation to `@import("azure_core").identity`.
- Updated `rest/arm_avs/build.zig` (a local `.path = "../.."` dependency) to drop the module, and migrated its two examples.

## Validation

- `zig build test` passes (exit 0), identical to the `origin/main` baseline.
- `rest/arm_avs` `zig build test` passes; both examples compile (they run and fail only at runtime on a missing `AZURE_SUBSCRIPTION_ID`, as expected).
- `zig fmt --check` clean on all changed files.
