### PR TITLE
kusto: implement complete buffered V1 and V2 result decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 | `azure_kusto_data` | `KustoClient` (experimental buffered query and management support) |
 | `azure_kusto_ingest` | `StreamingIngestClient` (experimental direct streaming ingestion); queued ingestion and managed queued fallback are planned, not implemented |
 
-Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished.
+Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished. Buffered Kusto datasets retain the raw response and tagged `KustoFrame` slices (including unknown V2 frames), decode V1 plus normal, progressive, and fragmented V2 tables into owned `KustoValue` values (null, strings, booleans, integers, reals, and Kusto lexical types), and preserve dynamic or unknown cells as raw JSON.
 
 ### Kusto authentication and connections
 
@@ -165,6 +165,8 @@ Metadata can expose the login authority for a sovereign or private cloud, but `T
 - Query requests default to a 4-minute server timeout and management requests to 10 minutes. Explicit server timeouts range from 1 second through 1 hour with millisecond precision; the client budget defaults to the server timeout plus 30 seconds. `no_request_timeout` requests the maximum server timeout.
 - In the current synchronous buffered transport, the client timeout bounds retries and backoff only; it cannot interrupt an in-flight `std.http` request. Hard cancellation is deferred to future streaming and cancellation transport work.
 - Explicit application, user, version, and request-ID headers override defaults. Results expose owned `client_request_id` and `activity_id`; dataset `deinit` frees them.
+- Buffered result rows are strict about matching the declared column width by default. Set `ClientRequestProperties.setClientResultsReaderAllowVaryingRowWidths` only for services that intentionally emit uneven rows; missing cells remain absent and extra cells are preserved as unknown raw JSON.
+- V2 buffered decoding requires a `DataSetHeader` first and `DataSetCompletion` last. It reconstructs progressive or fragmented `DataAppend`/`DataReplace` frames by table ID, treats row-embedded OneAPI errors as partial results, retains unknown frames, and exposes table/row iterators plus ID, kind, primary, properties, and status selectors. Network streaming, cancellation, and comptime typed conversion remain future work.
 - Queries may retry; management operations and streaming ingestion remain non-retryable.
 - Kusto `*Result` APIs return `KustoResult(T)`: `.ok`, `.partial` (possibly unreliable decoded buffered tables plus an owned `KustoError`), or `.err`; call `deinit`. A streaming `.err` records `.known_not_accepted` for a received non-2xx response and `.unknown` with the transport cause after transport entry fails, while pre-transport credential/policy errors stay in the outer Zig error union. Permanent and partial failures are never retryable.
 

--- a/sdk/kusto/common.zig
+++ b/sdk/kusto/common.zig
@@ -746,6 +746,33 @@ pub const ClientRequestProperties = struct {
         try setProperty(&self.options, allocator, name, value);
     }
 
+    /// Set whether buffered result rows may have a width different from their
+    /// declared column count.
+    pub fn setClientResultsReaderAllowVaryingRowWidths(
+        self: *ClientRequestProperties,
+        allocator: std.mem.Allocator,
+        enabled: bool,
+    ) !void {
+        try self.setOption(
+            allocator,
+            "client_results_reader_allow_varying_row_widths",
+            enabled,
+        );
+    }
+
+    /// Reads the buffered-result width option without coercing arbitrary JSON
+    /// values. A non-boolean option is rejected before a request is sent.
+    pub fn allowVaryingRowWidths(self: *const ClientRequestProperties) !bool {
+        const property = findProperty(
+            self.options.items,
+            "client_results_reader_allow_varying_row_widths",
+        ) orelse return false;
+        return switch (property.value) {
+            .bool => |enabled| enabled,
+            else => error.InvalidVaryingRowWidthOption,
+        };
+    }
+
     /// Set an arbitrary Kusto query parameter. The name and value are copied.
     pub fn setParameter(self: *ClientRequestProperties, allocator: std.mem.Allocator, name: []const u8, value: anytype) !void {
         var owned_value = try ownedValueFromAny(value, allocator);
@@ -873,6 +900,7 @@ pub const ClientRequestProperties = struct {
             if (timeout == 0 or timeout > max_server_timeout_ms + client_timeout_grace_ms)
                 return error.InvalidClientTimeout;
         }
+        _ = try self.allowVaryingRowWidths();
         const no_request_timeout = try self.requestsNoTimeout();
         if (!no_request_timeout and self.server_timeout_ms == null) {
             if (findProperty(self.options.items, "servertimeout")) |property| {
@@ -2148,6 +2176,17 @@ test "ClientRequestProperties applies reserved timeout precedence" {
 
     try props.setOption(allocator, "norequesttimeout", "invalid");
     try std.testing.expectError(error.InvalidNoRequestTimeout, props.validate(.query));
+}
+
+test "ClientRequestProperties reads varying row width option safely" {
+    const allocator = std.testing.allocator;
+    var props = ClientRequestProperties{};
+    defer props.deinit(allocator);
+    try std.testing.expect(!(try props.allowVaryingRowWidths()));
+    try props.setClientResultsReaderAllowVaryingRowWidths(allocator, true);
+    try std.testing.expect(try props.allowVaryingRowWidths());
+    try props.setOption(allocator, "client_results_reader_allow_varying_row_widths", "true");
+    try std.testing.expectError(error.InvalidVaryingRowWidthOption, props.validate(.query));
 }
 
 fn setRequestPropertiesForAllocationTest(allocator: std.mem.Allocator) !void {

--- a/sdk/kusto/data/result.zig
+++ b/sdk/kusto/data/result.zig
@@ -1,0 +1,2474 @@
+const std = @import("std");
+const serde = @import("serde");
+const kusto_common = @import("azure_kusto_common");
+const KustoErrorSource = kusto_common.KustoErrorSource;
+
+pub const DecodeOptions = struct {
+    allow_varying_row_widths: bool = false,
+};
+
+pub const KustoResponseProtocol = enum {
+    v1,
+    v2,
+};
+
+pub const KustoScalarKind = enum {
+    string,
+    bool,
+    int,
+    long,
+    real,
+    decimal,
+    datetime,
+    timespan,
+    guid,
+    dynamic,
+    unknown,
+};
+
+pub const KustoTableKind = enum {
+    primary_result,
+    query_result,
+    query_properties,
+    query_status,
+    query_completion_information,
+    query_trace_log,
+    query_perf_log,
+    query_plan,
+    table_of_contents,
+    unknown,
+};
+
+/// A decoded, allocator-owned Kusto scalar. `dynamic`, `unknown`, and
+/// `real_raw` retain their original JSON token rather than a lossy rendering.
+pub const KustoValue = union(enum) {
+    null,
+    string: []u8,
+    bool: bool,
+    int: i32,
+    long: i64,
+    real: f64,
+    real_raw: []u8,
+    decimal: []u8,
+    datetime: []u8,
+    timespan: []u8,
+    guid: []u8,
+    dynamic: []u8,
+    unknown: []u8,
+
+    pub fn deinit(self: *KustoValue, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .string,
+            .real_raw,
+            .decimal,
+            .datetime,
+            .timespan,
+            .guid,
+            .dynamic,
+            .unknown,
+            => |value| allocator.free(value),
+            else => {},
+        }
+        self.* = .null;
+    }
+
+    pub fn asString(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .string => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn isNull(self: KustoValue) bool {
+        return switch (self) {
+            .null => true,
+            else => false,
+        };
+    }
+
+    pub fn asBool(self: KustoValue) ?bool {
+        return switch (self) {
+            .bool => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asI32(self: KustoValue) ?i32 {
+        return switch (self) {
+            .int => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asI64(self: KustoValue) ?i64 {
+        return switch (self) {
+            .int => |value| value,
+            .long => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asF64(self: KustoValue) ?f64 {
+        return switch (self) {
+            .real => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asDecimal(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .decimal => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asDateTime(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .datetime => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asTimespan(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .timespan => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asGuid(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .guid => |value| value,
+            else => null,
+        };
+    }
+
+    /// Returns an owned lexical value for string-like scalar types.
+    pub fn lexical(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .string,
+            .decimal,
+            .datetime,
+            .timespan,
+            .guid,
+            => |value| value,
+            else => null,
+        };
+    }
+
+    /// Returns the exact original JSON token for raw JSON values.
+    pub fn rawJson(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .real_raw,
+            .dynamic,
+            .unknown,
+            => |value| value,
+            else => null,
+        };
+    }
+};
+
+pub const KustoResultColumn = struct {
+    name: []u8,
+    column_type: []u8,
+    scalar_kind: KustoScalarKind,
+    // ColumnType is authoritative. A V1 DataType-only column is advisory and
+    // may fall back to raw JSON when the wire value does not match its alias.
+    has_declared_type: bool = true,
+
+    pub fn deinit(self: *KustoResultColumn, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.column_type);
+        self.* = undefined;
+    }
+};
+
+pub const KustoResultRow = struct {
+    values: []KustoValue,
+    // This is the table's separately allocated column array, not a pointer to
+    // a movable table struct, so row name lookup remains valid after reallocation.
+    columns: []const KustoResultColumn,
+
+    pub fn deinit(self: *KustoResultRow, allocator: std.mem.Allocator) void {
+        for (self.values) |*value| value.deinit(allocator);
+        allocator.free(self.values);
+        self.* = undefined;
+    }
+
+    pub fn get(self: *const KustoResultRow, index: usize) ?*const KustoValue {
+        if (index >= self.values.len) return null;
+        return &self.values[index];
+    }
+
+    pub fn getByName(self: *const KustoResultRow, name: []const u8) ?*const KustoValue {
+        for (self.columns, 0..) |column, index| {
+            if (std.mem.eql(u8, column.name, name))
+                return self.get(index);
+        }
+        return null;
+    }
+};
+
+pub const RowIterator = struct {
+    rows: []const KustoResultRow,
+    index: usize = 0,
+
+    pub fn next(self: *RowIterator) ?*const KustoResultRow {
+        if (self.index >= self.rows.len) return null;
+        defer self.index += 1;
+        return &self.rows[self.index];
+    }
+};
+
+pub const KustoResultTable = struct {
+    id: ?i64 = null,
+    ordinal: ?i64 = null,
+    name: []u8,
+    kind: ?[]u8 = null,
+    known_kind: KustoTableKind = .unknown,
+    toc_name: ?[]u8 = null,
+    toc_id: ?[]u8 = null,
+    pretty_name: ?[]u8 = null,
+    columns: []KustoResultColumn,
+    rows: []KustoResultRow,
+    progress: ?f64 = null,
+    reported_row_count: ?i64 = null,
+    completed: bool = true,
+
+    pub fn deinit(self: *KustoResultTable, allocator: std.mem.Allocator) void {
+        deinitRows(self.rows, allocator);
+        allocator.free(self.rows);
+        deinitTableMetadata(self, allocator);
+        self.* = undefined;
+    }
+
+    pub fn rowIterator(self: *const KustoResultTable) RowIterator {
+        return .{ .rows = self.rows };
+    }
+};
+
+/// The raw JSON and ordinal for a buffered response frame. `raw_json` borrows
+/// the containing dataset's `raw_response`; it is not a second response copy.
+pub const KustoFramePayload = struct {
+    index: usize,
+    raw_json: []const u8,
+};
+
+/// An unrecognized V2 frame. Its decoded `frame_type` is owned by the
+/// dataset, while `raw_json` borrows the dataset's raw response.
+pub const KustoUnknownFrame = struct {
+    index: usize,
+    frame_type: []u8,
+    raw_json: []const u8,
+};
+
+/// A buffered Kusto response frame.
+///
+/// Known V2 frame kinds and a V1 response root are explicit union tags. Every
+/// variant exposes its exact JSON through `rawJson`, and an unknown frame also
+/// retains its exact decoded `FrameType` text.
+pub const KustoFrame = union(enum) {
+    v1_root: KustoFramePayload,
+    data_set_header: KustoFramePayload,
+    data_set_completion: KustoFramePayload,
+    data_table: KustoFramePayload,
+    table_header: KustoFramePayload,
+    table_fragment: KustoFramePayload,
+    table_progress: KustoFramePayload,
+    table_completion: KustoFramePayload,
+    unknown: KustoUnknownFrame,
+
+    pub fn deinit(self: *KustoFrame, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .unknown => |frame| allocator.free(frame.frame_type),
+            else => {},
+        }
+        self.* = undefined;
+    }
+
+    pub fn index(self: KustoFrame) usize {
+        return switch (self) {
+            inline else => |frame| frame.index,
+        };
+    }
+
+    pub fn rawJson(self: KustoFrame) []const u8 {
+        return switch (self) {
+            inline else => |frame| frame.raw_json,
+        };
+    }
+
+    pub fn frameType(self: KustoFrame) []const u8 {
+        return switch (self) {
+            .v1_root => "V1",
+            .data_set_header => "DataSetHeader",
+            .data_set_completion => "DataSetCompletion",
+            .data_table => "DataTable",
+            .table_header => "TableHeader",
+            .table_fragment => "TableFragment",
+            .table_progress => "TableProgress",
+            .table_completion => "TableCompletion",
+            .unknown => |frame| frame.frame_type,
+        };
+    }
+};
+
+pub const FrameIterator = struct {
+    frames: []const KustoFrame,
+    index: usize = 0,
+
+    pub fn next(self: *FrameIterator) ?*const KustoFrame {
+        if (self.index >= self.frames.len) return null;
+        defer self.index += 1;
+        return &self.frames[self.index];
+    }
+};
+
+pub const TableIterator = struct {
+    tables: []const KustoResultTable,
+    index: usize = 0,
+
+    pub fn next(self: *TableIterator) ?*const KustoResultTable {
+        if (self.index >= self.tables.len) return null;
+        defer self.index += 1;
+        return &self.tables[self.index];
+    }
+};
+
+pub const KustoResponseDataSet = struct {
+    protocol: KustoResponseProtocol,
+    tables: []KustoResultTable,
+    raw_response: []u8,
+    frames: []KustoFrame,
+    v1_exceptions: [][]u8,
+    version: ?[]u8 = null,
+    is_progressive: bool = false,
+    is_fragmented: ?bool = null,
+    error_reporting_placement: ?[]u8 = null,
+    completed: bool = false,
+    has_errors: ?bool = null,
+    cancelled: bool = false,
+    client_request_id: ?[]u8 = null,
+    activity_id: ?[]u8 = null,
+
+    pub fn deinit(self: *KustoResponseDataSet, allocator: std.mem.Allocator) void {
+        for (self.tables) |*table| table.deinit(allocator);
+        allocator.free(self.tables);
+        for (self.frames) |*frame| frame.deinit(allocator);
+        allocator.free(self.frames);
+        for (self.v1_exceptions) |value| allocator.free(value);
+        allocator.free(self.v1_exceptions);
+        allocator.free(self.raw_response);
+        if (self.version) |value| allocator.free(value);
+        if (self.error_reporting_placement) |value| allocator.free(value);
+        if (self.client_request_id) |value| allocator.free(value);
+        if (self.activity_id) |value| allocator.free(value);
+        self.* = undefined;
+    }
+
+    pub fn tableIterator(self: *const KustoResponseDataSet) TableIterator {
+        return .{ .tables = self.tables };
+    }
+
+    pub fn frameIterator(self: *const KustoResponseDataSet) FrameIterator {
+        return .{ .frames = self.frames };
+    }
+
+    pub fn tableById(self: *const KustoResponseDataSet, id: i64) ?*const KustoResultTable {
+        for (self.tables) |*table| {
+            if (table.id != null and table.id.? == id) return table;
+        }
+        return null;
+    }
+
+    pub fn tableByKind(self: *const KustoResponseDataSet, kind: []const u8) ?*const KustoResultTable {
+        for (self.tables) |*table| {
+            if (table.kind) |table_kind| {
+                if (std.ascii.eqlIgnoreCase(table_kind, kind)) return table;
+            }
+            if (table.known_kind != .unknown and
+                std.ascii.eqlIgnoreCase(tableKindName(table.known_kind), kind))
+                return table;
+        }
+        return null;
+    }
+
+    pub fn queryProperties(self: *const KustoResponseDataSet) ?*const KustoResultTable {
+        for (self.tables) |*table| {
+            if (table.known_kind == .query_properties) return table;
+        }
+        return null;
+    }
+
+    pub fn queryStatus(self: *const KustoResponseDataSet) ?*const KustoResultTable {
+        for (self.tables) |*table| {
+            if (table.known_kind == .query_status or table.known_kind == .query_completion_information)
+                return table;
+        }
+        return null;
+    }
+
+    /// Prefers explicit primary/query-result metadata. The V1 fallback exists
+    /// for management responses that consist of one ordinary result table.
+    pub fn primaryTable(self: *const KustoResponseDataSet) ?*const KustoResultTable {
+        for (self.tables) |*table| {
+            if (table.known_kind == .primary_result or table.known_kind == .query_result)
+                return table;
+        }
+        for (self.tables) |*table| {
+            if (std.ascii.eqlIgnoreCase(table.name, "PrimaryResult") or
+                (table.toc_name != null and std.ascii.eqlIgnoreCase(table.toc_name.?, "PrimaryResult")))
+                return table;
+        }
+        if (self.protocol == .v1 and self.tables.len == 1)
+            return &self.tables[0];
+        return null;
+    }
+};
+
+pub const DecodeOutcome = struct {
+    dataset: KustoResponseDataSet,
+    failure: ?kusto_common.KustoError = null,
+
+    pub fn deinit(self: *DecodeOutcome, allocator: std.mem.Allocator) void {
+        self.dataset.deinit(allocator);
+        if (self.failure) |*failure| failure.deinit();
+        self.* = undefined;
+    }
+};
+
+const Field = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+const JsonTokenKind = enum {
+    object_begin,
+    object_end,
+    array_begin,
+    array_end,
+    string,
+    number,
+    true_lit,
+    false_lit,
+    null_lit,
+};
+
+const TableBuilder = struct {
+    table: KustoResultTable,
+    rows: std.ArrayList(KustoResultRow) = .empty,
+    active: bool = true,
+
+    fn deinit(self: *TableBuilder, allocator: std.mem.Allocator) void {
+        if (!self.active) return;
+        deinitRows(self.rows.items, allocator);
+        self.rows.deinit(allocator);
+        deinitTableMetadata(&self.table, allocator);
+        self.active = false;
+    }
+
+    fn take(self: *TableBuilder, allocator: std.mem.Allocator) !KustoResultTable {
+        self.table.rows = try self.rows.toOwnedSlice(allocator);
+        self.rows = .empty;
+        self.active = false;
+        return self.table;
+    }
+};
+
+pub fn decode(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    options: DecodeOptions,
+    operation: kusto_common.KustoOperation,
+) !DecodeOutcome {
+    var dataset = KustoResponseDataSet{
+        .protocol = .v1,
+        .tables = &.{},
+        .raw_response = try allocator.dupe(u8, body),
+        .frames = &.{},
+        .v1_exceptions = &.{},
+    };
+    errdefer dataset.deinit(allocator);
+    var failure: ?kusto_common.KustoError = null;
+    errdefer if (failure) |*value| value.deinit();
+    if (!try std.json.validate(allocator, dataset.raw_response))
+        return error.MalformedKustoResponse;
+
+    var deserializer = serde.json.Deserializer.init(dataset.raw_response);
+    const root_token = deserializer.scanner.next() catch return error.MalformedKustoResponse;
+    switch (root_token) {
+        .object_begin => try parseV1(allocator, &dataset, options, operation, &failure),
+        .array_begin => try parseV2(allocator, &dataset, options, operation, &failure),
+        else => return error.MalformedKustoResponse,
+    }
+
+    if (failure == null) {
+        if (try queryStatusFailure(allocator, &dataset, operation)) |status_failure|
+            failure = status_failure;
+    }
+
+    return .{ .dataset = dataset, .failure = failure };
+}
+
+fn parseV1(
+    allocator: std.mem.Allocator,
+    dataset: *KustoResponseDataSet,
+    options: DecodeOptions,
+    operation: kusto_common.KustoOperation,
+    failure: *?kusto_common.KustoError,
+) !void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const fields = try parseObjectFields(arena.allocator(), dataset.raw_response);
+    const tables_raw = requiredField(fields, "Tables") orelse return error.MalformedKustoResponse;
+
+    var exceptions = std.ArrayList([]u8).empty;
+    errdefer {
+        for (exceptions.items) |value| allocator.free(value);
+        exceptions.deinit(allocator);
+    }
+    if (field(fields, "Exceptions")) |raw|
+        try collectExceptions(allocator, raw, &exceptions);
+
+    dataset.tables = try parseV1Tables(allocator, tables_raw, options, &exceptions);
+    dataset.v1_exceptions = try exceptions.toOwnedSlice(allocator);
+    exceptions = .empty;
+    dataset.frames = try allocator.alloc(KustoFrame, 1);
+    dataset.frames[0] = .{ .v1_root = .{
+        .index = 0,
+        .raw_json = dataset.raw_response,
+    } };
+    dataset.protocol = .v1;
+    dataset.completed = true;
+
+    const has_table_of_contents = try applyV1TableOfContents(allocator, dataset);
+    if (!has_table_of_contents)
+        applyShortV1TableKinds(dataset);
+    if (dataset.v1_exceptions.len > 0) {
+        var in_band = kusto_common.errors.inBandFailure(
+            allocator,
+            operation,
+            .v1_exception,
+            false,
+        );
+        errdefer in_band.deinit();
+        in_band.detail.message = try allocator.dupe(u8, dataset.v1_exceptions[0]);
+        rememberFailure(failure, in_band);
+    }
+}
+
+fn parseV1Tables(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    options: DecodeOptions,
+    exceptions: *std.ArrayList([]u8),
+) ![]KustoResultTable {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .array_begin)
+        return error.MalformedKustoResponse;
+
+    var tables = std.ArrayList(KustoResultTable).empty;
+    errdefer {
+        for (tables.items) |*table| table.deinit(allocator);
+        tables.deinit(allocator);
+    }
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const table_raw = try captureValue(scanner, raw);
+            var table = try parseV1Table(allocator, table_raw, options, exceptions);
+            errdefer table.deinit(allocator);
+            table.ordinal = @intCast(tables.items.len);
+            try tables.append(allocator, table);
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    try ensureScannerComplete(scanner, raw);
+    return tables.toOwnedSlice(allocator);
+}
+
+fn parseV1Table(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    options: DecodeOptions,
+    exceptions: *std.ArrayList([]u8),
+) !KustoResultTable {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const fields = try parseObjectFields(arena.allocator(), raw);
+    const name_raw = requiredField(fields, "TableName") orelse return error.MalformedKustoResponse;
+    const columns_raw = requiredField(fields, "Columns") orelse return error.MalformedKustoResponse;
+    const rows_raw = requiredField(fields, "Rows") orelse return error.MalformedKustoResponse;
+
+    const name = try decodeStringOwned(allocator, name_raw);
+    errdefer allocator.free(name);
+    const kind = if (field(fields, "TableKind")) |kind_raw|
+        try decodeStringOwned(allocator, kind_raw)
+    else
+        null;
+    errdefer if (kind) |value| allocator.free(value);
+    const columns = try parseColumns(allocator, columns_raw);
+    errdefer {
+        for (columns) |*column| column.deinit(allocator);
+        allocator.free(columns);
+    }
+    const rows = try parseV1Rows(allocator, rows_raw, columns, options, exceptions);
+    return .{
+        .name = name,
+        .kind = kind,
+        .known_kind = normalizeTableKind(kind orelse name),
+        .columns = columns,
+        .rows = rows,
+        .completed = true,
+    };
+}
+
+fn parseV1Rows(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    columns: []const KustoResultColumn,
+    options: DecodeOptions,
+    exceptions: *std.ArrayList([]u8),
+) ![]KustoResultRow {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .array_begin)
+        return error.MalformedKustoResponse;
+
+    var rows = std.ArrayList(KustoResultRow).empty;
+    errdefer {
+        deinitRows(rows.items, allocator);
+        rows.deinit(allocator);
+    }
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const row_raw = try captureValue(scanner, raw);
+            const token = try singleToken(row_raw);
+            switch (token) {
+                .array_begin => {
+                    var row = try parseRow(allocator, row_raw, columns, options);
+                    errdefer row.deinit(allocator);
+                    try rows.append(allocator, row);
+                },
+                .object_begin => try collectV1RowExceptions(allocator, row_raw, exceptions),
+                else => return error.MalformedKustoResponse,
+            }
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    try ensureScannerComplete(scanner, raw);
+    return rows.toOwnedSlice(allocator);
+}
+
+fn collectV1RowExceptions(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    exceptions: *std.ArrayList([]u8),
+) !void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const fields = try parseObjectFields(arena.allocator(), raw);
+    const errors_raw = requiredField(fields, "Exceptions") orelse return error.MalformedKustoResponse;
+    try collectExceptions(allocator, errors_raw, exceptions);
+}
+
+fn collectExceptions(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    exceptions: *std.ArrayList([]u8),
+) !void {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .array_begin)
+        return error.MalformedKustoResponse;
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const item_raw = try captureValue(scanner, raw);
+            const item = try decodeStringOwned(allocator, item_raw);
+            errdefer allocator.free(item);
+            try exceptions.append(allocator, item);
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    try ensureScannerComplete(scanner, raw);
+}
+
+fn applyV1TableOfContents(
+    allocator: std.mem.Allocator,
+    dataset: *KustoResponseDataSet,
+) !bool {
+    var found = false;
+    for (dataset.tables, 0..) |*toc, toc_index| {
+        if (!isV1TableOfContents(dataset.tables, toc_index))
+            continue;
+        found = true;
+        toc.known_kind = .table_of_contents;
+        for (toc.rows) |*row| {
+            const ordinal_value = row.getByName("Ordinal") orelse continue;
+            const ordinal = valueAsI64(ordinal_value.*) orelse continue;
+            if (ordinal < 0) continue;
+            const target_index = std.math.cast(usize, ordinal) orelse continue;
+            if (target_index >= toc_index) continue;
+            const target = &dataset.tables[target_index];
+            target.ordinal = ordinal;
+
+            if (row.getByName("Kind")) |value| {
+                if (value.lexical()) |kind| {
+                    try replaceOptionalString(allocator, &target.kind, kind);
+                    target.known_kind = normalizeTableKind(kind);
+                }
+            }
+            if (row.getByName("Name")) |value| {
+                if (value.lexical()) |name|
+                    try replaceOptionalString(allocator, &target.toc_name, name);
+            }
+            if (row.getByName("PrettyName")) |value| {
+                if (value.lexical()) |pretty_name|
+                    try replaceOptionalString(allocator, &target.pretty_name, pretty_name);
+            }
+            if (row.getByName("Id")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |id_text| {
+                    if (target.toc_id) |old| allocator.free(old);
+                    target.toc_id = id_text;
+                }
+                if (valueAsI64(value.*)) |id| target.id = id;
+            }
+        }
+    }
+    return found;
+}
+
+fn applyShortV1TableKinds(dataset: *KustoResponseDataSet) void {
+    if (dataset.tables.len == 0 or dataset.tables.len > 2) return;
+    if (dataset.tables[0].known_kind == .unknown)
+        dataset.tables[0].known_kind = .primary_result;
+    if (dataset.tables[0].id == null)
+        dataset.tables[0].id = 0;
+    if (dataset.tables.len == 2) {
+        if (dataset.tables[1].known_kind == .unknown)
+            dataset.tables[1].known_kind = .query_properties;
+        if (dataset.tables[1].id == null)
+            dataset.tables[1].id = 1;
+    }
+}
+
+fn isV1TableOfContents(tables: []const KustoResultTable, index: usize) bool {
+    const table = &tables[index];
+    if (table.known_kind == .table_of_contents or
+        std.ascii.eqlIgnoreCase(table.name, "TableOfContents"))
+        return true;
+    if (index != tables.len - 1 or table.columns.len < v1_toc_column_names.len)
+        return false;
+    for (v1_toc_column_names) |expected| {
+        var found = false;
+        for (table.columns) |column| {
+            if (std.ascii.eqlIgnoreCase(column.name, expected)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) return false;
+    }
+    return true;
+}
+
+const v1_toc_column_names = [_][]const u8{
+    "Ordinal",
+    "Kind",
+    "Name",
+    "Id",
+    "PrettyName",
+};
+
+fn parseV2(
+    allocator: std.mem.Allocator,
+    dataset: *KustoResponseDataSet,
+    options: DecodeOptions,
+    operation: kusto_common.KustoOperation,
+    failure: *?kusto_common.KustoError,
+) !void {
+    var deserializer = serde.json.Deserializer.init(dataset.raw_response);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .array_begin)
+        return error.MalformedKustoResponse;
+
+    var builders = std.ArrayList(TableBuilder).empty;
+    errdefer deinitBuilders(&builders, allocator);
+    var frames = std.ArrayList(KustoFrame).empty;
+    errdefer deinitFrames(&frames, allocator);
+    var table_indexes = std.AutoHashMap(i64, usize).init(allocator);
+    defer table_indexes.deinit();
+
+    var saw_header = false;
+    var saw_completion = false;
+    var frame_index: usize = 0;
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse)
+        return error.MalformedKustoResponse;
+
+    while (true) {
+        const frame_raw = try captureValue(scanner, dataset.raw_response);
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const fields = try parseObjectFields(arena.allocator(), frame_raw);
+        const frame_type_raw = requiredField(fields, "FrameType") orelse return error.MalformedKustoResponse;
+        const frame_type = try decodeStringTemp(arena.allocator(), frame_type_raw);
+
+        var frame = try makeFrame(allocator, frame_index, frame_type, frame_raw);
+        frames.append(allocator, frame) catch |err| {
+            frame.deinit(allocator);
+            return err;
+        };
+
+        if (saw_completion) return error.MalformedKustoResponse;
+        if (!saw_header and !std.mem.eql(u8, frame_type, "DataSetHeader"))
+            return error.MalformedKustoResponse;
+
+        if (std.mem.eql(u8, frame_type, "DataSetHeader")) {
+            if (saw_header) return error.MalformedKustoResponse;
+            try parseDataSetHeader(allocator, dataset, fields);
+            saw_header = true;
+        } else if (std.mem.eql(u8, frame_type, "DataTable")) {
+            const id = try parseRequiredId(fields, "TableId");
+            if (table_indexes.get(id) != null) return error.MalformedKustoResponse;
+            var builder = try parseDataTable(allocator, fields, id, options, operation, failure);
+            errdefer builder.deinit(allocator);
+            builder.table.ordinal = @intCast(builders.items.len);
+            try table_indexes.put(id, builders.items.len);
+            try builders.append(allocator, builder);
+        } else if (std.mem.eql(u8, frame_type, "TableHeader")) {
+            if (!allowsTableFrames(dataset)) return error.MalformedKustoResponse;
+            const id = try parseRequiredId(fields, "TableId");
+            if (table_indexes.get(id) != null) return error.MalformedKustoResponse;
+            var builder = try parseTableHeader(allocator, fields, id);
+            errdefer builder.deinit(allocator);
+            builder.table.ordinal = @intCast(builders.items.len);
+            try table_indexes.put(id, builders.items.len);
+            try builders.append(allocator, builder);
+        } else if (std.mem.eql(u8, frame_type, "TableFragment")) {
+            if (!allowsTableFrames(dataset)) return error.MalformedKustoResponse;
+            const id = try parseRequiredId(fields, "TableId");
+            const index = table_indexes.get(id) orelse return error.MalformedKustoResponse;
+            try applyTableFragment(
+                allocator,
+                &builders.items[index],
+                fields,
+                options,
+                operation,
+                failure,
+            );
+        } else if (std.mem.eql(u8, frame_type, "TableProgress")) {
+            if (!allowsTableFrames(dataset)) return error.MalformedKustoResponse;
+            const id = try parseRequiredId(fields, "TableId");
+            const index = table_indexes.get(id) orelse return error.MalformedKustoResponse;
+            try applyTableProgress(&builders.items[index], fields);
+        } else if (std.mem.eql(u8, frame_type, "TableCompletion")) {
+            const id = try parseRequiredId(fields, "TableId");
+            const index = table_indexes.get(id) orelse return error.MalformedKustoResponse;
+            try applyTableCompletion(allocator, &builders.items[index], fields, operation, failure);
+        } else if (std.mem.eql(u8, frame_type, "DataSetCompletion")) {
+            if (saw_completion) return error.MalformedKustoResponse;
+            try applyDataSetCompletion(allocator, dataset, builders.items, fields, operation, failure);
+            saw_completion = true;
+        }
+
+        switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+            .end => break,
+            .more => frame_index += 1,
+        }
+    }
+    try ensureScannerComplete(scanner, dataset.raw_response);
+    if (!saw_header or !saw_completion) return error.MalformedKustoResponse;
+
+    dataset.tables = try finishBuilders(allocator, &builders);
+    dataset.frames = try frames.toOwnedSlice(allocator);
+    frames = .empty;
+    dataset.v1_exceptions = try allocator.alloc([]u8, 0);
+    dataset.protocol = .v2;
+}
+
+fn allowsTableFrames(dataset: *const KustoResponseDataSet) bool {
+    return dataset.is_progressive or dataset.is_fragmented == true;
+}
+
+fn makeFrame(
+    allocator: std.mem.Allocator,
+    index: usize,
+    frame_type: []const u8,
+    raw_json: []const u8,
+) !KustoFrame {
+    const payload = KustoFramePayload{ .index = index, .raw_json = raw_json };
+    if (std.mem.eql(u8, frame_type, "DataSetHeader"))
+        return .{ .data_set_header = payload };
+    if (std.mem.eql(u8, frame_type, "DataSetCompletion"))
+        return .{ .data_set_completion = payload };
+    if (std.mem.eql(u8, frame_type, "DataTable"))
+        return .{ .data_table = payload };
+    if (std.mem.eql(u8, frame_type, "TableHeader"))
+        return .{ .table_header = payload };
+    if (std.mem.eql(u8, frame_type, "TableFragment"))
+        return .{ .table_fragment = payload };
+    if (std.mem.eql(u8, frame_type, "TableProgress"))
+        return .{ .table_progress = payload };
+    if (std.mem.eql(u8, frame_type, "TableCompletion"))
+        return .{ .table_completion = payload };
+    return .{ .unknown = .{
+        .index = index,
+        .frame_type = try allocator.dupe(u8, frame_type),
+        .raw_json = raw_json,
+    } };
+}
+
+fn parseDataSetHeader(
+    allocator: std.mem.Allocator,
+    dataset: *KustoResponseDataSet,
+    fields: []const Field,
+) !void {
+    const version_raw = requiredField(fields, "Version") orelse return error.MalformedKustoResponse;
+    const progressive_raw = requiredField(fields, "IsProgressive") orelse return error.MalformedKustoResponse;
+    dataset.version = try decodeStringOwned(allocator, version_raw);
+    dataset.is_progressive = try decodeBool(progressive_raw);
+    if (field(fields, "IsFragmented")) |raw|
+        dataset.is_fragmented = try decodeBool(raw);
+    if (field(fields, "ErrorReportingPlacement")) |raw|
+        dataset.error_reporting_placement = try decodeStringOwned(allocator, raw);
+}
+
+fn parseDataTable(
+    allocator: std.mem.Allocator,
+    fields: []const Field,
+    id: i64,
+    options: DecodeOptions,
+    operation: kusto_common.KustoOperation,
+    failure: *?kusto_common.KustoError,
+) !TableBuilder {
+    var builder = TableBuilder{ .table = try parseTableMetadata(allocator, fields, id, true) };
+    errdefer builder.deinit(allocator);
+    const rows_raw = requiredField(fields, "Rows") orelse return error.MalformedKustoResponse;
+    const rows = try parseRows(
+        allocator,
+        rows_raw,
+        builder.table.columns,
+        options,
+        operation,
+        failure,
+    );
+    try appendOwnedRows(allocator, &builder.rows, rows);
+    builder.table.reported_row_count = @intCast(builder.rows.items.len);
+    return builder;
+}
+
+fn parseTableHeader(
+    allocator: std.mem.Allocator,
+    fields: []const Field,
+    id: i64,
+) !TableBuilder {
+    return .{ .table = try parseTableMetadata(allocator, fields, id, false) };
+}
+
+fn parseTableMetadata(
+    allocator: std.mem.Allocator,
+    fields: []const Field,
+    id: i64,
+    completed: bool,
+) !KustoResultTable {
+    const name_raw = requiredField(fields, "TableName") orelse return error.MalformedKustoResponse;
+    const kind_raw = requiredField(fields, "TableKind") orelse return error.MalformedKustoResponse;
+    const columns_raw = requiredField(fields, "Columns") orelse return error.MalformedKustoResponse;
+    const name = try decodeStringOwned(allocator, name_raw);
+    errdefer allocator.free(name);
+    const kind = try decodeStringOwned(allocator, kind_raw);
+    errdefer allocator.free(kind);
+    const columns = try parseColumns(allocator, columns_raw);
+    return .{
+        .id = id,
+        .name = name,
+        .kind = kind,
+        .known_kind = normalizeTableKind(kind),
+        .columns = columns,
+        .rows = &.{},
+        .completed = completed,
+    };
+}
+
+fn applyTableFragment(
+    allocator: std.mem.Allocator,
+    builder: *TableBuilder,
+    fields: []const Field,
+    options: DecodeOptions,
+    operation: kusto_common.KustoOperation,
+    failure: *?kusto_common.KustoError,
+) !void {
+    if (builder.table.completed) return error.MalformedKustoResponse;
+    if (field(fields, "FieldCount")) |raw| {
+        const field_count = try decodeNonNegativeI64(raw);
+        if (field_count != builder.table.columns.len) return error.MalformedKustoResponse;
+    }
+    const type_raw = requiredField(fields, "TableFragmentType") orelse return error.MalformedKustoResponse;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const fragment_type = try decodeStringTemp(arena.allocator(), type_raw);
+    const is_append = std.mem.eql(u8, fragment_type, "DataAppend");
+    const is_replace = std.mem.eql(u8, fragment_type, "DataReplace");
+    if (!is_append and !is_replace) return error.UnsupportedTableFragmentType;
+    const rows_raw = requiredField(fields, "Rows") orelse return error.MalformedKustoResponse;
+    const rows = try parseRows(
+        allocator,
+        rows_raw,
+        builder.table.columns,
+        options,
+        operation,
+        failure,
+    );
+    if (is_append) {
+        try appendOwnedRows(allocator, &builder.rows, rows);
+    } else {
+        deinitRows(builder.rows.items, allocator);
+        builder.rows.clearRetainingCapacity();
+        try appendOwnedRows(allocator, &builder.rows, rows);
+    }
+}
+
+fn applyTableProgress(builder: *TableBuilder, fields: []const Field) !void {
+    if (builder.table.completed) return error.MalformedKustoResponse;
+    const progress_raw = requiredField(fields, "TableProgress") orelse return error.MalformedKustoResponse;
+    const progress = try decodeFiniteNumber(progress_raw);
+    if (progress < 0 or progress > 100) return error.MalformedKustoResponse;
+    builder.table.progress = progress;
+}
+
+fn applyTableCompletion(
+    allocator: std.mem.Allocator,
+    builder: *TableBuilder,
+    fields: []const Field,
+    operation: kusto_common.KustoOperation,
+    failure: *?kusto_common.KustoError,
+) !void {
+    if (builder.table.completed) return error.MalformedKustoResponse;
+    const row_count_raw = requiredField(fields, "RowCount") orelse return error.MalformedKustoResponse;
+    const row_count = try decodeNonNegativeI64(row_count_raw);
+    if (row_count != builder.rows.items.len) return error.MalformedKustoResponse;
+    builder.table.reported_row_count = row_count;
+    builder.table.completed = true;
+
+    const has_errors = if (field(fields, "HasErrors")) |raw| try decodeBool(raw) else false;
+    const cancelled = if (field(fields, "Cancelled")) |raw| try decodeBool(raw) else false;
+    if (try completionFailure(
+        allocator,
+        operation,
+        .table_completion,
+        field(fields, "OneApiErrors"),
+        has_errors,
+        cancelled,
+    )) |in_band|
+        rememberFailure(failure, in_band);
+}
+
+fn applyDataSetCompletion(
+    allocator: std.mem.Allocator,
+    dataset: *KustoResponseDataSet,
+    builders: []const TableBuilder,
+    fields: []const Field,
+    operation: kusto_common.KustoOperation,
+    failure: *?kusto_common.KustoError,
+) !void {
+    for (builders) |builder| {
+        if (!builder.table.completed) return error.MalformedKustoResponse;
+    }
+    const has_errors_raw = requiredField(fields, "HasErrors") orelse return error.MalformedKustoResponse;
+    const cancelled_raw = requiredField(fields, "Cancelled") orelse return error.MalformedKustoResponse;
+    const has_errors = try decodeBool(has_errors_raw);
+    const cancelled = try decodeBool(cancelled_raw);
+    dataset.completed = true;
+    dataset.has_errors = has_errors;
+    dataset.cancelled = cancelled;
+    if (try completionFailure(
+        allocator,
+        operation,
+        .dataset_completion,
+        field(fields, "OneApiErrors"),
+        has_errors,
+        cancelled,
+    )) |in_band|
+        rememberFailure(failure, in_band);
+}
+
+fn completionFailure(
+    allocator: std.mem.Allocator,
+    operation: kusto_common.KustoOperation,
+    source: kusto_common.KustoErrorSource,
+    errors_raw: ?[]const u8,
+    has_errors: bool,
+    cancelled: bool,
+) !?kusto_common.KustoError {
+    if (errors_raw) |raw| {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const errors = serde.json.fromSlice(
+            []kusto_common.errors.OneApiEnvelope,
+            arena.allocator(),
+            raw,
+        ) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return error.MalformedKustoResponse;
+        };
+        if (errors.len > 0)
+            return try kusto_common.errors.fromOneApiEnvelope(
+                allocator,
+                operation,
+                source,
+                errors[0],
+                cancelled,
+            );
+    }
+    if (has_errors or cancelled)
+        return kusto_common.errors.inBandFailure(allocator, operation, source, cancelled);
+    return null;
+}
+
+fn parseColumns(allocator: std.mem.Allocator, raw: []const u8) ![]KustoResultColumn {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .array_begin)
+        return error.MalformedKustoResponse;
+
+    var columns = std.ArrayList(KustoResultColumn).empty;
+    errdefer {
+        for (columns.items) |*column| column.deinit(allocator);
+        columns.deinit(allocator);
+    }
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const column_raw = try captureValue(scanner, raw);
+            var arena = std.heap.ArenaAllocator.init(allocator);
+            defer arena.deinit();
+            const fields = try parseObjectFields(arena.allocator(), column_raw);
+            const name_raw = requiredField(fields, "ColumnName") orelse return error.MalformedKustoResponse;
+            const column_type_raw = field(fields, "ColumnType");
+            const type_raw = column_type_raw orelse field(fields, "DataType");
+            // V1 DataType is advisory: service status payloads can contain a
+            // structured value even when DataType says String.
+            const has_declared_type = column_type_raw != null;
+            const name = try decodeStringOwned(allocator, name_raw);
+            const column_type = (if (type_raw) |value|
+                decodeStringOwned(allocator, value)
+            else
+                allocator.dupe(u8, "string")) catch |err| {
+                allocator.free(name);
+                return err;
+            };
+            var column = KustoResultColumn{
+                .name = name,
+                .column_type = column_type,
+                .scalar_kind = normalizeScalarKind(column_type),
+                .has_declared_type = has_declared_type,
+            };
+            columns.append(allocator, column) catch |err| {
+                column.deinit(allocator);
+                return err;
+            };
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    try ensureScannerComplete(scanner, raw);
+    return columns.toOwnedSlice(allocator);
+}
+
+fn parseRows(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    columns: []const KustoResultColumn,
+    options: DecodeOptions,
+    operation: kusto_common.KustoOperation,
+    failure: *?kusto_common.KustoError,
+) ![]KustoResultRow {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .array_begin)
+        return error.MalformedKustoResponse;
+
+    var rows = std.ArrayList(KustoResultRow).empty;
+    errdefer {
+        deinitRows(rows.items, allocator);
+        rows.deinit(allocator);
+    }
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const row_raw = try captureValue(scanner, raw);
+            switch (try singleToken(row_raw)) {
+                .array_begin => {
+                    var row = try parseRow(allocator, row_raw, columns, options);
+                    errdefer row.deinit(allocator);
+                    try rows.append(allocator, row);
+                },
+                .object_begin => {
+                    const in_band = try rowEmbeddedOneApiFailure(
+                        allocator,
+                        operation,
+                        row_raw,
+                    );
+                    rememberFailure(failure, in_band);
+                },
+                else => return error.MalformedKustoResponse,
+            }
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    try ensureScannerComplete(scanner, raw);
+    return rows.toOwnedSlice(allocator);
+}
+
+fn rowEmbeddedOneApiFailure(
+    allocator: std.mem.Allocator,
+    operation: kusto_common.KustoOperation,
+    raw: []const u8,
+) !kusto_common.KustoError {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const fields = try parseObjectFields(arena.allocator(), raw);
+    if (fields.len != 1) return error.MalformedKustoResponse;
+    const errors_raw = requiredField(fields, "OneApiErrors") orelse return error.MalformedKustoResponse;
+    const errors = serde.json.fromSlice(
+        []kusto_common.errors.OneApiEnvelope,
+        arena.allocator(),
+        errors_raw,
+    ) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return error.MalformedKustoResponse;
+    };
+    if (errors.len == 0 or errors[0].@"error" == null)
+        return error.MalformedKustoResponse;
+    return kusto_common.errors.fromOneApiEnvelope(
+        allocator,
+        operation,
+        .data_table,
+        errors[0],
+        false,
+    );
+}
+
+fn parseRow(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    columns: []const KustoResultColumn,
+    options: DecodeOptions,
+) !KustoResultRow {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .array_begin)
+        return error.MalformedKustoResponse;
+
+    var values = std.ArrayList(KustoValue).empty;
+    errdefer {
+        for (values.items) |*value| value.deinit(allocator);
+        values.deinit(allocator);
+    }
+    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            const cell_raw = try captureValue(scanner, raw);
+            const column = if (values.items.len < columns.len)
+                &columns[values.items.len]
+            else
+                null;
+            const scalar_kind = if (column) |item| item.scalar_kind else .unknown;
+            const allow_untyped_fallback = if (column) |item| !item.has_declared_type else false;
+            var value = try decodeValue(allocator, scalar_kind, cell_raw, allow_untyped_fallback);
+            errdefer value.deinit(allocator);
+            try values.append(allocator, value);
+            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    try ensureScannerComplete(scanner, raw);
+    if (!options.allow_varying_row_widths and values.items.len != columns.len)
+        return error.MalformedKustoResponse;
+    return .{
+        .values = try values.toOwnedSlice(allocator),
+        .columns = columns,
+    };
+}
+
+fn decodeValue(
+    allocator: std.mem.Allocator,
+    scalar_kind: KustoScalarKind,
+    raw: []const u8,
+    allow_untyped_fallback: bool,
+) !KustoValue {
+    const token = try singleToken(raw);
+    if (token == .null_lit) return .null;
+    return switch (scalar_kind) {
+        .string => switch (token) {
+            .string => .{ .string = try decodeStringOwned(allocator, raw) },
+            else => if (allow_untyped_fallback)
+                .{ .unknown = try allocator.dupe(u8, raw) }
+            else
+                error.MalformedKustoResponse,
+        },
+        .bool => .{ .bool = try decodeKustoBool(raw) },
+        .int => .{ .int = try decodeInteger(i32, raw) },
+        .long => .{ .long = try decodeInteger(i64, raw) },
+        .real => switch (token) {
+            .number => {
+                const value = std.fmt.parseFloat(f64, raw) catch return .{
+                    .real_raw = try allocator.dupe(u8, raw),
+                };
+                if (std.math.isFinite(value)) return .{ .real = value };
+                return .{ .real_raw = try allocator.dupe(u8, raw) };
+            },
+            .string => .{ .real_raw = try allocator.dupe(u8, raw) },
+            else => error.MalformedKustoResponse,
+        },
+        .decimal => switch (token) {
+            .string => .{ .decimal = try decodeStringOwned(allocator, raw) },
+            .number => .{ .decimal = try allocator.dupe(u8, raw) },
+            else => error.MalformedKustoResponse,
+        },
+        .datetime => .{ .datetime = try decodeStringOwned(allocator, raw) },
+        .timespan => .{ .timespan = try decodeStringOwned(allocator, raw) },
+        .guid => .{ .guid = try decodeStringOwned(allocator, raw) },
+        .dynamic => .{ .dynamic = try allocator.dupe(u8, raw) },
+        .unknown => .{ .unknown = try allocator.dupe(u8, raw) },
+    };
+}
+
+fn appendOwnedRows(
+    allocator: std.mem.Allocator,
+    destination: *std.ArrayList(KustoResultRow),
+    rows: []KustoResultRow,
+) !void {
+    errdefer {
+        deinitRows(rows, allocator);
+        allocator.free(rows);
+    }
+    try destination.appendSlice(allocator, rows);
+    allocator.free(rows);
+}
+
+fn finishBuilders(
+    allocator: std.mem.Allocator,
+    builders: *std.ArrayList(TableBuilder),
+) ![]KustoResultTable {
+    var tables = std.ArrayList(KustoResultTable).empty;
+    errdefer {
+        for (tables.items) |*table| table.deinit(allocator);
+        tables.deinit(allocator);
+    }
+    for (builders.items) |*builder| {
+        var table = try builder.take(allocator);
+        tables.append(allocator, table) catch |err| {
+            table.deinit(allocator);
+            return err;
+        };
+    }
+    builders.deinit(allocator);
+    builders.* = .empty;
+    return tables.toOwnedSlice(allocator);
+}
+
+fn deinitBuilders(builders: *std.ArrayList(TableBuilder), allocator: std.mem.Allocator) void {
+    for (builders.items) |*builder| builder.deinit(allocator);
+    builders.deinit(allocator);
+    builders.* = .empty;
+}
+
+fn deinitFrames(frames: *std.ArrayList(KustoFrame), allocator: std.mem.Allocator) void {
+    for (frames.items) |*frame| frame.deinit(allocator);
+    frames.deinit(allocator);
+    frames.* = .empty;
+}
+
+fn deinitRows(rows: []KustoResultRow, allocator: std.mem.Allocator) void {
+    for (rows) |*row| row.deinit(allocator);
+}
+
+fn deinitTableMetadata(table: *KustoResultTable, allocator: std.mem.Allocator) void {
+    for (table.columns) |*column| column.deinit(allocator);
+    allocator.free(table.columns);
+    allocator.free(table.name);
+    if (table.kind) |value| allocator.free(value);
+    if (table.toc_name) |value| allocator.free(value);
+    if (table.toc_id) |value| allocator.free(value);
+    if (table.pretty_name) |value| allocator.free(value);
+}
+
+fn parseObjectFields(allocator: std.mem.Allocator, raw: []const u8) ![]Field {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    if ((scanner.next() catch return error.MalformedKustoResponse) != .object_begin)
+        return error.MalformedKustoResponse;
+
+    var fields = std.ArrayList(Field).empty;
+    if (scanner.isContainerEmpty('}') catch return error.MalformedKustoResponse) {
+        _ = scanner.next() catch return error.MalformedKustoResponse;
+    } else {
+        while (true) {
+            scanner.skipWhitespace();
+            const key_start = scanner.pos;
+            const key_token = scanner.next() catch return error.MalformedKustoResponse;
+            if (key_token != .string) return error.MalformedKustoResponse;
+            const key_raw = raw[key_start..scanner.pos];
+            const key = try decodeStringTemp(allocator, key_raw);
+            for (fields.items) |existing| {
+                if (std.mem.eql(u8, existing.name, key))
+                    return error.MalformedKustoResponse;
+            }
+            scanner.expectColon() catch return error.MalformedKustoResponse;
+            const value = try captureValue(scanner, raw);
+            try fields.append(allocator, .{ .name = key, .value = value });
+            switch (scanner.finishContainer('}') catch return error.MalformedKustoResponse) {
+                .end => break,
+                .more => {},
+            }
+        }
+    }
+    try ensureScannerComplete(scanner, raw);
+    return fields.toOwnedSlice(allocator);
+}
+
+fn field(fields: []const Field, name: []const u8) ?[]const u8 {
+    for (fields) |entry| {
+        if (std.mem.eql(u8, entry.name, name)) return entry.value;
+    }
+    return null;
+}
+
+fn requiredField(fields: []const Field, name: []const u8) ?[]const u8 {
+    return field(fields, name);
+}
+
+fn captureValue(scanner: anytype, input: []const u8) ![]const u8 {
+    scanner.skipWhitespace();
+    const start = scanner.pos;
+    scanner.skipValue() catch return error.MalformedKustoResponse;
+    return input[start..scanner.pos];
+}
+
+fn ensureScannerComplete(scanner: anytype, input: []const u8) !void {
+    scanner.skipWhitespace();
+    if (scanner.pos != input.len) return error.MalformedKustoResponse;
+}
+
+fn singleToken(raw: []const u8) !JsonTokenKind {
+    var deserializer = serde.json.Deserializer.init(raw);
+    const scanner = &deserializer.scanner;
+    const token = scanner.next() catch return error.MalformedKustoResponse;
+    return switch (token) {
+        .object_begin => .object_begin,
+        .object_end => .object_end,
+        .array_begin => .array_begin,
+        .array_end => .array_end,
+        .string => .string,
+        .number => .number,
+        .true_lit => .true_lit,
+        .false_lit => .false_lit,
+        .null_lit => .null_lit,
+    };
+}
+
+fn decodeStringOwned(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
+    const value = serde.json.fromSlice([]const u8, allocator, raw) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return error.MalformedKustoResponse;
+    };
+    return @constCast(value);
+}
+
+fn decodeStringTemp(allocator: std.mem.Allocator, raw: []const u8) ![]const u8 {
+    return serde.json.fromSlice([]const u8, allocator, raw) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return error.MalformedKustoResponse;
+    };
+}
+
+fn decodeBool(raw: []const u8) !bool {
+    return switch (try singleToken(raw)) {
+        .true_lit => true,
+        .false_lit => false,
+        else => error.MalformedKustoResponse,
+    };
+}
+
+fn decodeKustoBool(raw: []const u8) !bool {
+    return switch (try singleToken(raw)) {
+        .true_lit => true,
+        .false_lit => false,
+        .number => switch (try decodeInteger(i64, raw)) {
+            0 => false,
+            1 => true,
+            else => error.MalformedKustoResponse,
+        },
+        else => error.MalformedKustoResponse,
+    };
+}
+
+fn decodeInteger(comptime T: type, raw: []const u8) !T {
+    switch (try singleToken(raw)) {
+        .number => {},
+        else => return error.MalformedKustoResponse,
+    }
+    return std.fmt.parseInt(T, raw, 10) catch error.MalformedKustoResponse;
+}
+
+fn decodeFiniteNumber(raw: []const u8) !f64 {
+    switch (try singleToken(raw)) {
+        .number => {},
+        else => return error.MalformedKustoResponse,
+    }
+    const value = std.fmt.parseFloat(f64, raw) catch return error.MalformedKustoResponse;
+    if (!std.math.isFinite(value)) return error.MalformedKustoResponse;
+    return value;
+}
+
+fn decodeNonNegativeI64(raw: []const u8) !i64 {
+    const value = try decodeInteger(i64, raw);
+    if (value < 0) return error.MalformedKustoResponse;
+    return value;
+}
+
+fn parseRequiredId(fields: []const Field, name: []const u8) !i64 {
+    const raw = requiredField(fields, name) orelse return error.MalformedKustoResponse;
+    return decodeInteger(i64, raw);
+}
+
+fn replaceOptionalString(
+    allocator: std.mem.Allocator,
+    destination: *?[]u8,
+    source: []const u8,
+) !void {
+    const owned = try allocator.dupe(u8, source);
+    if (destination.*) |old| allocator.free(old);
+    destination.* = owned;
+}
+
+fn valueAsI64(value: KustoValue) ?i64 {
+    return switch (value) {
+        .int => |item| item,
+        .long => |item| item,
+        .string, .decimal => |item| std.fmt.parseInt(i64, item, 10) catch null,
+        .unknown => |item| rawAsI64(item),
+        else => null,
+    };
+}
+
+fn rawAsI64(raw: []const u8) ?i64 {
+    if ((singleToken(raw) catch return null) != .number) return null;
+    return std.fmt.parseInt(i64, raw, 10) catch null;
+}
+
+fn valueTextOwned(allocator: std.mem.Allocator, value: KustoValue) !?[]u8 {
+    if (value.lexical()) |item| return @as(?[]u8, try allocator.dupe(u8, item));
+    return switch (value) {
+        .int => |item| try std.fmt.allocPrint(allocator, "{d}", .{item}),
+        .long => |item| try std.fmt.allocPrint(allocator, "{d}", .{item}),
+        .bool => |item| try allocator.dupe(u8, if (item) "true" else "false"),
+        .unknown => |item| blk: {
+            switch (try singleToken(item)) {
+                .string => break :blk @as(?[]u8, try decodeStringOwned(allocator, item)),
+                .number, .true_lit, .false_lit => break :blk @as(?[]u8, try allocator.dupe(u8, item)),
+                else => break :blk null,
+            }
+        },
+        else => null,
+    };
+}
+
+fn rememberFailure(
+    destination: *?kusto_common.KustoError,
+    incoming: kusto_common.KustoError,
+) void {
+    if (destination.*) |_| {
+        var discarded = incoming;
+        discarded.deinit();
+    } else {
+        destination.* = incoming;
+    }
+}
+
+fn queryStatusFailure(
+    allocator: std.mem.Allocator,
+    dataset: *const KustoResponseDataSet,
+    operation: kusto_common.KustoOperation,
+) !?kusto_common.KustoError {
+    return switch (dataset.protocol) {
+        .v1 => queryStatusFailureV1(allocator, dataset, operation),
+        .v2 => queryCompletionInformationFailure(allocator, dataset, operation),
+    };
+}
+
+fn queryStatusFailureV1(
+    allocator: std.mem.Allocator,
+    dataset: *const KustoResponseDataSet,
+    operation: kusto_common.KustoOperation,
+) !?kusto_common.KustoError {
+    for (dataset.tables) |*table| {
+        if (table.known_kind != .query_status and
+            !std.ascii.eqlIgnoreCase(table.name, "QueryStatus"))
+            continue;
+        for (table.rows) |*row| {
+            const severity_value = row.getByName("Severity") orelse continue;
+            const severity = valueAsI64(severity_value.*) orelse continue;
+            if (severity > 2) continue;
+
+            var result = kusto_common.errors.inBandFailure(
+                allocator,
+                operation,
+                .query_status,
+                false,
+            );
+            errdefer result.deinit();
+            if (row.getByName("StatusCode")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.detail.code = text;
+            }
+            if (row.getByName("StatusDescription")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.detail.message = text;
+            }
+            if (row.getByName("ClientActivityId") orelse row.getByName("RequestId")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.client_request_id = text;
+            }
+            if (row.getByName("ActivityId")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.activity_id = text;
+            }
+            return result;
+        }
+    }
+    return null;
+}
+
+fn queryCompletionInformationFailure(
+    allocator: std.mem.Allocator,
+    dataset: *const KustoResponseDataSet,
+    operation: kusto_common.KustoOperation,
+) !?kusto_common.KustoError {
+    for (dataset.tables) |*table| {
+        if (table.known_kind != .query_completion_information)
+            continue;
+        for (table.rows) |*row| {
+            const level_value = row.getByName("Level") orelse continue;
+            const level = valueAsI64(level_value.*) orelse continue;
+            if (level > 2) continue;
+
+            var result = kusto_common.errors.inBandFailure(
+                allocator,
+                operation,
+                .query_status,
+                false,
+            );
+            errdefer result.deinit();
+            if (row.getByName("StatusCodeName")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.detail.code = text;
+            }
+            if (result.detail.code == null) {
+                if (row.getByName("StatusCode")) |value| {
+                    if (try valueTextOwned(allocator, value.*)) |text|
+                        result.detail.code = text;
+                }
+            }
+            if (row.getByName("Payload")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.detail.message = text;
+            }
+            if (row.getByName("ClientRequestId")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.client_request_id = text;
+            }
+            if (row.getByName("ActivityId")) |value| {
+                if (try valueTextOwned(allocator, value.*)) |text|
+                    result.activity_id = text;
+            }
+            return result;
+        }
+    }
+    return null;
+}
+
+fn normalizeScalarKind(column_type: []const u8) KustoScalarKind {
+    if (std.ascii.eqlIgnoreCase(column_type, "string") or
+        std.ascii.eqlIgnoreCase(column_type, "System.String"))
+        return .string;
+    if (std.ascii.eqlIgnoreCase(column_type, "bool") or
+        std.ascii.eqlIgnoreCase(column_type, "boolean") or
+        std.ascii.eqlIgnoreCase(column_type, "sbyte") or
+        std.ascii.eqlIgnoreCase(column_type, "System.SByte") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Boolean"))
+        return .bool;
+    if (std.ascii.eqlIgnoreCase(column_type, "int") or
+        std.ascii.eqlIgnoreCase(column_type, "int32") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Int32"))
+        return .int;
+    if (std.ascii.eqlIgnoreCase(column_type, "long") or
+        std.ascii.eqlIgnoreCase(column_type, "int64") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Int64"))
+        return .long;
+    if (std.ascii.eqlIgnoreCase(column_type, "real") or
+        std.ascii.eqlIgnoreCase(column_type, "float") or
+        std.ascii.eqlIgnoreCase(column_type, "double") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Single") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Double"))
+        return .real;
+    if (std.ascii.eqlIgnoreCase(column_type, "decimal") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Decimal"))
+        return .decimal;
+    if (std.ascii.eqlIgnoreCase(column_type, "datetime") or
+        std.ascii.eqlIgnoreCase(column_type, "date") or
+        std.ascii.eqlIgnoreCase(column_type, "System.DateTime"))
+        return .datetime;
+    if (std.ascii.eqlIgnoreCase(column_type, "timespan") or
+        std.ascii.eqlIgnoreCase(column_type, "time") or
+        std.ascii.eqlIgnoreCase(column_type, "System.TimeSpan"))
+        return .timespan;
+    if (std.ascii.eqlIgnoreCase(column_type, "guid") or
+        std.ascii.eqlIgnoreCase(column_type, "uuid") or
+        std.ascii.eqlIgnoreCase(column_type, "uniqueid") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Guid"))
+        return .guid;
+    if (std.ascii.eqlIgnoreCase(column_type, "dynamic") or
+        std.ascii.eqlIgnoreCase(column_type, "object") or
+        std.ascii.eqlIgnoreCase(column_type, "System.Object"))
+        return .dynamic;
+    return .unknown;
+}
+
+fn normalizeTableKind(kind: []const u8) KustoTableKind {
+    if (std.ascii.eqlIgnoreCase(kind, "PrimaryResult")) return .primary_result;
+    if (std.ascii.eqlIgnoreCase(kind, "QueryResult")) return .query_result;
+    if (std.ascii.eqlIgnoreCase(kind, "QueryProperties")) return .query_properties;
+    if (std.ascii.eqlIgnoreCase(kind, "QueryStatus")) return .query_status;
+    if (std.ascii.eqlIgnoreCase(kind, "QueryCompletionInformation")) return .query_completion_information;
+    if (std.ascii.eqlIgnoreCase(kind, "QueryTraceLog")) return .query_trace_log;
+    if (std.ascii.eqlIgnoreCase(kind, "QueryPerfLog")) return .query_perf_log;
+    if (std.ascii.eqlIgnoreCase(kind, "QueryPlan")) return .query_plan;
+    if (std.ascii.eqlIgnoreCase(kind, "TableOfContents")) return .table_of_contents;
+    return .unknown;
+}
+
+fn tableKindName(kind: KustoTableKind) []const u8 {
+    return switch (kind) {
+        .primary_result => "PrimaryResult",
+        .query_result => "QueryResult",
+        .query_properties => "QueryProperties",
+        .query_status => "QueryStatus",
+        .query_completion_information => "QueryCompletionInformation",
+        .query_trace_log => "QueryTraceLog",
+        .query_perf_log => "QueryPerfLog",
+        .query_plan => "QueryPlan",
+        .table_of_contents => "TableOfContents",
+        .unknown => "",
+    };
+}
+
+fn expectString(value: *const KustoValue, expected: []const u8) !void {
+    try std.testing.expectEqualStrings(expected, value.asString() orelse return error.TestUnexpectedResult);
+}
+
+test "V1 management response owns typed values" {
+    const body =
+        \\{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"Name","DataType":"string"},{"ColumnName":"Count","ColumnType":"long"},{"ColumnName":"Enabled","ColumnType":"bool"}],"Rows":[["db",9223372036854775807,true]]}]}
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .management);
+    defer decoded.deinit(std.testing.allocator);
+
+    try std.testing.expect(decoded.failure == null);
+    try std.testing.expectEqual(KustoResponseProtocol.v1, decoded.dataset.protocol);
+    try std.testing.expectEqual(@as(usize, 1), decoded.dataset.frames.len);
+    switch (decoded.dataset.frames[0]) {
+        .v1_root => |frame| try std.testing.expectEqualStrings(body, frame.raw_json),
+        else => return error.TestUnexpectedResult,
+    }
+    const table = decoded.dataset.primaryTable().?;
+    try std.testing.expectEqualStrings("Table_0", table.name);
+    try expectString(table.rows[0].get(0).?, "db");
+    try std.testing.expectEqual(@as(?i64, std.math.maxInt(i64)), table.rows[0].get(1).?.asI64());
+    try std.testing.expectEqual(@as(?bool, true), table.rows[0].get(2).?.asBool());
+}
+
+test "V1 DataType aliases decode typed values without ColumnType" {
+    const body =
+        \\{"Tables":[{"TableName":"Aliases","Columns":[
+        \\ {"ColumnName":"Long","DataType":"Int64"},{"ColumnName":"Dynamic","DataType":"Object"},{"ColumnName":"Date","DataType":"Date"},{"ColumnName":"Guid","DataType":"UUID"},{"ColumnName":"Time","DataType":"Time"},{"ColumnName":"Byte","DataType":"SByte"}
+        \\],"Rows":[[42,{"nested":"escaped \"value\""},"2026-01-02","123e4567-e89b-12d3-a456-426614174000","00:00:01",true]]}]}
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .management);
+    defer decoded.deinit(std.testing.allocator);
+
+    const values = decoded.dataset.tables[0].rows[0].values;
+    try std.testing.expectEqual(@as(?i64, 42), values[0].asI64());
+    try std.testing.expectEqualStrings(
+        "{\"nested\":\"escaped \\\"value\\\"\"}",
+        values[1].rawJson().?,
+    );
+    try std.testing.expectEqualStrings("2026-01-02", values[2].asDateTime().?);
+    try std.testing.expectEqualStrings(
+        "123e4567-e89b-12d3-a456-426614174000",
+        values[3].asGuid().?,
+    );
+    try std.testing.expectEqualStrings("00:00:01", values[4].asTimespan().?);
+    try std.testing.expectEqual(@as(?bool, true), values[5].asBool());
+}
+
+test "V1 DataType-only string columns preserve structured values" {
+    const body =
+        \\{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"StatusDescription","DataType":"String"}],"Rows":[[{"ExecutionTime":0,"resource_usage":{"cpu":null}}]]}]}
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(KustoTableKind.primary_result, decoded.dataset.tables[0].known_kind);
+    try std.testing.expectEqualStrings(
+        "{\"ExecutionTime\":0,\"resource_usage\":{\"cpu\":null}}",
+        decoded.dataset.tables[0].rows[0].get(0).?.rawJson().?,
+    );
+}
+
+test "Kusto booleans accept numeric zero and one only" {
+    const body =
+        \\{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"False","ColumnType":"bool"},{"ColumnName":"True","ColumnType":"boolean"}],"Rows":[[0,1]]}]}
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+    const values = decoded.dataset.tables[0].rows[0].values;
+    try std.testing.expectEqual(@as(?bool, false), values[0].asBool());
+    try std.testing.expectEqual(@as(?bool, true), values[1].asBool());
+
+    const invalid =
+        \\{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"Value","ColumnType":"bool"}],"Rows":[[2]]}]}
+    ;
+    try std.testing.expectError(
+        error.MalformedKustoResponse,
+        decode(std.testing.allocator, invalid, .{}, .query),
+    );
+}
+
+test "short V1 datasets classify primary and query properties tables" {
+    const body =
+        \\{"Tables":[
+        \\ {"TableName":"Table_0","Columns":[{"ColumnName":"Value","DataType":"Int64"}],"Rows":[[42]]},
+        \\ {"TableName":"Table_1","Columns":[{"ColumnName":"Key","DataType":"String"}],"Rows":[["Visualization"]]}
+        \\]}
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(KustoTableKind.primary_result, decoded.dataset.tables[0].known_kind);
+    try std.testing.expectEqual(KustoTableKind.query_properties, decoded.dataset.tables[1].known_kind);
+    try std.testing.expectEqual(@as(?i64, 0), decoded.dataset.tables[0].id);
+    try std.testing.expectEqual(@as(?i64, 1), decoded.dataset.tables[1].id);
+    try std.testing.expect(decoded.dataset.primaryTable() == &decoded.dataset.tables[0]);
+    try std.testing.expect(decoded.dataset.queryProperties() == &decoded.dataset.tables[1]);
+}
+
+test "V1 final generic TOC selects multiple query result tables" {
+    const body =
+        \\{"Tables":[
+        \\ {"TableName":"Table_0","Columns":[{"ColumnName":"a","DataType":"Int32","ColumnType":"int"}],"Rows":[[1],[2],[3]]},
+        \\ {"TableName":"Table_1","Columns":[{"ColumnName":"a","DataType":"String","ColumnType":"string"},{"ColumnName":"b","DataType":"Int32","ColumnType":"int"}],"Rows":[["a",1],["b",2],["c",3]]},
+        \\ {"TableName":"Table_2","Columns":[{"ColumnName":"Value","DataType":"String","ColumnType":"string"}],"Rows":[["{\"Visualization\":null}"],["{\"Visualization\":null}"]]},
+        \\ {"TableName":"Table_3","Columns":[{"ColumnName":"Severity","DataType":"Int32","ColumnType":"int"},{"ColumnName":"StatusCode","DataType":"Int32","ColumnType":"int"},{"ColumnName":"StatusDescription","DataType":"String","ColumnType":"string"},{"ColumnName":"ClientActivityId","DataType":"String","ColumnType":"string"}],"Rows":[[4,0,"Query completed successfully","blab6"],[6,0,"statistics","blab6"]]},
+        \\ {"TableName":"Table_4","Columns":[
+        \\   {"ColumnName":"Ordinal","DataType":"Int64","ColumnType":"long"},{"ColumnName":"Kind","DataType":"String","ColumnType":"string"},{"ColumnName":"Name","DataType":"String","ColumnType":"string"},{"ColumnName":"Id","DataType":"String","ColumnType":"string"},{"ColumnName":"PrettyName","DataType":"String","ColumnType":"string"}
+        \\ ],"Rows":[[0,"QueryResult","PrimaryResult","e43f725a-26fd-4219-8869-30c21e1b139c",""],[1,"QueryResult","PrimaryResult","0f66e92a-8d0e-43da-8a66-ddb6bf84c49d",""],[2,"QueryProperties","@ExtendedProperties","d52bc55b-fc74-4a63-adb9-b72ff939e4c2",""],[3,"QueryStatus","QueryStatus","00000000-0000-0000-0000-000000000000",""]]}
+        \\]}
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    try std.testing.expect(decoded.failure == null);
+    try std.testing.expectEqual(KustoTableKind.query_result, decoded.dataset.tables[0].known_kind);
+    try std.testing.expectEqual(KustoTableKind.query_result, decoded.dataset.tables[1].known_kind);
+    try std.testing.expectEqual(KustoTableKind.table_of_contents, decoded.dataset.tables[4].known_kind);
+    try std.testing.expectEqualStrings("PrimaryResult", decoded.dataset.tables[0].toc_name.?);
+    try std.testing.expect(decoded.dataset.queryProperties() != null);
+    try std.testing.expect(decoded.dataset.queryStatus() != null);
+    try std.testing.expectEqual(@as(?i64, 1), decoded.dataset.primaryTable().?.rows[0].get(0).?.asI64());
+}
+
+test "V2 normal tables expose tagged frames and iterators" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false,"IsFragmented":false,"ErrorReportingPlacement":"EndOfDataSet"},
+        \\ {"FrameType":"DataTable","TableId":7,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"A","ColumnType":"string"}],"Rows":[["one"],["two"]]},
+        \\ {"FrameType":"DataTable","TableId":8,"TableKind":"QueryProperties","TableName":"QueryProperties","Columns":[],"Rows":[]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    const dataset = &decoded.dataset;
+    try std.testing.expectEqual(KustoResponseProtocol.v2, dataset.protocol);
+    try std.testing.expectEqual(@as(usize, 4), dataset.frames.len);
+    try std.testing.expectEqualStrings("DataTable", dataset.frames[1].frameType());
+    switch (dataset.frames[1]) {
+        .data_table => {},
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(std.mem.indexOf(u8, dataset.frames[1].rawJson(), "\"DataTable\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, dataset.raw_response, "\"PrimaryResult\"") != null);
+    try std.testing.expect(dataset.tableById(7) != null);
+    try std.testing.expect(dataset.tableByKind("QueryProperties") != null);
+    try std.testing.expect(dataset.queryProperties() != null);
+    var tables = dataset.tableIterator();
+    try std.testing.expect(tables.next() != null);
+    const primary = dataset.primaryTable().?;
+    var rows = primary.rowIterator();
+    try expectString(rows.next().?.getByName("A").?, "one");
+    try expectString(rows.next().?.get(0).?, "two");
+    try std.testing.expect(rows.next() == null);
+    var frames = dataset.frameIterator();
+    try std.testing.expect(frames.next() != null);
+    try std.testing.expectEqualStrings("DataTable", frames.next().?.frameType());
+}
+
+test "V2 normal and progressive tables decode equivalently" {
+    const normal =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":4,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"V","ColumnType":"long"}],"Rows":[[1],[2]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    const progressive =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":4,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"V","ColumnType":"long"}]},
+        \\ {"FrameType":"TableFragment","TableId":4,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[[1],[2]]},
+        \\ {"FrameType":"TableCompletion","TableId":4,"RowCount":2},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var normal_decoded = try decode(std.testing.allocator, normal, .{}, .query);
+    defer normal_decoded.deinit(std.testing.allocator);
+    var progressive_decoded = try decode(std.testing.allocator, progressive, .{}, .query);
+    defer progressive_decoded.deinit(std.testing.allocator);
+    const normal_rows = normal_decoded.dataset.primaryTable().?.rows;
+    const progressive_rows = progressive_decoded.dataset.primaryTable().?.rows;
+    try std.testing.expectEqual(normal_rows.len, progressive_rows.len);
+    for (normal_rows, progressive_rows) |left, right|
+        try std.testing.expectEqual(left.get(0).?.asI64(), right.get(0).?.asI64());
+}
+
+test "progressive datasets accept normal metadata DataTable frames" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"DataTable","TableId":10,"TableKind":"QueryProperties","TableName":"QueryProperties","Columns":[{"ColumnName":"Name","ColumnType":"String"}],"Rows":[["metadata"]]},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"V","ColumnType":"long"}]},
+        \\ {"FrameType":"TableFragment","TableId":1,"TableFragmentType":"DataAppend","Rows":[[42]]},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":1},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), decoded.dataset.tables.len);
+    try std.testing.expectEqualStrings(
+        "metadata",
+        decoded.dataset.queryProperties().?.rows[0].get(0).?.asString().?,
+    );
+    try std.testing.expectEqual(
+        @as(?i64, 42),
+        decoded.dataset.primaryTable().?.rows[0].get(0).?.asI64(),
+    );
+}
+
+test "fragmented datasets accept mixed normal and table frames" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false,"IsFragmented":true,"ErrorReportingPlacement":"EndOfTable"},
+        \\ {"FrameType":"DataTable","TableId":10,"TableKind":"QueryProperties","TableName":"QueryProperties","Columns":[{"ColumnName":"Name","ColumnType":"string"}],"Rows":[["metadata"]]},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"V","ColumnType":"long"}]},
+        \\ {"FrameType":"TableFragment","TableId":1,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[[42]]},
+        \\ {"FrameType":"TableProgress","TableId":1,"TableProgress":100},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":1},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    const dataset = &decoded.dataset;
+    try std.testing.expectEqual(@as(?bool, true), dataset.is_fragmented);
+    try std.testing.expectEqualStrings("EndOfTable", dataset.error_reporting_placement.?);
+    try expectString(dataset.queryProperties().?.rows[0].get(0).?, "metadata");
+    const primary = dataset.primaryTable().?;
+    try std.testing.expectEqual(@as(?f64, 100), primary.progress);
+    try std.testing.expectEqual(@as(?i64, 1), primary.reported_row_count);
+    try std.testing.expectEqual(@as(?i64, 42), primary.rows[0].get(0).?.asI64());
+}
+
+test "V2 progressive append replace and interleaved IDs reconstruct rows" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"First","Columns":[{"ColumnName":"V","ColumnType":"string"}]},
+        \\ {"FrameType":"TableHeader","TableId":2,"TableKind":"SecondaryResult","TableName":"Second","Columns":[{"ColumnName":"V","ColumnType":"string"}]},
+        \\ {"FrameType":"TableFragment","TableId":1,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[["A"]]},
+        \\ {"FrameType":"TableFragment","TableId":2,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[["B"]]},
+        \\ {"FrameType":"TableProgress","TableId":1,"TableProgress":50},
+        \\ {"FrameType":"TableFragment","TableId":1,"FieldCount":1,"TableFragmentType":"DataReplace","Rows":[["C"]]},
+        \\ {"FrameType":"TableFragment","TableId":1,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[["D"]]},
+        \\ {"FrameType":"TableCompletion","TableId":2,"RowCount":1},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":2},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    const first = decoded.dataset.tableById(1).?;
+    const second = decoded.dataset.tableById(2).?;
+    try std.testing.expectEqual(@as(?f64, 50), first.progress);
+    try std.testing.expectEqual(@as(usize, 2), first.rows.len);
+    try expectString(first.rows[0].get(0).?, "C");
+    try expectString(first.rows[1].get(0).?, "D");
+    try expectString(second.rows[0].get(0).?, "B");
+    const tags = [_]std.meta.Tag(KustoFrame){
+        .data_set_header,
+        .table_header,
+        .table_header,
+        .table_fragment,
+        .table_fragment,
+        .table_progress,
+        .table_fragment,
+        .table_fragment,
+        .table_completion,
+        .table_completion,
+        .data_set_completion,
+    };
+    for (decoded.dataset.frames, tags) |frame, tag|
+        try std.testing.expectEqual(tag, std.meta.activeTag(frame));
+}
+
+test "V2 completion errors keep reconstructed tables" {
+    const table_error =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"V","ColumnType":"string"}]},
+        \\ {"FrameType":"TableFragment","TableId":1,"TableFragmentType":"DataAppend","Rows":[["before"]]},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":1,"OneApiErrors":[{"error":{"code":"TableFailure","message":"bad table"}}]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var table_decoded = try decode(std.testing.allocator, table_error, .{}, .query);
+    defer table_decoded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(KustoErrorSource.table_completion, table_decoded.failure.?.source);
+    try expectString(table_decoded.dataset.primaryTable().?.rows[0].get(0).?, "before");
+
+    const dataset_error =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"V","ColumnType":"string"}],"Rows":[["before"]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":true,"Cancelled":false,"OneApiErrors":[{"error":{"code":"DataSetFailure","message":"bad dataset"}}]}
+        \\]
+    ;
+    var dataset_decoded = try decode(std.testing.allocator, dataset_error, .{}, .query);
+    defer dataset_decoded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(KustoErrorSource.dataset_completion, dataset_decoded.failure.?.source);
+    try std.testing.expectEqualStrings("DataSetFailure", dataset_decoded.failure.?.detail.code.?);
+}
+
+test "V2 row-embedded OneApiErrors retain DataTable and fragment rows" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"QueryProperties","TableName":"@ExtendedProperties","Columns":[{"ColumnName":"TableId","ColumnType":"int"},{"ColumnName":"Key","ColumnType":"string"},{"ColumnName":"Value","ColumnType":"dynamic"}],"Rows":[[1,"Visualization","{\"Visualization\":null}"]]},
+        \\ {"FrameType":"DataTable","TableId":1,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"x","ColumnType":"long"}],"Rows":[[1],[2],[3],[4],[5],{"OneApiErrors":[{"error":{"code":"LimitsExceeded","message":"Request is invalid and cannot be executed.","@type":"Kusto.Data.Exceptions.KustoServicePartialQueryFailureLimitsExceededException","@message":"Query execution has exceeded the allowed limits (80DA0003): .","@context":{"clientRequestId":"KPC.execute;d3a43e37-0d7f-47a9-b6cd-a889b2aee3d3","activityId":"a57ec272-8846-49e6-b458-460b841ed47d"},"@permanent":false}}]}]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":true,"Cancelled":false,"OneApiErrors":[{"error":{"code":"LimitsExceeded","message":"Request is invalid and cannot be executed."}}]}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(KustoErrorSource.data_table, decoded.failure.?.source);
+    try std.testing.expectEqualStrings("LimitsExceeded", decoded.failure.?.detail.code.?);
+    try std.testing.expectEqualStrings(
+        "Request is invalid and cannot be executed.",
+        decoded.failure.?.detail.message.?,
+    );
+    try std.testing.expectEqualStrings(
+        "Kusto.Data.Exceptions.KustoServicePartialQueryFailureLimitsExceededException",
+        decoded.failure.?.detail.error_type.?,
+    );
+    try std.testing.expectEqualStrings(
+        "Query execution has exceeded the allowed limits (80DA0003): .",
+        decoded.failure.?.detail.description.?,
+    );
+    try std.testing.expectEqual(@as(?bool, false), decoded.failure.?.permanent);
+    try std.testing.expectEqualStrings(
+        "KPC.execute;d3a43e37-0d7f-47a9-b6cd-a889b2aee3d3",
+        decoded.failure.?.client_request_id.?,
+    );
+    try std.testing.expectEqualStrings(
+        "a57ec272-8846-49e6-b458-460b841ed47d",
+        decoded.failure.?.activity_id.?,
+    );
+    try std.testing.expectEqual(@as(usize, 1), decoded.dataset.queryProperties().?.rows.len);
+    try std.testing.expectEqual(@as(?i64, 5), decoded.dataset.primaryTable().?.rows[4].get(0).?.asI64());
+    try std.testing.expectEqual(@as(usize, 5), decoded.dataset.primaryTable().?.rows.len);
+
+    const fragment_only =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"V","ColumnType":"long"}]},
+        \\ {"FrameType":"TableFragment","TableId":1,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[[42],{"OneApiErrors":[{"error":{"code":"FragmentFailure","message":"partial fragment"}}]}]},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":1},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var fragment_decoded = try decode(std.testing.allocator, fragment_only, .{}, .query);
+    defer fragment_decoded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(KustoErrorSource.data_table, fragment_decoded.failure.?.source);
+    try std.testing.expectEqualStrings("FragmentFailure", fragment_decoded.failure.?.detail.code.?);
+    try std.testing.expectEqual(@as(usize, 1), fragment_decoded.dataset.primaryTable().?.rows.len);
+}
+
+test "V2 row objects must be OneApiErrors" {
+    const malformed = [_][]const u8{
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[],"Rows":[{"unexpected":true}]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[],"Rows":[{"OneApiErrors":[]}]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+    };
+    for (malformed) |body| {
+        try std.testing.expectError(
+            error.MalformedKustoResponse,
+            decode(std.testing.allocator, body, .{}, .query),
+        );
+    }
+}
+
+test "V2 QueryCompletionInformation failures produce a partial failure" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"QueryCompletionInformation","TableName":"QueryCompletionInformation","Columns":[
+        \\   {"ColumnName":"Timestamp","ColumnType":"datetime"},{"ColumnName":"ClientRequestId","ColumnType":"string"},{"ColumnName":"ActivityId","ColumnType":"guid"},{"ColumnName":"SubActivityId","ColumnType":"guid"},{"ColumnName":"ParentActivityId","ColumnType":"guid"},{"ColumnName":"Level","ColumnType":"int"},{"ColumnName":"LevelName","ColumnType":"string"},{"ColumnName":"StatusCode","ColumnType":"int"},{"ColumnName":"StatusCodeName","ColumnType":"string"},{"ColumnName":"EventType","ColumnType":"int"},{"ColumnName":"EventTypeName","ColumnType":"string"},{"ColumnName":"Payload","ColumnType":"string"}
+        \\ ],"Rows":[["2024-01-01T00:00:00Z","row-request","123e4567-e89b-12d3-a456-426614174000","123e4567-e89b-12d3-a456-426614174001","123e4567-e89b-12d3-a456-426614174002",2,"Error",429,"LimitsExceeded",0,"QueryError","truncated"],["2024-01-01T00:00:01Z","stats-request","123e4567-e89b-12d3-a456-426614174003","123e4567-e89b-12d3-a456-426614174004","123e4567-e89b-12d3-a456-426614174005",6,"Stats",200,"Succeeded",0,"QueryResourceConsumption","statistics"]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(KustoErrorSource.query_status, decoded.failure.?.source);
+    try std.testing.expectEqualStrings("LimitsExceeded", decoded.failure.?.detail.code.?);
+    try std.testing.expectEqualStrings("truncated", decoded.failure.?.detail.message.?);
+    try std.testing.expectEqualStrings("row-request", decoded.failure.?.client_request_id.?);
+    try std.testing.expectEqualStrings(
+        "123e4567-e89b-12d3-a456-426614174000",
+        decoded.failure.?.activity_id.?,
+    );
+
+    const normal =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"QueryCompletionInformation","TableName":"QueryCompletionInformation","Columns":[{"ColumnName":"Level","ColumnType":"int"},{"ColumnName":"Payload","ColumnType":"string"}],"Rows":[[4,"warning"],[6,"statistics"]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var normal_decoded = try decode(std.testing.allocator, normal, .{}, .query);
+    defer normal_decoded.deinit(std.testing.allocator);
+    try std.testing.expect(normal_decoded.failure == null);
+}
+
+test "scalar aliases preserve lexical and raw JSON values" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"T","Columns":[
+        \\   {"ColumnName":"S","ColumnType":"string"},{"ColumnName":"B","ColumnType":"boolean"},{"ColumnName":"I","ColumnType":"int32"},{"ColumnName":"L","ColumnType":"int64"},{"ColumnName":"R","ColumnType":"double"},{"ColumnName":"D","ColumnType":"decimal"},{"ColumnName":"Date","ColumnType":"date"},{"ColumnName":"Time","ColumnType":"time"},{"ColumnName":"Id","ColumnType":"uniqueid"},{"ColumnName":"Dyn","ColumnType":"dynamic"},{"ColumnName":"Unknown","ColumnType":"custom"}
+        \\ ],"Rows":[["escaped\n\"value\"",true,-12,9223372036854775807,-12.5e+2,"12.340","2026-01-02","00:00:01","123e4567-e89b-12d3-a456-426614174000",{"a":[1,{"b":null}]},"raw"]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    const values = decoded.dataset.primaryTable().?.rows[0].values;
+    try expectString(&values[0], "escaped\n\"value\"");
+    try std.testing.expectEqual(@as(?bool, true), values[1].asBool());
+    try std.testing.expectEqual(@as(?i32, -12), values[2].asI32());
+    try std.testing.expectEqual(@as(?i64, std.math.maxInt(i64)), values[3].asI64());
+    try std.testing.expectApproxEqAbs(@as(f64, -1250), values[4].asF64().?, 0.001);
+    try std.testing.expectEqualStrings("12.340", values[5].lexical().?);
+    try std.testing.expectEqualStrings("2026-01-02", values[6].lexical().?);
+    try std.testing.expectEqualStrings("00:00:01", values[7].lexical().?);
+    try std.testing.expectEqualStrings("123e4567-e89b-12d3-a456-426614174000", values[8].lexical().?);
+    try std.testing.expectEqualStrings("{\"a\":[1,{\"b\":null}]}", values[9].rawJson().?);
+    try std.testing.expectEqualStrings("\"raw\"", values[10].rawJson().?);
+}
+
+test "real values reject incompatible JSON while preserving special strings" {
+    const special =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"R","ColumnType":"Real"}],"Rows":[["NaN"],[1e999]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, special, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+    const rows = decoded.dataset.primaryTable().?.rows;
+    try std.testing.expectEqualStrings("\"NaN\"", rows[0].get(0).?.rawJson().?);
+    try std.testing.expectEqualStrings("1e999", rows[1].get(0).?.rawJson().?);
+
+    const incompatible = [_][]const u8{
+        "true",
+        "[]",
+        "{}",
+    };
+    for (incompatible) |value| {
+        const body = try std.fmt.allocPrint(
+            std.testing.allocator,
+            \\[
+            \\ {{"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false}},
+            \\ {{"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"T","Columns":[{{"ColumnName":"R","ColumnType":"real"}}],"Rows":[[{s}]]}},
+            \\ {{"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}}
+            \\]
+        ,
+            .{value},
+        );
+        defer std.testing.allocator.free(body);
+        try std.testing.expectError(
+            error.MalformedKustoResponse,
+            decode(std.testing.allocator, body, .{}, .query),
+        );
+    }
+}
+
+test "documented table kinds normalize and retain canonical names" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":1,"TableKind":"QueryTraceLog","TableName":"Trace","Columns":[],"Rows":[]},
+        \\ {"FrameType":"DataTable","TableId":2,"TableKind":"queryperflog","TableName":"Perf","Columns":[],"Rows":[]},
+        \\ {"FrameType":"DataTable","TableId":3,"TableKind":"QueryPlan","TableName":"Plan","Columns":[],"Rows":[]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(KustoTableKind.query_trace_log, decoded.dataset.tables[0].known_kind);
+    try std.testing.expectEqual(KustoTableKind.query_perf_log, decoded.dataset.tables[1].known_kind);
+    try std.testing.expectEqual(KustoTableKind.query_plan, decoded.dataset.tables[2].known_kind);
+    try std.testing.expect(decoded.dataset.tableByKind("QueryTraceLog") != null);
+    try std.testing.expect(decoded.dataset.tableByKind("QueryPerfLog") != null);
+    try std.testing.expect(decoded.dataset.tableByKind("QueryPlan") != null);
+    try std.testing.expectEqualStrings("QueryTraceLog", tableKindName(.query_trace_log));
+    try std.testing.expectEqualStrings("QueryPerfLog", tableKindName(.query_perf_log));
+    try std.testing.expectEqualStrings("QueryPlan", tableKindName(.query_plan));
+}
+
+test "unknown tagged frames and table kinds are retained without state changes" {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"FutureFrame","Nested":{"a":[1,2]}},
+        \\ {"FrameType":"DataTable","TableId":3,"TableKind":"FutureKind","TableName":"T","Columns":[{"ColumnName":"X","ColumnType":"future"}],"Rows":[[{"opaque":true}]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    var decoded = try decode(std.testing.allocator, body, .{}, .query);
+    defer decoded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), decoded.dataset.frames.len);
+    switch (decoded.dataset.frames[1]) {
+        .unknown => |frame| {
+            try std.testing.expectEqualStrings("FutureFrame", frame.frame_type);
+            try std.testing.expectEqualStrings(
+                "{\"FrameType\":\"FutureFrame\",\"Nested\":{\"a\":[1,2]}}",
+                frame.raw_json,
+            );
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(KustoTableKind.unknown, decoded.dataset.tables[0].known_kind);
+    try std.testing.expectEqualStrings("{\"opaque\":true}", decoded.dataset.tables[0].rows[0].get(0).?.rawJson().?);
+}
+
+test "ordering and row-width violations are rejected while varying widths are safe" {
+    const missing_header =
+        \\[{"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}]
+    ;
+    try std.testing.expectError(
+        error.MalformedKustoResponse,
+        decode(std.testing.allocator, missing_header, .{}, .query),
+    );
+    const unknown_fragment_type =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[]},
+        \\ {"FrameType":"TableFragment","TableId":1,"TableFragmentType":"Future","Rows":[]},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":0},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    try std.testing.expectError(
+        error.UnsupportedTableFragmentType,
+        decode(std.testing.allocator, unknown_fragment_type, .{}, .query),
+    );
+    const invalid_dynamic =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"D","ColumnType":"dynamic"}],"Rows":[[{"invalid":"\uZZZZ"}]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    try std.testing.expectError(
+        error.MalformedKustoResponse,
+        decode(std.testing.allocator, invalid_dynamic, .{}, .query),
+    );
+
+    const varying =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"A","ColumnType":"string"},{"ColumnName":"B","ColumnType":"long"}],"Rows":[["one"],["two",2,{"extra":true}]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+    ;
+    try std.testing.expectError(
+        error.MalformedKustoResponse,
+        decode(std.testing.allocator, varying, .{}, .query),
+    );
+    var decoded = try decode(
+        std.testing.allocator,
+        varying,
+        .{ .allow_varying_row_widths = true },
+        .query,
+    );
+    defer decoded.deinit(std.testing.allocator);
+    const rows = decoded.dataset.primaryTable().?.rows;
+    try std.testing.expectEqual(@as(usize, 1), rows[0].values.len);
+    try std.testing.expectEqual(@as(usize, 3), rows[1].values.len);
+    try std.testing.expectEqualStrings("{\"extra\":true}", rows[1].values[2].rawJson().?);
+}
+
+test "V2 frame state rejects invalid IDs ordering and metadata" {
+    const malformed = [_][]const u8{
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"A","Columns":[],"Rows":[]},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"B","Columns":[],"Rows":[]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false,"IsFragmented":false},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableFragment","TableId":9,"TableFragmentType":"DataAppend","Rows":[]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"A","ColumnType":"string"}]},
+        \\ {"FrameType":"TableFragment","TableId":1,"FieldCount":2,"TableFragmentType":"DataAppend","Rows":[]},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":0},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[]},
+        \\ {"FrameType":"TableProgress","TableId":1,"TableProgress":101},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":0},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
+        ,
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false},
+        \\ {"FrameType":"FutureFrame"}
+        \\]
+        ,
+    };
+    for (malformed) |body| {
+        try std.testing.expectError(
+            error.MalformedKustoResponse,
+            decode(std.testing.allocator, body, .{}, .query),
+        );
+    }
+}
+
+fn parseAllocationFixture(allocator: std.mem.Allocator) !void {
+    const body =
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+        \\ {"FrameType":"DataTable","TableId":10,"TableKind":"QueryProperties","TableName":"QueryProperties","Columns":[{"ColumnName":"Name","ColumnType":"string"}],"Rows":[["metadata"],{"OneApiErrors":[{"error":{"code":"DataTableFailure","message":"partial data table"}}]}]},
+        \\ {"FrameType":"TableHeader","TableId":1,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"S","ColumnType":"string"},{"ColumnName":"D","ColumnType":"dynamic"}]},
+        \\ {"FrameType":"TableFragment","TableId":1,"FieldCount":2,"TableFragmentType":"DataAppend","Rows":[["escaped\nvalue",{"nested":[1,2]}],{"OneApiErrors":[{"error":{"code":"FragmentFailure","message":"partial fragment"}}]}]},
+        \\ {"FrameType":"FutureFrame","nested":{"a":[1,2]}},
+        \\ {"FrameType":"TableCompletion","TableId":1,"RowCount":1},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false,"OneApiErrors":[{"error":{"code":"DuplicateFailure","message":"reported later"}}]}
+        \\]
+    ;
+    var decoded = try decode(allocator, body, .{}, .query);
+    defer decoded.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 2), decoded.dataset.tables.len);
+    try std.testing.expectEqual(KustoErrorSource.data_table, decoded.failure.?.source);
+}
+
+test "complex result parsing releases all allocation failures" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parseAllocationFixture,
+        .{},
+    );
+}

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const core = @import("azure_core");
 const serde = @import("serde");
 const kusto_common = @import("azure_kusto_common");
+const result = @import("result.zig");
 
 pub const ConnectionProperties = kusto_common.ConnectionProperties;
 pub const ClientRequestProperties = kusto_common.ClientRequestProperties;
@@ -25,80 +26,23 @@ pub const KustoErrorSource = kusto_common.KustoErrorSource;
 pub const KustoOperationOutcome = kusto_common.KustoOperationOutcome;
 pub const KustoResult = kusto_common.KustoResult;
 
-// ─────────────────── Response Types ──────────────────
-
-pub const KustoResultColumn = struct {
-    name: []const u8,
-    column_type: []const u8,
-
-    pub fn deinit(self: KustoResultColumn, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
-        allocator.free(self.column_type);
-    }
-};
-
-pub const KustoResultRow = struct {
-    values: []const []const u8,
-    columns: []const KustoResultColumn,
-
-    pub fn deinit(self: KustoResultRow, allocator: std.mem.Allocator) void {
-        for (self.values) |value| allocator.free(value);
-        allocator.free(self.values);
-    }
-
-    /// Get a value by column name.
-    pub fn getByName(self: KustoResultRow, name: []const u8) ?[]const u8 {
-        for (self.columns, 0..) |col, i| {
-            if (std.mem.eql(u8, col.name, name)) {
-                return if (i < self.values.len) self.values[i] else null;
-            }
-        }
-        return null;
-    }
-};
-
-pub const KustoResultTable = struct {
-    name: []const u8,
-    kind: ?[]const u8 = null,
-    columns: []const KustoResultColumn,
-    rows: []const KustoResultRow,
-
-    pub fn deinit(self: *KustoResultTable, allocator: std.mem.Allocator) void {
-        for (self.rows) |row| row.deinit(allocator);
-        allocator.free(self.rows);
-        for (self.columns) |column| column.deinit(allocator);
-        allocator.free(self.columns);
-        allocator.free(self.name);
-        if (self.kind) |kind| allocator.free(kind);
-        self.* = .{ .name = "", .columns = &.{}, .rows = &.{} };
-    }
-};
-
-pub const KustoResponseDataSet = struct {
-    tables: []KustoResultTable,
-    client_request_id: ?[]u8 = null,
-    activity_id: ?[]u8 = null,
-
-    pub fn deinit(self: *KustoResponseDataSet, allocator: std.mem.Allocator) void {
-        for (self.tables) |*table| table.deinit(allocator);
-        allocator.free(self.tables);
-        if (self.client_request_id) |value| allocator.free(value);
-        if (self.activity_id) |value| allocator.free(value);
-        self.tables = &.{};
-        self.client_request_id = null;
-        self.activity_id = null;
-    }
-
-    /// Get the primary result table (first table named "PrimaryResult" or index 0).
-    pub fn primaryTable(self: KustoResponseDataSet) ?KustoResultTable {
-        for (self.tables) |t| {
-            if (std.mem.eql(u8, t.name, "PrimaryResult")) return t;
-        }
-        return if (self.tables.len > 0) self.tables[0] else null;
-    }
-};
-
-// ─────────────────── KustoClient ─────────────────────
+pub const DecodeOptions = result.DecodeOptions;
+pub const KustoResponseProtocol = result.KustoResponseProtocol;
+pub const KustoScalarKind = result.KustoScalarKind;
+pub const KustoTableKind = result.KustoTableKind;
+pub const KustoValue = result.KustoValue;
+pub const KustoResultColumn = result.KustoResultColumn;
+pub const KustoResultRow = result.KustoResultRow;
+pub const KustoResultTable = result.KustoResultTable;
+pub const KustoFramePayload = result.KustoFramePayload;
+pub const KustoUnknownFrame = result.KustoUnknownFrame;
+pub const KustoFrame = result.KustoFrame;
+pub const RowIterator = result.RowIterator;
+pub const TableIterator = result.TableIterator;
+pub const FrameIterator = result.FrameIterator;
+pub const KustoResponseDataSet = result.KustoResponseDataSet;
+pub const DecodeOutcome = result.DecodeOutcome;
+pub const decodeResponseDataSet = result.decode;
 
 pub const KustoClientOptions = struct {
     application_name: []const u8 = "azure-sdk-zig",
@@ -140,9 +84,6 @@ pub const KustoClient = struct {
     }
 
     /// Create a client that borrows `connection`; this client has no deinit.
-    ///
-    /// The connection must outlive this client and all copies of it. Serialize
-    /// their use because `KustoConnection.supports_concurrent_use` is false.
     pub fn initWithConnection(connection: *KustoConnection, options: KustoClientOptions) KustoClient {
         return .{
             .runtime = .{ .shared = connection },
@@ -151,45 +92,78 @@ pub const KustoClient = struct {
         };
     }
 
-    /// Execute a KQL query. Uses v2 REST endpoint.
-    pub fn executeQuery(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
+    /// Execute a KQL query. Uses the V2 REST endpoint.
+    pub fn executeQuery(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        database: []const u8,
+        query: []const u8,
+        properties: ?ClientRequestProperties,
+    ) !KustoResponseDataSet {
         const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternal(allocator, url, database, query, properties, .query);
     }
 
-    /// Execute a management command (starts with `.`). Uses v1 REST endpoint.
-    pub fn executeMgmt(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !KustoResponseDataSet {
+    /// Execute a management command (starts with `.`). Uses the V1 REST endpoint.
+    pub fn executeMgmt(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        database: []const u8,
+        command: []const u8,
+        properties: ?ClientRequestProperties,
+    ) !KustoResponseDataSet {
         const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternal(allocator, url, database, command, properties, .management);
     }
 
-    /// Auto-routing: commands starting with `.` go to mgmt, others to query.
-    pub fn execute(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query_or_command: []const u8) !KustoResponseDataSet {
+    /// Auto-routing: commands starting with `.` go to management, others to query.
+    pub fn execute(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        database: []const u8,
+        query_or_command: []const u8,
+    ) !KustoResponseDataSet {
         const trimmed = std.mem.trimStart(u8, query_or_command, " \t\n\r");
-        if (trimmed.len > 0 and trimmed[0] == '.') {
+        if (trimmed.len > 0 and trimmed[0] == '.')
             return self.executeMgmt(allocator, database, query_or_command, null);
-        }
         return self.executeQuery(allocator, database, query_or_command, null);
     }
 
-    /// `Result(...)` variants of the execute methods.
-    pub fn executeQueryResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query: []const u8, properties: ?ClientRequestProperties) !KustoResult(KustoResponseDataSet) {
+    pub fn executeQueryResult(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        database: []const u8,
+        query: []const u8,
+        properties: ?ClientRequestProperties,
+    ) !KustoResult(KustoResponseDataSet) {
         const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternalResult(allocator, url, database, query, properties, .query);
     }
-    pub fn executeMgmtResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, command: []const u8, properties: ?ClientRequestProperties) !KustoResult(KustoResponseDataSet) {
+
+    pub fn executeMgmtResult(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        database: []const u8,
+        command: []const u8,
+        properties: ?ClientRequestProperties,
+    ) !KustoResult(KustoResponseDataSet) {
         const url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/mgmt", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternalResult(allocator, url, database, command, properties, .management);
     }
-    pub fn executeResult(self: *KustoClient, allocator: std.mem.Allocator, database: []const u8, query_or_command: []const u8) !KustoResult(KustoResponseDataSet) {
+
+    pub fn executeResult(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        database: []const u8,
+        query_or_command: []const u8,
+    ) !KustoResult(KustoResponseDataSet) {
         const trimmed = std.mem.trimStart(u8, query_or_command, " \t\n\r");
-        if (trimmed.len > 0 and trimmed[0] == '.') {
+        if (trimmed.len > 0 and trimmed[0] == '.')
             return self.executeMgmtResult(allocator, database, query_or_command, null);
-        }
         return self.executeQueryResult(allocator, database, query_or_command, null);
     }
 
@@ -202,8 +176,8 @@ pub const KustoClient = struct {
         properties: ?ClientRequestProperties,
         kind: KustoRequestKind,
     ) !KustoResponseDataSet {
-        var r = try self.executeInternalResult(allocator, url, database, csl, properties, kind);
-        return switch (r) {
+        var response_result = try self.executeInternalResult(allocator, url, database, csl, properties, kind);
+        return switch (response_result) {
             .ok => |value| value,
             .partial => |*partial| {
                 std.log.warn("{f}", .{partial.failure});
@@ -233,86 +207,65 @@ pub const KustoClient = struct {
         const body = try serializeRequest(allocator, database, csl, props, kind);
         defer allocator.free(body);
 
-        var req = core.http.Request.init(allocator, .POST, url);
-        defer req.deinit();
-        try req.setHeader("Content-Type", "application/json; charset=utf-8");
-        try req.setHeader("Accept", "application/json");
-        try req.setHeader("Accept-Encoding", "gzip, deflate");
-        try req.setHeader("x-ms-app", props.application orelse self.application_name);
-        if (props.user) |user| try req.setHeader("x-ms-user", user);
-        try req.setHeader("x-ms-client-version", props.client_version orelse self.client_version);
-        try req.setHeader("x-ms-version", "2024-12-12");
-        if (props.client_request_id) |request_id| {
-            try req.setHeader("x-ms-client-request-id", request_id);
-        }
-        try core.pipeline.ensureRequestId(&req);
-        req.operation_timeout_ms = try props.effectiveClientTimeoutMs(kind);
-        req.body = body;
-        req.retryable = kind == .query;
+        var request = core.http.Request.init(allocator, .POST, url);
+        defer request.deinit();
+        try request.setHeader("Content-Type", "application/json; charset=utf-8");
+        try request.setHeader("Accept", "application/json");
+        try request.setHeader("Accept-Encoding", "gzip, deflate");
+        try request.setHeader("x-ms-app", props.application orelse self.application_name);
+        if (props.user) |user| try request.setHeader("x-ms-user", user);
+        try request.setHeader("x-ms-client-version", props.client_version orelse self.client_version);
+        try request.setHeader("x-ms-version", "2024-12-12");
+        if (props.client_request_id) |request_id|
+            try request.setHeader("x-ms-client-request-id", request_id);
+        try core.pipeline.ensureRequestId(&request);
+        request.operation_timeout_ms = try props.effectiveClientTimeoutMs(kind);
+        request.body = body;
+        request.retryable = kind == .query;
 
-        var resp = try self.send(&req);
-        defer resp.deinit();
-
+        var response = try self.send(&request);
+        defer response.deinit();
         const operation: KustoOperation = if (kind == .query) .query else .management;
-        if (!resp.isSuccess()) {
+        if (!response.isSuccess()) {
             var failure = try kusto_common.errors.fromHttpResponse(
                 allocator,
                 operation,
-                &resp,
+                &response,
                 .known_not_accepted,
             );
             errdefer failure.deinit();
             try kusto_common.errors.applyResponseCorrelation(
                 &failure,
-                &resp,
-                req.getHeader("x-ms-client-request-id"),
+                &response,
+                request.getHeader("x-ms-client-request-id"),
             );
             return .{ .err = failure };
         }
 
-        var in_band_failure = try inspectInBandFailure(allocator, resp.body, operation);
-        errdefer if (in_band_failure) |*failure| failure.deinit();
-        if (in_band_failure) |*failure| {
-            if (failure.source == .v1_exception) {
-                try kusto_common.errors.applyResponseCorrelation(
-                    failure,
-                    &resp,
-                    req.getHeader("x-ms-client-request-id"),
-                );
-                const owned_failure = failure.*;
-                in_band_failure = null;
-                return .{ .err = owned_failure };
-            }
-        }
-
-        var dataset = try parseResponseDataSet(allocator, resp.body);
+        const decoded = try result.decode(
+            allocator,
+            response.body,
+            .{ .allow_varying_row_widths = try props.allowVaryingRowWidths() },
+            operation,
+        );
+        var dataset = decoded.dataset;
         errdefer dataset.deinit(allocator);
-        const response_request_id = resp.getHeader("x-ms-client-request-id") orelse req.getHeader("x-ms-client-request-id");
-        if (response_request_id) |request_id| {
+        var in_band_failure = decoded.failure;
+        errdefer if (in_band_failure) |*failure| failure.deinit();
+        const response_request_id = response.getHeader("x-ms-client-request-id") orelse request.getHeader("x-ms-client-request-id");
+        if (response_request_id) |request_id|
             dataset.client_request_id = try allocator.dupe(u8, request_id);
-        }
-        if (resp.getHeader("x-ms-activity-id")) |activity_id| {
+        if (response.getHeader("x-ms-activity-id")) |activity_id|
             dataset.activity_id = try allocator.dupe(u8, activity_id);
-        }
         if (in_band_failure) |*failure| {
             try kusto_common.errors.applyResponseCorrelation(
                 failure,
-                &resp,
-                req.getHeader("x-ms-client-request-id"),
+                &response,
+                request.getHeader("x-ms-client-request-id"),
             );
             const owned_failure = failure.*;
             in_band_failure = null;
             return .{ .partial = .{ .value = dataset, .failure = owned_failure } };
-        }
-        if (try queryStatusFailure(allocator, dataset, operation)) |classified_failure| {
-            var failure = classified_failure;
-            errdefer failure.deinit();
-            try kusto_common.errors.applyResponseCorrelation(
-                &failure,
-                &resp,
-                req.getHeader("x-ms-client-request-id"),
-            );
-            return .{ .partial = .{ .value = dataset, .failure = failure } };
         }
         return .{ .ok = dataset };
     }
@@ -324,9 +277,9 @@ pub const KustoClient = struct {
         };
     }
 
-    fn send(self: *KustoClient, req: *core.http.Request) !core.http.Response {
+    fn send(self: *KustoClient, request: *core.http.Request) !core.http.Response {
         return switch (self.runtime) {
-            .shared => |connection| connection.send(req),
+            .shared => |connection| connection.send(request),
             .legacy => |*legacy| {
                 const connection = legacy.connection;
                 if (connection.credential != null or
@@ -336,7 +289,7 @@ pub const KustoClient = struct {
                 {
                     return error.AuthenticatedConnectionRequired;
                 }
-                return legacy.pipeline.send(req);
+                return legacy.pipeline.send(request);
             },
         };
     }
@@ -351,415 +304,6 @@ fn serializeRequest(
 ) ![]u8 {
     return kusto_common.serializeRequestBody(allocator, database, csl, properties, kind);
 }
-
-// ─────────────────── Response Parsing ────────────────
-
-/// Wire shape of a single column descriptor inside a Kusto v2 DataTable frame.
-const KustoColumnSchema = struct {
-    ColumnName: []const u8,
-    ColumnType: ?[]const u8 = null,
-};
-
-const KustoFrameTypeSchema = struct {
-    FrameType: ?[]const u8 = null,
-};
-
-/// Wire shape of frame metadata. Rows are scanned separately because they
-/// contain dynamically typed JSON values.
-const KustoFrameSchema = struct {
-    FrameType: []const u8,
-    TableName: ?[]const u8 = null,
-    TableKind: ?[]const u8 = null,
-    Columns: ?[]const KustoColumnSchema = null,
-};
-
-fn parseResponseDataSet(allocator: std.mem.Allocator, body: []const u8) !KustoResponseDataSet {
-    if (!try std.json.validate(allocator, body)) return error.MalformedKustoResponse;
-
-    var deserializer = serde.json.Deserializer.init(body);
-    const scanner = &deserializer.scanner;
-    const first = scanner.next() catch return error.MalformedKustoResponse;
-    if (first != .array_begin) return error.MalformedKustoResponse;
-
-    var tables = std.ArrayList(KustoResultTable).empty;
-    errdefer {
-        for (tables.items) |*table| table.deinit(allocator);
-        tables.deinit(allocator);
-    }
-
-    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
-        _ = scanner.next() catch return error.MalformedKustoResponse;
-    } else {
-        while (true) {
-            const frame_slice = captureValue(scanner, body) catch return error.MalformedKustoResponse;
-            if (try parseFrame(allocator, frame_slice)) |parsed| {
-                var table = parsed;
-                errdefer table.deinit(allocator);
-                try tables.append(allocator, table);
-            }
-            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
-                .end => break,
-                .more => {},
-            }
-        }
-    }
-
-    scanner.skipWhitespace();
-    if (scanner.pos != body.len) return error.MalformedKustoResponse;
-    return .{ .tables = try tables.toOwnedSlice(allocator) };
-}
-
-const CompletionFrameSchema = struct {
-    FrameType: ?[]const u8 = null,
-    HasErrors: ?bool = null,
-    Cancelled: ?bool = null,
-    OneApiErrors: ?[]kusto_common.errors.OneApiEnvelope = null,
-};
-
-/// Classifies only the first completion failure. Progressive reconstruction and
-/// deduplication are intentionally deferred; tables were already buffered by
-/// `parseResponseDataSet` before this pass.
-fn inspectInBandFailure(
-    allocator: std.mem.Allocator,
-    body: []const u8,
-    operation: KustoOperation,
-) !?KustoError {
-    var deserializer = serde.json.Deserializer.init(body);
-    const scanner = &deserializer.scanner;
-    const first = scanner.next() catch return error.MalformedKustoResponse;
-    if (first == .object_begin) return inspectV1Exception(allocator, body, operation);
-    if (first != .array_begin) return error.MalformedKustoResponse;
-    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
-        _ = scanner.next() catch return error.MalformedKustoResponse;
-        return null;
-    }
-    while (true) {
-        const frame_slice = captureValue(scanner, body) catch return error.MalformedKustoResponse;
-        var arena = std.heap.ArenaAllocator.init(allocator);
-        defer arena.deinit();
-        const frame = serde.json.fromSlice(CompletionFrameSchema, arena.allocator(), frame_slice) catch |err| {
-            if (err == error.OutOfMemory) return error.OutOfMemory;
-            return error.MalformedKustoResponse;
-        };
-        const source: ?KustoErrorSource = if (std.mem.eql(u8, frame.FrameType orelse "", "DataSetCompletion"))
-            .dataset_completion
-        else if (std.mem.eql(u8, frame.FrameType orelse "", "TableCompletion"))
-            .table_completion
-        else
-            null;
-        if (source) |failure_source| {
-            const cancelled = frame.Cancelled orelse false;
-            if (frame.OneApiErrors) |errors| {
-                if (errors.len > 0) {
-                    return try kusto_common.errors.fromOneApiEnvelope(
-                        allocator,
-                        operation,
-                        failure_source,
-                        errors[0],
-                        cancelled,
-                    );
-                }
-            }
-            if ((frame.HasErrors orelse false) or cancelled) {
-                return kusto_common.errors.inBandFailure(
-                    allocator,
-                    operation,
-                    failure_source,
-                    cancelled,
-                );
-            }
-        }
-        switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
-            .end => break,
-            .more => {},
-        }
-    }
-    return null;
-}
-
-fn inspectV1Exception(
-    allocator: std.mem.Allocator,
-    body: []const u8,
-    operation: KustoOperation,
-) !?KustoError {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-    var scanner = std.json.Scanner.initCompleteInput(arena.allocator(), body);
-    defer scanner.deinit();
-    const value = std.json.parseFromTokenSourceLeaky(
-        std.json.Value,
-        arena.allocator(),
-        &scanner,
-        .{},
-    ) catch |err| {
-        if (err == error.OutOfMemory) return error.OutOfMemory;
-        return error.MalformedKustoResponse;
-    };
-    const message = findV1Exception(&value) orelse return null;
-    var failure = kusto_common.errors.inBandFailure(
-        allocator,
-        operation,
-        .v1_exception,
-        false,
-    );
-    errdefer failure.deinit();
-    failure.detail.message = try allocator.dupe(u8, message);
-    return failure;
-}
-
-fn findV1Exception(value: *const std.json.Value) ?[]const u8 {
-    switch (value.*) {
-        .object => |object| {
-            if (object.get("Exceptions")) |exceptions_value| {
-                switch (exceptions_value) {
-                    .array => |exceptions| {
-                        for (exceptions.items) |exception| {
-                            switch (exception) {
-                                .string => |message| return message,
-                                else => {},
-                            }
-                        }
-                    },
-                    else => {},
-                }
-            }
-            for (object.values()) |*entry_value| {
-                if (findV1Exception(entry_value)) |message| return message;
-            }
-        },
-        .array => |items| {
-            for (items.items) |*item| {
-                if (findV1Exception(item)) |message| return message;
-            }
-        },
-        else => {},
-    }
-    return null;
-}
-
-fn queryStatusFailure(
-    allocator: std.mem.Allocator,
-    dataset: KustoResponseDataSet,
-    operation: KustoOperation,
-) !?KustoError {
-    for (dataset.tables) |table| {
-        const is_query_status = std.mem.eql(u8, table.name, "QueryStatus") or
-            (table.kind != null and std.mem.eql(u8, table.kind.?, "QueryCompletionInformation"));
-        if (!is_query_status) continue;
-        for (table.rows) |row| {
-            const severity_text = row.getByName("Severity") orelse continue;
-            const severity = std.fmt.parseInt(i32, severity_text, 10) catch continue;
-            if (severity > 2) continue;
-            var failure = kusto_common.errors.inBandFailure(
-                allocator,
-                operation,
-                .query_status,
-                false,
-            );
-            errdefer failure.deinit();
-            if (row.getByName("StatusCode")) |code| {
-                failure.detail.code = try allocator.dupe(u8, code);
-            }
-            if (row.getByName("StatusDescription")) |message| {
-                failure.detail.message = try allocator.dupe(u8, message);
-            }
-            if (row.getByName("ClientActivityId") orelse row.getByName("RequestId")) |request_id| {
-                failure.client_request_id = try allocator.dupe(u8, request_id);
-            }
-            if (row.getByName("ActivityId")) |activity_id| {
-                failure.activity_id = try allocator.dupe(u8, activity_id);
-            }
-            return failure;
-        }
-    }
-    return null;
-}
-
-fn captureValue(scanner: anytype, input: []const u8) ![]const u8 {
-    scanner.skipWhitespace();
-    const start = scanner.pos;
-    try scanner.skipValue();
-    return input[start..scanner.pos];
-}
-
-fn parseFrame(allocator: std.mem.Allocator, frame_slice: []const u8) !?KustoResultTable {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    const frame_type_schema = serde.json.fromSlice(KustoFrameTypeSchema, arena.allocator(), frame_slice) catch |err| {
-        if (err == error.OutOfMemory) return error.OutOfMemory;
-        return error.MalformedKustoResponse;
-    };
-    const frame_type = frame_type_schema.FrameType orelse return null;
-    if (!std.mem.eql(u8, frame_type, "DataTable")) return null;
-
-    const frame = serde.json.fromSlice(KustoFrameSchema, arena.allocator(), frame_slice) catch |err| {
-        if (err == error.OutOfMemory) return error.OutOfMemory;
-        return error.MalformedKustoResponse;
-    };
-    const table_name_src = frame.TableName orelse return error.MalformedKustoResponse;
-    const columns_src = frame.Columns orelse return error.MalformedKustoResponse;
-    const rows_slice = try findRowsSlice(arena.allocator(), frame_slice);
-
-    const table_name = try allocator.dupe(u8, table_name_src);
-    errdefer allocator.free(table_name);
-    const table_kind = if (frame.TableKind) |kind|
-        try allocator.dupe(u8, kind)
-    else
-        null;
-    errdefer if (table_kind) |kind| allocator.free(kind);
-
-    var columns = std.ArrayList(KustoResultColumn).empty;
-    errdefer {
-        for (columns.items) |column| column.deinit(allocator);
-        columns.deinit(allocator);
-    }
-    for (columns_src) |column_src| {
-        {
-            var column = KustoResultColumn{
-                .name = try allocator.dupe(u8, column_src.ColumnName),
-                .column_type = undefined,
-            };
-            errdefer allocator.free(column.name);
-            column.column_type = try allocator.dupe(u8, column_src.ColumnType orelse "string");
-            errdefer allocator.free(column.column_type);
-            try columns.append(allocator, column);
-        }
-    }
-    const columns_slice = try columns.toOwnedSlice(allocator);
-    errdefer {
-        for (columns_slice) |column| column.deinit(allocator);
-        allocator.free(columns_slice);
-    }
-
-    const rows = try parseRows(allocator, rows_slice, columns_slice);
-    return .{
-        .name = table_name,
-        .kind = table_kind,
-        .columns = columns_slice,
-        .rows = rows,
-    };
-}
-
-fn findRowsSlice(allocator: std.mem.Allocator, frame_slice: []const u8) ![]const u8 {
-    var deserializer = serde.json.Deserializer.init(frame_slice);
-    const scanner = &deserializer.scanner;
-    const first = scanner.next() catch return error.MalformedKustoResponse;
-    if (first != .object_begin) return error.MalformedKustoResponse;
-
-    var rows_slice: ?[]const u8 = null;
-    if (scanner.isContainerEmpty('}') catch return error.MalformedKustoResponse) {
-        _ = scanner.next() catch return error.MalformedKustoResponse;
-    } else {
-        while (true) {
-            scanner.skipWhitespace();
-            const key_start = scanner.pos;
-            const key_token = scanner.next() catch return error.MalformedKustoResponse;
-            if (key_token != .string) return error.MalformedKustoResponse;
-            const key_slice = frame_slice[key_start..scanner.pos];
-            const key = serde.json.fromSlice([]const u8, allocator, key_slice) catch |err| {
-                if (err == error.OutOfMemory) return error.OutOfMemory;
-                return error.MalformedKustoResponse;
-            };
-            scanner.expectColon() catch return error.MalformedKustoResponse;
-            const value_slice = captureValue(scanner, frame_slice) catch return error.MalformedKustoResponse;
-            if (std.mem.eql(u8, key, "Rows")) {
-                if (rows_slice != null) return error.MalformedKustoResponse;
-                rows_slice = value_slice;
-            }
-            switch (scanner.finishContainer('}') catch return error.MalformedKustoResponse) {
-                .end => break,
-                .more => {},
-            }
-        }
-    }
-    scanner.skipWhitespace();
-    if (scanner.pos != frame_slice.len) return error.MalformedKustoResponse;
-    return rows_slice orelse error.MalformedKustoResponse;
-}
-
-fn parseRows(
-    allocator: std.mem.Allocator,
-    rows_slice: []const u8,
-    columns: []const KustoResultColumn,
-) ![]KustoResultRow {
-    var deserializer = serde.json.Deserializer.init(rows_slice);
-    const scanner = &deserializer.scanner;
-    const first = scanner.next() catch return error.MalformedKustoResponse;
-    if (first != .array_begin) return error.MalformedKustoResponse;
-
-    var rows = std.ArrayList(KustoResultRow).empty;
-    errdefer {
-        for (rows.items) |row| row.deinit(allocator);
-        rows.deinit(allocator);
-    }
-    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
-        _ = scanner.next() catch return error.MalformedKustoResponse;
-    } else {
-        while (true) {
-            const row_slice = captureValue(scanner, rows_slice) catch return error.MalformedKustoResponse;
-            const values = try parseRowValues(allocator, row_slice);
-            {
-                var row = KustoResultRow{ .values = values, .columns = columns };
-                errdefer row.deinit(allocator);
-                try rows.append(allocator, row);
-            }
-            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
-                .end => break,
-                .more => {},
-            }
-        }
-    }
-    scanner.skipWhitespace();
-    if (scanner.pos != rows_slice.len) return error.MalformedKustoResponse;
-    return rows.toOwnedSlice(allocator);
-}
-
-fn parseRowValues(allocator: std.mem.Allocator, row_slice: []const u8) ![]const []const u8 {
-    var deserializer = serde.json.Deserializer.init(row_slice);
-    const scanner = &deserializer.scanner;
-    const first = scanner.next() catch return error.MalformedKustoResponse;
-    if (first != .array_begin) return error.MalformedKustoResponse;
-
-    var values = std.ArrayList([]const u8).empty;
-    errdefer {
-        for (values.items) |value| allocator.free(value);
-        values.deinit(allocator);
-    }
-    if (scanner.isContainerEmpty(']') catch return error.MalformedKustoResponse) {
-        _ = scanner.next() catch return error.MalformedKustoResponse;
-    } else {
-        while (true) {
-            const cell_slice = captureValue(scanner, row_slice) catch return error.MalformedKustoResponse;
-            const value = try decodeCell(allocator, cell_slice);
-            {
-                errdefer allocator.free(value);
-                try values.append(allocator, value);
-            }
-            switch (scanner.finishContainer(']') catch return error.MalformedKustoResponse) {
-                .end => break,
-                .more => {},
-            }
-        }
-    }
-    scanner.skipWhitespace();
-    if (scanner.pos != row_slice.len) return error.MalformedKustoResponse;
-    return values.toOwnedSlice(allocator);
-}
-
-fn decodeCell(allocator: std.mem.Allocator, cell_slice: []const u8) ![]const u8 {
-    var deserializer = serde.json.Deserializer.init(cell_slice);
-    const token = deserializer.scanner.peek() catch return error.MalformedKustoResponse;
-    if (token == .string) {
-        return serde.json.fromSlice([]const u8, allocator, cell_slice) catch |err| {
-            if (err == error.OutOfMemory) return error.OutOfMemory;
-            return error.MalformedKustoResponse;
-        };
-    }
-    return allocator.dupe(u8, std.mem.trim(u8, cell_slice, " \t\n\r"));
-}
-
-// ─────────────────────── Tests ───────────────────────
 
 const TestTokenCredential = struct {
     credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
@@ -785,38 +329,48 @@ const TestTokenCredential = struct {
     }
 };
 
-test "KustoClient executeQuery" {
+const empty_v2_response =
+    \\[
+    \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+    \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+    \\]
+;
+
+test "KustoClient executes a normal V2 query" {
     const allocator = std.testing.allocator;
     const response_body =
-        \\[{"FrameType":"DataTable","TableName":"PrimaryResult","Columns":[{"ColumnName":"Count","ColumnType":"long"}],"Rows":[[42]]}]
+        \\[
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"Count","ColumnType":"long"}],"Rows":[[42]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+        \\]
     ;
     var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
 
-    const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" };
-    var client = KustoClient.init(conn, mock.asTransport(), .{});
+    var dataset = try client.executeQuery(allocator, "TestDB", "StormEvents | count", null);
+    defer dataset.deinit(allocator);
 
-    var result = try client.executeQuery(allocator, "TestDB", "StormEvents | count", null);
-    defer result.deinit(allocator);
-
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v2/rest/query") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v2/rest/query") != null);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
     const request_id = mock.last_headers.get("x-ms-client-request-id").?;
     try std.testing.expectEqual(@as(usize, 36), request_id.len);
-    try std.testing.expectEqualStrings(request_id, result.client_request_id.?);
-
-    const primary = result.primaryTable().?;
-    try std.testing.expectEqualStrings("PrimaryResult", primary.name);
-    try std.testing.expectEqual(@as(usize, 1), primary.columns.len);
-    try std.testing.expectEqualStrings("Count", primary.columns[0].name);
-    try std.testing.expectEqual(@as(usize, 1), primary.rows.len);
-    try std.testing.expectEqualStrings("42", primary.rows[0].values[0]);
+    try std.testing.expectEqualStrings(request_id, dataset.client_request_id.?);
+    try std.testing.expectEqual(
+        @as(?i64, 42),
+        dataset.primaryTable().?.rows[0].getByName("Count").?.asI64(),
+    );
 }
 
 test "shared KustoClient authenticates queries" {
     const allocator = std.testing.allocator;
     var credential = TestTokenCredential{};
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
     const connection = try KustoConnection.init(
         allocator,
@@ -830,13 +384,13 @@ test "shared KustoClient authenticates queries" {
     defer connection.deinit();
 
     var client = KustoClient.initWithConnection(connection, .{});
-    var result = try client.executeQuery(
+    var dataset = try client.executeQuery(
         allocator,
         "db",
         "print 1",
         .{ .client_request_id = "kusto-test-request-id" },
     );
-    defer result.deinit(allocator);
+    defer dataset.deinit(allocator);
 
     try std.testing.expectEqual(@as(usize, 1), credential.call_count);
     try std.testing.expectEqualStrings(
@@ -854,10 +408,10 @@ test "shared KustoClient authenticates queries" {
     );
 }
 
-test "shared KustoClient uses explicit engine endpoint for queries" {
+test "shared KustoClient uses an explicit engine endpoint" {
     const allocator = std.testing.allocator;
     var credential = TestTokenCredential{};
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
     const connection = try KustoConnection.init(
         allocator,
@@ -875,9 +429,8 @@ test "shared KustoClient uses explicit engine endpoint for queries" {
     defer connection.deinit();
 
     var client = KustoClient.initWithConnection(connection, .{});
-    var result = try client.executeQuery(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-
+    var dataset = try client.executeQuery(allocator, "db", "print 1", null);
+    defer dataset.deinit(allocator);
     try std.testing.expectEqualStrings(
         "https://query-engine.kusto.windows.net/v2/rest/query",
         mock.last_url.?,
@@ -887,7 +440,7 @@ test "shared KustoClient uses explicit engine endpoint for queries" {
 test "copied shared KustoClient remains usable" {
     const allocator = std.testing.allocator;
     var credential = TestTokenCredential{};
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
     const connection = try KustoConnection.init(
         allocator,
@@ -902,9 +455,8 @@ test "copied shared KustoClient remains usable" {
 
     const copied = KustoClient.initWithConnection(connection, .{});
     var moved = copied;
-    var result = try moved.executeQuery(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-
+    var dataset = try moved.executeQuery(allocator, "db", "print 1", null);
+    defer dataset.deinit(allocator);
     try std.testing.expect(mock.last_url != null);
     try std.testing.expectEqual(@as(usize, 1), credential.call_count);
 }
@@ -912,7 +464,7 @@ test "copied shared KustoClient remains usable" {
 test "legacy authenticated KustoClient fails before transport" {
     const allocator = std.testing.allocator;
     var credential = TestTokenCredential{};
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
     var client = KustoClient.init(
         .{
@@ -931,166 +483,123 @@ test "legacy authenticated KustoClient fails before transport" {
     try std.testing.expectEqual(@as(usize, 0), credential.call_count);
 }
 
-test "shared KustoClient retries queries" {
+test "shared KustoClient retries queries but not management commands" {
     const allocator = std.testing.allocator;
-    var credential = TestTokenCredential{};
-    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+    var query_credential = TestTokenCredential{};
+    const query_responses = [_]core.http.SequenceMockTransport.CannedResponse{
         .{ .status = 500, .body = "server error" },
-        .{ .status = 200, .body = "[]" },
+        .{ .status = 200, .body = empty_v2_response },
     };
-    var sequence = core.http.SequenceMockTransport.init(allocator, &responses);
-    const connection = try KustoConnection.init(
+    var query_sequence = core.http.SequenceMockTransport.init(allocator, &query_responses);
+    const query_connection = try KustoConnection.init(
         allocator,
         .{
             .cluster_url = "https://cluster.kusto.windows.net",
-            .credential = credential.asCredential(),
+            .credential = query_credential.asCredential(),
         },
-        sequence.asTransport(),
+        query_sequence.asTransport(),
         .{
             .metadata_mode = .disabled,
-            .retry = .{
-                .max_retries = 1,
-                .initial_delay_ms = 0,
-                .max_delay_ms = 0,
-            },
+            .retry = .{ .max_retries = 1, .initial_delay_ms = 0, .max_delay_ms = 0 },
         },
     );
-    defer connection.deinit();
+    defer query_connection.deinit();
+    var query_client = KustoClient.initWithConnection(query_connection, .{});
+    var dataset = try query_client.executeQuery(allocator, "db", "print 1", null);
+    defer dataset.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 2), query_sequence.call_count);
 
-    var client = KustoClient.initWithConnection(connection, .{});
-    var result = try client.executeQuery(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-    try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
-}
-
-test "shared KustoClient does not retry management commands" {
-    const allocator = std.testing.allocator;
-    var credential = TestTokenCredential{};
-    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
-        .{
-            .status = 500,
-            .body = "{\"error\":{\"code\":\"ServerError\",\"message\":\"failed\"}}",
-        },
-        .{ .status = 200, .body = "[]" },
+    var management_credential = TestTokenCredential{};
+    const management_responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 500, .body = "{\"error\":{\"code\":\"ServerError\",\"message\":\"failed\"}}" },
+        .{ .status = 200, .body = empty_v2_response },
     };
-    var sequence = core.http.SequenceMockTransport.init(allocator, &responses);
-    const connection = try KustoConnection.init(
+    var management_sequence = core.http.SequenceMockTransport.init(allocator, &management_responses);
+    const management_connection = try KustoConnection.init(
         allocator,
         .{
             .cluster_url = "https://cluster.kusto.windows.net",
-            .credential = credential.asCredential(),
+            .credential = management_credential.asCredential(),
         },
-        sequence.asTransport(),
+        management_sequence.asTransport(),
         .{
             .metadata_mode = .disabled,
-            .retry = .{
-                .max_retries = 1,
-                .initial_delay_ms = 0,
-                .max_delay_ms = 0,
-            },
+            .retry = .{ .max_retries = 1, .initial_delay_ms = 0, .max_delay_ms = 0 },
         },
     );
-    defer connection.deinit();
-
-    var client = KustoClient.initWithConnection(connection, .{});
+    defer management_connection.deinit();
+    var management_client = KustoClient.initWithConnection(management_connection, .{});
     try std.testing.expectError(
         error.KustoQueryFailed,
-        client.executeMgmt(allocator, "db", ".show tables", null),
+        management_client.executeMgmt(allocator, "db", ".show tables", null),
     );
-    try std.testing.expectEqual(@as(usize, 1), sequence.call_count);
+    try std.testing.expectEqual(@as(usize, 1), management_sequence.call_count);
 }
 
-test "KustoClient executeMgmt" {
+test "KustoClient executes management and auto-routes requests" {
     const allocator = std.testing.allocator;
     const response_body =
-        \\[{"FrameType":"DataTable","TableName":"Table_0","Columns":[{"ColumnName":"DatabaseName","ColumnType":"string"}],"Rows":[["TestDB"]]}]
+        \\{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"DatabaseName","ColumnType":"string"}],"Rows":[["TestDB"]]}]}
     ;
     var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
 
-    const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" };
-    var client = KustoClient.init(conn, mock.asTransport(), .{});
-
-    var result = try client.executeMgmt(allocator, "TestDB", ".show databases", null);
-    defer result.deinit(allocator);
-
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
-    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"servertimeout\":\"00:10:00.000\"") != null);
+    var management = try client.executeMgmt(allocator, "TestDB", ".show databases", null);
+    defer management.deinit(allocator);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"servertimeout\":\"00:10:00.000\"") != null);
     try std.testing.expectEqual(@as(?u64, 630_000), mock.last_operation_timeout_ms);
-    const table = result.tables[0];
-    try std.testing.expectEqualStrings("TestDB", table.rows[0].values[0]);
+
+    var auto_management = try client.execute(allocator, "db", " \t.show databases");
+    defer auto_management.deinit(allocator);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
+
+    mock.response_body = empty_v2_response;
+    var auto_query = try client.execute(allocator, "db", "StormEvents | count");
+    defer auto_query.deinit(allocator);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "/v2/rest/query") != null);
 }
 
-test "KustoClient execute auto-routes to mgmt" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
-    defer mock.deinit();
-
-    const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = KustoClient.init(conn, mock.asTransport(), .{});
-
-    var result = try client.execute(allocator, "db", ".show databases");
-    defer result.deinit(allocator);
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v1/rest/mgmt") != null);
-}
-
-test "KustoClient execute auto-routes to query" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
-    defer mock.deinit();
-
-    const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = KustoClient.init(conn, mock.asTransport(), .{});
-
-    var result = try client.execute(allocator, "db", "StormEvents | count");
-    defer result.deinit(allocator);
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "/v2/rest/query") != null);
-}
-
-test "KustoClient query failure returns error" {
+test "KustoClient returns query HTTP failures" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 400,
         \\{"error":{"code":"BadRequest","message":"Invalid query"}}
     );
     defer mock.deinit();
-
-    const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = KustoClient.init(conn, mock.asTransport(), .{});
-
-    const result = client.executeQuery(allocator, "db", "INVALID", null);
-    try std.testing.expectError(error.KustoQueryFailed, result);
-}
-
-test "KustoResultRow getByName" {
-    const cols = [_]KustoResultColumn{
-        .{ .name = "Name", .column_type = "string" },
-        .{ .name = "Age", .column_type = "long" },
-    };
-    const vals = [_][]const u8{ "Alice", "30" };
-    const row = KustoResultRow{ .values = &vals, .columns = &cols };
-    try std.testing.expectEqualStrings("Alice", row.getByName("Name").?);
-    try std.testing.expectEqualStrings("30", row.getByName("Age").?);
-    try std.testing.expect(row.getByName("Missing") == null);
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    try std.testing.expectError(
+        error.KustoQueryFailed,
+        client.executeQuery(allocator, "db", "INVALID", null),
+    );
 }
 
 test "Kusto request bodies round trip caller strings" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
-
-    const conn = kusto_common.ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = KustoClient.init(conn, mock.asTransport(), .{});
-
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
     const database = "db\"\\\n\t\x01";
     const query = "print value = \"a\\\\b\"\n\t\r";
-    var query_result = try client.executeQuery(
+    var query_dataset = try client.executeQuery(
         allocator,
         database,
         query,
         .{ .client_request_id = "ignored-for-now", .application = "ignored-for-now" },
     );
-    defer query_result.deinit(allocator);
-
+    defer query_dataset.deinit(allocator);
     var query_arena = std.heap.ArenaAllocator.init(allocator);
     defer query_arena.deinit();
     const query_wire = try serde.json.fromSlice(
@@ -1100,35 +609,45 @@ test "Kusto request bodies round trip caller strings" {
     );
     try std.testing.expectEqualStrings(database, query_wire.db);
     try std.testing.expectEqualStrings(query, query_wire.csl);
-    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"properties\":{\"Options\":{\"servertimeout\":\"00:04:00.000\"},\"Parameters\":{}}") != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        mock.last_body.?,
+        "\"properties\":{\"Options\":{\"servertimeout\":\"00:04:00.000\"},\"Parameters\":{}}",
+    ) != null);
     try std.testing.expectEqual(@as(?u64, 270_000), mock.last_operation_timeout_ms);
 
     const command = ".show table [a\"b\\\\c]\n\t";
-    var mgmt_result = try client.executeMgmt(
+    mock.response_body =
+        \\{"Tables":[]}
+    ;
+    var management_dataset = try client.executeMgmt(
         allocator,
         database,
         command,
         .{ .server_timeout_ms = 300000 },
     );
-    defer mgmt_result.deinit(allocator);
-
-    var mgmt_arena = std.heap.ArenaAllocator.init(allocator);
-    defer mgmt_arena.deinit();
-    const mgmt_wire = try serde.json.fromSlice(
+    defer management_dataset.deinit(allocator);
+    var management_arena = std.heap.ArenaAllocator.init(allocator);
+    defer management_arena.deinit();
+    const management_wire = try serde.json.fromSlice(
         struct { db: []const u8, csl: []const u8 },
-        mgmt_arena.allocator(),
+        management_arena.allocator(),
         mock.last_body.?,
     );
-    try std.testing.expectEqualStrings(database, mgmt_wire.db);
-    try std.testing.expectEqualStrings(command, mgmt_wire.csl);
-    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"properties\":{\"Options\":{\"servertimeout\":\"00:05:00.000\"},\"Parameters\":{}}") != null);
+    try std.testing.expectEqualStrings(database, management_wire.db);
+    try std.testing.expectEqualStrings(command, management_wire.csl);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        mock.last_body.?,
+        "\"properties\":{\"Options\":{\"servertimeout\":\"00:05:00.000\"},\"Parameters\":{}}",
+    ) != null);
     try std.testing.expectEqual(@as(?u64, 330_000), mock.last_operation_timeout_ms);
 }
 
 test "KustoClient applies diagnostic headers and owns response correlation" {
     const allocator = std.testing.allocator;
     var credential = TestTokenCredential{};
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     mock.response_headers_list = &.{
         .{ .name = "X-MS-Client-Request-Id", .value = "echoed-request-id" },
         .{ .name = "x-ms-activity-id", .value = "activity-id" },
@@ -1161,9 +680,8 @@ test "KustoClient applies diagnostic headers and owns response correlation" {
         .application_name = "default-app",
         .client_version = "default-version",
     });
-    var result = try client.executeQuery(allocator, "db", "print 1", properties);
-    defer result.deinit(allocator);
-
+    var dataset = try client.executeQuery(allocator, "db", "print 1", properties);
+    defer dataset.deinit(allocator);
     try std.testing.expectEqualStrings("caller-request-id", mock.last_headers.get("x-ms-client-request-id").?);
     try std.testing.expectEqualStrings("caller-app", mock.last_headers.get("x-ms-app").?);
     try std.testing.expectEqualStrings("caller-user", mock.last_headers.get("x-ms-user").?);
@@ -1171,118 +689,27 @@ test "KustoClient applies diagnostic headers and owns response correlation" {
     try std.testing.expectEqualStrings("2024-12-12", mock.last_headers.get("x-ms-version").?);
     try std.testing.expectEqualStrings("gzip, deflate", mock.last_headers.get("Accept-Encoding").?);
     try std.testing.expectEqual(@as(?u64, 120_000), mock.last_operation_timeout_ms);
-    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"servertimeout\":\"00:01:30.001\"") != null);
-    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"best_effort\":true") != null);
-    try std.testing.expect(std.mem.find(u8, mock.last_body.?, "\"limit\":5") != null);
-    try std.testing.expectEqualStrings("echoed-request-id", result.client_request_id.?);
-    try std.testing.expectEqualStrings("activity-id", result.activity_id.?);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"servertimeout\":\"00:01:30.001\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"best_effort\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"limit\":5") != null);
+    try std.testing.expectEqualStrings("echoed-request-id", dataset.client_request_id.?);
+    try std.testing.expectEqualStrings("activity-id", dataset.activity_id.?);
 }
 
 test "KustoClient rejects invalid request properties before transport" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "[]");
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
-    const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = KustoClient.init(conn, mock.asTransport(), .{});
-
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
     try std.testing.expectError(
         error.InvalidServerTimeout,
         client.executeQuery(allocator, "db", "print 1", .{ .server_timeout_ms = 999 }),
     );
     try std.testing.expectEqual(@as(usize, 0), mock.call_count);
-}
-
-test "Kusto response preserves dynamic JSON cells" {
-    const response_body =
-        \\[
-        \\  {"FrameType":"DataSetHeader","Version":"v2.0"},
-        \\  {"FrameType":"DataTable","TableName":"PrimaryResult","Columns":[
-        \\    {"ColumnName":"Text","ColumnType":"string"},
-        \\    {"ColumnName":"Object","ColumnType":"dynamic"},
-        \\    {"ColumnName":"Array","ColumnType":"dynamic"},
-        \\    {"ColumnName":"Null","ColumnType":"string"},
-        \\    {"ColumnName":"Boolean","ColumnType":"bool"},
-        \\    {"ColumnName":"Number","ColumnType":"real"},
-        \\    {"ColumnName":"EmptyArray","ColumnType":"dynamic"}
-        \\  ],"Rows":[[
-        \\    "line\n\"quote\" \\ slash \u2603",
-        \\    {"a":[1,2],"s":"x,y"},
-        \\    [1,{"nested":[true,null]}],
-        \\    null,
-        \\    false,
-        \\    -12.5e+2,
-        \\    []
-        \\  ]]},
-        \\  {"FrameType":"DataSetCompletion","HasErrors":false}
-        \\]
-    ;
-
-    var dataset = try parseResponseDataSet(std.testing.allocator, response_body);
-    defer dataset.deinit(std.testing.allocator);
-
-    try std.testing.expectEqual(@as(usize, 1), dataset.tables.len);
-    const values = dataset.tables[0].rows[0].values;
-    try std.testing.expectEqual(@as(usize, 7), values.len);
-    try std.testing.expectEqualStrings("line\n\"quote\" \\ slash \xE2\x98\x83", values[0]);
-    try std.testing.expectEqualStrings("{\"a\":[1,2],\"s\":\"x,y\"}", values[1]);
-    try std.testing.expectEqualStrings("[1,{\"nested\":[true,null]}]", values[2]);
-    try std.testing.expectEqualStrings("null", values[3]);
-    try std.testing.expectEqualStrings("false", values[4]);
-    try std.testing.expectEqualStrings("-12.5e+2", values[5]);
-    try std.testing.expectEqualStrings("[]", values[6]);
-}
-
-test "Kusto response accepts empty dataset and skips non-table frames" {
-    var empty = try parseResponseDataSet(std.testing.allocator, "[]");
-    defer empty.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 0), empty.tables.len);
-
-    var frames = try parseResponseDataSet(std.testing.allocator,
-        \\[{"FrameType":"DataSetHeader","nested":{"values":[1,2]}},{"FrameType":"DataSetCompletion"}]
-    );
-    defer frames.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 0), frames.tables.len);
-}
-
-test "Kusto response rejects malformed bodies and DataTable shapes" {
-    const malformed = [_][]const u8{
-        "not json",
-        "{}",
-        "[",
-        "[] trailing",
-        \\[{"FrameType":"DataTable","TableName":"T","Columns":[]}]
-        ,
-        \\[{"FrameType":"DataTable","TableName":"T","Columns":[],"Rows":{}}]
-        ,
-        \\[{"FrameType":"DataTable","TableName":"T","Columns":[],"Rows":[42]}]
-        ,
-        \\[{"FrameType":"DataTable","TableName":"T","Columns":{},"Rows":[]}]
-        ,
-        \\[{"FrameType":"DataTable","Columns":[],"Rows":[]}]
-        ,
-        \\[{"FrameType":"DataTable","TableName":"T","Columns":[],"Rows":[["\uZZZZ"]]}]
-        ,
-    };
-    for (malformed) |body| {
-        try std.testing.expectError(
-            error.MalformedKustoResponse,
-            parseResponseDataSet(std.testing.allocator, body),
-        );
-    }
-}
-
-test "Kusto dataset and Result deinit own all parsed allocations" {
-    const response_body =
-        \\[{"FrameType":"DataTable","TableName":"T","Columns":[{"ColumnName":"C"}],"Rows":[["value"]]}]
-    ;
-
-    var dataset = try parseResponseDataSet(std.testing.allocator, response_body);
-    dataset.deinit(std.testing.allocator);
-
-    var result: KustoResult(KustoResponseDataSet) = .{
-        .ok = try parseResponseDataSet(std.testing.allocator, response_body),
-    };
-    result.deinit(std.testing.allocator);
 }
 
 test "Kusto non-2xx malformed body is a structured HTTP failure" {
@@ -1294,10 +721,9 @@ test "Kusto non-2xx malformed body is a structured HTTP failure" {
         mock.asTransport(),
         .{},
     );
-
-    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-    switch (result) {
+    var response_result = try client.executeQueryResult(allocator, "db", "print 1", null);
+    defer response_result.deinit(allocator);
+    switch (response_result) {
         .err => |failure| {
             try std.testing.expectEqual(@as(?u16, 502), failure.http_status);
             try std.testing.expectEqual(KustoErrorSource.http, failure.source);
@@ -1310,10 +736,31 @@ test "Kusto non-2xx malformed body is a structured HTTP failure" {
     }
 }
 
-test "V1 exception payload is a structured in-band failure" {
+test "KustoClient decodes V1 management responses" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200,
-        \\{"Tables":[{"TableName":"Table_0","Columns":[],"Rows":[{"Exceptions":["partial V1 failure"]}]}]}
+    const response_body =
+        \\{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"DatabaseName","ColumnType":"string"},{"ColumnName":"Count","ColumnType":"long"}],"Rows":[["TestDB",42]]}]}
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, response_body);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+
+    var dataset = try client.executeMgmt(allocator, "db", ".show databases", null);
+    defer dataset.deinit(allocator);
+    try std.testing.expect(std.mem.endsWith(u8, mock.last_url.?, "/v1/rest/mgmt"));
+    const table = dataset.primaryTable().?;
+    try std.testing.expectEqualStrings("TestDB", table.rows[0].getByName("DatabaseName").?.asString().?);
+    try std.testing.expectEqual(@as(?i64, 42), table.rows[0].getByName("Count").?.asI64());
+}
+
+test "KustoClient preserves structured HTTP failures" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 400,
+        \\{"error":{"code":"BadRequest","message":"Invalid query"}}
     );
     defer mock.deinit();
     var client = KustoClient.init(
@@ -1322,27 +769,28 @@ test "V1 exception payload is a structured in-band failure" {
         .{},
     );
 
-    var result = try client.executeMgmtResult(allocator, "db", ".show tables", null);
-    defer result.deinit(allocator);
-    switch (result) {
+    var response_result = try client.executeQueryResult(allocator, "db", "bad", null);
+    defer response_result.deinit(allocator);
+    switch (response_result) {
         .err => |failure| {
-            try std.testing.expectEqual(KustoErrorSource.v1_exception, failure.source);
-            try std.testing.expectEqual(KustoOperationOutcome.partial, failure.outcome);
-            try std.testing.expectEqualStrings("partial V1 failure", failure.detail.message.?);
-            try std.testing.expectEqual(@as(usize, 36), failure.client_request_id.?.len);
+            try std.testing.expectEqual(KustoErrorSource.http, failure.source);
+            try std.testing.expectEqual(@as(?u16, 400), failure.http_status);
+            try std.testing.expectEqualStrings("BadRequest", failure.detail.code.?);
         },
         else => return error.TestUnexpectedResult,
     }
 }
 
-test "DataSetCompletion OneApiErrors preserves buffered tables as partial" {
+test "KustoClient returns completion failures with buffered V2 tables" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200,
+    const response_body =
         \\[
-        \\ {"FrameType":"DataTable","TableName":"PrimaryResult","Columns":[{"ColumnName":"Value"}],"Rows":[["before failure"]]},
-        \\ {"FrameType":"DataSetCompletion","HasErrors":true,"OneApiErrors":[{"error":{"code":"LimitsExceeded","message":"partial failure","@permanent":false,"@context":{"clientRequestId":"context-request","activityId":"context-activity"}}}]}
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"Value","ColumnType":"string"}],"Rows":[["before failure"]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":true,"Cancelled":false,"OneApiErrors":[{"error":{"code":"LimitsExceeded","message":"partial failure"}}]}
         \\]
-    );
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, response_body);
     mock.response_headers_list = &.{
         .{ .name = "x-ms-client-request-id", .value = "response-request" },
         .{ .name = "x-ms-activity-id", .value = "response-activity" },
@@ -1354,27 +802,29 @@ test "DataSetCompletion OneApiErrors preserves buffered tables as partial" {
         .{},
     );
 
-    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-    switch (result) {
+    var response_result = try client.executeQueryResult(allocator, "db", "print 1", null);
+    defer response_result.deinit(allocator);
+    switch (response_result) {
         .partial => |partial| {
-            try std.testing.expectEqual(@as(usize, 1), partial.value.tables.len);
-            try std.testing.expectEqualStrings("before failure", partial.value.tables[0].rows[0].values[0]);
             try std.testing.expectEqual(KustoErrorSource.dataset_completion, partial.failure.source);
             try std.testing.expectEqualStrings("LimitsExceeded", partial.failure.detail.code.?);
             try std.testing.expectEqualStrings("response-request", partial.failure.client_request_id.?);
             try std.testing.expectEqualStrings("response-activity", partial.failure.activity_id.?);
-            try std.testing.expect(!partial.failure.retryable);
+            try std.testing.expectEqualStrings(
+                "before failure",
+                partial.value.primaryTable().?.rows[0].get(0).?.asString().?,
+            );
         },
         else => return error.TestUnexpectedResult,
     }
 }
 
-test "TableCompletion OneApiErrors is classified as partial" {
+test "KustoClient returns V1 exceptions as partial buffered results" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200,
-        \\[{"FrameType":"TableCompletion","HasErrors":true,"OneApiErrors":[{"error":{"code":"TableFailure","message":"failed table"}}]}]
-    );
+    const response_body =
+        \\{"Tables":[{"TableName":"Table_0","Columns":[{"ColumnName":"Value","ColumnType":"string"}],"Rows":[["before"],{"Exceptions":["partial V1 failure"]}]}]}
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
     var client = KustoClient.init(
         .{ .cluster_url = "https://cluster.kusto.windows.net" },
@@ -1382,91 +832,48 @@ test "TableCompletion OneApiErrors is classified as partial" {
         .{},
     );
 
-    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-    switch (result) {
+    var response_result = try client.executeMgmtResult(allocator, "db", ".show tables", null);
+    defer response_result.deinit(allocator);
+    switch (response_result) {
         .partial => |partial| {
-            try std.testing.expectEqual(KustoErrorSource.table_completion, partial.failure.source);
-            try std.testing.expectEqualStrings("TableFailure", partial.failure.detail.code.?);
+            try std.testing.expectEqual(KustoErrorSource.v1_exception, partial.failure.source);
+            try std.testing.expectEqualStrings("partial V1 failure", partial.failure.detail.message.?);
+            try std.testing.expectEqualStrings("before", partial.value.primaryTable().?.rows[0].get(0).?.asString().?);
         },
         else => return error.TestUnexpectedResult,
     }
 }
 
-test "QueryStatus failure rows are classified as partial" {
+test "KustoClient honors varying-result-width request property" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200,
-        \\[{"FrameType":"DataTable","TableName":"QueryStatus","Columns":[{"ColumnName":"Severity"},{"ColumnName":"StatusCode"},{"ColumnName":"StatusDescription"},{"ColumnName":"ClientActivityId"},{"ColumnName":"ActivityId"}],"Rows":[[1,"SyntaxError","bad query","row-request","row-activity"]]}]
-    );
-    defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
-
-    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-    switch (result) {
-        .partial => |partial| {
-            try std.testing.expectEqual(KustoErrorSource.query_status, partial.failure.source);
-            try std.testing.expectEqualStrings("SyntaxError", partial.failure.detail.code.?);
-            try std.testing.expectEqualStrings("bad query", partial.failure.detail.message.?);
-            try std.testing.expectEqualStrings("row-request", partial.failure.client_request_id.?);
-            try std.testing.expectEqualStrings("row-activity", partial.failure.activity_id.?);
-        },
-        else => return error.TestUnexpectedResult,
-    }
-}
-
-test "V2 QueryCompletionInformation failure rows are classified as partial" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200,
-        \\[{"FrameType":"DataTable","TableName":"Table_1","TableKind":"QueryCompletionInformation","Columns":[{"ColumnName":"Severity"},{"ColumnName":"StatusCode"},{"ColumnName":"StatusDescription"}],"Rows":[[2,"LimitsExceeded","result truncated"]]}]
-    );
-    defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
-
-    var result = try client.executeQueryResult(allocator, "db", "print 1", null);
-    defer result.deinit(allocator);
-    switch (result) {
-        .partial => |partial| {
-            try std.testing.expectEqualStrings("QueryCompletionInformation", partial.value.tables[0].kind.?);
-            try std.testing.expectEqual(KustoErrorSource.query_status, partial.failure.source);
-            try std.testing.expectEqualStrings("LimitsExceeded", partial.failure.detail.code.?);
-            try std.testing.expectEqualStrings("result truncated", partial.failure.detail.message.?);
-        },
-        else => return error.TestUnexpectedResult,
-    }
-}
-
-fn parseAllocationFixture(allocator: std.mem.Allocator, body: []const u8) !void {
-    var dataset = try parseResponseDataSet(allocator, body);
-    defer dataset.deinit(allocator);
-    try std.testing.expectEqual(@as(usize, 2), dataset.tables.len);
-    try std.testing.expectEqualStrings("escaped\nvalue", dataset.tables[0].rows[0].values[0]);
-}
-
-test "Kusto response parser handles every allocation failure" {
     const response_body =
         \\[
-        \\  {"FrameType":"DataSetHeader"},
-        \\  {"FrameType":"DataTable","TableName":"PrimaryResult","Columns":[
-        \\    {"ColumnName":"A","ColumnType":"string"},
-        \\    {"ColumnName":"B","ColumnType":"dynamic"}
-        \\  ],"Rows":[["escaped\nvalue",{"nested":[1,2]}],["second",null]]},
-        \\  {"FrameType":"DataTable","TableName":"SecondaryResult","Columns":[
-        \\    {"ColumnName":"C","ColumnType":"long"}
-        \\  ],"Rows":[[42]]}
+        \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\ {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"Value","ColumnType":"string"}],"Rows":[["one","extra"]]},
+        \\ {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
         \\]
     ;
-    try std.testing.checkAllAllocationFailures(
-        std.testing.allocator,
-        parseAllocationFixture,
-        .{response_body},
+    var mock = core.http.MockTransport.init(allocator, 200, response_body);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
     );
+    var properties = ClientRequestProperties{};
+    defer properties.deinit(allocator);
+    try properties.setClientResultsReaderAllowVaryingRowWidths(allocator, true);
+
+    var dataset = try client.executeQuery(allocator, "db", "print 1", properties);
+    defer dataset.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 2), dataset.primaryTable().?.rows[0].values.len);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        mock.last_body.?,
+        "\"client_results_reader_allow_varying_row_widths\":true",
+    ) != null);
+}
+
+test {
+    _ = @import("result.zig");
 }

--- a/sdk/kusto/error.zig
+++ b/sdk/kusto/error.zig
@@ -14,6 +14,7 @@ pub const KustoErrorSource = enum {
     http,
     dataset_completion,
     table_completion,
+    data_table,
     query_status,
     v1_exception,
     transport,


### PR DESCRIPTION
Closes #50

Adds an allocator-owned Kusto result model with typed scalar values, tagged raw frames, V1 table-of-contents handling, and strict V2 normal, fragmented, and progressive reconstruction. Buffered decoding now preserves dynamic and unknown JSON, applies append/replace fragments, exposes table/row/frame iterators and selectors, and reports completion, status, and row-embedded OneAPI failures with partial datasets.

Integrates the documented varying-row-width request option, restores client/authentication/retry regression coverage, and documents ownership and protocol behavior.

Validation: `zig fmt --check sdk/ build.zig` and `zig build test --summary all` (346/346 tests).