### PR TITLE
docs(codegen): design for replacing jco with QuickJS

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -150,3 +150,5 @@ when onboarding a brand-new package.
   <https://github.com/Azure/typespec-azure/tree/main/packages/typespec-client-generator-core>
 - jco:
   <https://github.com/bytecodealliance/jco>
+- Design (draft): replacing `jco` with QuickJS —
+  [`design/replace-jco-with-quickjs.md`](design/replace-jco-with-quickjs.md)

--- a/codegen/design/replace-jco-with-quickjs.md
+++ b/codegen/design/replace-jco-with-quickjs.md
@@ -1,0 +1,273 @@
+# Design: replace `jco` with QuickJS for the TypeSpec codegen toolchain
+
+**Status:** draft / design review. The runtime feasibility spikes (S1–S5)
+below are all complete and passing; no host code is implemented yet
+(Phases 1–4 are the remaining work).
+
+## Goal
+
+Run the **TypeSpec / TCGC code-model API from Zig** without `jco`,
+componentize-js, StarlingMonkey, the WebAssembly Component Model, or
+`wasmtime`. Instead, embed the **Zig-ported QuickJS**
+([`cataggar/quickjs-zig`](https://github.com/cataggar/quickjs-zig))
+directly in the Zig host so the TypeSpec compiler runs *in-process*, and
+AOT-compile the JS bundle to QuickJS bytecode with `qjsc`.
+
+> The task that motivated this was framed as "quickjs + zigar". Spike S5
+> determined **zigar does not fit** — it is a JS-hosts-Zig (N-API/V8)
+> toolkit, the inverse of what is needed — so the design uses
+> **quickjs only**, with the narrow Zig↔JS boundary hand-rolled against
+> `quickjs.h`.
+
+## What `jco` does today (the thing being replaced)
+
+In `codegen/tcgc-component/`:
+
+1. `esbuild` bundles `@typespec/compiler` + TCGC + Azure libs ->
+   `dist/bundled.js` (single ESM module).
+2. `jco componentize` snapshots that JS into a SpiderMonkey
+   (StarlingMonkey) engine -> `tcgc.wasm`, a **WASM Component** exporting
+   `azure:codegen/tcgc#compile(string,string) -> result<string,string>`
+   (see `wit/component.wit`).
+3. A **custom StarlingMonkey engine** must be built to raise the GC heap
+   cap 32 MiB -> 1 GiB or large ARM specs OOM (`scripts/build-engine.sh`).
+4. Zig `codegen-cli.wasm` imports `tcgc#compile` via the Component Model
+   (`cli/src/tcgc_import.zig`), composed with `tcgc.wasm` ->
+   `codegen-cli.composed.wasm`, run under **wasmtime** with WASI preopens
+   for stdlib + `/spec` + output.
+
+Pain points: custom engine build, `wabt` component embed/compose, WASI
+preopen juggling, wasmtime dependency, the 32 MiB heap workaround, and the
+known issue that WAMR cannot run the composed component (only wasmtime
+can).
+
+## Proposed architecture
+
+**Decision (locked): native Zig binary only.** No WASI, no wasmtime, no
+Component Model, no StarlingMonkey anywhere in the pipeline. The host links
+QuickJS as a static library and runs the TypeSpec JS in-process, servicing
+all file I/O directly from the native OS filesystem.
+
+```
+  .tsp files
+     │
+     ▼
+ ┌─────────────────────────────────────────────┐
+ │  Native Zig binary                           │
+ │  ├─ libquickjs (quickjs-zig, static)         │
+ │  ├─ embedded QuickJS bytecode of bundled.js  │  ← qjsc AOT
+ │  │    (@typespec/compiler + TCGC + azure)    │
+ │  ├─ host shims (Zig): file I/O, globals,      │
+ │  │    microtask/promise pump                  │
+ │  └─ tcgc.zig: compile(projectPath, opts)      │
+ │         -> JSON code model (string)           │
+ └─────────────────────────────────────────────┘
+     │ JSON code model
+     ▼
+  existing Zig emitter (cli/) -> Zig source
+```
+
+### Role of each tool
+
+- **quickjs-zig** — the JS engine, embedded in Zig. Zig is the host and
+  drives JS through the QuickJS C/Zig API (`JS_Eval`, `JS_Call`,
+  `JS_NewStringLen`, `JS_ToCString`, `JS_ExecutePendingJob`, …). Its
+  `build.zig` already builds `qjs` + `qjsc` and uses `qjsc` to codegen
+  `repl.c`, so the AOT-embed pattern is proven.
+- **qjsc** — AOT compiler. `qjsc -c` turns `dist/bundled.js` into QuickJS
+  **bytecode** baked into the Zig binary. ("Ahead-of-time" here = parse
+  done at build time + no JS source shipped, **not** native codegen — see
+  the performance section.)
+- **zigar** — evaluated and **not used** (see S5).
+
+### Reused unchanged
+
+- The `esbuild` bundle step (`scripts/build-component.mjs` bundling logic).
+- TypeSpec/TCGC `node_modules` at *build* time only.
+- `src/index.js` emitter logic and the `WasiHost`/`CompilerHost`
+  abstraction — keep the JS, but rename it (no longer "Wasi") and re-point
+  its leaf I/O from WASI preopens to Zig host functions that read the
+  **native filesystem** directly (baked virtualFs for stdlib + real paths
+  for the user's spec/output dirs — no preopen flags to construct).
+
+## Feasibility spikes
+
+All spikes were run against `quickjs-zig`'s `qjs`/`qjsc` and the real
+`tcgc-component` bundle. Reproduction artifacts are under
+[`spikes/`](./spikes): `demo_harness.mjs` (small inline service),
+`avs_harness.mjs` (the large ARM spec), and `host_polyfills.js` (the
+missing-global shims, which become the production Zig host shims).
+
+| Spike | Question | Result |
+| --- | --- | --- |
+| **S1** | Does the TCGC bundle run on QuickJS at all? | ✅ runs end-to-end |
+| **S2** | Does `qjsc` AOT-compile the bundle? | ✅ 1.27 MB bytecode, valid native exe |
+| **S3** | Does async `compile()` resolve? | ✅ QuickJS drains its own job queue |
+| **S4** | Memory on large ARM specs (AVS)? | ✅ no OOM (~297 MiB); ⚠️ JIT-less perf |
+| **S5** | Can zigar provide the Zig↔JS bridge? | ❌ no — hand-roll `quickjs.h` glue |
+
+### Pre-flight: language feature probe
+
+`quickjs-zig`'s `qjs` supports everything TypeSpec/TCGC needs:
+
+- ✅ **Unicode-property regex** `\p{L}` — the exact feature
+  (js-tokens / @babel/code-frame) that forced a StarlingMonkey stub.
+- ✅ async/await, top-level await (module mode), named capture groups,
+  lookbehind, BigInt, WeakRef, Proxy, FinalizationRegistry, performance.
+- ❌ Missing globals needing shims: `structuredClone`, `queueMicrotask`,
+  `TextEncoder`/`TextDecoder`, `URL`, `crypto.subtle`. All are small
+  JS/Zig polyfills.
+
+### S1 + S3 — full TypeSpec + TCGC runs end-to-end
+
+Built `dist/bundled.js` (2.35 MB esbuild bundle) and drove the WIT export
+`compile(projectPath, emitterOptions)` under `qjs` against a small inline
+TypeSpec service. **The full TypeSpec compiler + TCGC `createSdkContext`
+ran to completion and returned the JSON code model (4219 bytes)** — the
+same artifact `jco`'s `tcgc.wasm` produces. The async `compile()` resolved
+(QuickJS drained its own job queue). Concrete requirements discovered:
+
+1. **Large stack required.** QuickJS uses the C stack for JS recursion, so
+   the deeply recursive Ajv schema compile + TypeSpec checker overflow the
+   default ~256 KB limit. Needed `--stack-size ~400 MB` **and** a raised OS
+   stack (`ulimit -s 524288`). *Host implication:* run QuickJS on a
+   dedicated thread with a large stack and call `JS_SetMaxStackSize`
+   accordingly. (400 MB was a generous upper bound, not a measured floor —
+   tune later.)
+2. **Host globals to shim** (confirmed by hitting each in turn):
+   `TextEncoder`/`TextDecoder`, `queueMicrotask`, `structuredClone`, and
+   `crypto.subtle.digest("SHA-256", …)` (TCGC's
+   `computeCrossLanguageVersion`). All trivial in Zig
+   (`std.crypto.hash.sha2.Sha256`, `std.unicode`); see
+   `spikes/host_polyfills.js`.
+3. **Host FS surface:** serve the TypeSpec stdlib `.tsp` + `package.json`
+   from the dirs in `dist/stdlib-preopens.txt` (101 files) plus the user
+   spec via the existing inline `__spec_files` map. Zig reads these from
+   the real filesystem (no WASI).
+4. **Build note:** the bundle needs `@typespec/openapi`, `@typespec/streams`,
+   `@typespec/xml` present in `node_modules` (currently only transitive),
+   and `npm install --legacy-peer-deps` due to upstream `@typespec/openapi`
+   1.13 peer drift against the pinned 1.12 line.
+
+### S2 — AOT bytecode compiles, links, runs
+
+- `qjsc -c -m -s` compiled the 2.35 MB `dist/bundled.js` to **1.27 MB of
+  QuickJS bytecode in 1.4 s** (build-time cost, paid once).
+- `qjsc -e -m -s -S 400000000` generated a C `main` (uses quickjs-libc
+  `js_std_*` helpers; embeds `JS_SetMaxStackSize(rt, 400 MB)`).
+- Linked with `zig cc` against `quickjs-zig`'s `libquickjs.a` into a
+  **14 MB self-contained native executable**. (The shipped `libquickjs.a`
+  was built with UBSan refs — link the AOT exe with `-fsanitize=undefined`,
+  or rebuild the lib `ReleaseFast`.)
+- Running it instantiates the **entire bundle from bytecode in 134 ms**
+  vs **1.64 s** interpreting the source — **~12× faster cold start**, parse
+  cost eliminated. (Module top-level init only; calling `compile()` from
+  the AOT exe is Phase 2.)
+
+### S4 — no OOM on large specs; performance is the real trade-off
+
+Compiled real specs from `azure-rest-api-specs` under `qjs` (peak RSS via
+`getrusage(RUSAGE_CHILDREN)`):
+
+| Spec | .tsp files | compile | peak RSS | model |
+| --- | --- | --- | --- | --- |
+| keyvault-secrets (data-plane) | 5 | 15.7 s | 71 MiB | 58 KB, 1 client |
+| Microsoft.AVS (ARM) | 36 | 113 s | 297 MiB | 790 KB, 25 clients |
+
+- **Memory: PASS.** AVS — the exact spec that OOM'd StarlingMonkey at its
+  baked 32 MiB GC cap — compiles cleanly at ~297 MiB. QuickJS has no such
+  cap (`malloc limit: -1`), so the custom 1 GiB engine build is *entirely
+  eliminated*.
+- **Performance: the caveat.** QuickJS is **interpreter-only (no JIT)**, so
+  TypeSpec/TCGC compilation runs ~10× slower than Node/V8: ~16 s for a
+  small spec, ~113 s for a large ARM spec. AOT bytecode (S2) removes only
+  the ~1.5 s parse, *not* execution cost — runtime is interpreter-bound.
+
+#### Profile of the AVS 113 s (`perf`, 59,701 samples)
+
+C-level self-time, grouped:
+
+| Category | Share | Symbols |
+| --- | ---: | --- |
+| Interpreter dispatch | ~34% | `JS_CallInternal` |
+| Property / shape ops | ~13% | `get_shape_prop`, `JS_GetPropertyInternal`, `add_property`, `JS_NewObjectFromShape` |
+| Reference counting | ~11% | `JS_DupValue`, `JS_FreeValue`, `__js_rc`, `free_object` |
+| Allocation | ~8% | `__js_malloc/free/realloc`, arena |
+| Cycle GC | ~3% | `mark_children`, `gc_*` |
+| Map / atoms / closures / C-calls | rest | `map_find_record`, `__JS_AtomToValue`, `js_call_c_function` |
+
+Not hotspots: **regex ≈ 0.5%** (the StarlingMonkey-breaking Unicode regex
+is irrelevant to perf); the SHA-256/TextEncoder polyfills = **0%**; **no
+single TCGC pass dominates**. The cost is broad, fundamental interpreter +
+dynamic-dispatch + refcount/alloc overhead on TypeSpec's object-heavy work
+(~1.3 M objects, 95 K Maps): **no algorithmic low-hanging fruit, and a
+realistic baseline JIT would yield only ~1.2–1.4×** (it attacks the ~34 %
+dispatch but still calls into the ~50 %+ runtime primitives). Cheap host
+knobs (GC threshold, interrupt-poll interval) buy only ~1–3 % combined.
+
+#### Performance decision: accept it
+
+Ship the QuickJS interpreter and rely on codegen being an **offline,
+embarrassingly-parallel CI batch** — once per package per TypeSpec bump,
+not interactive. Per-spec latency (~16 s small, ~113 s large) is
+acceptable; parallelize across packages in CI if total wall-clock matters.
+Revisit only if interactive/low-latency codegen becomes a hard requirement
+(the one reason would be to keep a JIT'd engine — i.e. SpiderMonkey — at
+the cost of the OOM/engine-build/Component-Model baggage we are removing).
+
+### S5 — zigar does not fit; hand-roll the QuickJS glue
+
+zigar's architecture is **JS-hosts-Zig**: a JS engine (V8/Node, JSC/Bun,
+or a browser) is the top-level host, and Zig is the guest, reached either
+as a native addon over **N-API** (`node-zigar-addon/src/napi.zig` →
+`@cInclude("node_api.h")`, `napi_create_string_utf8`,
+`napi_call_function`, …) or as Wasm via a bundler. `zigar-runtime/src/*`
+is all **JavaScript** that marshals Zig memory layouts into JS objects.
+
+That is the **opposite** of what this project needs (Zig as host, QuickJS
+embedded as guest), and zigar has **no QuickJS support** — its bridge is
+hard-wired to N-API/V8. Reusing it would mean embedding Node, defeating
+the entire point (tiny in-process engine, no Node/wasmtime).
+
+**Verdict: drop zigar.** The boundary is a single
+`compile(projectPath, emitterOptions) -> result<string,string>`; the host
+shims (FS-backed `CompilerHost`, global polyfills, microtask pump) are
+likewise narrow. All of it is hand-rolled directly against `quickjs.h`,
+whose required surface is confirmed present in `quickjs-zig`:
+
+- Marshal in/out: `JS_NewStringLen`, `JS_ToCStringLen`, `JS_GetPropertyStr`.
+- Call + drive: `JS_Call`, `JS_ExecutePendingJob` (promise pump),
+  `JS_IsException`.
+- Register host fns + shims: `JS_NewCFunction`, `JS_SetPropertyStr`.
+- Boot AOT bytecode + stack: `JS_ReadObject`, `JS_EvalFunction`,
+  `JS_SetMaxStackSize`.
+
+Estimated glue: ~30–50 lines of Zig for `compile()`, plus the host-fn
+registrations. (As `quickjs-zig` ports more of QuickJS to Zig, this glue
+can move from `@cImport` to native Zig calls, but the C ABI works today.)
+
+## Phased implementation (remaining work)
+
+- **Phase 1** — Host shims: Zig-backed `CompilerHost` leaf I/O (baked
+  stdlib virtualFs + real FS for the user spec) + the missing-global
+  polyfills; get keyvault-secrets JSON via an interpreted `qjs`-style
+  harness driven from Zig.
+- **Phase 2** — Embed: `qjsc` the bundle -> bytecode array; new Zig `tcgc`
+  module exposing `compile()` that boots a `JSContext`, registers host
+  fns, runs the bytecode module, calls the export, pumps jobs, returns the
+  string. Replaces the Component-Model import in `cli/src/tcgc_import.zig`
+  with an in-process call.
+- **Phase 3** — Wire into `codegen-cli`: drop wasmtime / wabt / jco /
+  StarlingMonkey from the build + docs; single native binary.
+- **Phase 4** — Parity: run the full package set incl. AVS; diff JSON
+  models byte-for-byte vs current `jco` output; perf/mem benchmarks;
+  update `codegen/README.md`.
+
+## Decisions
+
+1. ✅ **Target**: native Zig binary only. No WASI/wasmtime/Component Model
+   output.
+2. ✅ **zigar**: not used (S5). The Zig↔JS boundary is hand-rolled against
+   `quickjs.h`.
+3. ✅ **Performance**: accept the JIT-less interpreter; codegen is an
+   offline, parallelizable CI batch.

--- a/codegen/design/spikes/README.md
+++ b/codegen/design/spikes/README.md
@@ -1,0 +1,43 @@
+# QuickJS feasibility spikes
+
+Throwaway reproduction harnesses backing the spike results in
+[`../replace-jco-with-quickjs.md`](../replace-jco-with-quickjs.md). They run
+the real `tcgc-component` bundle under `quickjs-zig`'s `qjs` — **not** part
+of the build; kept only as evidence / a starting point for the Zig host.
+
+- `host_polyfills.js` — the missing-global shims (`TextEncoder`/
+  `TextDecoder`, `queueMicrotask`, `structuredClone`,
+  `crypto.subtle.digest("SHA-256")`). These become the production Zig host
+  shims (backed by `std.crypto` / `std.unicode`).
+- `demo_harness.mjs` — drives `compile()` against a small inline service.
+- `avs_harness.mjs` — drives `compile()` against the large `Microsoft.AVS`
+  ARM spec.
+
+## Reproduce
+
+From `codegen/tcgc-component/` (after `npm install --legacy-peer-deps` and
+building `dist/bundled.js` via the bundle step of
+`scripts/build-component.mjs`):
+
+```bash
+# 1. Bake the TypeSpec stdlib .tsp/package.json into a path->content map.
+node -e '
+const fs=require("fs"),path=require("path");
+const lines=fs.readFileSync("dist/stdlib-preopens.txt","utf8").trim().split("\n");const out={};
+function walk(h,v){for(const e of fs.readdirSync(h,{withFileTypes:true})){const hp=path.join(h,e.name),vp=v+"/"+e.name;if(e.isDirectory())walk(hp,vp);else if(e.name.endsWith(".tsp")||e.name==="package.json")out[vp]=fs.readFileSync(hp,"utf8");}}
+for(const l of lines){const[h,v]=l.split("=");walk(h,v);}fs.writeFileSync("/tmp/stdlib.json",JSON.stringify(out));'
+
+# 2. (AVS only) bake the spec .tsp files into /tmp/avs_spec.json keyed at /spec/.
+node -e '
+const fs=require("fs"),path=require("path");
+const dir=process.env.HOME+"/azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/AVS";
+const out={};for(const e of fs.readdirSync(dir)){if(e.endsWith(".tsp"))out["/spec/"+e]=fs.readFileSync(path.join(dir,e),"utf8");}
+fs.writeFileSync("/tmp/avs_spec.json",JSON.stringify(out));'
+
+# 3. Run a harness. Large stack is required (QuickJS recurses on the C stack).
+cp ../docs/spikes/host_polyfills.js ./_polyfills.js
+cp ../docs/spikes/demo_harness.mjs ./_harness.mjs   # or avs_harness.mjs
+( ulimit -s 524288; \
+  /path/to/quickjs-zig/zig-out/bin/qjs --std --stack-size 400000000 \
+    -I ./_polyfills.js -m ./_harness.mjs )
+```

--- a/codegen/design/spikes/avs_harness.mjs
+++ b/codegen/design/spikes/avs_harness.mjs
@@ -1,0 +1,24 @@
+import * as std from "std";
+import { compile } from "./dist/bundled.js";
+
+const stdlib = JSON.parse(std.loadFile("/tmp/stdlib.json"));
+const avs = JSON.parse(std.loadFile("/tmp/avs_spec.json"));
+
+const specFiles = Object.assign({}, stdlib, avs);
+const options = {
+  "package-name": "vmware_avs",
+  "target-kind": "arm",
+  __spec_files: specFiles,
+};
+
+const t0 = Date.now();
+try {
+  const json = await compile("/spec", JSON.stringify(options));
+  const ms = Date.now() - t0;
+  let clients = 0, models = 0;
+  try { const o = JSON.parse(json); clients = (o.clients||[]).length; models = (o.models||o.types||[]).length; } catch {}
+  console.log("AVS COMPILE OK in", ms, "ms; json length =", json.length, "clients =", clients);
+} catch (e) {
+  const msg = (e && (e.payload || e.message)) || String(e);
+  console.log("AVS COMPILE ERROR:", String(msg).split("\n").slice(0,4).join("\n"));
+}

--- a/codegen/design/spikes/demo_harness.mjs
+++ b/codegen/design/spikes/demo_harness.mjs
@@ -1,0 +1,37 @@
+import * as std from "std";
+import { compile } from "./dist/bundled.js";
+
+const stdlib = JSON.parse(std.loadFile("/tmp/stdlib.json"));
+
+const main = `
+import "@typespec/http";
+import "@typespec/rest";
+
+using Http;
+
+@service(#{ title: "Widget Service" })
+namespace DemoService;
+
+model Widget {
+  @key id: string;
+  weight: int32;
+}
+
+@route("/widgets")
+interface Widgets {
+  @get list(): Widget[];
+  @get read(@path id: string): Widget;
+}
+`;
+
+const specFiles = Object.assign({}, stdlib, { "/spec/main.tsp": main });
+const options = { "package-name": "demo", __spec_files: specFiles };
+
+try {
+  const json = await compile("/spec", JSON.stringify(options));
+  console.log("COMPILE OK, json length =", json.length);
+  console.log(json.slice(0, 400));
+} catch (e) {
+  const msg = (e && (e.payload || e.message)) || String(e);
+  console.log("COMPILE ERROR:", msg);
+}

--- a/codegen/design/spikes/host_polyfills.js
+++ b/codegen/design/spikes/host_polyfills.js
@@ -1,0 +1,85 @@
+// Minimal host-global polyfills for running the TypeSpec/TCGC bundle
+// under QuickJS. In the real build these are provided by the Zig host.
+(function (g) {
+  if (typeof g.TextEncoder === "undefined") {
+    g.TextEncoder = class TextEncoder {
+      get encoding() { return "utf-8"; }
+      encode(str) {
+        str = String(str);
+        const out = [];
+        for (let i = 0; i < str.length; i++) {
+          let c = str.charCodeAt(i);
+          if (c >= 0xd800 && c <= 0xdbff && i + 1 < str.length) {
+            const c2 = str.charCodeAt(i + 1);
+            if (c2 >= 0xdc00 && c2 <= 0xdfff) { c = 0x10000 + ((c - 0xd800) << 10) + (c2 - 0xdc00); i++; }
+          }
+          if (c < 0x80) out.push(c);
+          else if (c < 0x800) out.push(0xc0 | (c >> 6), 0x80 | (c & 0x3f));
+          else if (c < 0x10000) out.push(0xe0 | (c >> 12), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+          else out.push(0xf0 | (c >> 18), 0x80 | ((c >> 12) & 0x3f), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+        }
+        return new Uint8Array(out);
+      }
+    };
+  }
+  if (typeof g.TextDecoder === "undefined") {
+    g.TextDecoder = class TextDecoder {
+      constructor(enc) { this.encoding = enc || "utf-8"; }
+      decode(buf) {
+        const b = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+        let s = "";
+        for (let i = 0; i < b.length;) {
+          let c = b[i++];
+          if (c >= 0xf0) { c = ((c & 7) << 18) | ((b[i++] & 63) << 12) | ((b[i++] & 63) << 6) | (b[i++] & 63); }
+          else if (c >= 0xe0) { c = ((c & 15) << 12) | ((b[i++] & 63) << 6) | (b[i++] & 63); }
+          else if (c >= 0xc0) { c = ((c & 31) << 6) | (b[i++] & 63); }
+          if (c > 0xffff) { c -= 0x10000; s += String.fromCharCode(0xd800 + (c >> 10), 0xdc00 + (c & 0x3ff)); }
+          else s += String.fromCharCode(c);
+        }
+        return s;
+      }
+    };
+  }
+  if (typeof g.queueMicrotask === "undefined") {
+    g.queueMicrotask = (cb) => Promise.resolve().then(cb);
+  }
+  if (typeof g.structuredClone === "undefined") {
+    g.structuredClone = (v) => v === undefined ? undefined : JSON.parse(JSON.stringify(v));
+  }
+})(globalThis);
+
+// Minimal crypto.subtle.digest("SHA-256") for the spike. The real Zig
+// host provides this via std.crypto.hash.sha2.Sha256.
+(function (g) {
+  function sha256(bytes) {
+    const K = [0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2];
+    let h0=0x6a09e667,h1=0xbb67ae85,h2=0x3c6ef372,h3=0xa54ff53a,h4=0x510e527f,h5=0x9b05688c,h6=0x1f83d9ab,h7=0x5be0cd19;
+    const l=bytes.length, bl=l*8;
+    const withPad=[...bytes,0x80];
+    while(withPad.length%64!==56) withPad.push(0);
+    for(let i=7;i>=0;i--) withPad.push((bl/Math.pow(2,i*8))&0xff);
+    const rotr=(x,n)=>(x>>>n)|(x<<(32-n));
+    for(let j=0;j<withPad.length;j+=64){
+      const w=new Array(64);
+      for(let i=0;i<16;i++) w[i]=(withPad[j+i*4]<<24)|(withPad[j+i*4+1]<<16)|(withPad[j+i*4+2]<<8)|(withPad[j+i*4+3]);
+      for(let i=16;i<64;i++){const s0=rotr(w[i-15],7)^rotr(w[i-15],18)^(w[i-15]>>>3);const s1=rotr(w[i-2],17)^rotr(w[i-2],19)^(w[i-2]>>>10);w[i]=(w[i-16]+s0+w[i-7]+s1)|0;}
+      let a=h0,b=h1,c=h2,d=h3,e=h4,f=h5,gg=h6,hh=h7;
+      for(let i=0;i<64;i++){
+        const S1=rotr(e,6)^rotr(e,11)^rotr(e,25);const ch=(e&f)^((~e)&gg);const t1=(hh+S1+ch+K[i]+w[i])|0;
+        const S0=rotr(a,2)^rotr(a,13)^rotr(a,22);const maj=(a&b)^(a&c)^(b&c);const t2=(S0+maj)|0;
+        hh=gg;gg=f;f=e;e=(d+t1)|0;d=c;c=b;b=a;a=(t1+t2)|0;
+      }
+      h0=(h0+a)|0;h1=(h1+b)|0;h2=(h2+c)|0;h3=(h3+d)|0;h4=(h4+e)|0;h5=(h5+f)|0;h6=(h6+gg)|0;h7=(h7+hh)|0;
+    }
+    const out=new Uint8Array(32);const hs=[h0,h1,h2,h3,h4,h5,h6,h7];
+    for(let i=0;i<8;i++){out[i*4]=(hs[i]>>>24)&0xff;out[i*4+1]=(hs[i]>>>16)&0xff;out[i*4+2]=(hs[i]>>>8)&0xff;out[i*4+3]=hs[i]&0xff;}
+    return out;
+  }
+  if (typeof g.crypto === "undefined") g.crypto = {};
+  if (!g.crypto.subtle) g.crypto.subtle = {
+    async digest(algo, data) {
+      const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+      return sha256(bytes).buffer;
+    }
+  };
+})(globalThis);


### PR DESCRIPTION
## Summary

Draft **design doc** (not implementation) for running the TypeSpec / TCGC
code-model API from Zig by embedding the **Zig-ported QuickJS** in-process,
replacing the `jco`/componentize-js/StarlingMonkey/Component-Model/wasmtime
pipeline. Adds `codegen/design/replace-jco-with-quickjs.md` plus
reproduction spikes under `codegen/design/spikes/`.

> The original idea was "quickjs + zigar"; spike S5 found zigar does not fit
> (it is JS-hosts-Zig via N-API/V8), so the design uses **quickjs only**,
> hand-rolling the narrow `compile()` boundary against `quickjs.h`.

## Feasibility — proven end-to-end (spikes S1–S5)

| Spike | Question | Result |
| --- | --- | --- |
| S1/S3 | Does TypeSpec+TCGC run on QuickJS? | ✅ same JSON model as `tcgc.wasm`; async `compile()` resolves |
| S2 | Does `qjsc` AOT-compile the bundle? | ✅ 2.35 MB → 1.27 MB bytecode; native exe boots ~12× faster |
| S4 | Memory on large ARM specs? | ✅ Microsoft.AVS no OOM (~297 MiB); ⚠️ JIT-less, ~10× slower than Node |
| S5 | Can zigar bridge Zig↔JS here? | ❌ no — hand-roll `quickjs.h` glue |

**Wins:** eliminates the custom 1 GiB StarlingMonkey engine build, `wabt`
component compose, the Component Model, and wasmtime — collapsing to a
single native Zig binary.

**Trade-off (accepted):** QuickJS has no JIT, so compilation is ~16 s
(small spec) to ~113 s (AVS). A `perf` profile (in the doc) shows the cost
is broad interpreter/refcount/alloc overhead with no algorithmic hotspot;
a realistic baseline JIT would buy only ~1.2–1.4×. Accepted because codegen
is an offline, embarrassingly-parallel CI batch.

## Scope of this PR

- ✅ Design doc + reproducible spikes (evidence).
- ❌ No host code yet — Phases 1–4 (Zig host shims, bytecode embed, rewire
  `codegen-cli`, jco-parity diff) remain and are described in the doc.

Opening as **draft** for design review of the approach before
implementation.