### PR TITLE
fix(kusto): make placeholder APIs honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 | `azure_messaging_eventhubs` | `ProducerClient`, `ConsumerClient` |
 | `azure_messaging_eventhubs_checkpointstore_blob` | Blob-backed checkpoint store |
 | `azure_messaging_servicebus` | `ServiceBusSenderClient`, `ServiceBusReceiverClient`, `ServiceBusAdministrationClient` |
-| `azure_kusto_data` | `KustoClient` (queries + management) |
-| `azure_kusto_ingest` | `StreamingIngestClient`, `QueuedIngestClient`, `ManagedIngestClient` |
+| `azure_kusto_data` | `KustoClient` (experimental buffered query and management support) |
+| `azure_kusto_ingest` | `StreamingIngestClient` (experimental direct streaming ingestion); queued ingestion and managed queued fallback are planned, not implemented |
+
+Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished.
 
 ### Infrastructure
 

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -275,7 +275,8 @@ pub const MockTransport = struct {
         }
         self.last_retryable = request.retryable;
 
-        const body_copy = try self.allocator.dupe(u8, self.response_body);
+        const response_body_copy = try self.allocator.dupe(u8, self.response_body);
+        errdefer self.allocator.free(response_body_copy);
         var headers = std.StringHashMap([]const u8).init(self.allocator);
         errdefer deinitOwnedHeaders(self.allocator, &headers);
         for (self.response_headers_list) |hdr| {
@@ -295,7 +296,7 @@ pub const MockTransport = struct {
         return .{
             .status_code = self.response_status,
             .headers = headers,
-            .body = body_copy,
+            .body = response_body_copy,
             .allocator = self.allocator,
         };
     }
@@ -386,10 +387,12 @@ test "mock transport" {
     defer mock.deinit();
     var req = Request.init(allocator, .POST, "https://vault.azure.net/secrets/mysecret");
     defer req.deinit();
+    req.body = "{\"value\":\"secret-value\"}";
     var resp = try mock.asTransport().send(&req);
     defer resp.deinit();
     try std.testing.expectEqual(@as(u16, 200), resp.status_code);
     try std.testing.expectEqualStrings("{\"status\":\"ok\"}", resp.body);
     try std.testing.expectEqual(Method.POST, mock.last_method.?);
     try std.testing.expectEqualStrings("https://vault.azure.net/secrets/mysecret", mock.last_url.?);
+    try std.testing.expectEqualStrings("{\"value\":\"secret-value\"}", mock.last_body.?);
 }

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -15,11 +15,21 @@ pub const ClientRequestProperties = kusto_common.ClientRequestProperties;
 pub const KustoResultColumn = struct {
     name: []const u8,
     column_type: []const u8,
+
+    pub fn deinit(self: KustoResultColumn, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.column_type);
+    }
 };
 
 pub const KustoResultRow = struct {
     values: []const []const u8,
     columns: []const KustoResultColumn,
+
+    pub fn deinit(self: KustoResultRow, allocator: std.mem.Allocator) void {
+        for (self.values) |value| allocator.free(value);
+        allocator.free(self.values);
+    }
 
     /// Get a value by column name.
     pub fn getByName(self: KustoResultRow, name: []const u8) ?[]const u8 {
@@ -36,10 +46,25 @@ pub const KustoResultTable = struct {
     name: []const u8,
     columns: []const KustoResultColumn,
     rows: []const KustoResultRow,
+
+    pub fn deinit(self: *KustoResultTable, allocator: std.mem.Allocator) void {
+        for (self.rows) |row| row.deinit(allocator);
+        allocator.free(self.rows);
+        for (self.columns) |column| column.deinit(allocator);
+        allocator.free(self.columns);
+        allocator.free(self.name);
+        self.* = .{ .name = "", .columns = &.{}, .rows = &.{} };
+    }
 };
 
 pub const KustoResponseDataSet = struct {
     tables: []KustoResultTable,
+
+    pub fn deinit(self: *KustoResponseDataSet, allocator: std.mem.Allocator) void {
+        for (self.tables) |*table| table.deinit(allocator);
+        allocator.free(self.tables);
+        self.tables = &.{};
+    }
 
     /// Get the primary result table (first table named "PrimaryResult" or index 0).
     pub fn primaryTable(self: KustoResponseDataSet) ?KustoResultTable {
@@ -136,12 +161,7 @@ pub const KustoClient = struct {
         csl: []const u8,
         properties: ?ClientRequestProperties,
     ) !core.errors.Result(KustoResponseDataSet) {
-        const props_json = if (properties) |p| try p.toJson(allocator) else try allocator.dupe(u8, "{}");
-        defer allocator.free(props_json);
-
-        const body = try std.fmt.allocPrint(allocator,
-            \\{{"db":"{s}","csl":"{s}","properties":{s}}}
-        , .{ database, csl, props_json });
+        const body = try serializeRequest(allocator, database, csl, properties);
         defer allocator.free(body);
 
         var req = core.http.Request.init(allocator, .POST, url);
@@ -165,6 +185,50 @@ pub const KustoClient = struct {
     }
 };
 
+const EmptyRequestProperties = struct {};
+
+const RequestWithEmptyProperties = struct {
+    db: []const u8,
+    csl: []const u8,
+    properties: EmptyRequestProperties = .{},
+};
+
+const TimeoutRequestProperties = struct {
+    Options: struct {
+        servertimeout: []const u8,
+    },
+};
+
+const RequestWithTimeout = struct {
+    db: []const u8,
+    csl: []const u8,
+    properties: TimeoutRequestProperties,
+};
+
+fn serializeRequest(
+    allocator: std.mem.Allocator,
+    database: []const u8,
+    csl: []const u8,
+    properties: ?ClientRequestProperties,
+) ![]u8 {
+    if (properties) |props| {
+        if (props.server_timeout_ms) |timeout| {
+            const minutes = @divTrunc(timeout, 60000);
+            const timeout_value = try std.fmt.allocPrint(allocator, "{d}m", .{minutes});
+            defer allocator.free(timeout_value);
+            return serde.json.toSlice(allocator, RequestWithTimeout{
+                .db = database,
+                .csl = csl,
+                .properties = .{ .Options = .{ .servertimeout = timeout_value } },
+            });
+        }
+    }
+    return serde.json.toSlice(allocator, RequestWithEmptyProperties{
+        .db = database,
+        .csl = csl,
+    });
+}
+
 // ─────────────────── Response Parsing ────────────────
 
 /// Wire shape of a single column descriptor inside a Kusto v2 DataTable frame.
@@ -173,138 +237,230 @@ const KustoColumnSchema = struct {
     ColumnType: ?[]const u8 = null,
 };
 
-/// Wire shape of a single Kusto v2 frame, columns only. Rows are dynamic
-/// JSON arrays of mixed-type values (string, int, bool, null, nested
-/// objects), which serde cannot deserialize into a uniform Zig type, so
-/// we parse `Rows` separately by walking the raw body.
-const KustoFrameSchema = struct {
+const KustoFrameTypeSchema = struct {
     FrameType: ?[]const u8 = null,
+};
+
+/// Wire shape of frame metadata. Rows are scanned separately because they
+/// contain dynamically typed JSON values.
+const KustoFrameSchema = struct {
+    FrameType: []const u8,
     TableName: ?[]const u8 = null,
     Columns: ?[]const KustoColumnSchema = null,
 };
 
 fn parseResponseDataSet(allocator: std.mem.Allocator, body: []const u8) !KustoResponseDataSet {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
+    if (!try std.json.validate(allocator, body)) return error.MalformedKustoResponse;
 
-    const frames = serde.json.fromSlice([]const KustoFrameSchema, arena.allocator(), body) catch
-        return .{ .tables = try allocator.alloc(KustoResultTable, 0) };
+    var deserializer = serde.json.Deserializer.init(body);
+    const scanner = &deserializer.scanner;
+    const first = scanner.next() catch return error.MalformedKustoResponse;
+    if (first != .array_begin) return error.MalformedKustoResponse;
 
     var tables = std.ArrayList(KustoResultTable).empty;
-    errdefer tables.deinit(allocator);
-
-    // Walk the raw body alongside the typed frames to grab `Rows`. We
-    // assume frames appear in the body in the same order they do in the
-    // typed slice.
-    var body_pos: usize = 0;
-    for (frames) |frame| {
-        const table_name_src = frame.TableName orelse continue;
-        const cols_src = frame.Columns orelse &[_]KustoColumnSchema{};
-
-        const table_name = try allocator.dupe(u8, table_name_src);
-        errdefer allocator.free(table_name);
-
-        const cols_slice = try allocator.alloc(KustoResultColumn, cols_src.len);
-        errdefer allocator.free(cols_slice);
-        for (cols_src, 0..) |col, i| {
-            cols_slice[i] = .{
-                .name = try allocator.dupe(u8, col.ColumnName),
-                .column_type = if (col.ColumnType) |ct| try allocator.dupe(u8, ct) else try allocator.dupe(u8, "string"),
-            };
-        }
-
-        const rows = try extractRows(allocator, body, &body_pos, cols_slice);
-
-        try tables.append(allocator, .{
-            .name = table_name,
-            .columns = cols_slice,
-            .rows = rows,
-        });
+    errdefer {
+        for (tables.items) |*table| table.deinit(allocator);
+        tables.deinit(allocator);
     }
 
-    return .{ .tables = try tables.toOwnedSlice(allocator) };
-}
-
-/// Extract the next `"Rows":[[...],[...],...]` array starting at or after
-/// `*body_pos`. Advances `*body_pos` past the consumed array. Each row's
-/// values are returned as raw JSON strings (unquoted if originally
-/// JSON-string typed) so the existing API surface is preserved.
-fn extractRows(
-    allocator: std.mem.Allocator,
-    body: []const u8,
-    body_pos: *usize,
-    columns: []const KustoResultColumn,
-) ![]KustoResultRow {
-    var rows = std.ArrayList(KustoResultRow).empty;
-    errdefer rows.deinit(allocator);
-
-    const rows_idx = std.mem.findPos(u8, body, body_pos.*, "\"Rows\":[") orelse {
-        return rows.toOwnedSlice(allocator);
-    };
-    const array_start = rows_idx + "\"Rows\":[".len;
-    var depth: u32 = 1;
-    var i = array_start;
-    while (i < body.len and depth > 0) : (i += 1) {
-        if (body[i] == '[') depth += 1;
-        if (body[i] == ']') depth -= 1;
-    }
-    const rows_content = body[array_start .. i - 1];
-    body_pos.* = i;
-
-    var row_depth: u32 = 0;
-    var row_start: ?usize = null;
-    for (rows_content, 0..) |ch, ri| {
-        if (ch == '[') {
-            if (row_depth == 0) row_start = ri + 1;
-            row_depth += 1;
-        } else if (ch == ']') {
-            row_depth -= 1;
-            if (row_depth == 0) {
-                if (row_start) |rs| {
-                    const row_text = rows_content[rs..ri];
-                    const values = try parseRowValues(allocator, row_text);
-                    try rows.append(allocator, .{ .values = values, .columns = columns });
-                }
-                row_start = null;
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const frame_slice = captureValue(scanner, body) catch return error.MalformedKustoResponse;
+            if (try parseFrame(allocator, frame_slice)) |parsed| {
+                var table = parsed;
+                errdefer table.deinit(allocator);
+                try tables.append(allocator, table);
+            }
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
             }
         }
     }
+
+    scanner.skipWhitespace();
+    if (scanner.pos != body.len) return error.MalformedKustoResponse;
+    return .{ .tables = try tables.toOwnedSlice(allocator) };
+}
+
+fn captureValue(scanner: anytype, input: []const u8) ![]const u8 {
+    scanner.skipWhitespace();
+    const start = scanner.pos;
+    try scanner.skipValue();
+    return input[start..scanner.pos];
+}
+
+fn parseFrame(allocator: std.mem.Allocator, frame_slice: []const u8) !?KustoResultTable {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const frame_type_schema = serde.json.fromSlice(KustoFrameTypeSchema, arena.allocator(), frame_slice) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return error.MalformedKustoResponse;
+    };
+    const frame_type = frame_type_schema.FrameType orelse return null;
+    if (!std.mem.eql(u8, frame_type, "DataTable")) return null;
+
+    const frame = serde.json.fromSlice(KustoFrameSchema, arena.allocator(), frame_slice) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return error.MalformedKustoResponse;
+    };
+    const table_name_src = frame.TableName orelse return error.MalformedKustoResponse;
+    const columns_src = frame.Columns orelse return error.MalformedKustoResponse;
+    const rows_slice = try findRowsSlice(arena.allocator(), frame_slice);
+
+    const table_name = try allocator.dupe(u8, table_name_src);
+    errdefer allocator.free(table_name);
+
+    var columns = std.ArrayList(KustoResultColumn).empty;
+    errdefer {
+        for (columns.items) |column| column.deinit(allocator);
+        columns.deinit(allocator);
+    }
+    for (columns_src) |column_src| {
+        {
+            var column = KustoResultColumn{
+                .name = try allocator.dupe(u8, column_src.ColumnName),
+                .column_type = undefined,
+            };
+            errdefer allocator.free(column.name);
+            column.column_type = try allocator.dupe(u8, column_src.ColumnType orelse "string");
+            errdefer allocator.free(column.column_type);
+            try columns.append(allocator, column);
+        }
+    }
+    const columns_slice = try columns.toOwnedSlice(allocator);
+    errdefer {
+        for (columns_slice) |column| column.deinit(allocator);
+        allocator.free(columns_slice);
+    }
+
+    const rows = try parseRows(allocator, rows_slice, columns_slice);
+    return .{
+        .name = table_name,
+        .columns = columns_slice,
+        .rows = rows,
+    };
+}
+
+fn findRowsSlice(allocator: std.mem.Allocator, frame_slice: []const u8) ![]const u8 {
+    var deserializer = serde.json.Deserializer.init(frame_slice);
+    const scanner = &deserializer.scanner;
+    const first = scanner.next() catch return error.MalformedKustoResponse;
+    if (first != .object_begin) return error.MalformedKustoResponse;
+
+    var rows_slice: ?[]const u8 = null;
+    if (scanner.isContainerEmpty('}') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            scanner.skipWhitespace();
+            const key_start = scanner.pos;
+            const key_token = scanner.next() catch return error.MalformedKustoResponse;
+            if (key_token != .string) return error.MalformedKustoResponse;
+            const key_slice = frame_slice[key_start..scanner.pos];
+            const key = serde.json.fromSlice([]const u8, allocator, key_slice) catch |err| {
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                return error.MalformedKustoResponse;
+            };
+            scanner.expectColon() catch return error.MalformedKustoResponse;
+            const value_slice = captureValue(scanner, frame_slice) catch return error.MalformedKustoResponse;
+            if (std.mem.eql(u8, key, "Rows")) {
+                if (rows_slice != null) return error.MalformedKustoResponse;
+                rows_slice = value_slice;
+            }
+            switch (scanner.finishContainer('}') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    scanner.skipWhitespace();
+    if (scanner.pos != frame_slice.len) return error.MalformedKustoResponse;
+    return rows_slice orelse error.MalformedKustoResponse;
+}
+
+fn parseRows(
+    allocator: std.mem.Allocator,
+    rows_slice: []const u8,
+    columns: []const KustoResultColumn,
+) ![]KustoResultRow {
+    var deserializer = serde.json.Deserializer.init(rows_slice);
+    const scanner = &deserializer.scanner;
+    const first = scanner.next() catch return error.MalformedKustoResponse;
+    if (first != .array_begin) return error.MalformedKustoResponse;
+
+    var rows = std.ArrayList(KustoResultRow).empty;
+    errdefer {
+        for (rows.items) |row| row.deinit(allocator);
+        rows.deinit(allocator);
+    }
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const row_slice = captureValue(scanner, rows_slice) catch return error.MalformedKustoResponse;
+            const values = try parseRowValues(allocator, row_slice);
+            {
+                var row = KustoResultRow{ .values = values, .columns = columns };
+                errdefer row.deinit(allocator);
+                try rows.append(allocator, row);
+            }
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    scanner.skipWhitespace();
+    if (scanner.pos != rows_slice.len) return error.MalformedKustoResponse;
     return rows.toOwnedSlice(allocator);
 }
 
-fn parseRowValues(allocator: std.mem.Allocator, row_text: []const u8) ![]const []const u8 {
+fn parseRowValues(allocator: std.mem.Allocator, row_slice: []const u8) ![]const []const u8 {
+    var deserializer = serde.json.Deserializer.init(row_slice);
+    const scanner = &deserializer.scanner;
+    const first = scanner.next() catch return error.MalformedKustoResponse;
+    if (first != .array_begin) return error.MalformedKustoResponse;
+
     var values = std.ArrayList([]const u8).empty;
-    errdefer values.deinit(allocator);
-
-    var in_string = false;
-    var val_start: usize = 0;
-    var i: usize = 0;
-
-    while (i < row_text.len) : (i += 1) {
-        const ch = row_text[i];
-        if (ch == '"' and (i == 0 or row_text[i - 1] != '\\')) {
-            in_string = !in_string;
-        } else if (ch == ',' and !in_string) {
-            const raw = std.mem.trim(u8, row_text[val_start..i], " \t");
-            try values.append(allocator, try unquote(allocator, raw));
-            val_start = i + 1;
+    errdefer {
+        for (values.items) |value| allocator.free(value);
+        values.deinit(allocator);
+    }
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const cell_slice = captureValue(scanner, row_slice) catch return error.MalformedKustoResponse;
+            const value = try decodeCell(allocator, cell_slice);
+            {
+                errdefer allocator.free(value);
+                try values.append(allocator, value);
+            }
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
         }
     }
-    if (val_start <= row_text.len) {
-        const raw = std.mem.trim(u8, row_text[val_start..], " \t");
-        if (raw.len > 0) {
-            try values.append(allocator, try unquote(allocator, raw));
-        }
-    }
-
+    scanner.skipWhitespace();
+    if (scanner.pos != row_slice.len) return error.MalformedKustoResponse;
     return values.toOwnedSlice(allocator);
 }
 
-fn unquote(allocator: std.mem.Allocator, raw: []const u8) ![]const u8 {
-    if (raw.len >= 2 and raw[0] == '"' and raw[raw.len - 1] == '"') {
-        return allocator.dupe(u8, raw[1 .. raw.len - 1]);
+fn decodeCell(allocator: std.mem.Allocator, cell_slice: []const u8) ![]const u8 {
+    var deserializer = serde.json.Deserializer.init(cell_slice);
+    const token = deserializer.scanner.peek() catch return error.MalformedKustoResponse;
+    if (token == .string) {
+        return serde.json.fromSlice([]const u8, allocator, cell_slice) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return error.MalformedKustoResponse;
+        };
     }
-    return allocator.dupe(u8, raw);
+    return allocator.dupe(u8, std.mem.trim(u8, cell_slice, " \t\n\r"));
 }
 
 // ─────────────────────── Tests ───────────────────────
@@ -320,23 +476,8 @@ test "KustoClient executeQuery" {
     const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" };
     var client = KustoClient.init(conn, mock.asTransport(), .{});
 
-    const result = try client.executeQuery(allocator, "TestDB", "StormEvents | count", null);
-    defer {
-        for (result.tables) |t| {
-            allocator.free(t.name);
-            for (t.columns) |c| {
-                allocator.free(c.name);
-                allocator.free(c.column_type);
-            }
-            allocator.free(t.columns);
-            for (t.rows) |r| {
-                for (r.values) |v| allocator.free(v);
-                allocator.free(r.values);
-            }
-            allocator.free(t.rows);
-        }
-        allocator.free(result.tables);
-    }
+    var result = try client.executeQuery(allocator, "TestDB", "StormEvents | count", null);
+    defer result.deinit(allocator);
 
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v2/rest/query") != null);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
@@ -360,23 +501,8 @@ test "KustoClient executeMgmt" {
     const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" };
     var client = KustoClient.init(conn, mock.asTransport(), .{});
 
-    const result = try client.executeMgmt(allocator, "TestDB", ".show databases", null);
-    defer {
-        for (result.tables) |t| {
-            allocator.free(t.name);
-            for (t.columns) |c| {
-                allocator.free(c.name);
-                allocator.free(c.column_type);
-            }
-            allocator.free(t.columns);
-            for (t.rows) |r| {
-                for (r.values) |v| allocator.free(v);
-                allocator.free(r.values);
-            }
-            allocator.free(t.rows);
-        }
-        allocator.free(result.tables);
-    }
+    var result = try client.executeMgmt(allocator, "TestDB", ".show databases", null);
+    defer result.deinit(allocator);
 
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
     const table = result.tables[0];
@@ -391,7 +517,8 @@ test "KustoClient execute auto-routes to mgmt" {
     const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
     var client = KustoClient.init(conn, mock.asTransport(), .{});
 
-    _ = try client.execute(allocator, "db", ".show databases");
+    var result = try client.execute(allocator, "db", ".show databases");
+    defer result.deinit(allocator);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
 }
 
@@ -403,7 +530,8 @@ test "KustoClient execute auto-routes to query" {
     const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
     var client = KustoClient.init(conn, mock.asTransport(), .{});
 
-    _ = try client.execute(allocator, "db", "StormEvents | count");
+    var result = try client.execute(allocator, "db", "StormEvents | count");
+    defer result.deinit(allocator);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v2/rest/query") != null);
 }
 
@@ -431,4 +559,174 @@ test "KustoResultRow getByName" {
     try std.testing.expectEqualStrings("Alice", row.getByName("Name").?);
     try std.testing.expectEqualStrings("30", row.getByName("Age").?);
     try std.testing.expect(row.getByName("Missing") == null);
+}
+
+test "Kusto request bodies round trip caller strings" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    defer mock.deinit();
+
+    const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
+    var client = KustoClient.init(conn, mock.asTransport(), .{});
+
+    const database = "db\"\\\n\t\x01";
+    const query = "print value = \"a\\\\b\"\n\t\r";
+    var query_result = try client.executeQuery(
+        allocator,
+        database,
+        query,
+        .{ .client_request_id = "ignored-for-now", .application = "ignored-for-now" },
+    );
+    defer query_result.deinit(allocator);
+
+    var query_arena = std.heap.ArenaAllocator.init(allocator);
+    defer query_arena.deinit();
+    const query_wire = try serde.json.fromSlice(
+        RequestWithEmptyProperties,
+        query_arena.allocator(),
+        mock.last_body.?,
+    );
+    try std.testing.expectEqualStrings(database, query_wire.db);
+    try std.testing.expectEqualStrings(query, query_wire.csl);
+    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"properties\":{}") != null);
+
+    const command = ".show table [a\"b\\\\c]\n\t";
+    var mgmt_result = try client.executeMgmt(
+        allocator,
+        database,
+        command,
+        .{ .server_timeout_ms = 300000 },
+    );
+    defer mgmt_result.deinit(allocator);
+
+    var mgmt_arena = std.heap.ArenaAllocator.init(allocator);
+    defer mgmt_arena.deinit();
+    const mgmt_wire = try serde.json.fromSlice(
+        RequestWithTimeout,
+        mgmt_arena.allocator(),
+        mock.last_body.?,
+    );
+    try std.testing.expectEqualStrings(database, mgmt_wire.db);
+    try std.testing.expectEqualStrings(command, mgmt_wire.csl);
+    try std.testing.expectEqualStrings("5m", mgmt_wire.properties.Options.servertimeout);
+}
+
+test "Kusto response preserves dynamic JSON cells" {
+    const response_body =
+        \\[
+        \\  {"FrameType":"DataSetHeader","Version":"v2.0"},
+        \\  {"FrameType":"DataTable","TableName":"PrimaryResult","Columns":[
+        \\    {"ColumnName":"Text","ColumnType":"string"},
+        \\    {"ColumnName":"Object","ColumnType":"dynamic"},
+        \\    {"ColumnName":"Array","ColumnType":"dynamic"},
+        \\    {"ColumnName":"Null","ColumnType":"string"},
+        \\    {"ColumnName":"Boolean","ColumnType":"bool"},
+        \\    {"ColumnName":"Number","ColumnType":"real"},
+        \\    {"ColumnName":"EmptyArray","ColumnType":"dynamic"}
+        \\  ],"Rows":[[
+        \\    "line\n\"quote\" \\ slash \u2603",
+        \\    {"a":[1,2],"s":"x,y"},
+        \\    [1,{"nested":[true,null]}],
+        \\    null,
+        \\    false,
+        \\    -12.5e+2,
+        \\    []
+        \\  ]]},
+        \\  {"FrameType":"DataSetCompletion","HasErrors":false}
+        \\]
+    ;
+
+    var dataset = try parseResponseDataSet(std.testing.allocator, response_body);
+    defer dataset.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), dataset.tables.len);
+    const values = dataset.tables[0].rows[0].values;
+    try std.testing.expectEqual(@as(usize, 7), values.len);
+    try std.testing.expectEqualStrings("line\n\"quote\" \\ slash \xE2\x98\x83", values[0]);
+    try std.testing.expectEqualStrings("{\"a\":[1,2],\"s\":\"x,y\"}", values[1]);
+    try std.testing.expectEqualStrings("[1,{\"nested\":[true,null]}]", values[2]);
+    try std.testing.expectEqualStrings("null", values[3]);
+    try std.testing.expectEqualStrings("false", values[4]);
+    try std.testing.expectEqualStrings("-12.5e+2", values[5]);
+    try std.testing.expectEqualStrings("[]", values[6]);
+}
+
+test "Kusto response accepts empty dataset and skips non-table frames" {
+    var empty = try parseResponseDataSet(std.testing.allocator, "[]");
+    defer empty.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), empty.tables.len);
+
+    var frames = try parseResponseDataSet(std.testing.allocator,
+        \\[{"FrameType":"DataSetHeader","nested":{"values":[1,2]}},{"FrameType":"DataSetCompletion"}]
+    );
+    defer frames.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), frames.tables.len);
+}
+
+test "Kusto response rejects malformed bodies and DataTable shapes" {
+    const malformed = [_][]const u8{
+        "not json",
+        "{}",
+        "[",
+        "[] trailing",
+        \\[{"FrameType":"DataTable","TableName":"T","Columns":[]}]
+        ,
+        \\[{"FrameType":"DataTable","TableName":"T","Columns":[],"Rows":{}}]
+        ,
+        \\[{"FrameType":"DataTable","TableName":"T","Columns":[],"Rows":[42]}]
+        ,
+        \\[{"FrameType":"DataTable","TableName":"T","Columns":{},"Rows":[]}]
+        ,
+        \\[{"FrameType":"DataTable","Columns":[],"Rows":[]}]
+        ,
+        \\[{"FrameType":"DataTable","TableName":"T","Columns":[],"Rows":[["\uZZZZ"]]}]
+        ,
+    };
+    for (malformed) |body| {
+        try std.testing.expectError(
+            error.MalformedKustoResponse,
+            parseResponseDataSet(std.testing.allocator, body),
+        );
+    }
+}
+
+test "Kusto dataset and Result deinit own all parsed allocations" {
+    const response_body =
+        \\[{"FrameType":"DataTable","TableName":"T","Columns":[{"ColumnName":"C"}],"Rows":[["value"]]}]
+    ;
+
+    var dataset = try parseResponseDataSet(std.testing.allocator, response_body);
+    dataset.deinit(std.testing.allocator);
+
+    var result: core.errors.Result(KustoResponseDataSet) = .{
+        .ok = try parseResponseDataSet(std.testing.allocator, response_body),
+    };
+    result.deinit(std.testing.allocator);
+}
+
+fn parseAllocationFixture(allocator: std.mem.Allocator, body: []const u8) !void {
+    var dataset = try parseResponseDataSet(allocator, body);
+    defer dataset.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 2), dataset.tables.len);
+    try std.testing.expectEqualStrings("escaped\nvalue", dataset.tables[0].rows[0].values[0]);
+}
+
+test "Kusto response parser handles every allocation failure" {
+    const response_body =
+        \\[
+        \\  {"FrameType":"DataSetHeader"},
+        \\  {"FrameType":"DataTable","TableName":"PrimaryResult","Columns":[
+        \\    {"ColumnName":"A","ColumnType":"string"},
+        \\    {"ColumnName":"B","ColumnType":"dynamic"}
+        \\  ],"Rows":[["escaped\nvalue",{"nested":[1,2]}],["second",null]]},
+        \\  {"FrameType":"DataTable","TableName":"SecondaryResult","Columns":[
+        \\    {"ColumnName":"C","ColumnType":"long"}
+        \\  ],"Rows":[[42]]}
+        \\]
+    ;
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parseAllocationFixture,
+        .{response_body},
+    );
 }

--- a/sdk/kusto/ingest/root.zig
+++ b/sdk/kusto/ingest/root.zig
@@ -1,9 +1,9 @@
 ///! Azure Kusto (Data Explorer) ingestion clients.
 ///!
-///! Provides three ingestion patterns matching the Go/Python/Node SDKs:
-///! - `StreamingIngestClient` — direct streaming via `/v1/rest/ingest`
-///! - `QueuedIngestClient` — reliable batched ingestion via data management
-///! - `ManagedIngestClient` — streaming with queued fallback
+///! Provides experimental direct streaming ingestion via
+///! `StreamingIngestClient`. Queued ingestion and managed queued fallback
+///! are represented by API placeholders that return explicit
+///! not-implemented errors.
 const std = @import("std");
 const core = @import("azure_core");
 const kusto_common = @import("azure_kusto_common");
@@ -16,7 +16,13 @@ pub const IngestionProperties = kusto_common.IngestionProperties;
 
 pub const IngestionResult = struct {
     status: IngestionStatus,
+    /// Allocator-owned when non-null; call `deinit` to release it.
     ingestion_id: ?[]const u8 = null,
+
+    pub fn deinit(self: *IngestionResult, allocator: std.mem.Allocator) void {
+        if (self.ingestion_id) |id| allocator.free(id);
+        self.ingestion_id = null;
+    }
 };
 
 pub const IngestionStatus = enum {
@@ -44,8 +50,8 @@ pub const IngestOptions = struct {
 /// Direct streaming ingestion via the engine endpoint.
 ///
 /// Data is sent directly to the Kusto engine via `POST /v1/rest/ingest/{db}/{table}`.
-/// Fast but limited to small payloads (<4MB). For larger or more reliable
-/// ingestion, use `QueuedIngestClient` or `ManagedIngestClient`.
+/// Fast but limited to small payloads (<4MB). Queued ingestion for larger or
+/// more reliable payloads is planned but not implemented.
 pub const StreamingIngestClient = struct {
     connection: ConnectionProperties,
     pipeline: core.pipeline.HttpPipeline,
@@ -102,24 +108,27 @@ pub const StreamingIngestClient = struct {
     }
 
     fn buildIngestUrl(self: *StreamingIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, options: IngestOptions) ![]u8 {
+        const encoded_database = try core.url.percentEncode(allocator, database);
+        defer allocator.free(encoded_database);
+        const encoded_table = try core.url.percentEncode(allocator, table);
+        defer allocator.free(encoded_table);
+
         if (options.mapping_name) |mapping| {
+            const encoded_mapping = try core.url.percentEncode(allocator, mapping);
+            defer allocator.free(encoded_mapping);
             return std.fmt.allocPrint(allocator, "{s}/v1/rest/ingest/{s}/{s}?streamFormat={s}&mappingName={s}", .{
-                self.connection.cluster_url, database, table, options.format.toString(), mapping,
+                self.connection.cluster_url, encoded_database, encoded_table, options.format.toString(), encoded_mapping,
             });
         }
         return std.fmt.allocPrint(allocator, "{s}/v1/rest/ingest/{s}/{s}?streamFormat={s}", .{
-            self.connection.cluster_url, database, table, options.format.toString(),
+            self.connection.cluster_url, encoded_database, encoded_table, options.format.toString(),
         });
     }
 };
 
 // ─────────────── QueuedIngestClient ──────────────────
 
-/// Reliable batched ingestion via the data management endpoint.
-///
-/// Uploads data to a temporary blob, then posts an ingestion message
-/// to a queue. The Kusto data management service processes the queue.
-/// Most reliable ingestion method, recommended for production.
+/// Queued ingestion is planned but not implemented.
 pub const QueuedIngestClient = struct {
     connection: ConnectionProperties,
     pipeline: core.pipeline.HttpPipeline,
@@ -132,75 +141,20 @@ pub const QueuedIngestClient = struct {
         };
     }
 
-    /// Ingest from a blob URL (blob already uploaded).
-    ///
-    /// Returns `IngestionResult{ .status = .failed }` on Azure-side
-    /// errors. Use `ingestFromBlobResult` to receive the structured
-    /// `AzureError` instead.
     pub fn ingestFromBlob(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !IngestionResult {
-        var r = try self.ingestFromBlobResult(allocator, properties, blob_url);
-        return switch (r) {
-            .ok => |v| v,
-            .err => blk: {
-                std.log.warn("{f}", .{r.err});
-                r.err.deinit();
-                break :blk .{ .status = .failed };
-            },
-        };
-    }
-
-    /// Same as `ingestFromBlob` but exposes Azure-side failures via Result.
-    pub fn ingestFromBlobResult(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !core.errors.Result(IngestionResult) {
-        // Build the ingestion message as JSON.
-        const msg = try self.buildIngestionMessage(allocator, properties, blob_url);
-        defer allocator.free(msg);
-
-        // In production: post to the ingestion queue obtained from DM endpoint.
-        // For now, send to the DM endpoint's mgmt API.
-        const dm_url = try self.getDmUrl(allocator);
-        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{dm_url});
-        defer allocator.free(url);
-
-        const body = try std.fmt.allocPrint(allocator,
-            \\{{"db":"{s}","csl":".ingest into table {s} ({s}) with (format='{s}')"}}
-        , .{ properties.database, properties.table, blob_url, properties.format.toString() });
-        defer allocator.free(body);
-
-        var req = core.http.Request.init(allocator, .POST, url);
-        defer req.deinit();
-        try req.setHeader("Content-Type", "application/json; charset=utf-8");
-        req.body = body;
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (!resp.isSuccess()) {
-            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-                return .{ .err = az_err };
-            }
-            return error.AzureRequestFailed;
-        }
-
-        return .{ .ok = .{ .status = .queued } };
-    }
-
-    fn getDmUrl(self: *QueuedIngestClient, allocator: std.mem.Allocator) ![]const u8 {
-        if (self.dm_url) |url| return url;
-        self.dm_url = try self.connection.getIngestUrl(allocator);
-        return self.dm_url.?;
-    }
-
-    fn buildIngestionMessage(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) ![]u8 {
         _ = self;
-        return std.fmt.allocPrint(allocator,
-            \\{{"Id":"","BlobPath":"{s}","DatabaseName":"{s}","TableName":"{s}","Format":"{s}","FlushImmediately":{s}}}
-        , .{
-            blob_url,
-            properties.database,
-            properties.table,
-            properties.format.toString(),
-            if (properties.flush_immediately) "true" else "false",
-        });
+        _ = allocator;
+        _ = properties;
+        _ = blob_url;
+        return error.QueuedIngestionNotImplemented;
+    }
+
+    pub fn ingestFromBlobResult(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !core.errors.Result(IngestionResult) {
+        _ = self;
+        _ = allocator;
+        _ = properties;
+        _ = blob_url;
+        return error.QueuedIngestionNotImplemented;
     }
 
     pub fn deinit(self: *QueuedIngestClient, allocator: std.mem.Allocator) void {
@@ -210,10 +164,7 @@ pub const QueuedIngestClient = struct {
 
 // ─────────────── ManagedIngestClient ─────────────────
 
-/// Tries streaming ingestion first, falls back to queued on failure.
-///
-/// Best of both worlds: low latency of streaming with the reliability
-/// of queued ingestion. Recommended for most use cases.
+/// Tries direct streaming ingestion; queued fallback is not implemented.
 pub const ManagedIngestClient = struct {
     streaming: StreamingIngestClient,
     queued: QueuedIngestClient,
@@ -225,19 +176,19 @@ pub const ManagedIngestClient = struct {
         };
     }
 
-    /// Ingest data — tries streaming first, falls back to queued via blob.
+    /// Ingest data through direct streaming.
+    ///
+    /// Returns `error.ManagedIngestionFallbackNotImplemented` if streaming
+    /// fails because queued fallback would be required.
     pub fn ingestFromSlice(self: *ManagedIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !IngestionResult {
-        // Try streaming first.
-        const streaming_result = self.streaming.ingestFromSlice(allocator, database, table, data, options) catch {
-            // Streaming failed — would fall back to queued in production.
-            // Queued requires blob upload which needs storage client integration.
-            return .{ .status = .failed };
+        var streaming_result = try self.streaming.ingestFromSliceResult(allocator, database, table, data, options);
+        return switch (streaming_result) {
+            .ok => |result| result,
+            .err => |*azure_error| {
+                azure_error.deinit();
+                return error.ManagedIngestionFallbackNotImplemented;
+            },
         };
-
-        if (streaming_result.status == .success) return streaming_result;
-
-        // Streaming returned failure status — fall back to queued.
-        return .{ .status = .failed };
     }
 
     pub fn deinit(self: *ManagedIngestClient, allocator: std.mem.Allocator) void {
@@ -277,6 +228,23 @@ test "StreamingIngestClient with mapping name" {
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mappingName=MyMapping") != null);
 }
 
+test "StreamingIngestClient percent-encodes URL components independently" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
+    var client = StreamingIngestClient.init(conn, mock.asTransport());
+
+    _ = try client.ingestFromSlice(allocator, "DB /&?=+", "Table /&?=+", "data", .{
+        .mapping_name = "Mapping /&?=+",
+    });
+    try std.testing.expectEqualStrings(
+        "https://cluster.kusto.windows.net/v1/rest/ingest/DB%20%2F%26%3F%3D%2B/Table%20%2F%26%3F%3D%2B?streamFormat=Csv&mappingName=Mapping%20%2F%26%3F%3D%2B",
+        mock.last_url.?,
+    );
+}
+
 test "StreamingIngestClient failure" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 400,
@@ -291,7 +259,18 @@ test "StreamingIngestClient failure" {
     try std.testing.expectEqual(IngestionStatus.failed, result.status);
 }
 
-test "QueuedIngestClient ingestFromBlob" {
+test "IngestionResult deinit through Result" {
+    const allocator = std.testing.allocator;
+    var result: core.errors.Result(IngestionResult) = .{ .ok = .{
+        .status = .success,
+        .ingestion_id = try allocator.dupe(u8, "ingestion-id"),
+    } };
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqualStrings("ingestion-id", result.ok.ingestion_id.?);
+}
+
+test "QueuedIngestClient does not send placeholder requests" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, "{}");
     defer mock.deinit();
@@ -300,14 +279,21 @@ test "QueuedIngestClient ingestFromBlob" {
     var client = QueuedIngestClient.init(conn, mock.asTransport());
     defer client.deinit(allocator);
 
-    const result = try client.ingestFromBlob(allocator, .{
+    const properties = IngestionProperties{
         .database = "TestDB",
         .table = "Logs",
         .format = .json,
-    }, "https://storage.blob.core.windows.net/container/blob.json");
-
-    try std.testing.expectEqual(IngestionStatus.queued, result.status);
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "ingest-mycluster") != null);
+    };
+    try std.testing.expectError(
+        error.QueuedIngestionNotImplemented,
+        client.ingestFromBlob(allocator, properties, "https://storage.blob.core.windows.net/container/blob.json"),
+    );
+    try std.testing.expect(mock.last_url == null);
+    try std.testing.expectError(
+        error.QueuedIngestionNotImplemented,
+        client.ingestFromBlobResult(allocator, properties, "https://storage.blob.core.windows.net/container/blob.json"),
+    );
+    try std.testing.expect(mock.last_url == null);
 }
 
 test "ManagedIngestClient ingestFromSlice success" {
@@ -321,6 +307,24 @@ test "ManagedIngestClient ingestFromSlice success" {
 
     const result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
     try std.testing.expectEqual(IngestionStatus.success, result.status);
+}
+
+test "ManagedIngestClient does not attempt unimplemented queued fallback" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 400,
+        \\{"error":{"code":"BadRequest","message":"Invalid data"}}
+    );
+    defer mock.deinit();
+
+    const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
+    var client = ManagedIngestClient.init(conn, mock.asTransport());
+    defer client.deinit(allocator);
+
+    try std.testing.expectError(
+        error.ManagedIngestionFallbackNotImplemented,
+        client.ingestFromSlice(allocator, "DB", "Table", "bad", .{}),
+    );
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/ingest/DB/Table") != null);
 }
 
 test "IngestionStatus toString" {


### PR DESCRIPTION
## Summary

- add owned cleanup for Kusto query and ingestion results
- serialize query requests safely and parse buffered rows with JSON-aware traversal
- percent-encode streaming-ingest URL components and return explicit errors for unimplemented queued behavior
- correct Kusto capability documentation

## Testing

- `zig fmt --check sdk/ build.zig`
- `zig build test --summary all`

Closes #45