### PR TITLE
kusto: add stable authenticated connection and pipeline state

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,32 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 
 Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished.
 
+### Kusto authentication and connections
+
+Create authenticated Kusto clients from a shared `KustoConnection`. This example assumes the caller already has a `*TokenCredential` named `credential` and a `*HttpTransport` named `transport`.
+
+```zig
+var builder = KustoConnectionStringBuilder.init("https://mycluster.kusto.windows.net");
+_ = builder.withTokenCredential(credential);
+const properties = builder.build();
+
+const connection = try KustoConnection.init(allocator, properties, transport, .{});
+defer connection.deinit();
+
+var client = KustoClient.initWithConnection(connection, .{});
+// Or: var ingest_client = StreamingIngestClient.initWithConnection(connection);
+```
+
+`KustoConnection` owns copies of its endpoint, scope, user-agent, policy, and token-cache state. It borrows the credential and transport; both must outlive the connection. Derived clients borrow the connection, require no `deinit`, and must not outlive the connection or any in-flight request.
+
+Connections and their derived clients are not safe for concurrent use. Externally serialize all calls, including calls made through separate clients that share a connection.
+
+The existing client constructors remain unauthenticated compatibility APIs only. Passing authentication configuration to them returns `AuthenticatedConnectionRequired`; authenticated code must use `initWithConnection`.
+
+`withAadAppKey` is deprecated and inert for connection creation. It is rejected with `AadAppKeyAuthenticationUnsupported`; supply an `azure_core.credentials.TokenCredential` instead.
+
+The public-cloud Kusto scope is the default. An explicit scope override is available; cloud metadata and sovereign-cloud scope discovery remain planned.
+
 ### Infrastructure
 
 | Package | Description |

--- a/sdk/core/http/pipeline.zig
+++ b/sdk/core/http/pipeline.zig
@@ -298,6 +298,9 @@ pub const RequestIdPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
+        if (request.getHeader("x-ms-client-request-id") != null) {
+            return callNext(request, next, final_transport);
+        }
         const uuid_mod = @import("../uuid.zig");
         const seed: u64 = @truncate(@as(u128, @bitCast(nanoTimestamp())));
         var prng = std.Random.DefaultPrng.init(seed);
@@ -350,7 +353,7 @@ pub const TracingPolicy = struct {
         span.setAttribute("url.full", request.url) catch {};
         span.setAttribute("az.namespace", self.az_namespace) catch {};
 
-        if (request.headers.get("x-ms-client-request-id")) |rid| {
+        if (request.getHeader("x-ms-client-request-id")) |rid| {
             span.setAttribute("az.client_request_id", rid) catch {};
         }
 
@@ -443,6 +446,27 @@ test "RequestIdPolicy injects x-ms-client-request-id" {
     // UUID format: 8-4-4-4-12 = 36 chars.
     try std.testing.expectEqual(@as(usize, 36), request_id.len);
     try std.testing.expectEqual(@as(u8, '-'), request_id[8]);
+}
+
+test "RequestIdPolicy preserves caller-provided request ID" {
+    const allocator = std.testing.allocator;
+    var mock = transport.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    var rid = RequestIdPolicy.init();
+    var policy_ptrs = [_]*HttpPolicy{rid.asPolicy()};
+    var pipeline_inst = HttpPipeline{
+        .policies = &policy_ptrs,
+        .transport_impl = mock.asTransport(),
+    };
+    var req = Request.init(allocator, .GET, "https://example.com");
+    defer req.deinit();
+    try req.setHeader("X-MS-Client-Request-Id", "caller-request-id");
+    var resp = try pipeline_inst.send(&req);
+    defer resp.deinit();
+    try std.testing.expectEqualStrings(
+        "caller-request-id",
+        req.getHeader("x-ms-client-request-id").?,
+    );
 }
 
 test "BearerTokenAuthPolicy injects Authorization header" {

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -44,19 +44,31 @@ pub const Request = struct {
     }
 
     pub fn setHeader(self: *Request, key: []const u8, value: []const u8) !void {
-        const owned_key = try self.allocator.dupe(u8, key);
-        errdefer self.allocator.free(owned_key);
         const owned_value = try self.allocator.dupe(u8, value);
         errdefer self.allocator.free(owned_value);
 
-        const entry = try self.headers.getOrPut(owned_key);
-        if (entry.found_existing) {
-            self.allocator.free(owned_key);
-            self.allocator.free(entry.value_ptr.*);
-        } else {
-            entry.key_ptr.* = owned_key;
+        var iterator = self.headers.iterator();
+        while (iterator.next()) |entry| {
+            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, key)) {
+                self.allocator.free(entry.value_ptr.*);
+                entry.value_ptr.* = owned_value;
+                return;
+            }
         }
-        entry.value_ptr.* = owned_value;
+
+        const owned_key = try self.allocator.dupe(u8, key);
+        errdefer self.allocator.free(owned_key);
+        try self.headers.put(owned_key, owned_value);
+    }
+
+    pub fn getHeader(self: *Request, key: []const u8) ?[]const u8 {
+        var iterator = self.headers.iterator();
+        while (iterator.next()) |entry| {
+            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, key)) {
+                return entry.value_ptr.*;
+            }
+        }
+        return null;
     }
 
     pub fn deinit(self: *Request) void {
@@ -368,6 +380,9 @@ test "request init and set header" {
     try std.testing.expectEqualStrings("application/json", req.headers.get("Accept").?);
     try req.setHeader("Accept", "application/xml");
     try std.testing.expectEqualStrings("application/xml", req.headers.get("Accept").?);
+    try req.setHeader("accept", "application/json");
+    try std.testing.expectEqual(@as(usize, 1), req.headers.count());
+    try std.testing.expectEqualStrings("application/json", req.getHeader("ACCEPT").?);
 }
 
 test "response isSuccess" {

--- a/sdk/kusto/common.zig
+++ b/sdk/kusto/common.zig
@@ -46,6 +46,16 @@ pub const ConnectionProperties = struct {
     application_client_id: ?[]const u8 = null,
     application_key: ?[]const u8 = null,
 
+    /// Renders only the cluster endpoint and authentication mode.
+    ///
+    /// Credential and application-key material is intentionally omitted.
+    pub fn format(self: ConnectionProperties, writer: anytype) !void {
+        try writer.print(
+            "ConnectionProperties(endpoint={s}, auth_mode={s})",
+            .{ self.cluster_url, connectionAuthMode(self) },
+        );
+    }
+
     /// Get the data management (ingest) URL by prepending `ingest-` to the hostname.
     pub fn getIngestUrl(self: ConnectionProperties, allocator: std.mem.Allocator) ![]u8 {
         // https://cluster.region.kusto.windows.net → https://ingest-cluster.region.kusto.windows.net
@@ -73,6 +83,9 @@ pub const KustoConnectionStringBuilder = struct {
     }
 
     /// Authenticate with Azure AD application key (client secret).
+    ///
+    /// Deprecated: use `withTokenCredential`; app-key authentication is not
+    /// supported by `KustoConnection`.
     pub fn withAadAppKey(self: *KustoConnectionStringBuilder, client_id: []const u8, client_secret: []const u8, authority_id: []const u8) *KustoConnectionStringBuilder {
         self.application_client_id = client_id;
         self.application_key = client_secret;
@@ -95,6 +108,152 @@ pub const KustoConnectionStringBuilder = struct {
             .application_client_id = self.application_client_id,
             .application_key = self.application_key,
         };
+    }
+
+    /// Renders only the cluster endpoint and authentication mode.
+    ///
+    /// Credential and application-key material is intentionally omitted.
+    pub fn format(self: KustoConnectionStringBuilder, writer: anytype) !void {
+        try writer.print(
+            "KustoConnectionStringBuilder(endpoint={s}, auth_mode={s})",
+            .{ self.cluster_url, connectionAuthMode(self.build()) },
+        );
+    }
+};
+
+fn connectionAuthMode(properties: ConnectionProperties) []const u8 {
+    if (properties.application_key != null or
+        properties.application_client_id != null or
+        properties.authority_id != null)
+    {
+        return "legacy_app_key";
+    }
+    return if (properties.credential != null) "token_credential" else "none";
+}
+
+// ─────────────── Shared Connection ───────────────
+
+pub const KustoRetryOptions = struct {
+    max_retries: u32 = 3,
+    initial_delay_ms: u64 = 800,
+    max_delay_ms: u64 = 60_000,
+};
+
+pub const KustoConnectionOptions = struct {
+    token_scope: []const u8 = "https://kusto.kusto.windows.net/.default",
+    user_agent: []const u8 = "azsdk-zig-kusto/0.1.0",
+    retry: KustoRetryOptions = .{},
+};
+
+/// Allocator-owned, stable HTTP connection shared by Kusto service clients.
+///
+/// The credential and transport are borrowed and must outlive this connection.
+/// This connection must outlive all derived clients and their in-flight
+/// requests. `HttpTransport` and the authentication cache are not thread-safe,
+/// so callers must externally serialize use of this connection and its derived
+/// clients.
+pub const KustoConnection = struct {
+    allocator: std.mem.Allocator,
+    cluster_url: []u8,
+    token_scope: []u8,
+    user_agent: []u8,
+    credential: *core.credentials.TokenCredential,
+    transport: *core.http.HttpTransport,
+    scopes: [1][]const u8,
+    request_id: core.pipeline.RequestIdPolicy,
+    telemetry: core.pipeline.TelemetryPolicy,
+    retry: core.pipeline.RetryPolicy,
+    auth: core.pipeline.BearerTokenAuthPolicy,
+    decompression: core.decompression.DecompressionPolicy,
+    policies: [5]*core.pipeline.HttpPolicy,
+    pipeline: core.pipeline.HttpPipeline,
+
+    /// This type has mutable policy state and requires external serialization.
+    pub const supports_concurrent_use = false;
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        properties: ConnectionProperties,
+        transport: *core.http.HttpTransport,
+        options: KustoConnectionOptions,
+    ) !*KustoConnection {
+        if (properties.application_key != null or
+            properties.application_client_id != null or
+            properties.authority_id != null)
+        {
+            return error.AadAppKeyAuthenticationUnsupported;
+        }
+        const credential = properties.credential orelse return error.KustoCredentialRequired;
+
+        const self = try allocator.create(KustoConnection);
+        errdefer allocator.destroy(self);
+
+        const normalized_cluster_url = std.mem.trimEnd(u8, properties.cluster_url, "/");
+        const owned_cluster_url = try allocator.dupe(u8, normalized_cluster_url);
+        errdefer allocator.free(owned_cluster_url);
+        const owned_token_scope = try allocator.dupe(u8, options.token_scope);
+        errdefer allocator.free(owned_token_scope);
+        const owned_user_agent = try allocator.dupe(u8, options.user_agent);
+        errdefer allocator.free(owned_user_agent);
+
+        self.allocator = allocator;
+        self.cluster_url = owned_cluster_url;
+        self.token_scope = owned_token_scope;
+        self.user_agent = owned_user_agent;
+        self.credential = credential;
+        self.transport = transport;
+        self.scopes = .{self.token_scope};
+        self.request_id = core.pipeline.RequestIdPolicy.init();
+        self.telemetry = core.pipeline.TelemetryPolicy.init(self.user_agent);
+        self.retry = core.pipeline.RetryPolicy.init();
+        self.retry.max_retries = options.retry.max_retries;
+        self.retry.initial_delay_ms = options.retry.initial_delay_ms;
+        self.retry.max_delay_ms = options.retry.max_delay_ms;
+        self.auth = core.pipeline.BearerTokenAuthPolicy.init(
+            allocator,
+            credential,
+            &self.scopes,
+        );
+        self.decompression = core.decompression.DecompressionPolicy.init();
+        self.policies = .{
+            self.request_id.asPolicy(),
+            self.telemetry.asPolicy(),
+            self.retry.asPolicy(),
+            self.auth.asPolicy(),
+            self.decompression.asPolicy(),
+        };
+        self.pipeline = .{
+            .policies = &self.policies,
+            .transport_impl = transport,
+        };
+        return self;
+    }
+
+    pub fn deinit(self: *KustoConnection) void {
+        const allocator = self.allocator;
+        self.auth.deinit();
+        allocator.free(self.cluster_url);
+        allocator.free(self.token_scope);
+        allocator.free(self.user_agent);
+        allocator.destroy(self);
+    }
+
+    pub fn send(self: *KustoConnection, request: *core.http.Request) !core.http.Response {
+        return self.pipeline.send(request);
+    }
+
+    pub fn clusterUrl(self: *const KustoConnection) []const u8 {
+        return self.cluster_url;
+    }
+
+    /// Renders only the cluster endpoint and authentication mode.
+    ///
+    /// Credential, token, and legacy app-key material is intentionally omitted.
+    pub fn format(self: *const KustoConnection, writer: anytype) !void {
+        try writer.print(
+            "KustoConnection(endpoint={s}, auth_mode=token_credential)",
+            .{self.cluster_url},
+        );
     }
 };
 
@@ -128,6 +287,30 @@ pub const IngestionProperties = struct {
 
 // ─────────────────────── Tests ───────────────────────
 
+const TestTokenCredential = struct {
+    credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
+    call_count: u32 = 0,
+    last_scope: ?[]const u8 = null,
+
+    fn asCredential(self: *TestTokenCredential) *core.credentials.TokenCredential {
+        return &self.credential;
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        request_context: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+    ) anyerror!core.credentials.AccessToken {
+        const self: *TestTokenCredential = @alignCast(@fieldParentPtr("credential", credential));
+        self.call_count += 1;
+        self.last_scope = request_context.scopes[0];
+        return .{
+            .token = "connection-test-token",
+            .expires_on = std.math.maxInt(i64),
+        };
+    }
+};
+
 test "KustoConnectionStringBuilder build" {
     var kcsb = KustoConnectionStringBuilder.init("https://mycluster.eastus.kusto.windows.net");
     _ = kcsb.withAadAppKey("app-id", "secret", "tenant-id");
@@ -136,6 +319,212 @@ test "KustoConnectionStringBuilder build" {
     try std.testing.expectEqualStrings("app-id", props.application_client_id.?);
     try std.testing.expectEqualStrings("secret", props.application_key.?);
     try std.testing.expectEqualStrings("tenant-id", props.authority_id.?);
+}
+
+test "KustoConnection owns normalized configuration" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    var credential = TestTokenCredential{};
+    var cluster_url = "https://cluster.kusto.windows.net///".*;
+    var token_scope = "scope-value".*;
+    var user_agent = "user-agent-value".*;
+
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = cluster_url[0..],
+            .credential = credential.asCredential(),
+        },
+        mock.asTransport(),
+        .{
+            .token_scope = token_scope[0..],
+            .user_agent = user_agent[0..],
+        },
+    );
+    defer connection.deinit();
+
+    cluster_url[0] = 'x';
+    token_scope[0] = 'x';
+    user_agent[0] = 'x';
+    try std.testing.expectEqualStrings("https://cluster.kusto.windows.net", connection.clusterUrl());
+    try std.testing.expectEqualStrings("scope-value", connection.token_scope);
+    try std.testing.expectEqualStrings("user-agent-value", connection.user_agent);
+}
+
+test "KustoConnection rejects unsupported and missing authentication" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+
+    try std.testing.expectError(
+        error.AadAppKeyAuthenticationUnsupported,
+        KustoConnection.init(
+            allocator,
+            .{ .cluster_url = "https://cluster.kusto.windows.net", .application_key = "secret" },
+            mock.asTransport(),
+            .{},
+        ),
+    );
+    try std.testing.expectError(
+        error.AadAppKeyAuthenticationUnsupported,
+        KustoConnection.init(
+            allocator,
+            .{ .cluster_url = "https://cluster.kusto.windows.net", .application_client_id = "client-id" },
+            mock.asTransport(),
+            .{},
+        ),
+    );
+    try std.testing.expectError(
+        error.AadAppKeyAuthenticationUnsupported,
+        KustoConnection.init(
+            allocator,
+            .{ .cluster_url = "https://cluster.kusto.windows.net", .authority_id = "tenant-id" },
+            mock.asTransport(),
+            .{},
+        ),
+    );
+    try std.testing.expectError(
+        error.KustoCredentialRequired,
+        KustoConnection.init(
+            allocator,
+            .{ .cluster_url = "https://cluster.kusto.windows.net" },
+            mock.asTransport(),
+            .{},
+        ),
+    );
+}
+
+test "Kusto connection formatting omits authentication material" {
+    const allocator = std.testing.allocator;
+    const sentinel_secret = "connection-format-sentinel-secret";
+    var builder = KustoConnectionStringBuilder.init("https://cluster.kusto.windows.net");
+    _ = builder.withAadAppKey("client-id", sentinel_secret, "tenant-id");
+    const properties = builder.build();
+    var buffer: [256]u8 = undefined;
+
+    const builder_rendered = try std.fmt.bufPrint(&buffer, "{f}", .{builder});
+    try std.testing.expect(std.mem.indexOf(u8, builder_rendered, sentinel_secret) == null);
+    try std.testing.expect(std.mem.indexOf(u8, builder_rendered, "legacy_app_key") != null);
+    const properties_rendered = try std.fmt.bufPrint(&buffer, "{f}", .{properties});
+    try std.testing.expect(std.mem.indexOf(u8, properties_rendered, sentinel_secret) == null);
+    try std.testing.expect(std.mem.indexOf(u8, properties_rendered, "legacy_app_key") != null);
+
+    var mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    var credential = TestTokenCredential{};
+    const connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = properties.cluster_url, .credential = credential.asCredential() },
+        mock.asTransport(),
+        .{},
+    );
+    defer connection.deinit();
+
+    const connection_rendered = try std.fmt.bufPrint(&buffer, "{f}", .{connection});
+    try std.testing.expect(std.mem.indexOf(u8, connection_rendered, sentinel_secret) == null);
+    try std.testing.expect(std.mem.indexOf(u8, connection_rendered, "token_credential") != null);
+}
+
+test "KustoConnection sends authenticated request with default and override scopes" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    var credential = TestTokenCredential{};
+
+    const connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        mock.asTransport(),
+        .{},
+    );
+    defer connection.deinit();
+
+    var request = core.http.Request.init(allocator, .GET, "https://cluster.kusto.windows.net/v2/rest/query");
+    defer request.deinit();
+    var response = try connection.send(&request);
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u32, 1), credential.call_count);
+    try std.testing.expectEqualStrings("https://kusto.kusto.windows.net/.default", credential.last_scope.?);
+    try std.testing.expect(std.mem.endsWith(u8, mock.last_headers.get("Authorization").?, "connection-test-token"));
+    try std.testing.expectEqualStrings("azsdk-zig-kusto/0.1.0", mock.last_headers.get("User-Agent").?);
+    try std.testing.expectEqualStrings("gzip, deflate", mock.last_headers.get("Accept-Encoding").?);
+    const request_id = mock.last_headers.get("x-ms-client-request-id").?;
+    try std.testing.expectEqual(@as(usize, 36), request_id.len);
+    try std.testing.expect(request_id[8] == '-' and request_id[13] == '-' and
+        request_id[18] == '-' and request_id[23] == '-');
+
+    var override_mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer override_mock.deinit();
+    const override_connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        override_mock.asTransport(),
+        .{ .token_scope = "https://custom.kusto.windows.net/.default" },
+    );
+    defer override_connection.deinit();
+    var override_request = core.http.Request.init(allocator, .GET, "https://cluster.kusto.windows.net/v2/rest/query");
+    defer override_request.deinit();
+    var override_response = try override_connection.send(&override_request);
+    defer override_response.deinit();
+
+    try std.testing.expectEqual(@as(u32, 2), credential.call_count);
+    try std.testing.expectEqualStrings("https://custom.kusto.windows.net/.default", credential.last_scope.?);
+    try std.testing.expect(std.mem.endsWith(u8, override_mock.last_headers.get("Authorization").?, "connection-test-token"));
+}
+
+test "KustoConnection applies retry options" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 500, .body = "retry" },
+        .{ .status = 200, .body = "ok" },
+    });
+    var credential = TestTokenCredential{};
+    const connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        transport.asTransport(),
+        .{ .retry = .{ .max_retries = 1, .initial_delay_ms = 0 } },
+    );
+    defer connection.deinit();
+    var request = core.http.Request.init(allocator, .GET, "https://cluster.kusto.windows.net/v2/rest/query");
+    defer request.deinit();
+    var response = try connection.send(&request);
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+}
+
+fn initializeConnection(
+    allocator: std.mem.Allocator,
+    credential: *core.credentials.TokenCredential,
+    transport: *core.http.HttpTransport,
+) !void {
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net/",
+            .credential = credential,
+        },
+        transport,
+        .{},
+    );
+    connection.deinit();
+}
+
+test "KustoConnection handles every initialization allocation failure" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    var credential = TestTokenCredential{};
+
+    try std.testing.checkAllAllocationFailures(
+        allocator,
+        initializeConnection,
+        .{ credential.asCredential(), mock.asTransport() },
+    );
 }
 
 test "KustoConnectionStringBuilder withTokenCredential" {

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -9,6 +9,9 @@ const kusto_common = @import("azure_kusto_common");
 
 pub const ConnectionProperties = kusto_common.ConnectionProperties;
 pub const ClientRequestProperties = kusto_common.ClientRequestProperties;
+pub const KustoConnection = kusto_common.KustoConnection;
+pub const KustoConnectionOptions = kusto_common.KustoConnectionOptions;
+pub const KustoRetryOptions = kusto_common.KustoRetryOptions;
 
 // ─────────────────── Response Types ──────────────────
 
@@ -82,10 +85,22 @@ pub const KustoClientOptions = struct {
 };
 
 /// Client for executing KQL queries and management commands against a Kusto cluster.
+///
+/// Clients created with `initWithConnection` borrow their `KustoConnection` and
+/// may be copied or moved. The connection must outlive every client copy. Since
+/// `KustoConnection.supports_concurrent_use` is false, callers must serialize
+/// requests that share one connection.
 pub const KustoClient = struct {
-    connection: ConnectionProperties,
-    pipeline: core.pipeline.HttpPipeline,
+    runtime: Runtime,
     application_name: []const u8,
+
+    const Runtime = union(enum) {
+        legacy: struct {
+            connection: ConnectionProperties,
+            pipeline: core.pipeline.HttpPipeline,
+        },
+        shared: *KustoConnection,
+    };
 
     pub fn init(
         connection: ConnectionProperties,
@@ -93,24 +108,37 @@ pub const KustoClient = struct {
         options: KustoClientOptions,
     ) KustoClient {
         return .{
-            .connection = connection,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .runtime = .{ .legacy = .{
+                .connection = connection,
+                .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            } },
+            .application_name = options.application_name,
+        };
+    }
+
+    /// Create a client that borrows `connection`; this client has no deinit.
+    ///
+    /// The connection must outlive this client and all copies of it. Serialize
+    /// their use because `KustoConnection.supports_concurrent_use` is false.
+    pub fn initWithConnection(connection: *KustoConnection, options: KustoClientOptions) KustoClient {
+        return .{
+            .runtime = .{ .shared = connection },
             .application_name = options.application_name,
         };
     }
 
     /// Execute a KQL query. Uses v2 REST endpoint.
     pub fn executeQuery(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.connection.cluster_url});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.clusterUrl()});
         defer allocator.free(url);
-        return self.executeInternal(allocator, url, database, query, properties);
+        return self.executeInternal(allocator, url, database, query, properties, true);
     }
 
     /// Execute a management command (starts with `.`). Uses v1 REST endpoint.
     pub fn executeMgmt(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.connection.cluster_url});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.clusterUrl()});
         defer allocator.free(url);
-        return self.executeInternal(allocator, url, database, command, properties);
+        return self.executeInternal(allocator, url, database, command, properties, false);
     }
 
     /// Auto-routing: commands starting with `.` go to mgmt, others to query.
@@ -124,14 +152,14 @@ pub const KustoClient = struct {
 
     /// `Result(...)` variants of the execute methods.
     pub fn executeQueryResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.connection.cluster_url});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.clusterUrl()});
         defer allocator.free(url);
-        return self.executeInternalResult(allocator, url, database, query, properties);
+        return self.executeInternalResult(allocator, url, database, query, properties, true);
     }
     pub fn executeMgmtResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.connection.cluster_url});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.clusterUrl()});
         defer allocator.free(url);
-        return self.executeInternalResult(allocator, url, database, command, properties);
+        return self.executeInternalResult(allocator, url, database, command, properties, false);
     }
     pub fn executeResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query_or_command: []const u8) !core.errors.Result(KustoResponseDataSet) {
         const trimmed = std.mem.trimStart(u8, query_or_command, " \t\n\r");
@@ -148,8 +176,9 @@ pub const KustoClient = struct {
         database: []const u8,
         csl: []const u8,
         properties: ?ClientRequestProperties,
+        retryable: bool,
     ) !KustoResponseDataSet {
-        var r = try self.executeInternalResult(allocator, url, database, csl, properties);
+        var r = try self.executeInternalResult(allocator, url, database, csl, properties, retryable);
         return r.unwrap(error.KustoQueryFailed);
     }
 
@@ -160,6 +189,7 @@ pub const KustoClient = struct {
         database: []const u8,
         csl: []const u8,
         properties: ?ClientRequestProperties,
+        retryable: bool,
     ) !core.errors.Result(KustoResponseDataSet) {
         const body = try serializeRequest(allocator, database, csl, properties);
         defer allocator.free(body);
@@ -169,9 +199,15 @@ pub const KustoClient = struct {
         try req.setHeader("Content-Type", "application/json; charset=utf-8");
         try req.setHeader("Accept", "application/json");
         try req.setHeader("x-ms-app", self.application_name);
+        if (properties) |props| {
+            if (props.client_request_id) |request_id| {
+                try req.setHeader("x-ms-client-request-id", request_id);
+            }
+        }
         req.body = body;
+        req.retryable = retryable;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -182,6 +218,30 @@ pub const KustoClient = struct {
         }
 
         return .{ .ok = try parseResponseDataSet(allocator, resp.body) };
+    }
+
+    fn clusterUrl(self: *const KustoClient) []const u8 {
+        return switch (self.runtime) {
+            .legacy => |legacy| legacy.connection.cluster_url,
+            .shared => |connection| connection.clusterUrl(),
+        };
+    }
+
+    fn send(self: *KustoClient, req: *core.http.Request) !core.http.Response {
+        return switch (self.runtime) {
+            .shared => |connection| connection.send(req),
+            .legacy => |*legacy| {
+                const connection = legacy.connection;
+                if (connection.credential != null or
+                    connection.authority_id != null or
+                    connection.application_client_id != null or
+                    connection.application_key != null)
+                {
+                    return error.AuthenticatedConnectionRequired;
+                }
+                return legacy.pipeline.send(req);
+            },
+        };
     }
 };
 
@@ -465,6 +525,30 @@ fn decodeCell(allocator: std.mem.Allocator, cell_slice: []const u8) ![]const u8 
 
 // ─────────────────────── Tests ───────────────────────
 
+const TestTokenCredential = struct {
+    credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
+    call_count: usize = 0,
+    last_scope: ?[]const u8 = null,
+
+    fn asCredential(self: *TestTokenCredential) *core.credentials.TokenCredential {
+        return &self.credential;
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        request_context: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+    ) anyerror!core.credentials.AccessToken {
+        const self: *TestTokenCredential = @alignCast(@fieldParentPtr("credential", credential));
+        self.call_count += 1;
+        self.last_scope = request_context.scopes[0];
+        return .{
+            .token = "data-client-test-token",
+            .expires_on = std.math.maxInt(i64),
+        };
+    }
+};
+
 test "KustoClient executeQuery" {
     const allocator = std.testing.allocator;
     const response_body =
@@ -488,6 +572,157 @@ test "KustoClient executeQuery" {
     try std.testing.expectEqualStrings("Count", primary.columns[0].name);
     try std.testing.expectEqual(@as(usize, 1), primary.rows.len);
     try std.testing.expectEqualStrings("42", primary.rows[0].values[0]);
+}
+
+test "shared KustoClient authenticates queries" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    defer mock.deinit();
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net/",
+            .credential = credential.asCredential(),
+        },
+        mock.asTransport(),
+        .{},
+    );
+    defer connection.deinit();
+
+    var client = KustoClient.initWithConnection(connection, .{});
+    var result = try client.executeQuery(
+        allocator,
+        "db",
+        "print 1",
+        .{ .client_request_id = "kusto-test-request-id" },
+    );
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), credential.call_count);
+    try std.testing.expectEqualStrings(
+        "https://kusto.kusto.windows.net/.default",
+        credential.last_scope.?,
+    );
+    try std.testing.expect(mock.last_headers.get("Authorization") != null);
+    try std.testing.expectEqualStrings(
+        "kusto-test-request-id",
+        mock.last_headers.get("x-ms-client-request-id").?,
+    );
+    try std.testing.expectEqualStrings(
+        "https://cluster.kusto.windows.net/v2/rest/query",
+        mock.last_url.?,
+    );
+}
+
+test "copied shared KustoClient remains usable" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    defer mock.deinit();
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential.asCredential(),
+        },
+        mock.asTransport(),
+        .{},
+    );
+    defer connection.deinit();
+
+    const copied = KustoClient.initWithConnection(connection, .{});
+    var moved = copied;
+    var result = try moved.executeQuery(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+
+    try std.testing.expect(mock.last_url != null);
+    try std.testing.expectEqual(@as(usize, 1), credential.call_count);
+}
+
+test "legacy authenticated KustoClient fails before transport" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential.asCredential(),
+        },
+        mock.asTransport(),
+        .{},
+    );
+
+    try std.testing.expectError(
+        error.AuthenticatedConnectionRequired,
+        client.executeQuery(allocator, "db", "print 1", null),
+    );
+    try std.testing.expect(mock.last_url == null);
+    try std.testing.expectEqual(@as(usize, 0), credential.call_count);
+}
+
+test "shared KustoClient retries queries" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 500, .body = "server error" },
+        .{ .status = 200, .body = "[]" },
+    };
+    var sequence = core.http.SequenceMockTransport.init(allocator, &responses);
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential.asCredential(),
+        },
+        sequence.asTransport(),
+        .{ .retry = .{
+            .max_retries = 1,
+            .initial_delay_ms = 0,
+            .max_delay_ms = 0,
+        } },
+    );
+    defer connection.deinit();
+
+    var client = KustoClient.initWithConnection(connection, .{});
+    var result = try client.executeQuery(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
+}
+
+test "shared KustoClient does not retry management commands" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 500,
+            .body = "{\"error\":{\"code\":\"ServerError\",\"message\":\"failed\"}}",
+        },
+        .{ .status = 200, .body = "[]" },
+    };
+    var sequence = core.http.SequenceMockTransport.init(allocator, &responses);
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential.asCredential(),
+        },
+        sequence.asTransport(),
+        .{ .retry = .{
+            .max_retries = 1,
+            .initial_delay_ms = 0,
+            .max_delay_ms = 0,
+        } },
+    );
+    defer connection.deinit();
+
+    var client = KustoClient.initWithConnection(connection, .{});
+    try std.testing.expectError(
+        error.KustoQueryFailed,
+        client.executeMgmt(allocator, "db", ".show tables", null),
+    );
+    try std.testing.expectEqual(@as(usize, 1), sequence.call_count);
 }
 
 test "KustoClient executeMgmt" {

--- a/sdk/kusto/ingest/root.zig
+++ b/sdk/kusto/ingest/root.zig
@@ -11,6 +11,9 @@ const kusto_common = @import("azure_kusto_common");
 pub const ConnectionProperties = kusto_common.ConnectionProperties;
 pub const DataFormat = kusto_common.DataFormat;
 pub const IngestionProperties = kusto_common.IngestionProperties;
+pub const KustoConnection = kusto_common.KustoConnection;
+pub const KustoConnectionOptions = kusto_common.KustoConnectionOptions;
+pub const KustoRetryOptions = kusto_common.KustoRetryOptions;
 
 // ─────────────────── Types ───────────────────────────
 
@@ -53,14 +56,32 @@ pub const IngestOptions = struct {
 /// Fast but limited to small payloads (<4MB). Queued ingestion for larger or
 /// more reliable payloads is planned but not implemented.
 pub const StreamingIngestClient = struct {
-    connection: ConnectionProperties,
-    pipeline: core.pipeline.HttpPipeline,
+    runtime: Runtime,
+
+    const Runtime = union(enum) {
+        legacy: struct {
+            connection: ConnectionProperties,
+            pipeline: core.pipeline.HttpPipeline,
+        },
+        shared: *KustoConnection,
+    };
 
     pub fn init(connection: ConnectionProperties, transport: *core.http.HttpTransport) StreamingIngestClient {
         return .{
-            .connection = connection,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .runtime = .{ .legacy = .{
+                .connection = connection,
+                .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            } },
         };
+    }
+
+    /// Creates a client borrowing `connection`.
+    ///
+    /// The connection must outlive this client and all copies of it. Shared
+    /// clients are not thread-safe; serialize use of the client and connection.
+    /// This client does not deinitialize the borrowed connection.
+    pub fn initWithConnection(connection: *KustoConnection) StreamingIngestClient {
+        return .{ .runtime = .{ .shared = connection } };
     }
 
     /// Ingest data from a byte slice.
@@ -93,8 +114,9 @@ pub const StreamingIngestClient = struct {
         try req.setHeader("Content-Encoding", "utf-8");
         try req.setHeader("x-ms-app", "azure-sdk-zig");
         req.body = data;
+        req.retryable = false;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -113,16 +135,33 @@ pub const StreamingIngestClient = struct {
         const encoded_table = try core.url.percentEncode(allocator, table);
         defer allocator.free(encoded_table);
 
+        const cluster_url = switch (self.runtime) {
+            .legacy => |legacy| legacy.connection.cluster_url,
+            .shared => |connection| connection.clusterUrl(),
+        };
+
         if (options.mapping_name) |mapping| {
             const encoded_mapping = try core.url.percentEncode(allocator, mapping);
             defer allocator.free(encoded_mapping);
             return std.fmt.allocPrint(allocator, "{s}/v1/rest/ingest/{s}/{s}?streamFormat={s}&mappingName={s}", .{
-                self.connection.cluster_url, encoded_database, encoded_table, options.format.toString(), encoded_mapping,
+                cluster_url, encoded_database, encoded_table, options.format.toString(), encoded_mapping,
             });
         }
         return std.fmt.allocPrint(allocator, "{s}/v1/rest/ingest/{s}/{s}?streamFormat={s}", .{
-            self.connection.cluster_url, encoded_database, encoded_table, options.format.toString(),
+            cluster_url, encoded_database, encoded_table, options.format.toString(),
         });
+    }
+
+    fn send(self: *StreamingIngestClient, request: *core.http.Request) !core.http.Response {
+        return switch (self.runtime) {
+            .shared => |connection| connection.send(request),
+            .legacy => |*legacy| {
+                if (connectionHasAuthentication(legacy.connection)) {
+                    return error.AuthenticatedConnectionRequired;
+                }
+                return legacy.pipeline.send(request);
+            },
+        };
     }
 };
 
@@ -130,15 +169,33 @@ pub const StreamingIngestClient = struct {
 
 /// Queued ingestion is planned but not implemented.
 pub const QueuedIngestClient = struct {
-    connection: ConnectionProperties,
-    pipeline: core.pipeline.HttpPipeline,
+    runtime: Runtime,
     dm_url: ?[]u8 = null,
+
+    const Runtime = union(enum) {
+        legacy: struct {
+            connection: ConnectionProperties,
+            pipeline: core.pipeline.HttpPipeline,
+        },
+        shared: *KustoConnection,
+    };
 
     pub fn init(connection: ConnectionProperties, transport: *core.http.HttpTransport) QueuedIngestClient {
         return .{
-            .connection = connection,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .runtime = .{ .legacy = .{
+                .connection = connection,
+                .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            } },
         };
+    }
+
+    /// Creates a client borrowing `connection`.
+    ///
+    /// The connection must outlive this client and all copies of it. Shared
+    /// clients are not thread-safe; serialize use of the client and connection.
+    /// This client does not deinitialize the borrowed connection.
+    pub fn initWithConnection(connection: *KustoConnection) QueuedIngestClient {
+        return .{ .runtime = .{ .shared = connection } };
     }
 
     pub fn ingestFromBlob(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !IngestionResult {
@@ -176,6 +233,18 @@ pub const ManagedIngestClient = struct {
         };
     }
 
+    /// Creates a client whose streaming and queued clients borrow `connection`.
+    ///
+    /// The connection must outlive this client and all copies of it. Shared
+    /// clients are not thread-safe; serialize use of the client and connection.
+    /// This client does not deinitialize the borrowed connection.
+    pub fn initWithConnection(connection: *KustoConnection) ManagedIngestClient {
+        return .{
+            .streaming = StreamingIngestClient.initWithConnection(connection),
+            .queued = QueuedIngestClient.initWithConnection(connection),
+        };
+    }
+
     /// Ingest data through direct streaming.
     ///
     /// Returns `error.ManagedIngestionFallbackNotImplemented` if streaming
@@ -196,6 +265,13 @@ pub const ManagedIngestClient = struct {
     }
 };
 
+fn connectionHasAuthentication(connection: ConnectionProperties) bool {
+    return connection.credential != null or
+        connection.application_client_id != null or
+        connection.application_key != null or
+        connection.authority_id != null;
+}
+
 // ─────────────────────── Tests ───────────────────────
 
 test "StreamingIngestClient ingestFromSlice" {
@@ -210,6 +286,7 @@ test "StreamingIngestClient ingestFromSlice" {
     try std.testing.expectEqual(IngestionStatus.success, result.status);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/ingest/TestDB/Logs") != null);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "streamFormat=Json") != null);
+    try std.testing.expectEqual(false, mock.last_retryable.?);
 }
 
 test "StreamingIngestClient with mapping name" {
@@ -226,6 +303,103 @@ test "StreamingIngestClient with mapping name" {
     });
     try std.testing.expectEqual(IngestionStatus.success, result.status);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mappingName=MyMapping") != null);
+}
+
+test "shared StreamingIngestClient authenticates through KustoConnection" {
+    const allocator = std.testing.allocator;
+    var token_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"shared-token","expires_in":3600}
+    );
+    defer token_mock.deinit();
+    var service_mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer service_mock.deinit();
+
+    const identity = core.identity;
+    var credential = identity.ClientSecretCredential.init(
+        allocator,
+        token_mock.asTransport(),
+        "tenant",
+        "client",
+        "secret",
+    );
+    const properties = ConnectionProperties{
+        .cluster_url = "https://cluster.kusto.windows.net",
+        .credential = credential.asCredential(),
+    };
+    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    defer connection.deinit();
+
+    var client = StreamingIngestClient.initWithConnection(connection);
+    const result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
+    try std.testing.expectEqual(IngestionStatus.success, result.status);
+    try std.testing.expect(token_mock.last_url != null);
+    try std.testing.expect(service_mock.last_headers.get("Authorization") != null);
+    try std.testing.expectEqual(false, service_mock.last_retryable.?);
+}
+
+test "shared StreamingIngestClient can be copied" {
+    const allocator = std.testing.allocator;
+    var service_mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer service_mock.deinit();
+
+    var credential = core.credentials.TokenCredential{ .getTokenFn = &successfulTokenRequest };
+    const properties = ConnectionProperties{
+        .cluster_url = "https://cluster.kusto.windows.net",
+        .credential = &credential,
+    };
+    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    defer connection.deinit();
+
+    const original = StreamingIngestClient.initWithConnection(connection);
+    var copied = original;
+    _ = try copied.ingestFromSlice(allocator, "DB", "Table", "data", .{});
+    try std.testing.expect(service_mock.last_url != null);
+}
+
+test "ManagedIngestClient shared initialization composes borrowed clients" {
+    const allocator = std.testing.allocator;
+    var service_mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer service_mock.deinit();
+
+    var credential = core.credentials.TokenCredential{ .getTokenFn = &successfulTokenRequest };
+    const properties = ConnectionProperties{
+        .cluster_url = "https://cluster.kusto.windows.net",
+        .credential = &credential,
+    };
+    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    defer connection.deinit();
+
+    var client = ManagedIngestClient.initWithConnection(connection);
+    defer client.deinit(allocator);
+    const result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
+    try std.testing.expectEqual(IngestionStatus.success, result.status);
+    try std.testing.expect(service_mock.last_headers.get("Authorization") != null);
+}
+
+test "configured shared connection does not retry streaming writes" {
+    const allocator = std.testing.allocator;
+    var service_mock = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 500, .body =
+        \\{"error":{"code":"ServerError","message":"retry me"}}
+        },
+        .{ .status = 200, .body = "{}" },
+    });
+
+    var credential = core.credentials.TokenCredential{ .getTokenFn = &successfulTokenRequest };
+    const properties = ConnectionProperties{
+        .cluster_url = "https://cluster.kusto.windows.net",
+        .credential = &credential,
+    };
+    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    defer connection.deinit();
+
+    var client = StreamingIngestClient.initWithConnection(connection);
+    const result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
+    try std.testing.expectEqual(
+        IngestionStatus.failed,
+        result.status,
+    );
+    try std.testing.expectEqual(@as(usize, 1), service_mock.call_count);
 }
 
 test "StreamingIngestClient percent-encodes URL components independently" {
@@ -257,6 +431,44 @@ test "StreamingIngestClient failure" {
 
     const result = try client.ingestFromSlice(allocator, "DB", "Table", "bad", .{});
     try std.testing.expectEqual(IngestionStatus.failed, result.status);
+}
+
+fn unexpectedTokenRequest(
+    _: *core.credentials.TokenCredential,
+    _: core.credentials.TokenRequestContext,
+    _: core.context.Context,
+) anyerror!core.credentials.AccessToken {
+    return error.UnexpectedTokenRequest;
+}
+
+fn successfulTokenRequest(
+    _: *core.credentials.TokenCredential,
+    _: core.credentials.TokenRequestContext,
+    _: core.context.Context,
+) anyerror!core.credentials.AccessToken {
+    return .{
+        .token = "shared-token",
+        .expires_on = std.math.maxInt(i64),
+    };
+}
+
+test "legacy authenticated StreamingIngestClient requires shared connection" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    var credential = core.credentials.TokenCredential{ .getTokenFn = &unexpectedTokenRequest };
+    const conn = ConnectionProperties{
+        .cluster_url = "https://cluster.kusto.windows.net",
+        .credential = &credential,
+    };
+    var client = StreamingIngestClient.init(conn, mock.asTransport());
+
+    try std.testing.expectError(
+        error.AuthenticatedConnectionRequired,
+        client.ingestFromSliceResult(allocator, "DB", "Table", "data", .{}),
+    );
+    try std.testing.expect(mock.last_url == null);
 }
 
 test "IngestionResult deinit through Result" {


### PR DESCRIPTION
Closes #46

Adds a heap-stable shared `KustoConnection` that owns policy and token-cache state while borrowing the caller credential and transport. Data and ingestion clients can now borrow this connection through `initWithConnection`, apply bearer authentication, telemetry, request IDs, retries, and decompression, and move safely without owning cleanup.

Legacy constructors remain available for unauthenticated compatibility and reject authentication configuration instead of silently sending anonymous requests. Management and ingestion writes are explicitly non-retryable, request headers are handled case-insensitively, and caller-provided request IDs are preserved.

Documents ownership, serialized-use requirements, app-key migration, and deferred cloud metadata behavior.