### PR TITLE
kusto: discover cloud metadata and validate endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,24 @@ The existing client constructors remain unauthenticated compatibility APIs only.
 
 `withAadAppKey` is deprecated and inert for connection creation. It is rejected with `AadAppKeyAuthenticationUnsupported`; supply an `azure_core.credentials.TokenCredential` instead.
 
-The public-cloud Kusto scope is the default. An explicit scope override is available; cloud metadata and sovereign-cloud scope discovery remain planned.
+Metadata discovery is enabled by default for authenticated connections. Before acquiring a token, the connection makes an unauthenticated, no-follow `GET` request to `/v1/rest/auth/metadata` on the engine endpoint. The response provides login authority details and `KustoServiceResourceId`; the resource ID is used to derive the token scope. Only a 404 or an empty metadata response uses the public-cloud fallback. When the caller supplies a `KustoCloudInfoCache`, discovered metadata is cached for reuse.
+
+Every initial, discovered, or explicitly configured endpoint is validated before token acquisition. Kusto accepts the current well-known public and sovereign Kusto domains by default; custom or private front-door hosts must be added as exact entries in `additional_trusted_hosts` (wildcards and suffix matches are not accepted). A malformed or untrusted endpoint is rejected before the credential is called. For Private Link, use the normal public cluster hostname and configure private DNS; do not pass a `privatelink` URL as the cluster endpoint.
+
+Use `KustoConnectionOptions` to override discovery when needed:
+
+```zig
+const options = KustoConnectionOptions{
+    .engine_endpoint = "https://mycluster.kusto.windows.net",
+    .data_management_endpoint = "https://ingest-mycluster.kusto.windows.net",
+    .token_scope = "https://kusto.kusto.windows.net/.default",
+};
+const connection = try KustoConnection.init(allocator, properties, transport, options);
+```
+
+Set `.metadata_mode = .disabled` for offline or custom bootstrap control. Trust validation still runs with discovery disabled, and the token scope defaults to the public-cloud scope unless `token_scope` is explicitly provided. Explicit endpoint and scope overrides are still subject to endpoint validation.
+
+Metadata can expose the login authority for a sovereign or private cloud, but `TokenCredential` is an opaque credential boundary: Kusto cannot reconfigure a generic credential at runtime. Callers using those clouds must construct or configure their credential for the discovered authority themselves; do not assume that every `azure_core` credential supports runtime authority changes.
 
 ### Infrastructure
 

--- a/build.zig
+++ b/build.zig
@@ -149,6 +149,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
+            .{ .name = "serde", .module = serde_mod },
         },
     });
 
@@ -396,6 +397,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
+                    .{ .name = "serde", .module = serde_mod },
                 },
             }),
         });

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -24,6 +24,12 @@ pub const Method = enum {
     }
 };
 
+/// Controls whether an HTTP transport may follow redirects.
+pub const RedirectPolicy = enum {
+    follow,
+    not_allowed,
+};
+
 /// An outgoing HTTP request.
 pub const Request = struct {
     method: Method = .GET,
@@ -32,6 +38,7 @@ pub const Request = struct {
     body: ?[]const u8 = null,
     allocator: std.mem.Allocator,
     retryable: bool = true,
+    redirect_policy: RedirectPolicy = .follow,
 
     pub fn init(allocator: std.mem.Allocator, method: Method, request_url: []const u8) Request {
         return .{
@@ -97,6 +104,8 @@ pub const Response = struct {
 ///
 /// Default implementation uses `std.http.Client` (TLS via `std.crypto.tls`).
 /// Users may supply their own for testing or custom networking.
+/// Custom implementations must honor `.not_allowed`; this is a security
+/// contract for bootstrap calls.
 pub const HttpTransport = struct {
     sendFn: *const fn (self: *HttpTransport, request: *Request) anyerror!Response,
 
@@ -158,7 +167,10 @@ pub const StdHttpTransport = struct {
         // Use lower-level API to access response headers.
         var req = try self.client.request(request.method.toStd(), uri, .{
             .extra_headers = extra.items,
-            .redirect_behavior = if (authenticated) .not_allowed else @enumFromInt(3),
+            .redirect_behavior = if (authenticated or request.redirect_policy == .not_allowed)
+                .not_allowed
+            else
+                @enumFromInt(3),
         });
         defer req.deinit();
 
@@ -242,6 +254,8 @@ pub const MockTransport = struct {
     last_headers: std.StringHashMap([]const u8),
     last_body: ?[]u8 = null,
     last_retryable: ?bool = null,
+    last_redirect_policy: ?RedirectPolicy = null,
+    call_count: usize = 0,
     response_headers_list: []const HeaderPair = &.{},
 
     pub fn init(allocator: std.mem.Allocator, status: u16, body: []const u8) MockTransport {
@@ -253,6 +267,8 @@ pub const MockTransport = struct {
             .last_method = null,
             .last_url = null,
             .last_headers = std.StringHashMap([]const u8).init(allocator),
+            .last_redirect_policy = null,
+            .call_count = 0,
         };
     }
 
@@ -268,6 +284,7 @@ pub const MockTransport = struct {
 
     fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
         const self: *MockTransport = @alignCast(@fieldParentPtr("transport", transport));
+        self.call_count += 1;
         self.last_method = request.method;
         if (self.last_url) |old| self.allocator.free(old);
         self.last_url = try self.allocator.dupe(u8, request.url);
@@ -286,6 +303,7 @@ pub const MockTransport = struct {
             try self.last_headers.put(name, value);
         }
         self.last_retryable = request.retryable;
+        self.last_redirect_policy = request.redirect_policy;
 
         const response_body_copy = try self.allocator.dupe(u8, self.response_body);
         errdefer self.allocator.free(response_body_copy);
@@ -376,6 +394,9 @@ test "request init and set header" {
     const allocator = std.testing.allocator;
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
+    try std.testing.expectEqual(RedirectPolicy.follow, req.redirect_policy);
+    req.redirect_policy = .not_allowed;
+    try std.testing.expectEqual(RedirectPolicy.not_allowed, req.redirect_policy);
     try req.setHeader("Accept", "application/json");
     try std.testing.expectEqualStrings("application/json", req.headers.get("Accept").?);
     try req.setHeader("Accept", "application/xml");
@@ -403,6 +424,7 @@ test "mock transport" {
     var req = Request.init(allocator, .POST, "https://vault.azure.net/secrets/mysecret");
     defer req.deinit();
     req.body = "{\"value\":\"secret-value\"}";
+    req.redirect_policy = .not_allowed;
     var resp = try mock.asTransport().send(&req);
     defer resp.deinit();
     try std.testing.expectEqual(@as(u16, 200), resp.status_code);
@@ -410,4 +432,6 @@ test "mock transport" {
     try std.testing.expectEqual(Method.POST, mock.last_method.?);
     try std.testing.expectEqualStrings("https://vault.azure.net/secrets/mysecret", mock.last_url.?);
     try std.testing.expectEqualStrings("{\"value\":\"secret-value\"}", mock.last_body.?);
+    try std.testing.expectEqual(RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
 }

--- a/sdk/kusto/common.zig
+++ b/sdk/kusto/common.zig
@@ -4,6 +4,7 @@
 ///! and common types used by both the data and ingest clients.
 const std = @import("std");
 const core = @import("azure_core");
+const serde = @import("serde");
 
 // ─────────────────────── Enums ───────────────────────
 
@@ -58,13 +59,7 @@ pub const ConnectionProperties = struct {
 
     /// Get the data management (ingest) URL by prepending `ingest-` to the hostname.
     pub fn getIngestUrl(self: ConnectionProperties, allocator: std.mem.Allocator) ![]u8 {
-        // https://cluster.region.kusto.windows.net → https://ingest-cluster.region.kusto.windows.net
-        if (std.mem.find(u8, self.cluster_url, "://")) |scheme_end| {
-            const scheme = self.cluster_url[0 .. scheme_end + 3];
-            const host = self.cluster_url[scheme_end + 3 ..];
-            return std.fmt.allocPrint(allocator, "{s}ingest-{s}", .{ scheme, host });
-        }
-        return std.fmt.allocPrint(allocator, "https://ingest-{s}", .{self.cluster_url});
+        return deriveIngestEndpoint(allocator, std.mem.trimEnd(u8, self.cluster_url, "/"));
     }
 };
 
@@ -139,8 +134,113 @@ pub const KustoRetryOptions = struct {
     max_delay_ms: u64 = 60_000,
 };
 
+pub const KustoMetadataMode = enum {
+    discover,
+    disabled,
+};
+
+/// Auth metadata returned by a Kusto engine. All strings are allocator-owned.
+pub const KustoCloudInfo = struct {
+    login_endpoint: []u8,
+    login_mfa_required: bool,
+    kusto_client_app_id: []u8,
+    kusto_client_redirect_uri: []u8,
+    kusto_service_resource_id: []u8,
+    first_party_authority_url: []u8,
+
+    pub fn clone(self: *const KustoCloudInfo, allocator: std.mem.Allocator) !KustoCloudInfo {
+        const login_endpoint = try allocator.dupe(u8, self.login_endpoint);
+        errdefer allocator.free(login_endpoint);
+        const app_id = try allocator.dupe(u8, self.kusto_client_app_id);
+        errdefer allocator.free(app_id);
+        const redirect_uri = try allocator.dupe(u8, self.kusto_client_redirect_uri);
+        errdefer allocator.free(redirect_uri);
+        const resource_id = try allocator.dupe(u8, self.kusto_service_resource_id);
+        errdefer allocator.free(resource_id);
+        const authority_url = try allocator.dupe(u8, self.first_party_authority_url);
+        errdefer allocator.free(authority_url);
+        return .{
+            .login_endpoint = login_endpoint,
+            .login_mfa_required = self.login_mfa_required,
+            .kusto_client_app_id = app_id,
+            .kusto_client_redirect_uri = redirect_uri,
+            .kusto_service_resource_id = resource_id,
+            .first_party_authority_url = authority_url,
+        };
+    }
+
+    pub fn deinit(self: *KustoCloudInfo, allocator: std.mem.Allocator) void {
+        allocator.free(self.login_endpoint);
+        allocator.free(self.kusto_client_app_id);
+        allocator.free(self.kusto_client_redirect_uri);
+        allocator.free(self.kusto_service_resource_id);
+        allocator.free(self.first_party_authority_url);
+    }
+};
+
+/// Caller-owned metadata cache. It is not synchronized; externally serialize
+/// access and do not deinitialize it while a caller is using the cache.
+pub const KustoCloudInfoCache = struct {
+    allocator: std.mem.Allocator,
+    entries: std.StringHashMap(KustoCloudInfo),
+
+    pub fn init(allocator: std.mem.Allocator) KustoCloudInfoCache {
+        return .{ .allocator = allocator, .entries = std.StringHashMap(KustoCloudInfo).init(allocator) };
+    }
+
+    pub fn deinit(self: *KustoCloudInfoCache) void {
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(self.allocator);
+        }
+        self.entries.deinit();
+    }
+
+    pub fn invalidate(self: *KustoCloudInfoCache, endpoint: []const u8) void {
+        const key = std.mem.trimEnd(u8, endpoint, "/");
+        if (self.entries.fetchRemove(key)) |entry| {
+            self.allocator.free(entry.key);
+            var info = entry.value;
+            info.deinit(self.allocator);
+        }
+    }
+
+    pub fn lookup(self: *const KustoCloudInfoCache, normalized_endpoint: []const u8) ?*const KustoCloudInfo {
+        return self.entries.getPtr(normalized_endpoint);
+    }
+
+    pub fn put(self: *KustoCloudInfoCache, normalized_endpoint: []const u8, info: *const KustoCloudInfo) !void {
+        const key = try self.allocator.dupe(u8, normalized_endpoint);
+        errdefer self.allocator.free(key);
+        const copy = try info.clone(self.allocator);
+        errdefer {
+            var mutable_copy = copy;
+            mutable_copy.deinit(self.allocator);
+        }
+        const result = try self.entries.getOrPut(key);
+        if (result.found_existing) {
+            self.allocator.free(key);
+            var old = result.value_ptr.*;
+            old.deinit(self.allocator);
+        } else {
+            result.key_ptr.* = key;
+        }
+        result.value_ptr.* = copy;
+    }
+};
+
 pub const KustoConnectionOptions = struct {
-    token_scope: []const u8 = "https://kusto.kusto.windows.net/.default",
+    /// Empty derives the scope from metadata, or uses the public default when
+    /// metadata discovery is disabled.
+    token_scope: []const u8 = "",
+    engine_endpoint: ?[]const u8 = null,
+    data_management_endpoint: ?[]const u8 = null,
+    metadata_mode: KustoMetadataMode = .discover,
+    cloud_info_cache: ?*KustoCloudInfoCache = null,
+    additional_trusted_hosts: []const []const u8 = &.{},
+    /// The connection never changes or inspects the credential's authority;
+    /// configure any credential authority when constructing that credential.
     user_agent: []const u8 = "azsdk-zig-kusto/0.1.0",
     retry: KustoRetryOptions = .{},
 };
@@ -154,9 +254,12 @@ pub const KustoConnectionOptions = struct {
 /// clients.
 pub const KustoConnection = struct {
     allocator: std.mem.Allocator,
+    /// Engine endpoint retained under its #46 field name for source compatibility.
     cluster_url: []u8,
+    data_management_url: ?[]u8,
     token_scope: []u8,
     user_agent: []u8,
+    cloud_info: ?KustoCloudInfo,
     credential: *core.credentials.TokenCredential,
     transport: *core.http.HttpTransport,
     scopes: [1][]const u8,
@@ -185,21 +288,86 @@ pub const KustoConnection = struct {
         }
         const credential = properties.credential orelse return error.KustoCredentialRequired;
 
-        const self = try allocator.create(KustoConnection);
-        errdefer allocator.destroy(self);
+        const configured_engine = options.engine_endpoint orelse properties.cluster_url;
+        const normalized_engine = std.mem.trimEnd(u8, configured_engine, "/");
+        const engine_uri = try validateHttpsOrigin(normalized_engine);
 
-        const normalized_cluster_url = std.mem.trimEnd(u8, properties.cluster_url, "/");
-        const owned_cluster_url = try allocator.dupe(u8, normalized_cluster_url);
-        errdefer allocator.free(owned_cluster_url);
-        const owned_token_scope = try allocator.dupe(u8, options.token_scope);
+        var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+        const engine_host = try endpointHost(engine_uri, &host_buffer);
+
+        var resolved_cloud_info: ?KustoCloudInfo = null;
+        errdefer if (resolved_cloud_info) |*info| info.deinit(allocator);
+        var builtin_rule: ?usize = null;
+        var fetched_cloud_info = false;
+
+        if (options.metadata_mode == .discover) {
+            if (options.cloud_info_cache) |cache| {
+                if (cache.lookup(normalized_engine)) |cached| {
+                    resolved_cloud_info = try cached.clone(allocator);
+                }
+            }
+            if (resolved_cloud_info == null) {
+                var fetched = try discoverCloudInfo(allocator, transport, normalized_engine);
+                errdefer fetched.deinit(allocator);
+                try validateCloudInfo(&fetched);
+                resolved_cloud_info = fetched;
+                fetched_cloud_info = true;
+            }
+            builtin_rule = trustedRuleForAuthority(engine_host, resolved_cloud_info.?.login_endpoint);
+            if (builtin_rule == null and !isAdditionalHost(engine_host, options.additional_trusted_hosts))
+                return error.UntrustedKustoEndpoint;
+            if (fetched_cloud_info) {
+                if (options.cloud_info_cache) |cache| {
+                    try cache.put(normalized_engine, &resolved_cloud_info.?);
+                }
+            }
+        } else {
+            builtin_rule = anyTrustedRule(engine_host);
+            if (builtin_rule == null and !isAdditionalHost(engine_host, options.additional_trusted_hosts))
+                return error.UntrustedKustoEndpoint;
+        }
+
+        const configured_dm = options.data_management_endpoint;
+        var owned_dm: ?[]u8 = null;
+        errdefer if (owned_dm) |url| allocator.free(url);
+        if (configured_dm) |dm| {
+            const normalized_dm = std.mem.trimEnd(u8, dm, "/");
+            const dm_uri = try validateHttpsOrigin(normalized_dm);
+            var dm_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+            const dm_host = try endpointHost(dm_uri, &dm_host_buffer);
+            const dm_builtin_ok = if (builtin_rule) |rule| hostMatchesRule(dm_host, rule) else false;
+            if (!dm_builtin_ok and !isAdditionalHost(dm_host, options.additional_trusted_hosts))
+                return error.UntrustedKustoEndpoint;
+            owned_dm = try allocator.dupe(u8, normalized_dm);
+        } else if (builtin_rule != null) {
+            owned_dm = try deriveIngestEndpoint(allocator, normalized_engine);
+        }
+
+        const scope_is_derived = options.token_scope.len == 0 and resolved_cloud_info != null;
+        const scope_source = if (options.token_scope.len != 0)
+            options.token_scope
+        else if (resolved_cloud_info) |info|
+            try resourceScope(allocator, info.kusto_service_resource_id, info.login_mfa_required)
+        else
+            "https://kusto.kusto.windows.net/.default";
+        defer if (scope_is_derived) allocator.free(scope_source);
+        const owned_token_scope = try allocator.dupe(u8, scope_source);
         errdefer allocator.free(owned_token_scope);
         const owned_user_agent = try allocator.dupe(u8, options.user_agent);
         errdefer allocator.free(owned_user_agent);
+        const owned_engine = try allocator.dupe(u8, normalized_engine);
+        errdefer allocator.free(owned_engine);
+
+        const self = try allocator.create(KustoConnection);
+        errdefer allocator.destroy(self);
 
         self.allocator = allocator;
-        self.cluster_url = owned_cluster_url;
+        self.cluster_url = owned_engine;
+        self.data_management_url = owned_dm;
         self.token_scope = owned_token_scope;
         self.user_agent = owned_user_agent;
+        self.cloud_info = resolved_cloud_info;
+        resolved_cloud_info = null;
         self.credential = credential;
         self.transport = transport;
         self.scopes = .{self.token_scope};
@@ -233,17 +401,41 @@ pub const KustoConnection = struct {
         const allocator = self.allocator;
         self.auth.deinit();
         allocator.free(self.cluster_url);
+        if (self.data_management_url) |url| allocator.free(url);
         allocator.free(self.token_scope);
         allocator.free(self.user_agent);
+        if (self.cloud_info) |*info| info.deinit(allocator);
         allocator.destroy(self);
     }
 
     pub fn send(self: *KustoConnection, request: *core.http.Request) !core.http.Response {
+        const targets_engine = sameHttpsOrigin(self.cluster_url, request.url);
+        const targets_data_management = if (self.data_management_url) |url|
+            sameHttpsOrigin(url, request.url)
+        else
+            false;
+        if (!targets_engine and !targets_data_management) {
+            return error.UntrustedKustoRequestEndpoint;
+        }
+        request.redirect_policy = .not_allowed;
         return self.pipeline.send(request);
     }
 
     pub fn clusterUrl(self: *const KustoConnection) []const u8 {
+        return self.engineUrl();
+    }
+
+    pub fn engineUrl(self: *const KustoConnection) []const u8 {
         return self.cluster_url;
+    }
+
+    pub fn dataManagementUrl(self: *const KustoConnection) ?[]const u8 {
+        return self.data_management_url;
+    }
+
+    pub fn cloudInfo(self: *const KustoConnection) ?*const KustoCloudInfo {
+        if (self.cloud_info) |*info| return info;
+        return null;
     }
 
     /// Renders only the cluster endpoint and authentication mode.
@@ -256,6 +448,227 @@ pub const KustoConnection = struct {
         );
     }
 };
+
+const MetadataWire = struct {
+    AzureAD: ?CloudInfoWire = null,
+};
+
+const CloudInfoWire = struct {
+    LoginEndpoint: ?[]const u8 = null,
+    LoginMfaRequired: bool = false,
+    KustoClientAppId: ?[]const u8 = null,
+    KustoClientRedirectUri: ?[]const u8 = null,
+    KustoServiceResourceId: ?[]const u8 = null,
+    FirstPartyAuthorityUrl: ?[]const u8 = null,
+};
+
+const TrustRule = struct {
+    login_endpoint: []const u8,
+    suffixes: []const []const u8,
+    hostnames: []const []const u8,
+};
+
+const public_suffixes = [_][]const u8{
+    ".dxp.aad.azure.com",                  ".dxp-dev.aad.azure.com",             ".kusto.azuresynapse.net",
+    ".kusto.windows.net",                  ".kustodev.azuresynapse-dogfood.net", ".kustodev.windows.net",
+    ".kustomfa.windows.net",               ".playfabapi.com",                    ".playfab.com",
+    ".azureplayfab.com",                   ".kusto.data.microsoft.com",          ".kusto.fabric.microsoft.com",
+    ".api.securityplatform.microsoft.com", ".securitycenter.windows.com",        ".arg-int.core.windows.net",
+    ".arg-df.core.windows.net",            ".arg.core.windows.net",
+};
+const public_hosts = [_][]const u8{
+    "ade.applicationinsights.io",        "ade.loganalytics.io",                   "adx.aimon.applicationinsights.azure.com",
+    "adx.applicationinsights.azure.com", "adx.int.applicationinsights.azure.com", "adx.int.loganalytics.azure.com",
+    "adx.int.monitor.azure.com",         "adx.loganalytics.azure.com",            "adx.monitor.azure.com",
+    "kusto.aria.microsoft.com",          "eu.kusto.aria.microsoft.com",
+};
+const usgov_suffixes = [_][]const u8{ ".kusto.usgovcloudapi.net", ".kustomfa.usgovcloudapi.net", ".arg.core.usgovcloudapi.net" };
+const usgov_hosts = [_][]const u8{ "adx.applicationinsights.azure.us", "adx.loganalytics.azure.us", "adx.monitor.azure.us" };
+const china_suffixes = [_][]const u8{ ".kusto.azuresynapse.azure.cn", ".kusto.chinacloudapi.cn", ".kustomfa.chinacloudapi.cn", ".playfab.cn", ".arg.core.chinacloudapi.cn" };
+const china_hosts = [_][]const u8{ "adx.applicationinsights.azure.cn", "adx.loganalytics.azure.cn", "adx.monitor.azure.cn" };
+const eaglex_suffixes = [_][]const u8{ ".kusto.core.eaglex.ic.gov", ".kustomfa.core.eaglex.ic.gov", ".arg.core.eaglex.ic.gov" };
+const eaglex_hosts = [_][]const u8{ "adx.applicationinsights.azure.eaglex.ic.gov", "adx.loganalytics.azure.eaglex.ic.gov", "adx.monitor.azure.eaglex.ic.gov" };
+const scloud_suffixes = [_][]const u8{ ".kusto.core.microsoft.scloud", ".kustomfa.core.microsoft.scloud", ".arg.core.microsoft.scloud" };
+const scloud_hosts = [_][]const u8{ "adx.applicationinsights.azure.microsoft.scloud", "adx.loganalytics.azure.microsoft.scloud", "adx.monitor.azure.microsoft.scloud" };
+const fr_suffixes = [_][]const u8{ ".kusto.sovcloud-api.fr", ".kustomfa.sovcloud-api.fr" };
+const fr_hosts = [_][]const u8{ "adx.applicationinsights.azure.fr", "adx.loganalytics.azure.fr", "adx.monitor.azure.fr" };
+const de_suffixes = [_][]const u8{ ".kusto.sovcloud-api.de", ".kustomfa.sovcloud-api.de" };
+const de_hosts = [_][]const u8{ "adx.applicationinsights.azure.de", "adx.loganalytics.azure.de", "adx.monitor.azure.de" };
+const sg_suffixes = [_][]const u8{ ".kusto.sovcloud-api.sg", ".kustomfa.sovcloud-api.sg" };
+const sg_hosts = [_][]const u8{ "adx.applicationinsights.azure.sg", "adx.loganalytics.azure.sg", "adx.monitor.azure.sg" };
+
+// Kept in sync with Azure/azure-kusto-go 7c44a0a6.
+const trusted_rules = [_]TrustRule{
+    .{ .login_endpoint = "https://login.microsoftonline.com", .suffixes = &public_suffixes, .hostnames = &public_hosts },
+    .{ .login_endpoint = "https://login.microsoftonline.us", .suffixes = &usgov_suffixes, .hostnames = &usgov_hosts },
+    .{ .login_endpoint = "https://login.partner.microsoftonline.cn", .suffixes = &china_suffixes, .hostnames = &china_hosts },
+    .{ .login_endpoint = "https://login.microsoftonline.eaglex.ic.gov", .suffixes = &eaglex_suffixes, .hostnames = &eaglex_hosts },
+    .{ .login_endpoint = "https://login.microsoftonline.microsoft.scloud", .suffixes = &scloud_suffixes, .hostnames = &scloud_hosts },
+    .{ .login_endpoint = "https://login.sovcloud-identity.fr", .suffixes = &fr_suffixes, .hostnames = &fr_hosts },
+    .{ .login_endpoint = "https://login.sovcloud-identity.de", .suffixes = &de_suffixes, .hostnames = &de_hosts },
+    .{ .login_endpoint = "https://login.sovcloud-identity.sg", .suffixes = &sg_suffixes, .hostnames = &sg_hosts },
+};
+
+fn validateHttpsOrigin(endpoint: []const u8) !std.Uri {
+    const uri = std.Uri.parse(endpoint) catch return error.InvalidKustoEndpoint;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https") or
+        uri.host == null or
+        uri.user != null or
+        uri.password != null or
+        !uri.path.isEmpty() or
+        uri.query != null or
+        uri.fragment != null)
+    {
+        return error.InvalidKustoEndpoint;
+    }
+    return uri;
+}
+
+fn endpointHost(uri: std.Uri, buffer: *[std.Io.net.HostName.max_len]u8) ![]const u8 {
+    const host = uri.getHost(buffer) catch return error.InvalidKustoEndpoint;
+    return host.bytes;
+}
+
+fn sameHttpsOrigin(expected_origin: []const u8, candidate_url: []const u8) bool {
+    const expected = std.Uri.parse(expected_origin) catch return false;
+    const candidate = std.Uri.parse(candidate_url) catch return false;
+    if (!std.ascii.eqlIgnoreCase(candidate.scheme, "https") or
+        candidate.host == null or
+        candidate.user != null or
+        candidate.password != null or
+        candidate.fragment != null)
+    {
+        return false;
+    }
+    var expected_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    var candidate_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const expected_host = expected.getHost(&expected_buffer) catch return false;
+    const candidate_host = candidate.getHost(&candidate_buffer) catch return false;
+    return std.ascii.eqlIgnoreCase(expected_host.bytes, candidate_host.bytes) and
+        (expected.port orelse 443) == (candidate.port orelse 443);
+}
+
+fn hostMatchesRule(host: []const u8, rule_index: usize) bool {
+    const rule = trusted_rules[rule_index];
+    for (rule.hostnames) |allowed| {
+        if (std.ascii.eqlIgnoreCase(host, allowed)) return true;
+    }
+    for (rule.suffixes) |suffix| {
+        if (host.len > suffix.len and std.ascii.endsWithIgnoreCase(host, suffix)) return true;
+    }
+    return false;
+}
+
+fn trustedRuleForAuthority(host: []const u8, login_endpoint: []const u8) ?usize {
+    const normalized_login = std.mem.trimEnd(u8, login_endpoint, "/");
+    for (trusted_rules, 0..) |rule, index| {
+        if (std.ascii.eqlIgnoreCase(normalized_login, rule.login_endpoint) and hostMatchesRule(host, index))
+            return index;
+    }
+    return null;
+}
+
+fn anyTrustedRule(host: []const u8) ?usize {
+    for (trusted_rules, 0..) |_, index| {
+        if (hostMatchesRule(host, index)) return index;
+    }
+    return null;
+}
+
+fn isAdditionalHost(host: []const u8, additional_hosts: []const []const u8) bool {
+    for (additional_hosts) |allowed| {
+        if (std.ascii.eqlIgnoreCase(host, allowed)) return true;
+    }
+    return false;
+}
+
+fn discoverCloudInfo(allocator: std.mem.Allocator, transport: *core.http.HttpTransport, engine_url: []const u8) !KustoCloudInfo {
+    const metadata_url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/auth/metadata", .{engine_url});
+    defer allocator.free(metadata_url);
+    var request = core.http.Request.init(allocator, .GET, metadata_url);
+    defer request.deinit();
+    request.retryable = false;
+    request.redirect_policy = .not_allowed;
+    try request.setHeader("Accept", "application/json");
+    try request.setHeader("Accept-Encoding", "gzip, deflate");
+    var response = try transport.send(&request);
+    defer response.deinit();
+
+    const body = std.mem.trim(u8, response.body, " \t\r\n");
+    if (response.status_code == 404 or (response.isSuccess() and body.len == 0))
+        return publicCloudInfo(allocator);
+    if (!response.isSuccess()) return error.KustoMetadataRequestFailed;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const wire = serde.json.fromSlice(MetadataWire, arena.allocator(), body) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.MalformedKustoMetadata,
+    };
+    const azure_ad = wire.AzureAD orelse return error.MalformedKustoMetadata;
+    const login_endpoint = azure_ad.LoginEndpoint orelse return error.InvalidKustoMetadata;
+    const resource_id = azure_ad.KustoServiceResourceId orelse return error.InvalidKustoMetadata;
+    return cloudInfoFromWire(allocator, azure_ad, login_endpoint, resource_id);
+}
+
+fn cloudInfoFromWire(allocator: std.mem.Allocator, wire: CloudInfoWire, login_endpoint: []const u8, resource_id: []const u8) !KustoCloudInfo {
+    const login = try allocator.dupe(u8, std.mem.trimEnd(u8, login_endpoint, "/"));
+    errdefer allocator.free(login);
+    const app_id = try allocator.dupe(u8, wire.KustoClientAppId orelse "");
+    errdefer allocator.free(app_id);
+    const redirect_uri = try allocator.dupe(u8, wire.KustoClientRedirectUri orelse "");
+    errdefer allocator.free(redirect_uri);
+    const resource = try allocator.dupe(u8, std.mem.trimEnd(u8, resource_id, "/"));
+    errdefer allocator.free(resource);
+    const authority_url = try allocator.dupe(u8, wire.FirstPartyAuthorityUrl orelse "");
+    errdefer allocator.free(authority_url);
+    return .{
+        .login_endpoint = login,
+        .login_mfa_required = wire.LoginMfaRequired,
+        .kusto_client_app_id = app_id,
+        .kusto_client_redirect_uri = redirect_uri,
+        .kusto_service_resource_id = resource,
+        .first_party_authority_url = authority_url,
+    };
+}
+
+fn publicCloudInfo(allocator: std.mem.Allocator) !KustoCloudInfo {
+    return cloudInfoFromWire(allocator, .{
+        .LoginEndpoint = "https://login.microsoftonline.com",
+        .KustoClientAppId = "db662dc1-0cfe-4e1c-a843-19a68e65be58",
+        .KustoClientRedirectUri = "https://microsoft/kustoclient",
+        .KustoServiceResourceId = "https://kusto.kusto.windows.net",
+        .FirstPartyAuthorityUrl = "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a",
+    }, "https://login.microsoftonline.com", "https://kusto.kusto.windows.net");
+}
+
+fn validateCloudInfo(info: *const KustoCloudInfo) !void {
+    _ = try validateHttpsOrigin(info.login_endpoint);
+    _ = try validateHttpsOrigin(info.kusto_service_resource_id);
+}
+
+fn resourceScope(allocator: std.mem.Allocator, resource_id: []const u8, mfa_required: bool) ![]u8 {
+    const resource = std.mem.trimEnd(u8, resource_id, "/");
+    if (!mfa_required) return std.fmt.allocPrint(allocator, "{s}/.default", .{resource});
+    if (std.mem.indexOf(u8, resource, ".kusto.")) |index| {
+        return std.fmt.allocPrint(
+            allocator,
+            "{s}.kustomfa.{s}/.default",
+            .{ resource[0..index], resource[index + ".kusto.".len ..] },
+        );
+    }
+    return std.fmt.allocPrint(allocator, "{s}/.default", .{resource});
+}
+
+fn deriveIngestEndpoint(allocator: std.mem.Allocator, engine_url: []const u8) ![]u8 {
+    const uri = try validateHttpsOrigin(engine_url);
+    var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const host = try endpointHost(uri, &host_buffer);
+    if (std.ascii.startsWithIgnoreCase(host, "ingest-"))
+        return allocator.dupe(u8, engine_url);
+    const scheme_end = std.mem.indexOf(u8, engine_url, "://") orelse return error.InvalidKustoEndpoint;
+    return std.fmt.allocPrint(allocator, "{s}://ingest-{s}", .{ engine_url[0..scheme_end], engine_url[scheme_end + 3 ..] });
+}
 
 // ─────────────── Request Properties ─────────────────
 
@@ -311,6 +724,332 @@ const TestTokenCredential = struct {
     }
 };
 
+const DiscoveryTestTransport = struct {
+    const CannedResponse = struct { status: u16, body: []const u8 };
+
+    allocator: std.mem.Allocator,
+    responses: []const CannedResponse,
+    transport: core.http.HttpTransport,
+    call_count: usize = 0,
+    bootstrap_has_authorization: ?bool = null,
+    bootstrap_retryable: ?bool = null,
+    bootstrap_redirect_policy: ?core.http.RedirectPolicy = null,
+    service_has_authorization: ?bool = null,
+    service_redirect_policy: ?core.http.RedirectPolicy = null,
+
+    fn init(allocator: std.mem.Allocator, responses: []const CannedResponse) DiscoveryTestTransport {
+        return .{
+            .allocator = allocator,
+            .responses = responses,
+            .transport = .{ .sendFn = &send },
+        };
+    }
+
+    fn asTransport(self: *DiscoveryTestTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn send(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
+        const self: *DiscoveryTestTransport = @alignCast(@fieldParentPtr("transport", transport));
+        if (self.call_count == 0) {
+            self.bootstrap_has_authorization = request.getHeader("Authorization") != null;
+            self.bootstrap_retryable = request.retryable;
+            self.bootstrap_redirect_policy = request.redirect_policy;
+        } else {
+            self.service_has_authorization = request.getHeader("Authorization") != null;
+            self.service_redirect_policy = request.redirect_policy;
+        }
+        const index = @min(self.call_count, self.responses.len - 1);
+        self.call_count += 1;
+        return .{
+            .status_code = self.responses[index].status,
+            .headers = std.StringHashMap([]const u8).init(self.allocator),
+            .body = try self.allocator.dupe(u8, self.responses[index].body),
+            .allocator = self.allocator,
+        };
+    }
+};
+
+const public_metadata =
+    \\{"AzureAD":{"LoginEndpoint":"https://login.microsoftonline.com","LoginMfaRequired":false,"KustoClientAppId":"app","KustoClientRedirectUri":"https://redirect","KustoServiceResourceId":"https://cluster.kusto.windows.net","FirstPartyAuthorityUrl":"https://authority"}}
+;
+
+test "KustoConnection discovers metadata and bootstraps without authentication" {
+    const allocator = std.testing.allocator;
+    var transport = DiscoveryTestTransport.init(allocator, &.{
+        .{ .status = 200, .body = public_metadata },
+        .{ .status = 200, .body = "ok" },
+    });
+    var credential = TestTokenCredential{};
+    const connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        transport.asTransport(),
+        .{},
+    );
+    defer connection.deinit();
+
+    const info = connection.cloudInfo().?;
+    try std.testing.expectEqualStrings("https://login.microsoftonline.com", info.login_endpoint);
+    try std.testing.expectEqualStrings("app", info.kusto_client_app_id);
+    try std.testing.expectEqualStrings("https://cluster.kusto.windows.net/.default", connection.token_scope);
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    try std.testing.expectEqual(false, transport.bootstrap_has_authorization.?);
+    try std.testing.expectEqual(false, transport.bootstrap_retryable.?);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, transport.bootstrap_redirect_policy.?);
+
+    var request = core.http.Request.init(allocator, .GET, "https://cluster.kusto.windows.net/v2/rest/query");
+    defer request.deinit();
+    var response = try connection.send(&request);
+    defer response.deinit();
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+    try std.testing.expectEqual(true, transport.service_has_authorization.?);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, transport.service_redirect_policy.?);
+}
+
+test "KustoConnection derives MFA scope from metadata" {
+    const allocator = std.testing.allocator;
+    var transport = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body =
+        \\{"AzureAD":{"LoginEndpoint":"https://login.microsoftonline.com","LoginMfaRequired":true,"KustoServiceResourceId":"https://cluster.kusto.windows.net"}}
+    }});
+    var credential = TestTokenCredential{};
+    const connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        transport.asTransport(),
+        .{},
+    );
+    defer connection.deinit();
+    try std.testing.expectEqualStrings("https://cluster.kustomfa.windows.net/.default", connection.token_scope);
+}
+
+test "KustoConnection uses public defaults for 404 and empty metadata" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var missing = DiscoveryTestTransport.init(allocator, &.{.{ .status = 404, .body = "" }});
+    const from_404 = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        missing.asTransport(),
+        .{},
+    );
+    defer from_404.deinit();
+    try std.testing.expectEqualStrings("db662dc1-0cfe-4e1c-a843-19a68e65be58", from_404.cloudInfo().?.kusto_client_app_id);
+
+    var empty = DiscoveryTestTransport.init(allocator, &.{.{ .status = 204, .body = " \r\n" }});
+    const from_empty = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        empty.asTransport(),
+        .{},
+    );
+    defer from_empty.deinit();
+    try std.testing.expectEqualStrings("https://kusto.kusto.windows.net/.default", from_empty.token_scope);
+}
+
+test "KustoConnection rejects malformed metadata and metadata failures" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var malformed = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body = "not json" }});
+    try std.testing.expectError(error.MalformedKustoMetadata, KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        malformed.asTransport(),
+        .{},
+    ));
+    var empty_object = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body = "{}" }});
+    try std.testing.expectError(error.MalformedKustoMetadata, KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        empty_object.asTransport(),
+        .{},
+    ));
+    var failed = DiscoveryTestTransport.init(allocator, &.{.{ .status = 500, .body = "no" }});
+    try std.testing.expectError(error.KustoMetadataRequestFailed, KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        failed.asTransport(),
+        .{},
+    ));
+    var redirected = DiscoveryTestTransport.init(allocator, &.{.{ .status = 302, .body = "" }});
+    try std.testing.expectError(error.KustoMetadataRequestFailed, KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        redirected.asTransport(),
+        .{},
+    ));
+}
+
+test "KustoConnection enforces authority keyed and custom endpoint trust" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var sovereign = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body =
+        \\{"AzureAD":{"LoginEndpoint":"https://login.microsoftonline.us","KustoServiceResourceId":"https://cluster.kusto.usgovcloudapi.net"}}
+    }});
+    const sovereign_connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.usgovcloudapi.net", .credential = credential.asCredential() },
+        sovereign.asTransport(),
+        .{},
+    );
+    defer sovereign_connection.deinit();
+
+    var mismatch = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body =
+        \\{"AzureAD":{"LoginEndpoint":"https://login.microsoftonline.us","KustoServiceResourceId":"https://cluster.kusto.windows.net"}}
+    }});
+    try std.testing.expectError(error.UntrustedKustoEndpoint, KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        mismatch.asTransport(),
+        .{},
+    ));
+
+    var custom = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body =
+        \\{"AzureAD":{"LoginEndpoint":"https://custom.authority","KustoServiceResourceId":"https://custom.example"}}
+    }});
+    const custom_connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://custom.example", .credential = credential.asCredential() },
+        custom.asTransport(),
+        .{ .additional_trusted_hosts = &.{"custom.example"} },
+    );
+    defer custom_connection.deinit();
+    try std.testing.expect(custom_connection.dataManagementUrl() == null);
+
+    var custom_dm_mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer custom_dm_mock.deinit();
+    const explicit_custom_dm = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://custom.example", .credential = credential.asCredential() },
+        custom_dm_mock.asTransport(),
+        .{
+            .metadata_mode = .disabled,
+            .data_management_endpoint = "https://custom-ingest.example",
+            .additional_trusted_hosts = &.{ "custom.example", "custom-ingest.example" },
+        },
+    );
+    defer explicit_custom_dm.deinit();
+    try std.testing.expectEqualStrings("https://custom-ingest.example", explicit_custom_dm.dataManagementUrl().?);
+}
+
+test "KustoConnection honors explicit endpoints and derives ingest endpoint" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    const explicit = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://ignored.kusto.windows.net", .credential = credential.asCredential() },
+        mock.asTransport(),
+        .{
+            .metadata_mode = .disabled,
+            .engine_endpoint = "https://query.kusto.windows.net/",
+            .data_management_endpoint = "https://ingest.query.kusto.windows.net/",
+            .token_scope = "scope",
+        },
+    );
+    defer explicit.deinit();
+    try std.testing.expectEqualStrings("https://query.kusto.windows.net", explicit.engineUrl());
+    try std.testing.expectEqualStrings("https://ingest.query.kusto.windows.net", explicit.dataManagementUrl().?);
+    try std.testing.expectEqualStrings("scope", explicit.token_scope);
+
+    const derived = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://query.kusto.windows.net", .credential = credential.asCredential() },
+        mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
+    defer derived.deinit();
+    try std.testing.expectEqualStrings("https://ingest-query.kusto.windows.net", derived.dataManagementUrl().?);
+}
+
+test "KustoConnection caches successful metadata but retries failed discovery" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var cache = KustoCloudInfoCache.init(allocator);
+    defer cache.deinit();
+    var cached_transport = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body = public_metadata }});
+    const first = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        cached_transport.asTransport(),
+        .{ .cloud_info_cache = &cache },
+    );
+    defer first.deinit();
+    const second = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        cached_transport.asTransport(),
+        .{ .cloud_info_cache = &cache },
+    );
+    defer second.deinit();
+    try std.testing.expectEqual(@as(usize, 1), cached_transport.call_count);
+
+    var retry_transport = DiscoveryTestTransport.init(allocator, &.{
+        .{ .status = 500, .body = "" },
+        .{ .status = 404, .body = "" },
+    });
+    var retry_cache = KustoCloudInfoCache.init(allocator);
+    defer retry_cache.deinit();
+    try std.testing.expectError(error.KustoMetadataRequestFailed, KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://retry.kusto.windows.net", .credential = credential.asCredential() },
+        retry_transport.asTransport(),
+        .{ .cloud_info_cache = &retry_cache },
+    ));
+    const retried = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://retry.kusto.windows.net", .credential = credential.asCredential() },
+        retry_transport.asTransport(),
+        .{ .cloud_info_cache = &retry_cache },
+    );
+    defer retried.deinit();
+    try std.testing.expectEqual(@as(usize, 2), retry_transport.call_count);
+
+    var untrusted_then_valid = DiscoveryTestTransport.init(allocator, &.{
+        .{ .status = 200, .body =
+        \\{"AzureAD":{"LoginEndpoint":"https://login.microsoftonline.us","KustoServiceResourceId":"https://cluster.kusto.windows.net"}}
+        },
+        .{ .status = 200, .body = public_metadata },
+    });
+    var trust_cache = KustoCloudInfoCache.init(allocator);
+    defer trust_cache.deinit();
+    try std.testing.expectError(error.UntrustedKustoEndpoint, KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        untrusted_then_valid.asTransport(),
+        .{ .cloud_info_cache = &trust_cache },
+    ));
+    const trusted_retry = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        untrusted_then_valid.asTransport(),
+        .{ .cloud_info_cache = &trust_cache },
+    );
+    defer trusted_retry.deinit();
+    try std.testing.expectEqual(@as(usize, 2), untrusted_then_valid.call_count);
+}
+
+test "KustoConnection authenticates only validated service origins" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    const connection = try KustoConnection.init(
+        allocator,
+        .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
+        mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
+    defer connection.deinit();
+
+    var request = core.http.Request.init(allocator, .GET, "https://attacker.example/query");
+    defer request.deinit();
+    try std.testing.expectError(error.UntrustedKustoRequestEndpoint, connection.send(&request));
+    try std.testing.expectEqual(@as(u32, 0), credential.call_count);
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+}
+
 test "KustoConnectionStringBuilder build" {
     var kcsb = KustoConnectionStringBuilder.init("https://mycluster.eastus.kusto.windows.net");
     _ = kcsb.withAadAppKey("app-id", "secret", "tenant-id");
@@ -340,6 +1079,7 @@ test "KustoConnection owns normalized configuration" {
         .{
             .token_scope = token_scope[0..],
             .user_agent = user_agent[0..],
+            .metadata_mode = .disabled,
         },
     );
     defer connection.deinit();
@@ -363,7 +1103,7 @@ test "KustoConnection rejects unsupported and missing authentication" {
             allocator,
             .{ .cluster_url = "https://cluster.kusto.windows.net", .application_key = "secret" },
             mock.asTransport(),
-            .{},
+            .{ .metadata_mode = .disabled },
         ),
     );
     try std.testing.expectError(
@@ -372,7 +1112,7 @@ test "KustoConnection rejects unsupported and missing authentication" {
             allocator,
             .{ .cluster_url = "https://cluster.kusto.windows.net", .application_client_id = "client-id" },
             mock.asTransport(),
-            .{},
+            .{ .metadata_mode = .disabled },
         ),
     );
     try std.testing.expectError(
@@ -417,7 +1157,7 @@ test "Kusto connection formatting omits authentication material" {
         allocator,
         .{ .cluster_url = properties.cluster_url, .credential = credential.asCredential() },
         mock.asTransport(),
-        .{},
+        .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
@@ -436,7 +1176,7 @@ test "KustoConnection sends authenticated request with default and override scop
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
         mock.asTransport(),
-        .{},
+        .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
@@ -461,7 +1201,10 @@ test "KustoConnection sends authenticated request with default and override scop
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
         override_mock.asTransport(),
-        .{ .token_scope = "https://custom.kusto.windows.net/.default" },
+        .{
+            .token_scope = "https://custom.kusto.windows.net/.default",
+            .metadata_mode = .disabled,
+        },
     );
     defer override_connection.deinit();
     var override_request = core.http.Request.init(allocator, .GET, "https://cluster.kusto.windows.net/v2/rest/query");
@@ -485,7 +1228,10 @@ test "KustoConnection applies retry options" {
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
         transport.asTransport(),
-        .{ .retry = .{ .max_retries = 1, .initial_delay_ms = 0 } },
+        .{
+            .metadata_mode = .disabled,
+            .retry = .{ .max_retries = 1, .initial_delay_ms = 0 },
+        },
     );
     defer connection.deinit();
     var request = core.http.Request.init(allocator, .GET, "https://cluster.kusto.windows.net/v2/rest/query");
@@ -509,6 +1255,23 @@ fn initializeConnection(
             .credential = credential,
         },
         transport,
+        .{ .metadata_mode = .disabled },
+    );
+    connection.deinit();
+}
+
+fn initializeDiscoveredConnection(
+    allocator: std.mem.Allocator,
+    credential: *core.credentials.TokenCredential,
+    transport: *core.http.HttpTransport,
+) !void {
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential,
+        },
+        transport,
         .{},
     );
     connection.deinit();
@@ -524,6 +1287,18 @@ test "KustoConnection handles every initialization allocation failure" {
         allocator,
         initializeConnection,
         .{ credential.asCredential(), mock.asTransport() },
+    );
+}
+
+test "KustoConnection cleans up discovery initialization allocation failures" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var transport = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body = public_metadata }});
+
+    try std.testing.checkAllAllocationFailures(
+        allocator,
+        initializeDiscoveredConnection,
+        .{ credential.asCredential(), transport.asTransport() },
     );
 }
 

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -11,6 +11,9 @@ pub const ConnectionProperties = kusto_common.ConnectionProperties;
 pub const ClientRequestProperties = kusto_common.ClientRequestProperties;
 pub const KustoConnection = kusto_common.KustoConnection;
 pub const KustoConnectionOptions = kusto_common.KustoConnectionOptions;
+pub const KustoMetadataMode = kusto_common.KustoMetadataMode;
+pub const KustoCloudInfo = kusto_common.KustoCloudInfo;
+pub const KustoCloudInfoCache = kusto_common.KustoCloudInfoCache;
 pub const KustoRetryOptions = kusto_common.KustoRetryOptions;
 
 // ─────────────────── Response Types ──────────────────
@@ -129,14 +132,14 @@ pub const KustoClient = struct {
 
     /// Execute a KQL query. Uses v2 REST endpoint.
     pub fn executeQuery(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.clusterUrl()});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternal(allocator, url, database, query, properties, true);
     }
 
     /// Execute a management command (starts with `.`). Uses v1 REST endpoint.
     pub fn executeMgmt(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.clusterUrl()});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternal(allocator, url, database, command, properties, false);
     }
@@ -152,12 +155,12 @@ pub const KustoClient = struct {
 
     /// `Result(...)` variants of the execute methods.
     pub fn executeQueryResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.clusterUrl()});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternalResult(allocator, url, database, query, properties, true);
     }
     pub fn executeMgmtResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
-        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.clusterUrl()});
+        const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternalResult(allocator, url, database, command, properties, false);
     }
@@ -220,10 +223,10 @@ pub const KustoClient = struct {
         return .{ .ok = try parseResponseDataSet(allocator, resp.body) };
     }
 
-    fn clusterUrl(self: *const KustoClient) []const u8 {
+    fn engineUrl(self: *const KustoClient) []const u8 {
         return switch (self.runtime) {
             .legacy => |legacy| legacy.connection.cluster_url,
-            .shared => |connection| connection.clusterUrl(),
+            .shared => |connection| connection.engineUrl(),
         };
     }
 
@@ -586,7 +589,7 @@ test "shared KustoClient authenticates queries" {
             .credential = credential.asCredential(),
         },
         mock.asTransport(),
-        .{},
+        .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
@@ -615,6 +618,36 @@ test "shared KustoClient authenticates queries" {
     );
 }
 
+test "shared KustoClient uses explicit engine endpoint for queries" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    defer mock.deinit();
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential.asCredential(),
+        },
+        mock.asTransport(),
+        .{
+            .metadata_mode = .disabled,
+            .engine_endpoint = "https://query-engine.kusto.windows.net",
+            .data_management_endpoint = "https://ingest-dm.kusto.windows.net",
+        },
+    );
+    defer connection.deinit();
+
+    var client = KustoClient.initWithConnection(connection, .{});
+    var result = try client.executeQuery(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqualStrings(
+        "https://query-engine.kusto.windows.net/v2/rest/query",
+        mock.last_url.?,
+    );
+}
+
 test "copied shared KustoClient remains usable" {
     const allocator = std.testing.allocator;
     var credential = TestTokenCredential{};
@@ -627,7 +660,7 @@ test "copied shared KustoClient remains usable" {
             .credential = credential.asCredential(),
         },
         mock.asTransport(),
-        .{},
+        .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
@@ -677,11 +710,14 @@ test "shared KustoClient retries queries" {
             .credential = credential.asCredential(),
         },
         sequence.asTransport(),
-        .{ .retry = .{
-            .max_retries = 1,
-            .initial_delay_ms = 0,
-            .max_delay_ms = 0,
-        } },
+        .{
+            .metadata_mode = .disabled,
+            .retry = .{
+                .max_retries = 1,
+                .initial_delay_ms = 0,
+                .max_delay_ms = 0,
+            },
+        },
     );
     defer connection.deinit();
 
@@ -709,11 +745,14 @@ test "shared KustoClient does not retry management commands" {
             .credential = credential.asCredential(),
         },
         sequence.asTransport(),
-        .{ .retry = .{
-            .max_retries = 1,
-            .initial_delay_ms = 0,
-            .max_delay_ms = 0,
-        } },
+        .{
+            .metadata_mode = .disabled,
+            .retry = .{
+                .max_retries = 1,
+                .initial_delay_ms = 0,
+                .max_delay_ms = 0,
+            },
+        },
     );
     defer connection.deinit();
 

--- a/sdk/kusto/ingest/root.zig
+++ b/sdk/kusto/ingest/root.zig
@@ -13,6 +13,9 @@ pub const DataFormat = kusto_common.DataFormat;
 pub const IngestionProperties = kusto_common.IngestionProperties;
 pub const KustoConnection = kusto_common.KustoConnection;
 pub const KustoConnectionOptions = kusto_common.KustoConnectionOptions;
+pub const KustoMetadataMode = kusto_common.KustoMetadataMode;
+pub const KustoCloudInfo = kusto_common.KustoCloudInfo;
+pub const KustoCloudInfoCache = kusto_common.KustoCloudInfoCache;
 pub const KustoRetryOptions = kusto_common.KustoRetryOptions;
 
 // ─────────────────── Types ───────────────────────────
@@ -137,7 +140,7 @@ pub const StreamingIngestClient = struct {
 
         const cluster_url = switch (self.runtime) {
             .legacy => |legacy| legacy.connection.cluster_url,
-            .shared => |connection| connection.clusterUrl(),
+            .shared => |connection| connection.engineUrl(),
         };
 
         if (options.mapping_name) |mapping| {
@@ -326,7 +329,12 @@ test "shared StreamingIngestClient authenticates through KustoConnection" {
         .cluster_url = "https://cluster.kusto.windows.net",
         .credential = credential.asCredential(),
     };
-    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    const connection = try KustoConnection.init(
+        allocator,
+        properties,
+        service_mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
     defer connection.deinit();
 
     var client = StreamingIngestClient.initWithConnection(connection);
@@ -335,6 +343,38 @@ test "shared StreamingIngestClient authenticates through KustoConnection" {
     try std.testing.expect(token_mock.last_url != null);
     try std.testing.expect(service_mock.last_headers.get("Authorization") != null);
     try std.testing.expectEqual(false, service_mock.last_retryable.?);
+}
+
+test "shared StreamingIngestClient uses explicit engine endpoint" {
+    const allocator = std.testing.allocator;
+    var service_mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer service_mock.deinit();
+
+    var credential = core.credentials.TokenCredential{ .getTokenFn = &successfulTokenRequest };
+    const properties = ConnectionProperties{
+        .cluster_url = "https://cluster.kusto.windows.net",
+        .credential = &credential,
+    };
+    const connection = try KustoConnection.init(
+        allocator,
+        properties,
+        service_mock.asTransport(),
+        .{
+            .metadata_mode = .disabled,
+            .engine_endpoint = "https://streaming-engine.kusto.windows.net",
+            .data_management_endpoint = "https://ingest-dm.kusto.windows.net",
+        },
+    );
+    defer connection.deinit();
+
+    var client = StreamingIngestClient.initWithConnection(connection);
+    _ = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
+
+    try std.testing.expectEqualStrings(
+        "https://streaming-engine.kusto.windows.net/v1/rest/ingest/DB/Table?streamFormat=Csv",
+        service_mock.last_url.?,
+    );
+    try std.testing.expect(std.mem.find(u8, service_mock.last_url.?, "ingest-dm") == null);
 }
 
 test "shared StreamingIngestClient can be copied" {
@@ -347,7 +387,12 @@ test "shared StreamingIngestClient can be copied" {
         .cluster_url = "https://cluster.kusto.windows.net",
         .credential = &credential,
     };
-    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    const connection = try KustoConnection.init(
+        allocator,
+        properties,
+        service_mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
     defer connection.deinit();
 
     const original = StreamingIngestClient.initWithConnection(connection);
@@ -366,7 +411,12 @@ test "ManagedIngestClient shared initialization composes borrowed clients" {
         .cluster_url = "https://cluster.kusto.windows.net",
         .credential = &credential,
     };
-    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    const connection = try KustoConnection.init(
+        allocator,
+        properties,
+        service_mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
     defer connection.deinit();
 
     var client = ManagedIngestClient.initWithConnection(connection);
@@ -390,7 +440,12 @@ test "configured shared connection does not retry streaming writes" {
         .cluster_url = "https://cluster.kusto.windows.net",
         .credential = &credential,
     };
-    const connection = try KustoConnection.init(allocator, properties, service_mock.asTransport(), .{});
+    const connection = try KustoConnection.init(
+        allocator,
+        properties,
+        service_mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
     defer connection.deinit();
 
     var client = StreamingIngestClient.initWithConnection(connection);


### PR DESCRIPTION
Closes #47

Adds unauthenticated, no-redirect Kusto cloud metadata discovery with narrow public-cloud fallback, metadata-derived token scopes, MFA resource handling, and an optional caller-owned endpoint cache that never retains failed or untrusted discovery results.

Validates engine, data-management, login, and resource endpoints against the current authority-keyed well-known Kusto domains or exact caller opt-ins before bearer authentication. Authenticated requests are restricted to validated service origins and cannot follow redirects.

Adds explicit engine, data-management, scope, and discovery-mode controls while preserving the existing connection fields and constructors, and documents sovereign/private credential authority requirements.