### PR TITLE
kusto: add a Kusto-specific error and retryability model

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Metadata can expose the login authority for a sovereign or private cloud, but `T
 - In the current synchronous buffered transport, the client timeout bounds retries and backoff only; it cannot interrupt an in-flight `std.http` request. Hard cancellation is deferred to future streaming and cancellation transport work.
 - Explicit application, user, version, and request-ID headers override defaults. Results expose owned `client_request_id` and `activity_id`; dataset `deinit` frees them.
 - Queries may retry; management operations and streaming ingestion remain non-retryable.
+- Kusto `*Result` APIs return `KustoResult(T)`: `.ok`, `.partial` (possibly unreliable decoded buffered tables plus an owned `KustoError`), or `.err`; call `deinit`. A streaming `.err` records `.known_not_accepted` for a received non-2xx response and `.unknown` with the transport cause after transport entry fails, while pre-transport credential/policy errors stay in the outer Zig error union. Permanent and partial failures are never retryable.
 
 ### Infrastructure
 

--- a/build.zig
+++ b/build.zig
@@ -388,6 +388,22 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&b.addRunArtifact(t).step);
     }
 
+    // Kusto error tests — needs core + serde
+    {
+        const t = b.addTest(.{
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("sdk/kusto/error.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "azure_core", .module = core_mod },
+                    .{ .name = "serde", .module = serde_mod },
+                },
+            }),
+        });
+        test_step.dependOn(&b.addRunArtifact(t).step);
+    }
+
     // Kusto common tests — needs core + identity
     {
         const t = b.addTest(.{

--- a/sdk/core/errors.zig
+++ b/sdk/core/errors.zig
@@ -94,6 +94,11 @@ pub fn logErrorResponse(response: http.Response) void {
 /// fast on `"AuthFailed"`) — the standard pattern in Azure SDKs for other
 /// languages.
 ///
+/// Kusto does not use this generic result because its 200 responses can carry
+/// partial service failures; its `KustoResult(T)` adds `.partial` and
+/// Kusto-specific diagnostic and outcome fields. This type remains the
+/// compatibility result for services with ordinary HTTP success semantics.
+///
 /// **Layered error model**
 ///
 /// - The outer Zig error union (`!Result(T)`) carries *local* failures —

--- a/sdk/core/http/pipeline.zig
+++ b/sdk/core/http/pipeline.zig
@@ -53,6 +53,7 @@ pub const HttpPipeline = struct {
     transport_impl: *HttpTransport,
 
     pub fn send(self: *HttpPipeline, request: *Request) !Response {
+        request.transport_started = false;
         return callNext(request, self.policies, self.transport_impl);
     }
 };

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -38,6 +38,10 @@ pub const Request = struct {
     body: ?[]const u8 = null,
     allocator: std.mem.Allocator,
     retryable: bool = true,
+    /// Set immediately before a transport implementation is called. This lets
+    /// non-idempotent clients distinguish pre-transport failures from an
+    /// attempt whose server-side outcome is unknown.
+    transport_started: bool = false,
     redirect_policy: RedirectPolicy = .follow,
     /// Best-effort budget checked before attempts and retry backoff. A blocking
     /// in-flight send can exceed this budget.
@@ -139,6 +143,7 @@ pub const HttpTransport = struct {
     sendFn: *const fn (self: *HttpTransport, request: *Request) anyerror!Response,
 
     pub fn send(self: *HttpTransport, request: *Request) !Response {
+        request.transport_started = true;
         return self.sendFn(self, request);
     }
 };

--- a/sdk/kusto/common.zig
+++ b/sdk/kusto/common.zig
@@ -6,6 +6,14 @@ const std = @import("std");
 const core = @import("azure_core");
 const serde = @import("serde");
 
+pub const errors = @import("error.zig");
+pub const KustoError = errors.KustoError;
+pub const KustoErrorDetail = errors.KustoErrorDetail;
+pub const KustoOperation = errors.KustoOperation;
+pub const KustoErrorSource = errors.KustoErrorSource;
+pub const KustoOperationOutcome = errors.KustoOperationOutcome;
+pub const KustoResult = errors.KustoResult;
+
 // ─────────────────────── Enums ───────────────────────
 
 /// Supported data formats for ingestion.

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -18,6 +18,12 @@ pub const KustoRetryOptions = kusto_common.KustoRetryOptions;
 pub const KustoRequestKind = kusto_common.KustoRequestKind;
 pub const QueryConsistency = kusto_common.QueryConsistency;
 pub const RequestProperty = kusto_common.RequestProperty;
+pub const KustoError = kusto_common.KustoError;
+pub const KustoErrorDetail = kusto_common.KustoErrorDetail;
+pub const KustoOperation = kusto_common.KustoOperation;
+pub const KustoErrorSource = kusto_common.KustoErrorSource;
+pub const KustoOperationOutcome = kusto_common.KustoOperationOutcome;
+pub const KustoResult = kusto_common.KustoResult;
 
 // ─────────────────── Response Types ──────────────────
 
@@ -53,6 +59,7 @@ pub const KustoResultRow = struct {
 
 pub const KustoResultTable = struct {
     name: []const u8,
+    kind: ?[]const u8 = null,
     columns: []const KustoResultColumn,
     rows: []const KustoResultRow,
 
@@ -62,6 +69,7 @@ pub const KustoResultTable = struct {
         for (self.columns) |column| column.deinit(allocator);
         allocator.free(self.columns);
         allocator.free(self.name);
+        if (self.kind) |kind| allocator.free(kind);
         self.* = .{ .name = "", .columns = &.{}, .rows = &.{} };
     }
 };
@@ -167,17 +175,17 @@ pub const KustoClient = struct {
     }
 
     /// `Result(...)` variants of the execute methods.
-    pub fn executeQueryResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
+    pub fn executeQueryResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !KustoResult(KustoResponseDataSet) {
         const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternalResult(allocator, url, database, query, properties, .query);
     }
-    pub fn executeMgmtResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !core.errors.Result(KustoResponseDataSet) {
+    pub fn executeMgmtResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !KustoResult(KustoResponseDataSet) {
         const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternalResult(allocator, url, database, command, properties, .management);
     }
-    pub fn executeResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query_or_command: []const u8) !core.errors.Result(KustoResponseDataSet) {
+    pub fn executeResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query_or_command: []const u8) !KustoResult(KustoResponseDataSet) {
         const trimmed = std.mem.trimStart(u8, query_or_command, " \t\n\r");
         if (trimmed.len > 0 and trimmed[0] == '.') {
             return self.executeMgmtResult(allocator, database, query_or_command, null);
@@ -195,7 +203,20 @@ pub const KustoClient = struct {
         kind: KustoRequestKind,
     ) !KustoResponseDataSet {
         var r = try self.executeInternalResult(allocator, url, database, csl, properties, kind);
-        return r.unwrap(error.KustoQueryFailed);
+        return switch (r) {
+            .ok => |value| value,
+            .partial => |*partial| {
+                std.log.warn("{f}", .{partial.failure});
+                partial.failure.deinit();
+                partial.value.deinit(allocator);
+                return error.KustoQueryFailed;
+            },
+            .err => |*failure| {
+                std.log.warn("{f}", .{failure.*});
+                failure.deinit();
+                return error.KustoQueryFailed;
+            },
+        };
     }
 
     fn executeInternalResult(
@@ -206,7 +227,7 @@ pub const KustoClient = struct {
         csl: []const u8,
         properties: ?ClientRequestProperties,
         kind: KustoRequestKind,
-    ) !core.errors.Result(KustoResponseDataSet) {
+    ) !KustoResult(KustoResponseDataSet) {
         const props: ClientRequestProperties = properties orelse ClientRequestProperties{};
         try props.validate(kind);
         const body = try serializeRequest(allocator, database, csl, props, kind);
@@ -232,11 +253,36 @@ pub const KustoClient = struct {
         var resp = try self.send(&req);
         defer resp.deinit();
 
+        const operation: KustoOperation = if (kind == .query) .query else .management;
         if (!resp.isSuccess()) {
-            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-                return .{ .err = az_err };
+            var failure = try kusto_common.errors.fromHttpResponse(
+                allocator,
+                operation,
+                &resp,
+                .known_not_accepted,
+            );
+            errdefer failure.deinit();
+            try kusto_common.errors.applyResponseCorrelation(
+                &failure,
+                &resp,
+                req.getHeader("x-ms-client-request-id"),
+            );
+            return .{ .err = failure };
+        }
+
+        var in_band_failure = try inspectInBandFailure(allocator, resp.body, operation);
+        errdefer if (in_band_failure) |*failure| failure.deinit();
+        if (in_band_failure) |*failure| {
+            if (failure.source == .v1_exception) {
+                try kusto_common.errors.applyResponseCorrelation(
+                    failure,
+                    &resp,
+                    req.getHeader("x-ms-client-request-id"),
+                );
+                const owned_failure = failure.*;
+                in_band_failure = null;
+                return .{ .err = owned_failure };
             }
-            return error.AzureRequestFailed;
         }
 
         var dataset = try parseResponseDataSet(allocator, resp.body);
@@ -247,6 +293,26 @@ pub const KustoClient = struct {
         }
         if (resp.getHeader("x-ms-activity-id")) |activity_id| {
             dataset.activity_id = try allocator.dupe(u8, activity_id);
+        }
+        if (in_band_failure) |*failure| {
+            try kusto_common.errors.applyResponseCorrelation(
+                failure,
+                &resp,
+                req.getHeader("x-ms-client-request-id"),
+            );
+            const owned_failure = failure.*;
+            in_band_failure = null;
+            return .{ .partial = .{ .value = dataset, .failure = owned_failure } };
+        }
+        if (try queryStatusFailure(allocator, dataset, operation)) |classified_failure| {
+            var failure = classified_failure;
+            errdefer failure.deinit();
+            try kusto_common.errors.applyResponseCorrelation(
+                &failure,
+                &resp,
+                req.getHeader("x-ms-client-request-id"),
+            );
+            return .{ .partial = .{ .value = dataset, .failure = failure } };
         }
         return .{ .ok = dataset };
     }
@@ -303,6 +369,7 @@ const KustoFrameTypeSchema = struct {
 const KustoFrameSchema = struct {
     FrameType: []const u8,
     TableName: ?[]const u8 = null,
+    TableKind: ?[]const u8 = null,
     Columns: ?[]const KustoColumnSchema = null,
 };
 
@@ -342,6 +409,172 @@ fn parseResponseDataSet(allocator: std.mem.Allocator, body: []const u8) !KustoRe
     return .{ .tables = try tables.toOwnedSlice(allocator) };
 }
 
+const CompletionFrameSchema = struct {
+    FrameType: ?[]const u8 = null,
+    HasErrors: ?bool = null,
+    Cancelled: ?bool = null,
+    OneApiErrors: ?[]kusto_common.errors.OneApiEnvelope = null,
+};
+
+/// Classifies only the first completion failure. Progressive reconstruction and
+/// deduplication are intentionally deferred; tables were already buffered by
+/// `parseResponseDataSet` before this pass.
+fn inspectInBandFailure(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    operation: KustoOperation,
+) !?KustoError {
+    var deserializer = serde.json.Deserializer.init(body);
+    const scanner = &deserializer.scanner;
+    const first = scanner.next() catch return error.MalformedKustoResponse;
+    if (first == .object_begin) return inspectV1Exception(allocator, body, operation);
+    if (first != .array_begin) return error.MalformedKustoResponse;
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+        return null;
+    }
+    while (true) {
+        const frame_slice = captureValue(scanner, body) catch return error.MalformedKustoResponse;
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const frame = serde.json.fromSlice(CompletionFrameSchema, arena.allocator(), frame_slice) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return error.MalformedKustoResponse;
+        };
+        const source: ?KustoErrorSource = if (std.mem.eql(u8, frame.FrameType orelse "", "DataSetCompletion"))
+            .dataset_completion
+        else if (std.mem.eql(u8, frame.FrameType orelse "", "TableCompletion"))
+            .table_completion
+        else
+            null;
+        if (source) |failure_source| {
+            const cancelled = frame.Cancelled orelse false;
+            if (frame.OneApiErrors) |errors| {
+                if (errors.len > 0) {
+                    return try kusto_common.errors.fromOneApiEnvelope(
+                        allocator,
+                        operation,
+                        failure_source,
+                        errors[0],
+                        cancelled,
+                    );
+                }
+            }
+            if ((frame.HasErrors orelse false) or cancelled) {
+                return kusto_common.errors.inBandFailure(
+                    allocator,
+                    operation,
+                    failure_source,
+                    cancelled,
+                );
+            }
+        }
+        switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+            .end => break,
+            .more => {},
+        }
+    }
+    return null;
+}
+
+fn inspectV1Exception(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    operation: KustoOperation,
+) !?KustoError {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var scanner = std.json.Scanner.initCompleteInput(arena.allocator(), body);
+    defer scanner.deinit();
+    const value = std.json.parseFromTokenSourceLeaky(
+        std.json.Value,
+        arena.allocator(),
+        &scanner,
+        .{},
+    ) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return error.MalformedKustoResponse;
+    };
+    const message = findV1Exception(&value) orelse return null;
+    var failure = kusto_common.errors.inBandFailure(
+        allocator,
+        operation,
+        .v1_exception,
+        false,
+    );
+    errdefer failure.deinit();
+    failure.detail.message = try allocator.dupe(u8, message);
+    return failure;
+}
+
+fn findV1Exception(value: *const std.json.Value) ?[]const u8 {
+    switch (value.*) {
+        .object => |object| {
+            if (object.get("Exceptions")) |exceptions_value| {
+                switch (exceptions_value) {
+                    .array => |exceptions| {
+                        for (exceptions.items) |exception| {
+                            switch (exception) {
+                                .string => |message| return message,
+                                else => {},
+                            }
+                        }
+                    },
+                    else => {},
+                }
+            }
+            for (object.values()) |*entry_value| {
+                if (findV1Exception(entry_value)) |message| return message;
+            }
+        },
+        .array => |items| {
+            for (items.items) |*item| {
+                if (findV1Exception(item)) |message| return message;
+            }
+        },
+        else => {},
+    }
+    return null;
+}
+
+fn queryStatusFailure(
+    allocator: std.mem.Allocator,
+    dataset: KustoResponseDataSet,
+    operation: KustoOperation,
+) !?KustoError {
+    for (dataset.tables) |table| {
+        const is_query_status = std.mem.eql(u8, table.name, "QueryStatus") or
+            (table.kind != null and std.mem.eql(u8, table.kind.?, "QueryCompletionInformation"));
+        if (!is_query_status) continue;
+        for (table.rows) |row| {
+            const severity_text = row.getByName("Severity") orelse continue;
+            const severity = std.fmt.parseInt(i32, severity_text, 10) catch continue;
+            if (severity > 2) continue;
+            var failure = kusto_common.errors.inBandFailure(
+                allocator,
+                operation,
+                .query_status,
+                false,
+            );
+            errdefer failure.deinit();
+            if (row.getByName("StatusCode")) |code| {
+                failure.detail.code = try allocator.dupe(u8, code);
+            }
+            if (row.getByName("StatusDescription")) |message| {
+                failure.detail.message = try allocator.dupe(u8, message);
+            }
+            if (row.getByName("ClientActivityId") orelse row.getByName("RequestId")) |request_id| {
+                failure.client_request_id = try allocator.dupe(u8, request_id);
+            }
+            if (row.getByName("ActivityId")) |activity_id| {
+                failure.activity_id = try allocator.dupe(u8, activity_id);
+            }
+            return failure;
+        }
+    }
+    return null;
+}
+
 fn captureValue(scanner: anytype, input: []const u8) ![]const u8 {
     scanner.skipWhitespace();
     const start = scanner.pos;
@@ -370,6 +603,11 @@ fn parseFrame(allocator: std.mem.Allocator, frame_slice: []const u8) !?KustoResu
 
     const table_name = try allocator.dupe(u8, table_name_src);
     errdefer allocator.free(table_name);
+    const table_kind = if (frame.TableKind) |kind|
+        try allocator.dupe(u8, kind)
+    else
+        null;
+    errdefer if (table_kind) |kind| allocator.free(kind);
 
     var columns = std.ArrayList(KustoResultColumn).empty;
     errdefer {
@@ -397,6 +635,7 @@ fn parseFrame(allocator: std.mem.Allocator, frame_slice: []const u8) !?KustoResu
     const rows = try parseRows(allocator, rows_slice, columns_slice);
     return .{
         .name = table_name,
+        .kind = table_kind,
         .columns = columns_slice,
         .rows = rows,
     };
@@ -1040,10 +1279,169 @@ test "Kusto dataset and Result deinit own all parsed allocations" {
     var dataset = try parseResponseDataSet(std.testing.allocator, response_body);
     dataset.deinit(std.testing.allocator);
 
-    var result: core.errors.Result(KustoResponseDataSet) = .{
+    var result: KustoResult(KustoResponseDataSet) = .{
         .ok = try parseResponseDataSet(std.testing.allocator, response_body),
     };
     result.deinit(std.testing.allocator);
+}
+
+test "Kusto non-2xx malformed body is a structured HTTP failure" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 502, "gateway said no");
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+
+    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+    switch (result) {
+        .err => |failure| {
+            try std.testing.expectEqual(@as(?u16, 502), failure.http_status);
+            try std.testing.expectEqual(KustoErrorSource.http, failure.source);
+            try std.testing.expectEqual(KustoOperationOutcome.known_not_accepted, failure.outcome);
+            try std.testing.expect(failure.retryable);
+            try std.testing.expect(failure.detail.code == null);
+            try std.testing.expectEqual(@as(usize, 36), failure.client_request_id.?.len);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "V1 exception payload is a structured in-band failure" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\{"Tables":[{"TableName":"Table_0","Columns":[],"Rows":[{"Exceptions":["partial V1 failure"]}]}]}
+    );
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+
+    var result = try client.executeMgmtResult(allocator, "db", ".show tables", null);
+    defer result.deinit(allocator);
+    switch (result) {
+        .err => |failure| {
+            try std.testing.expectEqual(KustoErrorSource.v1_exception, failure.source);
+            try std.testing.expectEqual(KustoOperationOutcome.partial, failure.outcome);
+            try std.testing.expectEqualStrings("partial V1 failure", failure.detail.message.?);
+            try std.testing.expectEqual(@as(usize, 36), failure.client_request_id.?.len);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "DataSetCompletion OneApiErrors preserves buffered tables as partial" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\[
+        \\ {"FrameType":"DataTable","TableName":"PrimaryResult","Columns":[{"ColumnName":"Value"}],"Rows":[["before failure"]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":true,"OneApiErrors":[{"error":{"code":"LimitsExceeded","message":"partial failure","@permanent":false,"@context":{"clientRequestId":"context-request","activityId":"context-activity"}}}]}
+        \\]
+    );
+    mock.response_headers_list = &.{
+        .{ .name = "x-ms-client-request-id", .value = "response-request" },
+        .{ .name = "x-ms-activity-id", .value = "response-activity" },
+    };
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+
+    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+    switch (result) {
+        .partial => |partial| {
+            try std.testing.expectEqual(@as(usize, 1), partial.value.tables.len);
+            try std.testing.expectEqualStrings("before failure", partial.value.tables[0].rows[0].values[0]);
+            try std.testing.expectEqual(KustoErrorSource.dataset_completion, partial.failure.source);
+            try std.testing.expectEqualStrings("LimitsExceeded", partial.failure.detail.code.?);
+            try std.testing.expectEqualStrings("response-request", partial.failure.client_request_id.?);
+            try std.testing.expectEqualStrings("response-activity", partial.failure.activity_id.?);
+            try std.testing.expect(!partial.failure.retryable);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "TableCompletion OneApiErrors is classified as partial" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\[{"FrameType":"TableCompletion","HasErrors":true,"OneApiErrors":[{"error":{"code":"TableFailure","message":"failed table"}}]}]
+    );
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+
+    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+    switch (result) {
+        .partial => |partial| {
+            try std.testing.expectEqual(KustoErrorSource.table_completion, partial.failure.source);
+            try std.testing.expectEqualStrings("TableFailure", partial.failure.detail.code.?);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "QueryStatus failure rows are classified as partial" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\[{"FrameType":"DataTable","TableName":"QueryStatus","Columns":[{"ColumnName":"Severity"},{"ColumnName":"StatusCode"},{"ColumnName":"StatusDescription"},{"ColumnName":"ClientActivityId"},{"ColumnName":"ActivityId"}],"Rows":[[1,"SyntaxError","bad query","row-request","row-activity"]]}]
+    );
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+
+    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+    switch (result) {
+        .partial => |partial| {
+            try std.testing.expectEqual(KustoErrorSource.query_status, partial.failure.source);
+            try std.testing.expectEqualStrings("SyntaxError", partial.failure.detail.code.?);
+            try std.testing.expectEqualStrings("bad query", partial.failure.detail.message.?);
+            try std.testing.expectEqualStrings("row-request", partial.failure.client_request_id.?);
+            try std.testing.expectEqualStrings("row-activity", partial.failure.activity_id.?);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "V2 QueryCompletionInformation failure rows are classified as partial" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\[{"FrameType":"DataTable","TableName":"Table_1","TableKind":"QueryCompletionInformation","Columns":[{"ColumnName":"Severity"},{"ColumnName":"StatusCode"},{"ColumnName":"StatusDescription"}],"Rows":[[2,"LimitsExceeded","result truncated"]]}]
+    );
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+
+    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
+    defer result.deinit(allocator);
+    switch (result) {
+        .partial => |partial| {
+            try std.testing.expectEqualStrings("QueryCompletionInformation", partial.value.tables[0].kind.?);
+            try std.testing.expectEqual(KustoErrorSource.query_status, partial.failure.source);
+            try std.testing.expectEqualStrings("LimitsExceeded", partial.failure.detail.code.?);
+            try std.testing.expectEqualStrings("result truncated", partial.failure.detail.message.?);
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 fn parseAllocationFixture(allocator: std.mem.Allocator, body: []const u8) !void {

--- a/sdk/kusto/error.zig
+++ b/sdk/kusto/error.zig
@@ -1,0 +1,412 @@
+const std = @import("std");
+const serde = @import("serde");
+const http = @import("azure_core").http;
+
+/// Kusto operation that produced a service failure.
+pub const KustoOperation = enum {
+    query,
+    management,
+    streaming_ingest,
+};
+
+/// Where Kusto reported a failure.
+pub const KustoErrorSource = enum {
+    http,
+    dataset_completion,
+    table_completion,
+    query_status,
+    v1_exception,
+    transport,
+};
+
+/// What is known about the operation after a response or transport failure.
+pub const KustoOperationOutcome = enum {
+    partial,
+    accepted,
+    known_not_accepted,
+    unknown,
+};
+
+/// Allocator-owned details from a OneAPI error, including its recursive cause.
+pub const KustoErrorDetail = struct {
+    code: ?[]u8 = null,
+    message: ?[]u8 = null,
+    error_type: ?[]u8 = null,
+    description: ?[]u8 = null,
+    permanent: ?bool = null,
+    inner_error: ?*KustoErrorDetail = null,
+
+    pub fn deinit(self: *KustoErrorDetail, allocator: std.mem.Allocator) void {
+        if (self.code) |value| allocator.free(value);
+        if (self.message) |value| allocator.free(value);
+        if (self.error_type) |value| allocator.free(value);
+        if (self.description) |value| allocator.free(value);
+        if (self.inner_error) |inner| {
+            inner.deinit(allocator);
+            allocator.destroy(inner);
+        }
+        self.* = .{};
+    }
+};
+
+/// An owned Kusto service failure. `retryable` is deliberately conservative:
+/// only known transient non-2xx HTTP failures can be retryable.
+pub const KustoError = struct {
+    allocator: std.mem.Allocator,
+    operation: KustoOperation,
+    source: KustoErrorSource,
+    outcome: KustoOperationOutcome,
+    http_status: ?u16 = null,
+    detail: KustoErrorDetail = .{},
+    client_request_id: ?[]u8 = null,
+    activity_id: ?[]u8 = null,
+    transport_error: ?anyerror = null,
+    permanent: ?bool = null,
+    cancelled: bool = false,
+    retryable: bool = false,
+
+    pub fn deinit(self: *KustoError) void {
+        self.detail.deinit(self.allocator);
+        if (self.client_request_id) |value| self.allocator.free(value);
+        if (self.activity_id) |value| self.allocator.free(value);
+        self.client_request_id = null;
+        self.activity_id = null;
+    }
+
+    pub fn format(self: KustoError, writer: anytype) !void {
+        try writer.print("KustoError(operation={s}, source={s}, outcome={s}", .{
+            @tagName(self.operation),
+            @tagName(self.source),
+            @tagName(self.outcome),
+        });
+        if (self.http_status) |status| try writer.print(", status={d}", .{status});
+        if (self.detail.code) |code| try writer.print(", code={s}", .{code});
+        if (self.detail.message) |message| try writer.print(", message={s}", .{message});
+        if (self.transport_error) |cause| try writer.print(", cause={s}", .{@errorName(cause)});
+        try writer.writeAll(")");
+    }
+};
+
+/// Kusto-specific result that keeps service failures separate from local Zig
+/// errors and retains decoded tables when a response completed partially.
+pub fn KustoResult(comptime T: type) type {
+    return union(enum) {
+        ok: T,
+        partial: struct { value: T, failure: KustoError },
+        err: KustoError,
+
+        const Self = @This();
+
+        pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+            switch (self.*) {
+                .ok => |*value| deinitValue(T, value, allocator),
+                .partial => |*partial| {
+                    deinitValue(T, &partial.value, allocator);
+                    partial.failure.deinit();
+                },
+                .err => |*failure| failure.deinit(),
+            }
+        }
+    };
+}
+
+fn deinitValue(comptime T: type, value: *T, allocator: std.mem.Allocator) void {
+    if (comptime @typeInfo(T) == .@"struct" and @hasDecl(T, "deinit")) {
+        value.deinit(allocator);
+    }
+}
+
+/// Wire types are public so data-frame decoding can use the same serde shape.
+pub const OneApiContext = struct {
+    clientRequestId: ?[]const u8 = null,
+    activityId: ?[]const u8 = null,
+};
+
+pub const OneApiErrorBody = struct {
+    code: ?[]const u8 = null,
+    message: ?[]const u8 = null,
+    @"@type": ?[]const u8 = null,
+    @"@message": ?[]const u8 = null,
+    @"@context": ?OneApiContext = null,
+    @"@permanent": ?bool = null,
+    innererror: ?*OneApiErrorBody = null,
+};
+
+pub const OneApiEnvelope = struct {
+    @"error": ?OneApiErrorBody = null,
+};
+
+/// Parses a OneAPI envelope. Invalid JSON intentionally still yields a
+/// structured HTTP failure; malformed service bodies are not local failures.
+pub fn fromHttpResponse(
+    allocator: std.mem.Allocator,
+    operation: KustoOperation,
+    response: *const http.Response,
+    outcome: KustoOperationOutcome,
+) !KustoError {
+    var result = init(allocator, operation, .http, outcome, response.status_code);
+    errdefer result.deinit();
+    try setIds(
+        &result,
+        response.getHeader("x-ms-client-request-id"),
+        response.getHeader("x-ms-activity-id"),
+        null,
+    );
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const envelope = serde.json.fromSlice(OneApiEnvelope, arena.allocator(), response.body) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        result.retryable = isRetryable(result);
+        return result;
+    };
+    if (envelope.@"error") |body| {
+        try populate(&result, body);
+        if (result.client_request_id == null and result.activity_id == null) {
+            try setIds(&result, null, null, body.@"@context");
+        } else if (body.@"@context") |context| {
+            if (result.client_request_id == null and context.clientRequestId != null)
+                result.client_request_id = try allocator.dupe(u8, context.clientRequestId.?);
+            if (result.activity_id == null and context.activityId != null)
+                result.activity_id = try allocator.dupe(u8, context.activityId.?);
+        }
+    }
+    result.retryable = isRetryable(result);
+    return result;
+}
+
+/// Converts the first OneAPI envelope from an in-band completion frame.
+pub fn fromOneApiEnvelope(
+    allocator: std.mem.Allocator,
+    operation: KustoOperation,
+    source: KustoErrorSource,
+    envelope: OneApiEnvelope,
+    cancelled: bool,
+) !KustoError {
+    var result = init(allocator, operation, source, .partial, null);
+    errdefer result.deinit();
+    if (envelope.@"error") |body| {
+        try populate(&result, body);
+        try setIds(&result, null, null, body.@"@context");
+    }
+    result.cancelled = cancelled;
+    result.retryable = isRetryable(result);
+    return result;
+}
+
+pub fn inBandFailure(
+    allocator: std.mem.Allocator,
+    operation: KustoOperation,
+    source: KustoErrorSource,
+    cancelled: bool,
+) KustoError {
+    var result = init(allocator, operation, source, .partial, null);
+    result.cancelled = cancelled;
+    result.retryable = false;
+    return result;
+}
+
+pub fn transportUnknown(
+    allocator: std.mem.Allocator,
+    transport_error: anyerror,
+    client_request_id: ?[]const u8,
+) !KustoError {
+    var result = init(allocator, .streaming_ingest, .transport, .unknown, null);
+    errdefer result.deinit();
+    result.transport_error = transport_error;
+    if (client_request_id) |value|
+        result.client_request_id = try allocator.dupe(u8, value);
+    return result;
+}
+
+/// Prefer correlation IDs carried by the HTTP response over values embedded in
+/// a OneAPI context. Completion-frame errors call this after classification.
+pub fn applyResponseCorrelation(
+    result: *KustoError,
+    response: *const http.Response,
+    fallback_request_id: ?[]const u8,
+) !void {
+    if (response.getHeader("x-ms-client-request-id")) |value| {
+        const owned = try result.allocator.dupe(u8, value);
+        if (result.client_request_id) |old| result.allocator.free(old);
+        result.client_request_id = owned;
+    } else if (result.client_request_id == null) {
+        if (fallback_request_id) |value|
+            result.client_request_id = try result.allocator.dupe(u8, value);
+    }
+    if (response.getHeader("x-ms-activity-id")) |value| {
+        const owned = try result.allocator.dupe(u8, value);
+        if (result.activity_id) |old| result.allocator.free(old);
+        result.activity_id = owned;
+    }
+}
+
+fn init(
+    allocator: std.mem.Allocator,
+    operation: KustoOperation,
+    source: KustoErrorSource,
+    outcome: KustoOperationOutcome,
+    status: ?u16,
+) KustoError {
+    return .{
+        .allocator = allocator,
+        .operation = operation,
+        .source = source,
+        .outcome = outcome,
+        .http_status = status,
+    };
+}
+
+fn populate(result: *KustoError, body: OneApiErrorBody) !void {
+    result.detail = try makeDetail(result.allocator, body);
+    result.permanent = body.@"@permanent";
+}
+
+fn makeDetail(allocator: std.mem.Allocator, body: OneApiErrorBody) !KustoErrorDetail {
+    var detail = KustoErrorDetail{};
+    errdefer detail.deinit(allocator);
+    if (body.code) |value| detail.code = try allocator.dupe(u8, value);
+    if (body.message) |value| detail.message = try allocator.dupe(u8, value);
+    if (body.@"@type") |value| detail.error_type = try allocator.dupe(u8, value);
+    if (body.@"@message") |value| detail.description = try allocator.dupe(u8, value);
+    detail.permanent = body.@"@permanent";
+    if (body.innererror) |inner| {
+        const owned_inner = try allocator.create(KustoErrorDetail);
+        errdefer allocator.destroy(owned_inner);
+        owned_inner.* = try makeDetail(allocator, inner.*);
+        detail.inner_error = owned_inner;
+    }
+    return detail;
+}
+
+fn setIds(
+    result: *KustoError,
+    header_request_id: ?[]const u8,
+    header_activity_id: ?[]const u8,
+    context: ?OneApiContext,
+) !void {
+    const request_id = header_request_id orelse if (context) |value| value.clientRequestId else null;
+    const activity_id = header_activity_id orelse if (context) |value| value.activityId else null;
+    if (request_id) |value| result.client_request_id = try result.allocator.dupe(u8, value);
+    errdefer if (result.client_request_id) |value| {
+        result.allocator.free(value);
+        result.client_request_id = null;
+    };
+    if (activity_id) |value| result.activity_id = try result.allocator.dupe(u8, value);
+}
+
+fn isRetryable(result: KustoError) bool {
+    if (result.permanent == true or result.cancelled or result.outcome == .partial or result.outcome == .unknown) return false;
+    if (result.source != .http) return false;
+    return switch (result.http_status orelse return false) {
+        408, 429, 500, 502, 503, 504, 520 => true,
+        else => false,
+    };
+}
+
+test "OneAPI HTTP errors preserve details and correlation IDs" {
+    const allocator = std.testing.allocator;
+    var response = http.Response{
+        .status_code = 400,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(u8,
+            \\{"error":{"code":"BadRequest","message":"bad","@type":"Kusto.Data.Exceptions","@message":"description","@permanent":true,"@context":{"clientRequestId":"context-request","activityId":"context-activity"},"innererror":{"code":"Inner","message":"inner"}}}
+        ),
+        .allocator = allocator,
+    };
+    defer response.deinit();
+    try response.headers.put(try allocator.dupe(u8, "x-ms-client-request-id"), try allocator.dupe(u8, "header-request"));
+    try response.headers.put(try allocator.dupe(u8, "x-ms-activity-id"), try allocator.dupe(u8, "header-activity"));
+    var failure = try fromHttpResponse(allocator, .query, &response, .known_not_accepted);
+    defer failure.deinit();
+    try std.testing.expectEqual(@as(?u16, 400), failure.http_status);
+    try std.testing.expectEqualStrings("BadRequest", failure.detail.code.?);
+    try std.testing.expectEqualStrings("Kusto.Data.Exceptions", failure.detail.error_type.?);
+    try std.testing.expectEqualStrings("description", failure.detail.description.?);
+    try std.testing.expectEqual(@as(?bool, true), failure.permanent);
+    try std.testing.expect(!failure.retryable);
+    try std.testing.expectEqualStrings("Inner", failure.detail.inner_error.?.code.?);
+    try std.testing.expectEqualStrings("header-request", failure.client_request_id.?);
+    try std.testing.expectEqualStrings("header-activity", failure.activity_id.?);
+}
+
+test "HTTP retryability is conservative" {
+    const allocator = std.testing.allocator;
+    var response = http.Response{
+        .status_code = 503,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(u8, "{\"error\":{\"@permanent\":false}}"),
+        .allocator = allocator,
+    };
+    defer response.deinit();
+    var transient = try fromHttpResponse(allocator, .query, &response, .known_not_accepted);
+    defer transient.deinit();
+    try std.testing.expect(transient.retryable);
+    response.status_code = 500;
+    response.allocator.free(response.body);
+    response.body = try allocator.dupe(u8, "{\"error\":{\"@permanent\":true}}");
+    var permanent = try fromHttpResponse(allocator, .query, &response, .known_not_accepted);
+    defer permanent.deinit();
+    try std.testing.expect(!permanent.retryable);
+    try std.testing.expectEqual(@as(?bool, true), permanent.permanent);
+}
+
+test "OneAPI context supplies correlation IDs without response headers" {
+    const allocator = std.testing.allocator;
+    var response = http.Response{
+        .status_code = 400,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(u8,
+            \\{"error":{"@context":{"clientRequestId":"context-request","activityId":"context-activity"}}}
+        ),
+        .allocator = allocator,
+    };
+    defer response.deinit();
+    var failure = try fromHttpResponse(allocator, .query, &response, .known_not_accepted);
+    defer failure.deinit();
+    try std.testing.expectEqualStrings("context-request", failure.client_request_id.?);
+    try std.testing.expectEqualStrings("context-activity", failure.activity_id.?);
+}
+
+test "malformed OneAPI bodies retain HTTP correlation" {
+    const allocator = std.testing.allocator;
+    var response = http.Response{
+        .status_code = 502,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(u8, "gateway said no"),
+        .allocator = allocator,
+    };
+    defer response.deinit();
+    try response.headers.put(try allocator.dupe(u8, "x-ms-client-request-id"), try allocator.dupe(u8, "request"));
+    try response.headers.put(try allocator.dupe(u8, "x-ms-activity-id"), try allocator.dupe(u8, "activity"));
+    var failure = try fromHttpResponse(allocator, .query, &response, .known_not_accepted);
+    defer failure.deinit();
+    try std.testing.expectEqualStrings("request", failure.client_request_id.?);
+    try std.testing.expectEqualStrings("activity", failure.activity_id.?);
+    try std.testing.expectEqual(@as(?bool, null), failure.permanent);
+    try std.testing.expect(failure.retryable);
+}
+
+fn parseFailureAllocationFixture(allocator: std.mem.Allocator) !void {
+    var response = http.Response{
+        .status_code = 429,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(u8,
+            \\{"error":{"code":"Throttled","message":"slow down","@type":"Kusto.Error","@message":"retry later","@context":{"clientRequestId":"request","activityId":"activity"},"innererror":{"code":"Cause","message":"nested"}}}
+        ),
+        .allocator = allocator,
+    };
+    defer response.deinit();
+    var failure = try fromHttpResponse(allocator, .query, &response, .known_not_accepted);
+    defer failure.deinit();
+    try std.testing.expect(failure.retryable);
+    try std.testing.expectEqualStrings("Cause", failure.detail.inner_error.?.code.?);
+}
+
+test "Kusto errors release every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parseFailureAllocationFixture,
+        .{},
+    );
+}

--- a/sdk/kusto/ingest/root.zig
+++ b/sdk/kusto/ingest/root.zig
@@ -17,11 +17,18 @@ pub const KustoMetadataMode = kusto_common.KustoMetadataMode;
 pub const KustoCloudInfo = kusto_common.KustoCloudInfo;
 pub const KustoCloudInfoCache = kusto_common.KustoCloudInfoCache;
 pub const KustoRetryOptions = kusto_common.KustoRetryOptions;
+pub const KustoError = kusto_common.KustoError;
+pub const KustoErrorDetail = kusto_common.KustoErrorDetail;
+pub const KustoOperation = kusto_common.KustoOperation;
+pub const KustoErrorSource = kusto_common.KustoErrorSource;
+pub const KustoOperationOutcome = kusto_common.KustoOperationOutcome;
+pub const KustoResult = kusto_common.KustoResult;
 
 // ─────────────────── Types ───────────────────────────
 
 pub const IngestionResult = struct {
     status: IngestionStatus,
+    outcome: KustoOperationOutcome = .accepted,
     /// Allocator-owned when non-null; call `deinit` to release it.
     ingestion_id: ?[]const u8 = null,
 
@@ -91,23 +98,25 @@ pub const StreamingIngestClient = struct {
     ///
     /// Returns `IngestionResult{ .status = .failed }` on any Azure-side
     /// error (and logs the error). Use `ingestFromSliceResult` to receive
-    /// the structured `AzureError` instead.
+    /// the structured Kusto failure and operation outcome instead.
     pub fn ingestFromSlice(self: *StreamingIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !IngestionResult {
         var r = try self.ingestFromSliceResult(allocator, database, table, data, options);
         return switch (r) {
             .ok => |v| v,
+            .partial => unreachable,
             .err => blk: {
+                const outcome = r.err.outcome;
                 std.log.warn("{f}", .{r.err});
                 r.err.deinit();
-                break :blk .{ .status = .failed };
+                break :blk .{ .status = .failed, .outcome = outcome };
             },
         };
     }
 
-    /// Same as `ingestFromSlice` but exposes Azure-side failures as the
-    /// `.err` variant of `Result` instead of collapsing them into
-    /// `IngestionResult{ .status = .failed }`.
-    pub fn ingestFromSliceResult(self: *StreamingIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !core.errors.Result(IngestionResult) {
+    /// Same as `ingestFromSlice` but exposes Kusto-side failures as `.err`.
+    /// A send failure after transport entry has `.outcome = .unknown`; a
+    /// non-2xx response is known not to have been accepted.
+    pub fn ingestFromSliceResult(self: *StreamingIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !KustoResult(IngestionResult) {
         const url = try self.buildIngestUrl(allocator, database, table, options);
         defer allocator.free(url);
 
@@ -116,17 +125,36 @@ pub const StreamingIngestClient = struct {
         try req.setHeader("Content-Type", "application/json");
         try req.setHeader("Content-Encoding", "utf-8");
         try req.setHeader("x-ms-app", "azure-sdk-zig");
+        try core.pipeline.ensureRequestId(&req);
         req.body = data;
         req.retryable = false;
 
-        var resp = try self.send(&req);
+        var resp = self.send(&req) catch |err| {
+            if (req.transport_started) {
+                return .{ .err = try kusto_common.errors.transportUnknown(
+                    allocator,
+                    err,
+                    req.getHeader("x-ms-client-request-id"),
+                ) };
+            }
+            return err;
+        };
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
-            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-                return .{ .err = az_err };
-            }
-            return error.AzureRequestFailed;
+            var failure = try kusto_common.errors.fromHttpResponse(
+                allocator,
+                .streaming_ingest,
+                &resp,
+                .known_not_accepted,
+            );
+            errdefer failure.deinit();
+            try kusto_common.errors.applyResponseCorrelation(
+                &failure,
+                &resp,
+                req.getHeader("x-ms-client-request-id"),
+            );
+            return .{ .err = failure };
         }
 
         return .{ .ok = .{ .status = .success } };
@@ -209,7 +237,7 @@ pub const QueuedIngestClient = struct {
         return error.QueuedIngestionNotImplemented;
     }
 
-    pub fn ingestFromBlobResult(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !core.errors.Result(IngestionResult) {
+    pub fn ingestFromBlobResult(self: *QueuedIngestClient, allocator: std.mem.Allocator, properties: IngestionProperties, blob_url: []const u8) !KustoResult(IngestionResult) {
         _ = self;
         _ = allocator;
         _ = properties;
@@ -253,14 +281,23 @@ pub const ManagedIngestClient = struct {
     /// Returns `error.ManagedIngestionFallbackNotImplemented` if streaming
     /// fails because queued fallback would be required.
     pub fn ingestFromSlice(self: *ManagedIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !IngestionResult {
-        var streaming_result = try self.streaming.ingestFromSliceResult(allocator, database, table, data, options);
-        return switch (streaming_result) {
-            .ok => |result| result,
-            .err => |*azure_error| {
-                azure_error.deinit();
+        var result = try self.ingestFromSliceResult(allocator, database, table, data, options);
+        return switch (result) {
+            .ok => |ingestion| ingestion,
+            .partial => unreachable,
+            .err => |*failure| {
+                const outcome = failure.outcome;
+                failure.deinit();
+                if (outcome == .unknown) return error.KustoIngestionOutcomeUnknown;
                 return error.ManagedIngestionFallbackNotImplemented;
             },
         };
+    }
+
+    /// Structured managed-ingestion result. Until queued fallback is
+    /// implemented, this preserves the direct-streaming failure and outcome.
+    pub fn ingestFromSliceResult(self: *ManagedIngestClient, allocator: std.mem.Allocator, database: []const u8, table: []const u8, data: []const u8, options: IngestOptions) !KustoResult(IngestionResult) {
+        return self.streaming.ingestFromSliceResult(allocator, database, table, data, options);
     }
 
     pub fn deinit(self: *ManagedIngestClient, allocator: std.mem.Allocator) void {
@@ -276,6 +313,18 @@ fn connectionHasAuthentication(connection: ConnectionProperties) bool {
 }
 
 // ─────────────────────── Tests ───────────────────────
+
+const TransportFailure = struct {
+    transport: core.http.HttpTransport = .{ .sendFn = &send },
+
+    fn asTransport(self: *TransportFailure) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn send(_: *core.http.HttpTransport, _: *core.http.Request) anyerror!core.http.Response {
+        return error.ConnectionResetByPeer;
+    }
+};
 
 test "StreamingIngestClient ingestFromSlice" {
     const allocator = std.testing.allocator;
@@ -486,6 +535,29 @@ test "StreamingIngestClient failure" {
 
     const result = try client.ingestFromSlice(allocator, "DB", "Table", "bad", .{});
     try std.testing.expectEqual(IngestionStatus.failed, result.status);
+    try std.testing.expectEqual(KustoOperationOutcome.known_not_accepted, result.outcome);
+}
+
+test "streaming non-2xx is known not accepted" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 400,
+        \\{"error":{"code":"BadRequest","message":"Invalid data"}}
+    );
+    defer mock.deinit();
+    var client = StreamingIngestClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+    );
+
+    var result = try client.ingestFromSliceResult(allocator, "DB", "Table", "bad", .{});
+    defer result.deinit(allocator);
+    switch (result) {
+        .err => |failure| {
+            try std.testing.expectEqual(KustoOperationOutcome.known_not_accepted, failure.outcome);
+            try std.testing.expect(!failure.retryable);
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 fn unexpectedTokenRequest(
@@ -526,9 +598,56 @@ test "legacy authenticated StreamingIngestClient requires shared connection" {
     try std.testing.expect(mock.last_url == null);
 }
 
+test "streaming transport failure has unknown outcome after transport entry" {
+    const allocator = std.testing.allocator;
+    var failing_transport = TransportFailure{};
+    var client = StreamingIngestClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        failing_transport.asTransport(),
+    );
+
+    var result = try client.ingestFromSliceResult(allocator, "DB", "Table", "data", .{});
+    defer result.deinit(allocator);
+    switch (result) {
+        .err => |failure| {
+            try std.testing.expectEqual(KustoErrorSource.transport, failure.source);
+            try std.testing.expectEqual(KustoOperationOutcome.unknown, failure.outcome);
+            try std.testing.expectEqual(error.ConnectionResetByPeer, failure.transport_error.?);
+            try std.testing.expectEqual(@as(usize, 36), failure.client_request_id.?.len);
+            try std.testing.expect(!failure.retryable);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "managed ingestion does not fall back after an unknown outcome" {
+    const allocator = std.testing.allocator;
+    var failing_transport = TransportFailure{};
+    var client = ManagedIngestClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        failing_transport.asTransport(),
+    );
+    defer client.deinit(allocator);
+
+    var result = try client.ingestFromSliceResult(allocator, "DB", "Table", "data", .{});
+    defer result.deinit(allocator);
+    switch (result) {
+        .err => |failure| {
+            try std.testing.expectEqual(KustoOperationOutcome.unknown, failure.outcome);
+            try std.testing.expectEqual(error.ConnectionResetByPeer, failure.transport_error.?);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    try std.testing.expectError(
+        error.KustoIngestionOutcomeUnknown,
+        client.ingestFromSlice(allocator, "DB", "Table", "data", .{}),
+    );
+}
+
 test "IngestionResult deinit through Result" {
     const allocator = std.testing.allocator;
-    var result: core.errors.Result(IngestionResult) = .{ .ok = .{
+    var result: KustoResult(IngestionResult) = .{ .ok = .{
         .status = .success,
         .ingestion_id = try allocator.dupe(u8, "ingestion-id"),
     } };


### PR DESCRIPTION
## Summary

- add allocator-owned OneAPI errors with recursive details, permanence, correlation, retryability, and operation outcomes
- return complete, partial, or failed Kusto results while preserving V1/V2 in-band failures and buffered partial tables
- distinguish rejected streaming ingestion from unknown transport outcomes and prevent managed fallback after ambiguous acceptance

## Testing

- `zig fmt --check sdk/ build.zig`
- `zig build test --summary all` (331/331)

Closes #49