### PR TITLE
kusto: implement request properties, telemetry, and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ Set `.metadata_mode = .disabled` for offline or custom bootstrap control. Trust 
 
 Metadata can expose the login authority for a sovereign or private cloud, but `TokenCredential` is an opaque credential boundary: Kusto cannot reconfigure a generic credential at runtime. Callers using those clouds must construct or configure their credential for the discovered authority themselves; do not assume that every `azure_core` credential supports runtime authority changes.
 
+### Kusto request properties, timeouts, and retries
+
+`ClientRequestProperties` emits object-valued `Options` and `Parameters` through structured serde values. Dynamic setters own their keys and values and require `deinit`; borrowed header strings must outlive the request.
+
+- Typed helper areas cover timeout, truncation, progressive results, cache, consistency, resources, and security. Unknown options preserve their JSON types; raw JSON fragments are not accepted. Query parameter values must be strings or Kusto `long` values; encode other scalar types as KQL literal strings such as `datetime(...)` or `dynamic(...)`.
+- Query requests default to a 4-minute server timeout and management requests to 10 minutes. Explicit server timeouts range from 1 second through 1 hour with millisecond precision; the client budget defaults to the server timeout plus 30 seconds. `no_request_timeout` requests the maximum server timeout.
+- In the current synchronous buffered transport, the client timeout bounds retries and backoff only; it cannot interrupt an in-flight `std.http` request. Hard cancellation is deferred to future streaming and cancellation transport work.
+- Explicit application, user, version, and request-ID headers override defaults. Results expose owned `client_request_id` and `activity_id`; dataset `deinit` frees them.
+- Queries may retry; management operations and streaming ingestion remain non-retryable.
+
 ### Infrastructure
 
 | Package | Description |

--- a/sdk/core/http/pipeline.zig
+++ b/sdk/core/http/pipeline.zig
@@ -10,13 +10,19 @@ fn nanoTimestamp() i128 {
     return std.Io.Timestamp.now(threaded.io(), .real).toNanoseconds();
 }
 
+fn monotonicNanoTimestamp() i128 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    return std.Io.Timestamp.now(threaded.io(), .awake).toNanoseconds();
+}
+
 fn unixTimestampSeconds() i64 {
     return @intCast(@divTrunc(nanoTimestamp(), std.time.ns_per_s));
 }
 
 fn sleepMs(ms: u64) void {
     var threaded: std.Io.Threaded = .init_single_threaded;
-    threaded.io().sleep(.fromMilliseconds(@intCast(ms)), .real) catch {};
+    const nanoseconds = @as(i96, ms) * std.time.ns_per_ms;
+    threaded.io().sleep(.fromNanoseconds(nanoseconds), .awake) catch {};
 }
 
 /// A single stage in the HTTP pipeline.
@@ -117,7 +123,10 @@ pub const LoggingPolicy = struct {
 /// Retries failed requests with exponential back-off and jitter.
 ///
 /// Retries on server errors (5xx) and throttling (429). Honors the
-/// `Retry-After` response header when present.
+/// `Retry-After` response header when present. For retryable requests,
+/// `Request.operation_timeout_ms` limits attempts and backoff, but blocking
+/// transports cannot interrupt an in-flight send. Non-retryable requests
+/// always make one send, which is likewise not interruptible.
 pub const RetryPolicy = struct {
     max_retries: u32 = 3,
     initial_delay_ms: u64 = 800,
@@ -147,9 +156,19 @@ pub const RetryPolicy = struct {
     ) !Response {
         if (!request.retryable) return callNext(request, next, final_transport);
         const self: *RetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
+        const deadline_ns: ?i128 = if (request.operation_timeout_ms) |timeout_ms|
+            std.math.add(
+                i128,
+                monotonicNanoTimestamp(),
+                @as(i128, timeout_ms) * std.time.ns_per_ms,
+            ) catch std.math.maxInt(i128)
+        else
+            null;
         var attempt: u32 = 0;
         var prng = std.Random.DefaultPrng.init(@truncate(@as(u128, @bitCast(nanoTimestamp()))));
         while (true) {
+            if (deadlineExpired(deadline_ns)) return error.OperationTimedOut;
+
             const result = callNext(request, next, final_transport);
             if (result) |resp| {
                 if (!isRetryable(resp.status_code) or attempt >= self.max_retries) return resp;
@@ -164,34 +183,71 @@ pub const RetryPolicy = struct {
                 if (retry_after_ms > 0) {
                     // Honor server's Retry-After, capped at max_delay.
                     const delay = @min(retry_after_ms, self.max_delay_ms);
-                    sleepMs(delay);
+                    if (!sleepWithinBudget(delay, deadline_ns)) return error.OperationTimedOut;
                 } else {
-                    const base_delay = @min(
-                        self.initial_delay_ms * (@as(u64, 1) << @intCast(attempt - 1)),
+                    const base_delay = exponentialDelayMs(
+                        self.initial_delay_ms,
                         self.max_delay_ms,
+                        attempt,
                     );
                     const jitter = prng.random().uintLessThan(u64, @max(base_delay, 1));
                     const delay = base_delay / 2 + jitter / 2;
-                    sleepMs(delay);
+                    if (!sleepWithinBudget(delay, deadline_ns)) return error.OperationTimedOut;
                 }
             } else |err| {
                 if (attempt >= self.max_retries) return err;
                 attempt += 1;
-                const base_delay = @min(
-                    self.initial_delay_ms * (@as(u64, 1) << @intCast(attempt - 1)),
+                const base_delay = exponentialDelayMs(
+                    self.initial_delay_ms,
                     self.max_delay_ms,
+                    attempt,
                 );
                 const jitter = prng.random().uintLessThan(u64, @max(base_delay, 1));
                 const delay = base_delay / 2 + jitter / 2;
-                sleepMs(delay);
+                if (!sleepWithinBudget(delay, deadline_ns)) return error.OperationTimedOut;
             }
         }
     }
 
+    fn deadlineExpired(deadline_ns: ?i128) bool {
+        const deadline = deadline_ns orelse return false;
+        return monotonicNanoTimestamp() >= deadline;
+    }
+
+    fn sleepWithinBudget(delay_ms: u64, deadline_ns: ?i128) bool {
+        const deadline = deadline_ns orelse {
+            sleepMs(delay_ms);
+            return true;
+        };
+        const now = monotonicNanoTimestamp();
+        if (now >= deadline) return false;
+
+        const remaining_ns = deadline - now;
+        const delay_ns = @as(i128, delay_ms) * std.time.ns_per_ms;
+        if (delay_ns >= remaining_ns) {
+            var threaded: std.Io.Threaded = .init_single_threaded;
+            threaded.io().sleep(
+                .fromNanoseconds(@intCast(remaining_ns)),
+                .awake,
+            ) catch {};
+            return false;
+        }
+        sleepMs(delay_ms);
+        return true;
+    }
+
+    fn exponentialDelayMs(initial_delay_ms: u64, max_delay_ms: u64, attempt: u32) u64 {
+        if (initial_delay_ms == 0 or max_delay_ms == 0) return 0;
+        const shift = attempt -| 1;
+        if (shift >= 64) return max_delay_ms;
+        const multiplier = @as(u64, 1) << @intCast(shift);
+        const scaled = std.math.mul(u64, initial_delay_ms, multiplier) catch
+            std.math.maxInt(u64);
+        return @min(scaled, max_delay_ms);
+    }
+
     fn parseRetryAfter(resp: Response) ?u64 {
-        const value = resp.headers.get("Retry-After") orelse
-            resp.headers.get("retry-after") orelse
-            return null;
+        const value = resp.getHeader("Retry-After") orelse return null;
         return std.fmt.parseInt(u64, value, 10) catch null;
     }
 
@@ -280,6 +336,17 @@ pub const BearerTokenAuthPolicy = struct {
     }
 };
 
+/// Ensures a request has a caller-preserving unique client request ID.
+pub fn ensureRequestId(request: *Request) !void {
+    if (request.getHeader("x-ms-client-request-id") != null) return;
+    const uuid_mod = @import("../uuid.zig");
+    const seed: u64 = @truncate(@as(u128, @bitCast(nanoTimestamp())));
+    var prng = std.Random.DefaultPrng.init(seed);
+    const id = uuid_mod.Uuid.init(prng.random());
+    const id_str = id.toString();
+    try request.setHeader("x-ms-client-request-id", &id_str);
+}
+
 /// Injects `x-ms-client-request-id` with a unique UUID per request.
 pub const RequestIdPolicy = struct {
     policy: HttpPolicy,
@@ -298,15 +365,7 @@ pub const RequestIdPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        if (request.getHeader("x-ms-client-request-id") != null) {
-            return callNext(request, next, final_transport);
-        }
-        const uuid_mod = @import("../uuid.zig");
-        const seed: u64 = @truncate(@as(u128, @bitCast(nanoTimestamp())));
-        var prng = std.Random.DefaultPrng.init(seed);
-        const id = uuid_mod.Uuid.init(prng.random());
-        const id_str = id.toString();
-        try request.setHeader("x-ms-client-request-id", &id_str);
+        try ensureRequestId(request);
         return callNext(request, next, final_transport);
     }
 };
@@ -536,6 +595,17 @@ test "RetryPolicy converts Retry-After seconds to milliseconds" {
     try std.testing.expectEqual(@as(u64, 10_000), RetryPolicy.retryAfterDelayMs(response));
 }
 
+test "RetryPolicy exponential delay saturates without overflow" {
+    try std.testing.expectEqual(
+        std.math.maxInt(u64),
+        RetryPolicy.exponentialDelayMs(std.math.maxInt(u64), std.math.maxInt(u64), 2),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 60_000),
+        RetryPolicy.exponentialDelayMs(800, 60_000, std.math.maxInt(u32)),
+    );
+}
+
 test "RetryPolicy passes through 404 without retry" {
     const allocator = std.testing.allocator;
     var mock = transport.MockTransport.init(allocator, 404, "not found");
@@ -600,9 +670,44 @@ test "RetryPolicy bypasses retries for non-retryable requests" {
     var req = Request.init(allocator, .POST, "https://example.com/create");
     defer req.deinit();
     req.retryable = false;
+    req.operation_timeout_ms = 0;
     var resp = try pip.send(&req);
     defer resp.deinit();
     try std.testing.expectEqual(@as(u16, 500), resp.status_code);
+    try std.testing.expectEqual(@as(usize, 1), seq.call_count);
+}
+
+test "RetryPolicy zero timeout prevents a retryable send" {
+    const allocator = std.testing.allocator;
+    var seq = transport.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 200, .body = "ok" },
+    });
+    var retry = RetryPolicy.init();
+    var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
+    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var req = Request.init(allocator, .GET, "https://example.com");
+    defer req.deinit();
+    req.operation_timeout_ms = 0;
+
+    try std.testing.expectError(error.OperationTimedOut, pip.send(&req));
+    try std.testing.expectEqual(@as(usize, 0), seq.call_count);
+}
+
+test "RetryPolicy timeout prevents a second attempt" {
+    const allocator = std.testing.allocator;
+    var seq = transport.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 500, .body = "error" },
+        .{ .status = 200, .body = "ok" },
+    });
+    var retry = RetryPolicy.init();
+    retry.initial_delay_ms = 100;
+    var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
+    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var req = Request.init(allocator, .GET, "https://example.com");
+    defer req.deinit();
+    req.operation_timeout_ms = 1;
+
+    try std.testing.expectError(error.OperationTimedOut, pip.send(&req));
     try std.testing.expectEqual(@as(usize, 1), seq.call_count);
 }
 

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -39,6 +39,9 @@ pub const Request = struct {
     allocator: std.mem.Allocator,
     retryable: bool = true,
     redirect_policy: RedirectPolicy = .follow,
+    /// Best-effort budget checked before attempts and retry backoff. A blocking
+    /// in-flight send can exceed this budget.
+    operation_timeout_ms: ?u64 = null,
 
     pub fn init(allocator: std.mem.Allocator, method: Method, request_url: []const u8) Request {
         return .{
@@ -51,6 +54,15 @@ pub const Request = struct {
     }
 
     pub fn setHeader(self: *Request, key: []const u8, value: []const u8) !void {
+        if (key.len == 0) return error.InvalidHttpHeaderName;
+        for (key) |byte| {
+            if (!isHttpTokenByte(byte)) return error.InvalidHttpHeaderName;
+        }
+        for (value) |byte| {
+            if ((byte < 0x20 and byte != '\t') or byte == 0x7f)
+                return error.InvalidHttpHeaderValue;
+        }
+
         const owned_value = try self.allocator.dupe(u8, value);
         errdefer self.allocator.free(owned_value);
 
@@ -83,6 +95,13 @@ pub const Request = struct {
     }
 };
 
+fn isHttpTokenByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or switch (byte) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        else => false,
+    };
+}
+
 /// An HTTP response.
 pub const Response = struct {
     status_code: u16,
@@ -92,6 +111,16 @@ pub const Response = struct {
 
     pub fn isSuccess(self: Response) bool {
         return self.status_code >= 200 and self.status_code < 300;
+    }
+
+    pub fn getHeader(self: *const Response, key: []const u8) ?[]const u8 {
+        var iterator = self.headers.iterator();
+        while (iterator.next()) |entry| {
+            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, key)) {
+                return entry.value_ptr.*;
+            }
+        }
+        return null;
     }
 
     pub fn deinit(self: *Response) void {
@@ -255,6 +284,7 @@ pub const MockTransport = struct {
     last_body: ?[]u8 = null,
     last_retryable: ?bool = null,
     last_redirect_policy: ?RedirectPolicy = null,
+    last_operation_timeout_ms: ?u64 = null,
     call_count: usize = 0,
     response_headers_list: []const HeaderPair = &.{},
 
@@ -287,8 +317,10 @@ pub const MockTransport = struct {
         self.call_count += 1;
         self.last_method = request.method;
         if (self.last_url) |old| self.allocator.free(old);
+        self.last_url = null;
         self.last_url = try self.allocator.dupe(u8, request.url);
         if (self.last_body) |old| self.allocator.free(old);
+        self.last_body = null;
         self.last_body = if (request.body) |body|
             try self.allocator.dupe(u8, body)
         else
@@ -304,6 +336,7 @@ pub const MockTransport = struct {
         }
         self.last_retryable = request.retryable;
         self.last_redirect_policy = request.redirect_policy;
+        self.last_operation_timeout_ms = request.operation_timeout_ms;
 
         const response_body_copy = try self.allocator.dupe(u8, self.response_body);
         errdefer self.allocator.free(response_body_copy);
@@ -395,6 +428,7 @@ test "request init and set header" {
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     try std.testing.expectEqual(RedirectPolicy.follow, req.redirect_policy);
+    try std.testing.expectEqual(@as(?u64, null), req.operation_timeout_ms);
     req.redirect_policy = .not_allowed;
     try std.testing.expectEqual(RedirectPolicy.not_allowed, req.redirect_policy);
     try req.setHeader("Accept", "application/json");
@@ -404,6 +438,8 @@ test "request init and set header" {
     try req.setHeader("accept", "application/json");
     try std.testing.expectEqual(@as(usize, 1), req.headers.count());
     try std.testing.expectEqualStrings("application/json", req.getHeader("ACCEPT").?);
+    try std.testing.expectError(error.InvalidHttpHeaderName, req.setHeader("bad name", "value"));
+    try std.testing.expectError(error.InvalidHttpHeaderValue, req.setHeader("x-value", "one\r\ntwo"));
 }
 
 test "response isSuccess" {
@@ -417,6 +453,26 @@ test "response isSuccess" {
     try std.testing.expect(resp.isSuccess());
 }
 
+test "response header lookup is case-insensitive" {
+    const allocator = std.testing.allocator;
+    var headers = std.StringHashMap([]const u8).init(allocator);
+    const name = try allocator.dupe(u8, "X-MS-Activity-Id");
+    errdefer allocator.free(name);
+    const value = try allocator.dupe(u8, "activity-id");
+    errdefer allocator.free(value);
+    try headers.put(name, value);
+
+    var resp = Response{
+        .status_code = 200,
+        .headers = headers,
+        .body = try allocator.dupe(u8, "ok"),
+        .allocator = allocator,
+    };
+    defer resp.deinit();
+    try std.testing.expectEqualStrings("activity-id", resp.getHeader("x-ms-activity-id").?);
+    try std.testing.expect(resp.getHeader("missing") == null);
+}
+
 test "mock transport" {
     const allocator = std.testing.allocator;
     var mock = MockTransport.init(allocator, 200, "{\"status\":\"ok\"}");
@@ -425,6 +481,7 @@ test "mock transport" {
     defer req.deinit();
     req.body = "{\"value\":\"secret-value\"}";
     req.redirect_policy = .not_allowed;
+    req.operation_timeout_ms = 12_345;
     var resp = try mock.asTransport().send(&req);
     defer resp.deinit();
     try std.testing.expectEqual(@as(u16, 200), resp.status_code);
@@ -433,5 +490,6 @@ test "mock transport" {
     try std.testing.expectEqualStrings("https://vault.azure.net/secrets/mysecret", mock.last_url.?);
     try std.testing.expectEqualStrings("{\"value\":\"secret-value\"}", mock.last_body.?);
     try std.testing.expectEqual(RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
+    try std.testing.expectEqual(@as(?u64, 12_345), mock.last_operation_timeout_ms);
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
 }

--- a/sdk/kusto/common.zig
+++ b/sdk/kusto/common.zig
@@ -672,21 +672,624 @@ fn deriveIngestEndpoint(allocator: std.mem.Allocator, engine_url: []const u8) ![
 
 // ─────────────── Request Properties ─────────────────
 
+/// The kind of Kusto operation for which request properties are being sent.
+pub const KustoRequestKind = enum { query, management };
+
+/// Default server timeout for queries.
+pub const query_default_server_timeout_ms: u64 = 240_000;
+/// Default server timeout for management commands.
+pub const management_default_server_timeout_ms: u64 = 600_000;
+/// Maximum timeout accepted by the Kusto service.
+pub const max_server_timeout_ms: u64 = 3_600_000;
+/// Extra time allowed for the client to receive a server response.
+pub const client_timeout_grace_ms: u64 = 30_000;
+
+/// Values accepted by Kusto's `queryconsistency` request option.
+pub const QueryConsistency = enum {
+    strong,
+    weak,
+    weak_by_query,
+    weak_by_database,
+    weak_by_session_id,
+
+    fn wireValue(self: QueryConsistency) []const u8 {
+        return switch (self) {
+            .strong => "strongconsistency",
+            .weak => "weakconsistency",
+            .weak_by_query => "weakconsistency_by_query",
+            .weak_by_database => "weakconsistency_by_database",
+            .weak_by_session_id => "weakconsistency_by_session_id",
+        };
+    }
+};
+
+/// An owned entry in a request property bag.
+pub const RequestProperty = struct {
+    name: []u8,
+    value: serde.Value,
+
+    fn deinit(self: *RequestProperty, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        self.value.deinit(allocator);
+    }
+};
+
 /// Client request properties for query/management commands.
 pub const ClientRequestProperties = struct {
     client_request_id: ?[]const u8 = null,
     application: ?[]const u8 = null,
     server_timeout_ms: ?i64 = null,
+    user: ?[]const u8 = null,
+    client_version: ?[]const u8 = null,
+    client_timeout_ms: ?u64 = null,
+    no_request_timeout: bool = false,
+    options: std.ArrayListUnmanaged(RequestProperty) = .empty,
+    parameters: std.ArrayListUnmanaged(RequestProperty) = .empty,
+
+    /// Releases the names and values owned by the option and parameter bags.
+    /// The string fields in this type are borrowed and are not released.
+    pub fn deinit(self: *ClientRequestProperties, allocator: std.mem.Allocator) void {
+        deinitPropertyList(&self.options, allocator);
+        deinitPropertyList(&self.parameters, allocator);
+    }
+
+    /// Set an arbitrary Kusto request option. The name and value are copied.
+    pub fn setOption(self: *ClientRequestProperties, allocator: std.mem.Allocator, name: []const u8, value: anytype) !void {
+        try setProperty(&self.options, allocator, name, value);
+    }
+
+    /// Set an arbitrary Kusto query parameter. The name and value are copied.
+    pub fn setParameter(self: *ClientRequestProperties, allocator: std.mem.Allocator, name: []const u8, value: anytype) !void {
+        var owned_value = try ownedValueFromAny(value, allocator);
+        validateQueryParameterValue(owned_value) catch |err| {
+            owned_value.deinit(allocator);
+            return err;
+        };
+        try setOwnedProperty(&self.parameters, allocator, name, owned_value);
+    }
+
+    pub fn setServerTimeoutMs(self: *ClientRequestProperties, timeout_ms: i64) void {
+        self.server_timeout_ms = timeout_ms;
+    }
+
+    pub fn setNoRequestTimeout(self: *ClientRequestProperties, enabled: bool) void {
+        self.no_request_timeout = enabled;
+    }
+
+    pub fn removeOption(self: *ClientRequestProperties, allocator: std.mem.Allocator, name: []const u8) bool {
+        return removeProperty(&self.options, allocator, name);
+    }
+
+    pub fn removeParameter(self: *ClientRequestProperties, allocator: std.mem.Allocator, name: []const u8) bool {
+        return removeProperty(&self.parameters, allocator, name);
+    }
+
+    pub fn setNoTruncation(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setOption(allocator, "notruncation", enabled);
+    }
+
+    pub fn setTruncationMaxRecords(self: *ClientRequestProperties, allocator: std.mem.Allocator, max_records: u64) !void {
+        try self.setOption(allocator, "truncationmaxrecords", max_records);
+    }
+
+    pub fn setTruncationMaxSize(self: *ClientRequestProperties, allocator: std.mem.Allocator, max_size: u64) !void {
+        try self.setOption(allocator, "truncationmaxsize", max_size);
+    }
+
+    pub fn setProgressiveEnabled(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setOption(allocator, "results_progressive_enabled", enabled);
+    }
+
+    pub fn setProgressiveResultsEnabled(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setProgressiveEnabled(allocator, enabled);
+    }
+
+    pub fn setProgressiveRowCount(self: *ClientRequestProperties, allocator: std.mem.Allocator, row_count: u64) !void {
+        try self.setOption(allocator, "query_results_progressive_row_count", row_count);
+    }
+
+    pub fn setProgressiveUpdatePeriod(self: *ClientRequestProperties, allocator: std.mem.Allocator, period_ms: u64) !void {
+        var buffer: [32]u8 = undefined;
+        try self.setOption(allocator, "query_results_progressive_update_period", formatTimespan(&buffer, period_ms));
+    }
+
+    pub fn setCacheMaxAge(self: *ClientRequestProperties, allocator: std.mem.Allocator, max_age_ms: u64) !void {
+        var buffer: [32]u8 = undefined;
+        try self.setOption(allocator, "query_results_cache_max_age", formatTimespan(&buffer, max_age_ms));
+    }
+
+    pub fn setQueryResultsCacheMaxAge(self: *ClientRequestProperties, allocator: std.mem.Allocator, max_age_ms: u64) !void {
+        try self.setCacheMaxAge(allocator, max_age_ms);
+    }
+
+    pub fn setCacheForceRefresh(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setOption(allocator, "query_results_cache_force_refresh", enabled);
+    }
+
+    pub fn setQueryResultsCacheForceRefresh(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setCacheForceRefresh(allocator, enabled);
+    }
+
+    pub fn setCachePerShard(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setOption(allocator, "query_results_cache_per_shard", enabled);
+    }
+
+    pub fn setQueryResultsCachePerShard(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setCachePerShard(allocator, enabled);
+    }
+
+    pub fn setQueryConsistency(self: *ClientRequestProperties, allocator: std.mem.Allocator, consistency: QueryConsistency) !void {
+        try self.setOption(allocator, "queryconsistency", consistency.wireValue());
+    }
+
+    pub fn setQueryWeakConsistencySessionId(self: *ClientRequestProperties, allocator: std.mem.Allocator, session_id: []const u8) !void {
+        try self.setOption(allocator, "query_weakconsistency_session_id", session_id);
+    }
+
+    pub fn setMaxMemoryPerIterator(self: *ClientRequestProperties, allocator: std.mem.Allocator, bytes: u64) !void {
+        try self.setOption(allocator, "maxmemoryconsumptionperiterator", bytes);
+    }
+
+    pub fn setMaxMemoryConsumptionPerIterator(self: *ClientRequestProperties, allocator: std.mem.Allocator, bytes: u64) !void {
+        try self.setMaxMemoryPerIterator(allocator, bytes);
+    }
+
+    pub fn setMaxMemoryPerQueryNode(self: *ClientRequestProperties, allocator: std.mem.Allocator, bytes: u64) !void {
+        try self.setOption(allocator, "max_memory_consumption_per_query_per_node", bytes);
+    }
+
+    pub fn setMaxMemoryConsumptionPerQueryPerNode(self: *ClientRequestProperties, allocator: std.mem.Allocator, bytes: u64) !void {
+        try self.setMaxMemoryPerQueryNode(allocator, bytes);
+    }
+
+    pub fn setRequestReadOnly(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setOption(allocator, "request_readonly", enabled);
+    }
+
+    pub fn setBlockRowLevelSecurity(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setOption(allocator, "request_block_row_level_security", enabled);
+    }
+
+    pub fn setForceRowLevelSecurity(self: *ClientRequestProperties, allocator: std.mem.Allocator, enabled: bool) !void {
+        try self.setOption(allocator, "query_force_row_level_security", enabled);
+    }
+
+    /// Validates explicit timeouts and any winning custom server timeout.
+    pub fn validate(self: *const ClientRequestProperties, kind: KustoRequestKind) !void {
+        _ = kind;
+        if (self.server_timeout_ms) |timeout| {
+            if (timeout < 1_000 or timeout > max_server_timeout_ms)
+                return error.InvalidServerTimeout;
+        }
+        if (self.client_timeout_ms) |timeout| {
+            if (timeout == 0 or timeout > max_server_timeout_ms + client_timeout_grace_ms)
+                return error.InvalidClientTimeout;
+        }
+        const no_request_timeout = try self.requestsNoTimeout();
+        if (!no_request_timeout and self.server_timeout_ms == null) {
+            if (findProperty(self.options.items, "servertimeout")) |property| {
+                _ = try timeoutFromValue(property.value);
+            }
+        }
+    }
+
+    /// Returns the server timeout after applying Kusto's operation default.
+    pub fn effectiveServerTimeoutMs(self: *const ClientRequestProperties, kind: KustoRequestKind) !u64 {
+        try self.validate(kind);
+        if (try self.requestsNoTimeout()) return max_server_timeout_ms;
+        if (self.server_timeout_ms) |timeout| return @intCast(timeout);
+        if (findProperty(self.options.items, "servertimeout")) |property|
+            return timeoutFromValue(property.value);
+        return defaultServerTimeout(kind);
+    }
+
+    /// Returns the client timeout, including the client grace period by default.
+    pub fn effectiveClientTimeoutMs(self: *const ClientRequestProperties, kind: KustoRequestKind) !u64 {
+        try self.validate(kind);
+        return self.client_timeout_ms orelse (try self.effectiveServerTimeoutMs(kind)) + client_timeout_grace_ms;
+    }
+
+    /// Returns the internal request-property adapter with operation defaults.
+    fn requestView(self: *const ClientRequestProperties, kind: KustoRequestKind) RequestPropertiesView {
+        return .{ .properties = self, .kind = kind };
+    }
 
     /// Serialize to JSON for the "properties" field in the REST body.
     pub fn toJson(self: ClientRequestProperties, allocator: std.mem.Allocator) ![]u8 {
-        if (self.server_timeout_ms) |timeout| {
-            const minutes = @divTrunc(timeout, 60000);
-            return std.fmt.allocPrint(allocator, "{{\"Options\":{{\"servertimeout\":\"{d}m\"}}}}", .{minutes});
-        }
-        return allocator.dupe(u8, "{}");
+        try self.validate(.query);
+        return serde.json.toSlice(allocator, RequestPropertiesView{ .properties = &self });
+    }
+
+    fn requestsNoTimeout(self: *const ClientRequestProperties) !bool {
+        if (self.no_request_timeout) return true;
+        const property = findProperty(self.options.items, "norequesttimeout") orelse return false;
+        return switch (property.value) {
+            .bool => |enabled| enabled,
+            else => error.InvalidNoRequestTimeout,
+        };
     }
 };
+
+const RequestPropertiesView = struct {
+    properties: *const ClientRequestProperties,
+    kind: ?KustoRequestKind = null,
+
+    pub fn zerdeSerialize(self: RequestPropertiesView, serializer: anytype) @TypeOf(serializer.*).Error!void {
+        var object = try serializer.beginStruct();
+        try object.serializeEntry(@as([]const u8, "Options"), OptionsView{ .properties = self.properties, .kind = self.kind });
+        try object.serializeEntry(@as([]const u8, "Parameters"), PropertyBagView{ .items = self.properties.parameters.items });
+        try object.end();
+    }
+};
+
+const KustoRequestWire = struct {
+    db: []const u8,
+    csl: []const u8,
+    properties: RequestPropertiesView,
+};
+
+pub fn serializeRequestBody(
+    allocator: std.mem.Allocator,
+    database: []const u8,
+    csl: []const u8,
+    properties: ClientRequestProperties,
+    kind: KustoRequestKind,
+) ![]u8 {
+    try properties.validate(kind);
+    return serde.json.toSlice(allocator, KustoRequestWire{
+        .db = database,
+        .csl = csl,
+        .properties = properties.requestView(kind),
+    });
+}
+
+const DynamicValue = struct {
+    value: *const serde.Value,
+
+    pub fn zerdeSerialize(self: DynamicValue, serializer: anytype) @TypeOf(serializer.*).Error!void {
+        switch (self.value.*) {
+            .null => try serializer.serializeNull(),
+            .bool => |value| try serializer.serializeBool(value),
+            .int => |value| try serializer.serializeInt(value),
+            .uint => |value| try serializer.serializeInt(value),
+            .float => |value| try serializer.serializeFloat(value),
+            .string => |value| try serializer.serializeString(value),
+            .array => |values| {
+                var array = try serializer.beginArray();
+                for (values) |*value| try serdeSerializeValue(value, &array);
+                try array.end();
+            },
+            .object => |entries| {
+                var object = try serializer.beginStruct();
+                for (entries) |*entry| try object.serializeEntry(entry.key, DynamicValue{ .value = &entry.value });
+                try object.end();
+            },
+        }
+    }
+};
+
+fn serdeSerializeValue(value: *const serde.Value, serializer: anytype) @TypeOf(serializer.*).Error!void {
+    try (DynamicValue{ .value = value }).zerdeSerialize(serializer);
+}
+
+const PropertyBagView = struct {
+    items: []const RequestProperty,
+
+    pub fn zerdeSerialize(self: PropertyBagView, serializer: anytype) @TypeOf(serializer.*).Error!void {
+        var object = try serializer.beginStruct();
+        for (self.items) |*property| {
+            try object.serializeEntry(property.name, DynamicValue{ .value = &property.value });
+        }
+        try object.end();
+    }
+};
+
+const OptionsView = struct {
+    properties: *const ClientRequestProperties,
+    kind: ?KustoRequestKind,
+
+    pub fn zerdeSerialize(self: OptionsView, serializer: anytype) @TypeOf(serializer.*).Error!void {
+        var object = try serializer.beginStruct();
+        const properties = self.properties;
+        const no_request_timeout = properties.requestsNoTimeout() catch unreachable;
+        const skip_custom_timeout = no_request_timeout or properties.server_timeout_ms != null;
+        for (properties.options.items) |*property| {
+            if ((skip_custom_timeout and std.mem.eql(u8, property.name, "servertimeout")) or
+                std.mem.eql(u8, property.name, "norequesttimeout"))
+                continue;
+            if (std.mem.eql(u8, property.name, "servertimeout")) {
+                var buffer: [32]u8 = undefined;
+                const timeout = timeoutFromValue(property.value) catch unreachable;
+                try object.serializeEntry(@as([]const u8, "servertimeout"), formatTimespan(&buffer, timeout));
+                continue;
+            }
+            try object.serializeEntry(property.name, DynamicValue{ .value = &property.value });
+        }
+
+        if (no_request_timeout) {
+            try object.serializeEntry(@as([]const u8, "norequesttimeout"), true);
+        } else if (properties.server_timeout_ms) |timeout| {
+            var buffer: [32]u8 = undefined;
+            const timeout_ms: u64 = if (timeout >= 0) @intCast(timeout) else 0;
+            try object.serializeEntry(@as([]const u8, "servertimeout"), formatTimespan(&buffer, timeout_ms));
+        } else if (findProperty(properties.options.items, "servertimeout") == null) {
+            if (self.kind) |kind| {
+                var buffer: [32]u8 = undefined;
+                try object.serializeEntry(@as([]const u8, "servertimeout"), formatTimespan(&buffer, defaultServerTimeout(kind)));
+            }
+        }
+        try object.end();
+    }
+};
+
+fn deinitPropertyList(items: *std.ArrayListUnmanaged(RequestProperty), allocator: std.mem.Allocator) void {
+    for (items.items) |*property| property.deinit(allocator);
+    items.deinit(allocator);
+    items.* = .empty;
+}
+
+fn setProperty(items: *std.ArrayListUnmanaged(RequestProperty), allocator: std.mem.Allocator, name: []const u8, value: anytype) !void {
+    try setOwnedProperty(items, allocator, name, try ownedValueFromAny(value, allocator));
+}
+
+fn setOwnedProperty(items: *std.ArrayListUnmanaged(RequestProperty), allocator: std.mem.Allocator, name: []const u8, value: serde.Value) !void {
+    var owned_value = value;
+    errdefer owned_value.deinit(allocator);
+
+    if (findPropertyIndex(items.items, name)) |index| {
+        items.items[index].value.deinit(allocator);
+        items.items[index].value = owned_value;
+        return;
+    }
+
+    const owned_name = try allocator.dupe(u8, name);
+    errdefer allocator.free(owned_name);
+    try items.append(allocator, .{ .name = owned_name, .value = owned_value });
+}
+
+fn validateQueryParameterValue(value: serde.Value) !void {
+    switch (value) {
+        .string, .int => {},
+        .uint => |item| if (item > std.math.maxInt(i64)) return error.InvalidQueryParameterValue,
+        else => return error.InvalidQueryParameterValue,
+    }
+}
+
+/// Equivalent to `serde.Value.fromAny`, but initializes every allocation before
+/// making it visible to an error cleanup path.
+fn ownedValueFromAny(value: anytype, allocator: std.mem.Allocator) !serde.Value {
+    const T = @TypeOf(value);
+    if (comptime T == serde.Value) return cloneSerdeValue(value, allocator);
+    switch (@typeInfo(T)) {
+        .bool => return .{ .bool = value },
+        .int => |info| {
+            if (info.signedness == .unsigned)
+                return .{ .uint = std.math.cast(u64, value) orelse return error.PropertyIntegerOutOfRange };
+            if (value >= 0)
+                return .{ .uint = std.math.cast(u64, value) orelse return error.PropertyIntegerOutOfRange };
+            return .{ .int = std.math.cast(i64, value) orelse return error.PropertyIntegerOutOfRange };
+        },
+        .comptime_int => {
+            if (value >= 0) {
+                if (value > std.math.maxInt(u64)) return error.PropertyIntegerOutOfRange;
+                return .{ .uint = @intCast(value) };
+            }
+            if (value < std.math.minInt(i64)) return error.PropertyIntegerOutOfRange;
+            return .{ .int = @intCast(value) };
+        },
+        .float, .comptime_float => return .{ .float = @floatCast(value) },
+        .void => return .null,
+        .optional => {
+            if (value) |child| return ownedValueFromAny(child, allocator);
+            return .null;
+        },
+        .pointer => |pointer| {
+            if (pointer.size == .slice) {
+                if (pointer.child == u8) return ownedString(value, allocator);
+                return ownedArray(pointer.child, value, allocator);
+            }
+            if (pointer.size == .one and @typeInfo(pointer.child) == .array and @typeInfo(pointer.child).array.child == u8)
+                return ownedString(value[0..], allocator);
+            return ownedValueFromAny(value.*, allocator);
+        },
+        .array => |array| return ownedArray(array.child, value[0..], allocator),
+        .@"struct" => |info| {
+            if (info.is_tuple) {
+                var values = try allocator.alloc(serde.Value, info.fields.len);
+                var initialized: usize = 0;
+                errdefer {
+                    for (values[0..initialized]) |item| item.deinit(allocator);
+                    allocator.free(values);
+                }
+                inline for (info.fields, 0..) |field, index| {
+                    values[index] = try ownedValueFromAny(@field(value, field.name), allocator);
+                    initialized += 1;
+                }
+                return .{ .array = values };
+            }
+            var entries = try allocator.alloc(serde.Entry, info.fields.len);
+            var initialized: usize = 0;
+            errdefer {
+                for (entries[0..initialized]) |entry| {
+                    allocator.free(entry.key);
+                    entry.value.deinit(allocator);
+                }
+                allocator.free(entries);
+            }
+            inline for (info.fields, 0..) |field, index| {
+                entries[index].key = try allocator.dupe(u8, field.name);
+                entries[index].value = ownedValueFromAny(@field(value, field.name), allocator) catch |err| {
+                    allocator.free(entries[index].key);
+                    return err;
+                };
+                initialized += 1;
+            }
+            return .{ .object = entries };
+        },
+        .@"enum" => return ownedString(@tagName(value), allocator),
+        else => return error.UnsupportedPropertyValue,
+    }
+}
+
+fn cloneSerdeValue(value: serde.Value, allocator: std.mem.Allocator) !serde.Value {
+    return switch (value) {
+        .null => .null,
+        .bool => |item| .{ .bool = item },
+        .int => |item| .{ .int = item },
+        .uint => |item| .{ .uint = item },
+        .float => |item| .{ .float = item },
+        .string => |item| ownedString(item, allocator),
+        .array => |items| blk: {
+            var result = try allocator.alloc(serde.Value, items.len);
+            var initialized: usize = 0;
+            errdefer {
+                for (result[0..initialized]) |item| item.deinit(allocator);
+                allocator.free(result);
+            }
+            for (items, 0..) |item, index| {
+                result[index] = try cloneSerdeValue(item, allocator);
+                initialized += 1;
+            }
+            break :blk .{ .array = result };
+        },
+        .object => |items| blk: {
+            var result = try allocator.alloc(serde.Entry, items.len);
+            var initialized: usize = 0;
+            errdefer {
+                for (result[0..initialized]) |item| {
+                    allocator.free(item.key);
+                    item.value.deinit(allocator);
+                }
+                allocator.free(result);
+            }
+            for (items, 0..) |item, index| {
+                result[index].key = try allocator.dupe(u8, item.key);
+                result[index].value = cloneSerdeValue(item.value, allocator) catch |err| {
+                    allocator.free(result[index].key);
+                    return err;
+                };
+                initialized += 1;
+            }
+            break :blk .{ .object = result };
+        },
+    };
+}
+
+fn ownedString(value: []const u8, allocator: std.mem.Allocator) !serde.Value {
+    return .{ .string = try allocator.dupe(u8, value) };
+}
+
+fn ownedArray(comptime Child: type, values: []const Child, allocator: std.mem.Allocator) !serde.Value {
+    var result = try allocator.alloc(serde.Value, values.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (result[0..initialized]) |item| item.deinit(allocator);
+        allocator.free(result);
+    }
+    for (values, 0..) |value, index| {
+        result[index] = try ownedValueFromAny(value, allocator);
+        initialized += 1;
+    }
+    return .{ .array = result };
+}
+
+fn removeProperty(items: *std.ArrayListUnmanaged(RequestProperty), allocator: std.mem.Allocator, name: []const u8) bool {
+    const index = findPropertyIndex(items.items, name) orelse return false;
+    var removed = items.orderedRemove(index);
+    removed.deinit(allocator);
+    return true;
+}
+
+fn findProperty(items: []const RequestProperty, name: []const u8) ?*const RequestProperty {
+    for (items) |*property| {
+        if (std.mem.eql(u8, property.name, name)) return property;
+    }
+    return null;
+}
+
+fn findPropertyIndex(items: []const RequestProperty, name: []const u8) ?usize {
+    for (items, 0..) |property, index| {
+        if (std.mem.eql(u8, property.name, name)) return index;
+    }
+    return null;
+}
+
+fn defaultServerTimeout(kind: KustoRequestKind) u64 {
+    return switch (kind) {
+        .query => query_default_server_timeout_ms,
+        .management => management_default_server_timeout_ms,
+    };
+}
+
+fn formatTimespan(buffer: []u8, timeout_ms: u64) []const u8 {
+    const hours = timeout_ms / 3_600_000;
+    const minutes = (timeout_ms / 60_000) % 60;
+    const seconds = (timeout_ms / 1_000) % 60;
+    const milliseconds = timeout_ms % 1_000;
+    return std.fmt.bufPrint(buffer, "{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{ hours, minutes, seconds, milliseconds }) catch unreachable;
+}
+
+fn timeoutFromValue(value: serde.Value) !u64 {
+    return switch (value) {
+        .uint => |timeout| validateServerTimeout(timeout),
+        .int => |timeout| if (timeout >= 0) validateServerTimeout(@intCast(timeout)) else error.InvalidServerTimeout,
+        .string => |timeout| validateServerTimeout(try parseTimespan(timeout)),
+        else => error.InvalidServerTimeout,
+    };
+}
+
+fn validateServerTimeout(timeout: u64) !u64 {
+    if (timeout < 1_000 or timeout > max_server_timeout_ms) return error.InvalidServerTimeout;
+    return timeout;
+}
+
+fn parseTimespan(value: []const u8) !u64 {
+    if (std.mem.endsWith(u8, value, "ms"))
+        return parseScaledDuration(value[0 .. value.len - 2], 1);
+    if (std.mem.endsWith(u8, value, "d"))
+        return parseScaledDuration(value[0 .. value.len - 1], 86_400_000);
+    if (std.mem.endsWith(u8, value, "h"))
+        return parseScaledDuration(value[0 .. value.len - 1], 3_600_000);
+    if (std.mem.endsWith(u8, value, "m"))
+        return parseScaledDuration(value[0 .. value.len - 1], 60_000);
+    if (std.mem.endsWith(u8, value, "s"))
+        return parseScaledDuration(value[0 .. value.len - 1], 1_000);
+    if (value.len != 12 or value[2] != ':' or value[5] != ':' or value[8] != '.')
+        return error.InvalidServerTimeout;
+    const hours = std.fmt.parseInt(u64, value[0..2], 10) catch return error.InvalidServerTimeout;
+    const minutes = std.fmt.parseInt(u64, value[3..5], 10) catch return error.InvalidServerTimeout;
+    const seconds = std.fmt.parseInt(u64, value[6..8], 10) catch return error.InvalidServerTimeout;
+    const milliseconds = std.fmt.parseInt(u64, value[9..12], 10) catch return error.InvalidServerTimeout;
+    if (minutes > 59 or seconds > 59) return error.InvalidServerTimeout;
+    const hour_ms = std.math.mul(u64, hours, 3_600_000) catch return error.InvalidServerTimeout;
+    const minute_ms = std.math.mul(u64, minutes, 60_000) catch return error.InvalidServerTimeout;
+    const second_ms = std.math.mul(u64, seconds, 1_000) catch return error.InvalidServerTimeout;
+    return std.math.add(u64, std.math.add(u64, hour_ms, minute_ms) catch return error.InvalidServerTimeout, std.math.add(u64, second_ms, milliseconds) catch return error.InvalidServerTimeout) catch error.InvalidServerTimeout;
+}
+
+fn parseScaledDuration(value: []const u8, unit_ms: u64) !u64 {
+    if (value.len == 0) return error.InvalidServerTimeout;
+    const decimal_index = std.mem.indexOfScalar(u8, value, '.');
+    const whole_text = if (decimal_index) |index| value[0..index] else value;
+    if (whole_text.len == 0) return error.InvalidServerTimeout;
+    const whole = std.fmt.parseInt(u64, whole_text, 10) catch return error.InvalidServerTimeout;
+    var result = std.math.mul(u64, whole, unit_ms) catch return error.InvalidServerTimeout;
+
+    if (decimal_index) |index| {
+        const fraction_text = value[index + 1 ..];
+        if (fraction_text.len == 0 or std.mem.indexOfScalar(u8, fraction_text, '.') != null)
+            return error.InvalidServerTimeout;
+        const fraction = std.fmt.parseInt(u64, fraction_text, 10) catch return error.InvalidServerTimeout;
+        var scale: u64 = 1;
+        for (fraction_text) |_| {
+            scale = std.math.mul(u64, scale, 10) catch return error.InvalidServerTimeout;
+        }
+        const scaled_fraction = std.math.mul(u64, fraction, unit_ms) catch return error.InvalidServerTimeout;
+        if (scaled_fraction % scale != 0) return error.InvalidServerTimeout;
+        result = std.math.add(u64, result, scaled_fraction / scale) catch return error.InvalidServerTimeout;
+    }
+    return result;
+}
 
 /// Ingestion properties for data upload.
 pub const IngestionProperties = struct {
@@ -1337,7 +1940,7 @@ test "ClientRequestProperties toJson default" {
     const props = ClientRequestProperties{};
     const json = try props.toJson(allocator);
     defer allocator.free(json);
-    try std.testing.expectEqualStrings("{}", json);
+    try std.testing.expectEqualStrings("{\"Options\":{},\"Parameters\":{}}", json);
 }
 
 test "ClientRequestProperties toJson with timeout" {
@@ -1345,5 +1948,208 @@ test "ClientRequestProperties toJson with timeout" {
     const props = ClientRequestProperties{ .server_timeout_ms = 300000 };
     const json = try props.toJson(allocator);
     defer allocator.free(json);
-    try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"5m\"}}", json);
+    try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:05:00.000\"},\"Parameters\":{}}", json);
+}
+
+test "ClientRequestProperties preserves millisecond timeout precision" {
+    const allocator = std.testing.allocator;
+    const props = ClientRequestProperties{ .server_timeout_ms = 90_001 };
+    const json = try props.toJson(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:01:30.001\"},\"Parameters\":{}}", json);
+}
+
+test "ClientRequestProperties validates timeout bounds" {
+    try std.testing.expectError(error.InvalidServerTimeout, (ClientRequestProperties{ .server_timeout_ms = 999 }).validate(.query));
+    try std.testing.expectError(error.InvalidServerTimeout, (ClientRequestProperties{ .server_timeout_ms = 3_600_001 }).validate(.management));
+    try std.testing.expectError(error.InvalidClientTimeout, (ClientRequestProperties{ .client_timeout_ms = 0 }).validate(.query));
+    try std.testing.expectError(error.InvalidClientTimeout, (ClientRequestProperties{ .client_timeout_ms = max_server_timeout_ms + client_timeout_grace_ms + 1 }).validate(.query));
+    try std.testing.expectEqual(@as(u64, 10_000), try parseTimespan("10s"));
+    try std.testing.expectEqual(@as(u64, 3_600_000), try parseTimespan("1h"));
+    try std.testing.expectEqual(@as(u64, 5_400_000), try parseTimespan("1.5h"));
+
+    const props = ClientRequestProperties{};
+    try std.testing.expectEqual(query_default_server_timeout_ms, try props.effectiveServerTimeoutMs(.query));
+    try std.testing.expectEqual(management_default_server_timeout_ms + client_timeout_grace_ms, try props.effectiveClientTimeoutMs(.management));
+}
+
+test "ClientRequestProperties typed helpers use Kusto wire names and types" {
+    const allocator = std.testing.allocator;
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    try props.setNoTruncation(allocator, true);
+    try props.setTruncationMaxRecords(allocator, 123);
+    try props.setProgressiveRowCount(allocator, 50);
+    try props.setProgressiveUpdatePeriod(allocator, 90_001);
+    try props.setCacheForceRefresh(allocator, false);
+    try props.setQueryConsistency(allocator, .weak_by_database);
+    try props.setMaxMemoryPerQueryNode(allocator, 456);
+    try props.setBlockRowLevelSecurity(allocator, true);
+    try props.setForceRowLevelSecurity(allocator, true);
+
+    const json = try props.toJson(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"Options\":{\"notruncation\":true,\"truncationmaxrecords\":123,\"query_results_progressive_row_count\":50,\"query_results_progressive_update_period\":\"00:01:30.001\",\"query_results_cache_force_refresh\":false,\"queryconsistency\":\"weakconsistency_by_database\",\"max_memory_consumption_per_query_per_node\":456,\"request_block_row_level_security\":true,\"query_force_row_level_security\":true},\"Parameters\":{}}",
+        json,
+    );
+}
+
+test "ClientRequestProperties supports non-byte slices" {
+    const allocator = std.testing.allocator;
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    const values = [_]u16{ 1, 2, 3 };
+    try props.setOption(allocator, "values", values[0..]);
+
+    const json = try props.toJson(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"Options\":{\"values\":[1,2,3]},\"Parameters\":{}}",
+        json,
+    );
+}
+
+test "ClientRequestProperties preserves nested dynamic values and escapes strings" {
+    const allocator = std.testing.allocator;
+    const Input = struct {
+        flag: bool,
+        signed: i64,
+        unsigned: u64,
+        decimal: f64,
+        text: []const u8,
+        absent: ?u8,
+        values: [2]u8,
+        child: struct { answer: u8 },
+    };
+
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    try props.setOption(allocator, "quoted\"name", Input{
+        .flag = true,
+        .signed = -2,
+        .unsigned = 3,
+        .decimal = 1.5,
+        .text = "line\n\"quoted\"",
+        .absent = null,
+        .values = .{ 4, 5 },
+        .child = .{ .answer = 6 },
+    });
+    const json = try props.toJson(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"Options\":{\"quoted\\\"name\":{\"flag\":true,\"signed\":-2,\"unsigned\":3,\"decimal\":1.5,\"text\":\"line\\n\\\"quoted\\\"\",\"absent\":null,\"values\":[4,5],\"child\":{\"answer\":6}}},\"Parameters\":{}}",
+        json,
+    );
+}
+
+test "ClientRequestProperties copies supplied serde values" {
+    const allocator = std.testing.allocator;
+    var value = try serde.Value.fromAny([]const u8, "copied", allocator);
+    defer value.deinit(allocator);
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    try props.setOption(allocator, "unknown", value);
+
+    const json = try props.toJson(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings("{\"Options\":{\"unknown\":\"copied\"},\"Parameters\":{}}", json);
+}
+
+test "ClientRequestProperties replaces duplicate keys and keeps both bags" {
+    const allocator = std.testing.allocator;
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    try props.setOption(allocator, "value", @as(u8, 1));
+    try props.setOption(allocator, "value", "replacement");
+    try props.setParameter(allocator, "p", @as(i64, 7));
+    const json = try props.toJson(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings("{\"Options\":{\"value\":\"replacement\"},\"Parameters\":{\"p\":7}}", json);
+    try std.testing.expectEqual(@as(usize, 1), props.options.items.len);
+}
+
+test "ClientRequestProperties enforces query parameter wire values" {
+    const allocator = std.testing.allocator;
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    try props.setParameter(allocator, "long", @as(i64, 42));
+    try props.setParameter(allocator, "dynamic", "dynamic([1, 2])");
+    try std.testing.expectError(
+        error.InvalidQueryParameterValue,
+        props.setParameter(allocator, "invalid", [_]u8{ 1, 2 }),
+    );
+
+    const json = try props.toJson(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"Options\":{},\"Parameters\":{\"long\":42,\"dynamic\":\"dynamic([1, 2])\"}}",
+        json,
+    );
+}
+
+test "ClientRequestProperties request view applies operation timeout defaults" {
+    const allocator = std.testing.allocator;
+    const props = ClientRequestProperties{};
+    const query_json = try serde.json.toSlice(allocator, props.requestView(.query));
+    defer allocator.free(query_json);
+    try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:04:00.000\"},\"Parameters\":{}}", query_json);
+    const management_json = try serde.json.toSlice(allocator, props.requestView(.management));
+    defer allocator.free(management_json);
+    try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:10:00.000\"},\"Parameters\":{}}", management_json);
+}
+
+test "ClientRequestProperties applies reserved timeout precedence" {
+    const allocator = std.testing.allocator;
+    var props = ClientRequestProperties{ .server_timeout_ms = 90_001 };
+    defer props.deinit(allocator);
+    try props.setOption(allocator, "servertimeout", "00:02:00.000");
+    {
+        const json = try serde.json.toSlice(allocator, props.requestView(.query));
+        defer allocator.free(json);
+        try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:01:30.001\"},\"Parameters\":{}}", json);
+    }
+
+    props.server_timeout_ms = null;
+    {
+        const json = try serde.json.toSlice(allocator, props.requestView(.query));
+        defer allocator.free(json);
+        try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:02:00.000\"},\"Parameters\":{}}", json);
+    }
+
+    try props.setOption(allocator, "servertimeout", @as(u64, 90_001));
+    {
+        const json = try serde.json.toSlice(allocator, props.requestView(.query));
+        defer allocator.free(json);
+        try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:01:30.001\"},\"Parameters\":{}}", json);
+    }
+
+    try props.setOption(allocator, "servertimeout", "1.5m");
+    {
+        const json = try serde.json.toSlice(allocator, props.requestView(.query));
+        defer allocator.free(json);
+        try std.testing.expectEqualStrings("{\"Options\":{\"servertimeout\":\"00:01:30.000\"},\"Parameters\":{}}", json);
+    }
+
+    try props.setOption(allocator, "norequesttimeout", true);
+    {
+        const json = try serde.json.toSlice(allocator, props.requestView(.query));
+        defer allocator.free(json);
+        try std.testing.expectEqualStrings("{\"Options\":{\"norequesttimeout\":true},\"Parameters\":{}}", json);
+    }
+
+    try props.setOption(allocator, "norequesttimeout", "invalid");
+    try std.testing.expectError(error.InvalidNoRequestTimeout, props.validate(.query));
+}
+
+fn setRequestPropertiesForAllocationTest(allocator: std.mem.Allocator) !void {
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    try props.setOption(allocator, "nested", .{ .name = "value", .items = [_]u8{ 1, 2 } });
+    try props.setOption(allocator, "nested", .{ .name = "replacement", .items = [_]u8{ 3, 4 } });
+    try props.setParameter(allocator, "parameter", "value");
+}
+
+test "ClientRequestProperties frees all owned dynamic properties" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, setRequestPropertiesForAllocationTest, .{});
 }

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -15,6 +15,9 @@ pub const KustoMetadataMode = kusto_common.KustoMetadataMode;
 pub const KustoCloudInfo = kusto_common.KustoCloudInfo;
 pub const KustoCloudInfoCache = kusto_common.KustoCloudInfoCache;
 pub const KustoRetryOptions = kusto_common.KustoRetryOptions;
+pub const KustoRequestKind = kusto_common.KustoRequestKind;
+pub const QueryConsistency = kusto_common.QueryConsistency;
+pub const RequestProperty = kusto_common.RequestProperty;
 
 // ─────────────────── Response Types ──────────────────
 
@@ -65,11 +68,17 @@ pub const KustoResultTable = struct {
 
 pub const KustoResponseDataSet = struct {
     tables: []KustoResultTable,
+    client_request_id: ?[]u8 = null,
+    activity_id: ?[]u8 = null,
 
     pub fn deinit(self: *KustoResponseDataSet, allocator: std.mem.Allocator) void {
         for (self.tables) |*table| table.deinit(allocator);
         allocator.free(self.tables);
+        if (self.client_request_id) |value| allocator.free(value);
+        if (self.activity_id) |value| allocator.free(value);
         self.tables = &.{};
+        self.client_request_id = null;
+        self.activity_id = null;
     }
 
     /// Get the primary result table (first table named "PrimaryResult" or index 0).
@@ -85,6 +94,7 @@ pub const KustoResponseDataSet = struct {
 
 pub const KustoClientOptions = struct {
     application_name: []const u8 = "azure-sdk-zig",
+    client_version: []const u8 = "azsdk-zig-kusto/0.1.0",
 };
 
 /// Client for executing KQL queries and management commands against a Kusto cluster.
@@ -96,6 +106,7 @@ pub const KustoClientOptions = struct {
 pub const KustoClient = struct {
     runtime: Runtime,
     application_name: []const u8,
+    client_version: []const u8,
 
     const Runtime = union(enum) {
         legacy: struct {
@@ -116,6 +127,7 @@ pub const KustoClient = struct {
                 .pipeline = .{ .policies = &.{}, .transport_impl = transport },
             } },
             .application_name = options.application_name,
+            .client_version = options.client_version,
         };
     }
 
@@ -127,6 +139,7 @@ pub const KustoClient = struct {
         return .{
             .runtime = .{ .shared = connection },
             .application_name = options.application_name,
+            .client_version = options.client_version,
         };
     }
 
@@ -134,14 +147,14 @@ pub const KustoClient = struct {
     pub fn executeQuery(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
         const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
-        return self.executeInternal(allocator, url, database, query, properties, true);
+        return self.executeInternal(allocator, url, database, query, properties, .query);
     }
 
     /// Execute a management command (starts with `.`). Uses v1 REST endpoint.
     pub fn executeMgmt(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
         const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.engineUrl()});
         defer allocator.free(url);
-        return self.executeInternal(allocator, url, database, command, properties, false);
+        return self.executeInternal(allocator, url, database, command, properties, .management);
     }
 
     /// Auto-routing: commands starting with `.` go to mgmt, others to query.
@@ -157,12 +170,12 @@ pub const KustoClient = struct {
     pub fn executeQueryResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
         const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
-        return self.executeInternalResult(allocator, url, database, query, properties, true);
+        return self.executeInternalResult(allocator, url, database, query, properties, .query);
     }
     pub fn executeMgmtResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
         const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.engineUrl()});
         defer allocator.free(url);
-        return self.executeInternalResult(allocator, url, database, command, properties, false);
+        return self.executeInternalResult(allocator, url, database, command, properties, .management);
     }
     pub fn executeResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query_or_command: []const u8) !core.errors.Result(KustoResponseDataSet) {
         const trimmed = std.mem.trimStart(u8, query_or_command, " \t\n\r");
@@ -179,9 +192,9 @@ pub const KustoClient = struct {
         database: []const u8,
         csl: []const u8,
         properties: ?ClientRequestProperties,
-        retryable: bool,
+        kind: KustoRequestKind,
     ) !KustoResponseDataSet {
-        var r = try self.executeInternalResult(allocator, url, database, csl, properties, retryable);
+        var r = try self.executeInternalResult(allocator, url, database, csl, properties, kind);
         return r.unwrap(error.KustoQueryFailed);
     }
 
@@ -192,23 +205,29 @@ pub const KustoClient = struct {
         database: []const u8,
         csl: []const u8,
         properties: ?ClientRequestProperties,
-        retryable: bool,
+        kind: KustoRequestKind,
     ) !core.errors.Result(KustoResponseDataSet) {
-        const body = try serializeRequest(allocator, database, csl, properties);
+        const props: ClientRequestProperties = properties orelse ClientRequestProperties{};
+        try props.validate(kind);
+        const body = try serializeRequest(allocator, database, csl, props, kind);
         defer allocator.free(body);
 
         var req = core.http.Request.init(allocator, .POST, url);
         defer req.deinit();
         try req.setHeader("Content-Type", "application/json; charset=utf-8");
         try req.setHeader("Accept", "application/json");
-        try req.setHeader("x-ms-app", self.application_name);
-        if (properties) |props| {
-            if (props.client_request_id) |request_id| {
-                try req.setHeader("x-ms-client-request-id", request_id);
-            }
+        try req.setHeader("Accept-Encoding", "gzip, deflate");
+        try req.setHeader("x-ms-app", props.application orelse self.application_name);
+        if (props.user) |user| try req.setHeader("x-ms-user", user);
+        try req.setHeader("x-ms-client-version", props.client_version orelse self.client_version);
+        try req.setHeader("x-ms-version", "2024-12-12");
+        if (props.client_request_id) |request_id| {
+            try req.setHeader("x-ms-client-request-id", request_id);
         }
+        try core.pipeline.ensureRequestId(&req);
+        req.operation_timeout_ms = try props.effectiveClientTimeoutMs(kind);
         req.body = body;
-        req.retryable = retryable;
+        req.retryable = kind == .query;
 
         var resp = try self.send(&req);
         defer resp.deinit();
@@ -220,7 +239,16 @@ pub const KustoClient = struct {
             return error.AzureRequestFailed;
         }
 
-        return .{ .ok = try parseResponseDataSet(allocator, resp.body) };
+        var dataset = try parseResponseDataSet(allocator, resp.body);
+        errdefer dataset.deinit(allocator);
+        const response_request_id = resp.getHeader("x-ms-client-request-id") orelse req.getHeader("x-ms-client-request-id");
+        if (response_request_id) |request_id| {
+            dataset.client_request_id = try allocator.dupe(u8, request_id);
+        }
+        if (resp.getHeader("x-ms-activity-id")) |activity_id| {
+            dataset.activity_id = try allocator.dupe(u8, activity_id);
+        }
+        return .{ .ok = dataset };
     }
 
     fn engineUrl(self: *const KustoClient) []const u8 {
@@ -248,48 +276,14 @@ pub const KustoClient = struct {
     }
 };
 
-const EmptyRequestProperties = struct {};
-
-const RequestWithEmptyProperties = struct {
-    db: []const u8,
-    csl: []const u8,
-    properties: EmptyRequestProperties = .{},
-};
-
-const TimeoutRequestProperties = struct {
-    Options: struct {
-        servertimeout: []const u8,
-    },
-};
-
-const RequestWithTimeout = struct {
-    db: []const u8,
-    csl: []const u8,
-    properties: TimeoutRequestProperties,
-};
-
 fn serializeRequest(
     allocator: std.mem.Allocator,
     database: []const u8,
     csl: []const u8,
-    properties: ?ClientRequestProperties,
+    properties: ClientRequestProperties,
+    kind: KustoRequestKind,
 ) ![]u8 {
-    if (properties) |props| {
-        if (props.server_timeout_ms) |timeout| {
-            const minutes = @divTrunc(timeout, 60000);
-            const timeout_value = try std.fmt.allocPrint(allocator, "{d}m", .{minutes});
-            defer allocator.free(timeout_value);
-            return serde.json.toSlice(allocator, RequestWithTimeout{
-                .db = database,
-                .csl = csl,
-                .properties = .{ .Options = .{ .servertimeout = timeout_value } },
-            });
-        }
-    }
-    return serde.json.toSlice(allocator, RequestWithEmptyProperties{
-        .db = database,
-        .csl = csl,
-    });
+    return kusto_common.serializeRequestBody(allocator, database, csl, properties, kind);
 }
 
 // ─────────────────── Response Parsing ────────────────
@@ -568,6 +562,9 @@ test "KustoClient executeQuery" {
 
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v2/rest/query") != null);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
+    const request_id = mock.last_headers.get("x-ms-client-request-id").?;
+    try std.testing.expectEqual(@as(usize, 36), request_id.len);
+    try std.testing.expectEqualStrings(request_id, result.client_request_id.?);
 
     const primary = result.primaryTable().?;
     try std.testing.expectEqualStrings("PrimaryResult", primary.name);
@@ -779,6 +776,8 @@ test "KustoClient executeMgmt" {
     defer result.deinit(allocator);
 
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"servertimeout\":\"00:10:00.000\"") != null);
+    try std.testing.expectEqual(@as(?u64, 630_000), mock.last_operation_timeout_ms);
     const table = result.tables[0];
     try std.testing.expectEqualStrings("TestDB", table.rows[0].values[0]);
 }
@@ -856,13 +855,14 @@ test "Kusto request bodies round trip caller strings" {
     var query_arena = std.heap.ArenaAllocator.init(allocator);
     defer query_arena.deinit();
     const query_wire = try serde.json.fromSlice(
-        RequestWithEmptyProperties,
+        struct { db: []const u8, csl: []const u8 },
         query_arena.allocator(),
         mock.last_body.?,
     );
     try std.testing.expectEqualStrings(database, query_wire.db);
     try std.testing.expectEqualStrings(query, query_wire.csl);
-    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"properties\":{}") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"properties\":{\"Options\":{\"servertimeout\":\"00:04:00.000\"},\"Parameters\":{}}") != null);
+    try std.testing.expectEqual(@as(?u64, 270_000), mock.last_operation_timeout_ms);
 
     const command = ".show table [a\"b\\\\c]\n\t";
     var mgmt_result = try client.executeMgmt(
@@ -876,13 +876,81 @@ test "Kusto request bodies round trip caller strings" {
     var mgmt_arena = std.heap.ArenaAllocator.init(allocator);
     defer mgmt_arena.deinit();
     const mgmt_wire = try serde.json.fromSlice(
-        RequestWithTimeout,
+        struct { db: []const u8, csl: []const u8 },
         mgmt_arena.allocator(),
         mock.last_body.?,
     );
     try std.testing.expectEqualStrings(database, mgmt_wire.db);
     try std.testing.expectEqualStrings(command, mgmt_wire.csl);
-    try std.testing.expectEqualStrings("5m", mgmt_wire.properties.Options.servertimeout);
+    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"properties\":{\"Options\":{\"servertimeout\":\"00:05:00.000\"},\"Parameters\":{}}") != null);
+    try std.testing.expectEqual(@as(?u64, 330_000), mock.last_operation_timeout_ms);
+}
+
+test "KustoClient applies diagnostic headers and owns response correlation" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    mock.response_headers_list = &.{
+        .{ .name = "X-MS-Client-Request-Id", .value = "echoed-request-id" },
+        .{ .name = "x-ms-activity-id", .value = "activity-id" },
+    };
+    defer mock.deinit();
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential.asCredential(),
+        },
+        mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
+    defer connection.deinit();
+
+    var properties = ClientRequestProperties{
+        .client_request_id = "caller-request-id",
+        .application = "caller-app",
+        .user = "caller-user",
+        .client_version = "caller-version",
+        .server_timeout_ms = 90_001,
+        .client_timeout_ms = 120_000,
+    };
+    defer properties.deinit(allocator);
+    try properties.setOption(allocator, "best_effort", true);
+    try properties.setParameter(allocator, "limit", @as(i64, 5));
+
+    var client = KustoClient.initWithConnection(connection, .{
+        .application_name = "default-app",
+        .client_version = "default-version",
+    });
+    var result = try client.executeQuery(allocator, "db", "print 1", properties);
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqualStrings("caller-request-id", mock.last_headers.get("x-ms-client-request-id").?);
+    try std.testing.expectEqualStrings("caller-app", mock.last_headers.get("x-ms-app").?);
+    try std.testing.expectEqualStrings("caller-user", mock.last_headers.get("x-ms-user").?);
+    try std.testing.expectEqualStrings("caller-version", mock.last_headers.get("x-ms-client-version").?);
+    try std.testing.expectEqualStrings("2024-12-12", mock.last_headers.get("x-ms-version").?);
+    try std.testing.expectEqualStrings("gzip, deflate", mock.last_headers.get("Accept-Encoding").?);
+    try std.testing.expectEqual(@as(?u64, 120_000), mock.last_operation_timeout_ms);
+    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"servertimeout\":\"00:01:30.001\"") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"best_effort\":true") != null);
+    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"limit\":5") != null);
+    try std.testing.expectEqualStrings("echoed-request-id", result.client_request_id.?);
+    try std.testing.expectEqualStrings("activity-id", result.activity_id.?);
+}
+
+test "KustoClient rejects invalid request properties before transport" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    defer mock.deinit();
+    const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
+    var client = KustoClient.init(conn, mock.asTransport(), .{});
+
+    try std.testing.expectError(
+        error.InvalidServerTimeout,
+        client.executeQuery(allocator, "db", "print 1", .{ .server_timeout_ms = 999 }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
 }
 
 test "Kusto response preserves dynamic JSON cells" {


### PR DESCRIPTION
## Summary

- add allocator-owned Kusto Options and Parameters with typed helpers and open custom options
- add exact server timeouts, best-effort client retry budgets, diagnostic headers, and safe generated request IDs
- expose owned response correlation IDs and document timeout, retry, and parameter semantics

## Testing

- `zig fmt --check sdk/ build.zig`
- `zig build test --summary all` (317/317)

Closes #48