### PR TITLE
kusto: add comptime query parameters, typed rows, and safe KQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Pure Zig implementation of Azure service clients with **zero C dependencies**.
 
-**53 source files · 219 tests · Zig 0.16+**
+**60 source files · 358 tests · Zig 0.16+**
 
 ## Quick Start
 
@@ -166,9 +166,45 @@ Metadata can expose the login authority for a sovereign or private cloud, but `T
 - In the current synchronous buffered transport, the client timeout bounds retries and backoff only; it cannot interrupt an in-flight `std.http` request. Hard cancellation is deferred to future streaming and cancellation transport work.
 - Explicit application, user, version, and request-ID headers override defaults. Results expose owned `client_request_id` and `activity_id`; dataset `deinit` frees them.
 - Buffered result rows are strict about matching the declared column width by default. Set `ClientRequestProperties.setClientResultsReaderAllowVaryingRowWidths` only for services that intentionally emit uneven rows; missing cells remain absent and extra cells are preserved as unknown raw JSON.
-- V2 buffered decoding requires a `DataSetHeader` first and `DataSetCompletion` last. It reconstructs progressive or fragmented `DataAppend`/`DataReplace` frames by table ID, treats row-embedded OneAPI errors as partial results, retains unknown frames, and exposes table/row iterators plus ID, kind, primary, properties, and status selectors. Network streaming, cancellation, and comptime typed conversion remain future work.
+- V2 buffered decoding requires a `DataSetHeader` first and `DataSetCompletion` last. It reconstructs progressive or fragmented `DataAppend`/`DataReplace` frames by table ID, treats row-embedded OneAPI errors as partial results, retains unknown frames, and exposes table/row iterators plus ID, kind, primary, properties, and status selectors. Network streaming and cancellation remain future work.
 - Queries may retry; management operations and streaming ingestion remain non-retryable.
 - Kusto `*Result` APIs return `KustoResult(T)`: `.ok`, `.partial` (possibly unreliable decoded buffered tables plus an owned `KustoError`), or `.err`; call `deinit`. A streaming `.err` records `.known_not_accepted` for a received non-2xx response and `.unknown` with the transport cause after transport entry fails, while pre-transport credential/policy errors stay in the outer Zig error union. Permanent and partial failures are never retryable.
+
+### Typed KQL and result rows
+
+Use `azure_kusto_data.kql.QueryParameters` to declare parameter types once. Its generated `Name` enum is the only runtime value accepted by `kql.Builder.parameter`, and `bind` copies values into `ClientRequestProperties.Parameters`; values are never interpolated into CSL.
+
+```zig
+const kusto = @import("azure_kusto_data");
+const Params = struct { account: []const u8, minimum: i64 };
+const Binding = kusto.kql.QueryParameters(Params);
+
+var properties = try Binding.bind(allocator, .{ .account = user_input, .minimum = 10 });
+defer properties.deinit(allocator);
+var query = try kusto.kql.Builder(Binding).init(allocator);
+defer query.deinit();
+try query.literal("StormEvents | where ");
+try query.identifier("Account");
+try query.literal(" == ");
+try query.parameter(.account);
+try query.literal(" | take ");
+try query.parameter(.minimum);
+var dataset = try client.executeQuery(allocator, "db", query.bytes(), properties);
+defer dataset.deinit(allocator);
+```
+
+`literal` is comptime-trusted KQL. Runtime identifiers, strings, and parameter references are bracketed or escaped and UTF-8 validated; `unsafeRaw` is the only unescaped runtime path. `kql.DateTime`, `Timespan`, `Decimal`, `Guid`, and `dynamic(value)` provide explicit typed parameter values; their source slices are borrowed only while `bind` runs.
+
+Typed result rows scan a table schema once and allocate values independent of the dataset. Call the decoder's `deinitRow` (or the typed iterator's `deinitRow`) for every successful row. `KustoDateTime`, `KustoTimespan`, `KustoDecimal`, `KustoGuid`, `KustoDynamic`, strings, and cloned `KustoValue` fields are owned decoded values.
+
+```zig
+const Row = struct { Account: []u8, Count: i64 };
+const table = dataset.primaryTable().?;
+const Decoder = kusto.KustoRowDecoder(Row);
+const decoder = try table.rowDecoder(Row);
+var row = try decoder.rowAs(&table.rows[0], allocator);
+defer Decoder.deinitRow(&row, allocator);
+```
 
 ### Infrastructure
 

--- a/sdk/kusto/data/kql.zig
+++ b/sdk/kusto/data/kql.zig
@@ -1,0 +1,558 @@
+//! Typed query parameters and safe KQL construction.
+//!
+//! Parameter wrapper values borrow their lexical input during `bind`; the
+//! returned `ClientRequestProperties` owns its copied wire values. Query text
+//! is never assembled from runtime parameter values.
+const std = @import("std");
+const serde = @import("serde");
+const kusto_common = @import("azure_kusto_common");
+
+pub const ClientRequestProperties = kusto_common.ClientRequestProperties;
+
+/// A borrowed datetime lexical value for a typed query parameter.
+pub const DateTime = struct { value: []const u8 };
+/// A borrowed timespan lexical value for a typed query parameter.
+pub const Timespan = struct { value: []const u8 };
+/// A borrowed decimal lexical value for a typed query parameter.
+pub const Decimal = struct { value: []const u8 };
+/// A borrowed GUID lexical value for a typed query parameter.
+pub const Guid = struct { value: []const u8 };
+
+/// Wrap a value which will be JSON-serialized and sent as `dynamic(...)`.
+/// This deliberately accepts structured Zig values rather than raw KQL.
+pub fn Dynamic(comptime T: type) type {
+    return struct {
+        value: T,
+
+        pub const __kusto_dynamic_wrapper = true;
+    };
+}
+
+pub fn dynamic(value: anytype) Dynamic(@TypeOf(value)) {
+    return .{ .value = value };
+}
+
+const ParameterKind = enum {
+    string,
+    bool,
+    int,
+    long,
+    real,
+    datetime,
+    timespan,
+    decimal,
+    guid,
+    dynamic,
+
+    fn declarationType(self: ParameterKind) []const u8 {
+        return switch (self) {
+            .string => "string",
+            .bool => "bool",
+            .int => "int",
+            .long => "long",
+            .real => "real",
+            .datetime => "datetime",
+            .timespan => "timespan",
+            .decimal => "decimal",
+            .guid => "guid",
+            .dynamic => "dynamic",
+        };
+    }
+};
+
+/// Creates a typed parameter binder for a non-tuple struct.
+///
+/// The generated `Name` enum is the only accepted runtime parameter-reference
+/// type for `Builder.parameter`.
+pub fn QueryParameters(comptime T: type) type {
+    validateParameterStruct(T);
+    const declaration_text = makeDeclaration(T);
+
+    return struct {
+        pub const Value = T;
+        pub const Name = std.meta.FieldEnum(T);
+        pub const declaration = declaration_text;
+        pub const __kusto_query_parameters = true;
+
+        /// Copies encoded values into an owned request-property bag.
+        pub fn bind(allocator: std.mem.Allocator, values: T) !ClientRequestProperties {
+            var properties = ClientRequestProperties{};
+            errdefer properties.deinit(allocator);
+            inline for (std.meta.fields(T)) |field| {
+                try bindField(
+                    allocator,
+                    &properties,
+                    field.name,
+                    classifyParameterType(field.name, field.type),
+                    @field(values, field.name),
+                );
+            }
+            return properties;
+        }
+
+        /// Prepends this binding's deterministic declaration to raw trusted KQL.
+        pub fn prepend(allocator: std.mem.Allocator, query: []const u8) ![]u8 {
+            return concatenateDeclaration(allocator, declaration_text, query);
+        }
+
+        pub fn prependDeclaration(allocator: std.mem.Allocator, query: []const u8) ![]u8 {
+            return prepend(allocator, query);
+        }
+    };
+}
+
+/// Appends a deterministic query-parameter declaration to a query allocation.
+fn concatenateDeclaration(
+    allocator: std.mem.Allocator,
+    declaration: []const u8,
+    query: []const u8,
+) ![]u8 {
+    const length = std.math.add(usize, declaration.len, query.len) catch return error.OutOfMemory;
+    const result = try allocator.alloc(u8, length);
+    @memcpy(result[0..declaration.len], declaration);
+    @memcpy(result[declaration.len..], query);
+    return result;
+}
+
+/// A KQL builder which makes runtime values safe by default.
+///
+/// `literal` is comptime-only trusted KQL. `unsafeRaw` is intentionally the
+/// only runtime method which inserts unescaped query syntax.
+pub fn Builder(comptime Binding: type) type {
+    validateBinding(Binding);
+
+    return struct {
+        const Self = @This();
+
+        allocator: std.mem.Allocator,
+        buffer: std.ArrayList(u8) = .empty,
+
+        pub fn init(allocator: std.mem.Allocator) !Self {
+            var self = Self{ .allocator = allocator };
+            errdefer self.deinit();
+            try self.buffer.appendSlice(allocator, Binding.declaration);
+            return self;
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.buffer.deinit(self.allocator);
+            self.buffer = .empty;
+        }
+
+        /// Appends a comptime-trusted KQL fragment.
+        pub fn literal(self: *Self, comptime text: []const u8) !void {
+            try self.buffer.appendSlice(self.allocator, text);
+        }
+
+        /// Appends a validated bracketed KQL string-name.
+        pub fn identifier(self: *Self, value: []const u8) !void {
+            if (value.len == 0 or !std.unicode.utf8ValidateSlice(value))
+                return error.InvalidKustoIdentifier;
+            try self.buffer.appendSlice(self.allocator, "['");
+            try self.appendEscaped(value);
+            try self.buffer.appendSlice(self.allocator, "']");
+        }
+
+        /// Appends a validated single-quoted KQL string literal.
+        pub fn string(self: *Self, value: []const u8) !void {
+            if (!std.unicode.utf8ValidateSlice(value))
+                return error.InvalidKustoString;
+            try self.buffer.append(self.allocator, '\'');
+            try self.appendEscaped(value);
+            try self.buffer.append(self.allocator, '\'');
+        }
+
+        /// Appends a declaration-bound parameter reference.
+        pub fn parameter(self: *Self, name: Binding.Name) !void {
+            try self.buffer.appendSlice(self.allocator, "['");
+            try self.buffer.appendSlice(self.allocator, @tagName(name));
+            try self.buffer.appendSlice(self.allocator, "']");
+        }
+
+        /// Appends runtime KQL without escaping. Prefer every other method.
+        pub fn unsafeRaw(self: *Self, value: []const u8) !void {
+            try self.buffer.appendSlice(self.allocator, value);
+        }
+
+        /// Borrows the completed query bytes until `deinit` or `takeBytes`.
+        pub fn bytes(self: *const Self) []const u8 {
+            return self.buffer.items;
+        }
+
+        /// Transfers the completed query allocation to the caller.
+        pub fn takeBytes(self: *Self) ![]u8 {
+            const result = try self.buffer.toOwnedSlice(self.allocator);
+            self.buffer = .empty;
+            return result;
+        }
+
+        fn appendEscaped(self: *Self, value: []const u8) !void {
+            for (value) |byte| {
+                switch (byte) {
+                    '\'' => try self.buffer.appendSlice(self.allocator, "\\'"),
+                    '\\' => try self.buffer.appendSlice(self.allocator, "\\\\"),
+                    '\n' => try self.buffer.appendSlice(self.allocator, "\\n"),
+                    '\r' => try self.buffer.appendSlice(self.allocator, "\\r"),
+                    '\t' => try self.buffer.appendSlice(self.allocator, "\\t"),
+                    0x08 => try self.buffer.appendSlice(self.allocator, "\\b"),
+                    0x0c => try self.buffer.appendSlice(self.allocator, "\\f"),
+                    else => {
+                        if (byte < 0x20 or byte == 0x7f) {
+                            const digits = "01234567";
+                            const escaped = [_]u8{
+                                '\\',
+                                digits[(byte >> 6) & 0x07],
+                                digits[(byte >> 3) & 0x07],
+                                digits[byte & 0x07],
+                            };
+                            try self.buffer.appendSlice(self.allocator, &escaped);
+                        } else {
+                            try self.buffer.append(self.allocator, byte);
+                        }
+                    },
+                }
+            }
+        }
+    };
+}
+
+fn validateBinding(comptime Binding: type) void {
+    if (!@hasDecl(Binding, "__kusto_query_parameters") or
+        !@hasDecl(Binding, "Name") or
+        !@hasDecl(Binding, "declaration"))
+    {
+        @compileError("kql.Builder requires a type returned by kql.QueryParameters");
+    }
+}
+
+fn validateParameterStruct(comptime T: type) void {
+    const info = switch (@typeInfo(T)) {
+        .@"struct" => |item| item,
+        else => @compileError("kql.QueryParameters requires a non-tuple struct"),
+    };
+    if (info.is_tuple)
+        @compileError("kql.QueryParameters requires a non-tuple struct");
+    inline for (std.meta.fields(T)) |field| {
+        validateParameterName(field.name);
+        _ = classifyParameterType(field.name, field.type);
+    }
+}
+
+fn validateParameterName(comptime name: []const u8) void {
+    if (name.len == 0 or !isIdentifierStart(name[0])) {
+        @compileError(std.fmt.comptimePrint(
+            "Kusto parameter field '{s}' is not a safe Kusto parameter identifier",
+            .{name},
+        ));
+    }
+    for (name[1..]) |byte| {
+        if (!isIdentifierContinue(byte)) {
+            @compileError(std.fmt.comptimePrint(
+                "Kusto parameter field '{s}' is not a safe Kusto parameter identifier",
+                .{name},
+            ));
+        }
+    }
+}
+
+fn isIdentifierStart(byte: u8) bool {
+    return std.ascii.isAlphabetic(byte) or byte == '_';
+}
+
+fn isIdentifierContinue(byte: u8) bool {
+    return isIdentifierStart(byte) or std.ascii.isDigit(byte);
+}
+
+fn classifyParameterType(comptime field_name: []const u8, comptime T: type) ParameterKind {
+    if (T == DateTime) return .datetime;
+    if (T == Timespan) return .timespan;
+    if (T == Decimal) return .decimal;
+    if (T == Guid) return .guid;
+    if (isDynamicWrapper(T)) return .dynamic;
+    if (isByteString(T)) return .string;
+    if (T == bool) return .bool;
+    if (T == i64 or T == u32) return .long;
+    if (T == i8 or T == i16 or T == i32 or T == u8 or T == u16) return .int;
+    if (T == f32 or T == f64) return .real;
+    @compileError(std.fmt.comptimePrint(
+        "Kusto parameter field '{s}' has unsupported type {s}; supported types are byte strings, bool, i8/i16/i32/i64, u8/u16/u32, f32/f64, kql.DateTime, kql.Timespan, kql.Decimal, kql.Guid, and kql.dynamic(...)",
+        .{ field_name, @typeName(T) },
+    ));
+}
+
+fn isDynamicWrapper(comptime T: type) bool {
+    return @typeInfo(T) == .@"struct" and @hasDecl(T, "__kusto_dynamic_wrapper");
+}
+
+fn isByteString(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .array => |array| array.child == u8,
+        .pointer => |pointer| switch (pointer.size) {
+            .slice => pointer.child == u8,
+            .one => switch (@typeInfo(pointer.child)) {
+                .array => |array| array.child == u8,
+                else => false,
+            },
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn makeDeclaration(comptime T: type) []const u8 {
+    if (std.meta.fields(T).len == 0) return "";
+    comptime var result: []const u8 = "declare query_parameters (";
+    inline for (std.meta.fields(T), 0..) |field, index| {
+        if (index != 0) result = result ++ ", ";
+        result = result ++ "['" ++ field.name ++ "']:" ++ classifyParameterType(field.name, field.type).declarationType();
+    }
+    return result ++ ");\n";
+}
+
+fn bindField(
+    allocator: std.mem.Allocator,
+    properties: *ClientRequestProperties,
+    comptime name: []const u8,
+    comptime kind: ParameterKind,
+    value: anytype,
+) !void {
+    switch (kind) {
+        .string => {
+            const text: []const u8 = switch (@typeInfo(@TypeOf(value))) {
+                .array => value[0..],
+                .pointer => |pointer| switch (pointer.size) {
+                    .slice => value,
+                    .one => value[0..],
+                    else => unreachable,
+                },
+                else => unreachable,
+            };
+            if (!std.unicode.utf8ValidateSlice(text))
+                return error.InvalidKustoStringParameter;
+            const wire = try serializeDynamic(allocator, text);
+            defer allocator.free(wire);
+            try properties.setParameter(allocator, name, wire);
+        },
+        .long => {
+            const wire = try std.fmt.allocPrint(allocator, "long({d})", .{value});
+            defer allocator.free(wire);
+            try properties.setParameter(allocator, name, wire);
+        },
+        .bool => try properties.setParameter(
+            allocator,
+            name,
+            if (value) "bool(true)" else "bool(false)",
+        ),
+        .int => {
+            const wire = try std.fmt.allocPrint(allocator, "int({d})", .{value});
+            defer allocator.free(wire);
+            try properties.setParameter(allocator, name, wire);
+        },
+        .real => {
+            const wire = try realWireValue(allocator, value);
+            defer allocator.free(wire);
+            try properties.setParameter(allocator, name, wire);
+        },
+        .datetime => try bindLexical(allocator, properties, name, "datetime", value.value),
+        .timespan => try bindLexical(allocator, properties, name, "timespan", value.value),
+        .decimal => try bindLexical(allocator, properties, name, "decimal", value.value),
+        .guid => try bindLexical(allocator, properties, name, "guid", value.value),
+        .dynamic => {
+            const json = try serializeDynamic(allocator, value.value);
+            defer allocator.free(json);
+            const wire = try std.fmt.allocPrint(allocator, "dynamic({s})", .{json});
+            defer allocator.free(wire);
+            try properties.setParameter(allocator, name, wire);
+        },
+    }
+}
+
+fn serializeDynamic(allocator: std.mem.Allocator, value: anytype) ![]u8 {
+    var output: serde.compat.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    serde.json.toWriter(&output.writer, value) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
+        else => return err,
+    };
+    return output.toOwnedSlice() catch error.OutOfMemory;
+}
+
+fn bindLexical(
+    allocator: std.mem.Allocator,
+    properties: *ClientRequestProperties,
+    comptime name: []const u8,
+    comptime type_name: []const u8,
+    value: []const u8,
+) !void {
+    const wire = try std.fmt.allocPrint(allocator, "{s}({s})", .{ type_name, value });
+    defer allocator.free(wire);
+    try properties.setParameter(allocator, name, wire);
+}
+
+fn realWireValue(allocator: std.mem.Allocator, value: anytype) ![]u8 {
+    if (std.math.isNan(value))
+        return allocator.dupe(u8, "real(nan)");
+    if (std.math.isInf(value))
+        return allocator.dupe(u8, if (value < 0) "real(-inf)" else "real(+inf)");
+    return std.fmt.allocPrint(allocator, "real({d})", .{value});
+}
+
+test "typed query parameters have deterministic declaration and wire values" {
+    const Payload = struct { nested: []const u8, values: [2]i32 };
+    const Params = struct {
+        text: []const u8,
+        literal: @TypeOf("literal"),
+        bytes: [3]u8,
+        signed: i32,
+        small_unsigned: u16,
+        count: i64,
+        wide_unsigned: u32,
+        enabled: bool,
+        ratio: f64,
+        ratio32: f32,
+        when: DateTime,
+        span: Timespan,
+        amount: Decimal,
+        id: Guid,
+        payload: Dynamic(Payload),
+    };
+    const Binding = QueryParameters(Params);
+    try std.testing.expectEqualStrings(
+        "declare query_parameters (['text']:string, ['literal']:string, ['bytes']:string, ['signed']:int, ['small_unsigned']:int, ['count']:long, ['wide_unsigned']:long, ['enabled']:bool, ['ratio']:real, ['ratio32']:real, ['when']:datetime, ['span']:timespan, ['amount']:decimal, ['id']:guid, ['payload']:dynamic);\n",
+        Binding.declaration,
+    );
+
+    var properties = try Binding.bind(std.testing.allocator, .{
+        .text = "a\"b",
+        .literal = "literal",
+        .bytes = .{ 'x', 'y', 'z' },
+        .signed = -2,
+        .small_unsigned = 3,
+        .count = 4,
+        .wide_unsigned = 5,
+        .enabled = true,
+        .ratio = 1.5,
+        .ratio32 = 2.5,
+        .when = .{ .value = "2026-01-02T03:04:05Z" },
+        .span = .{ .value = "01:02:03" },
+        .amount = .{ .value = "12.340" },
+        .id = .{ .value = "123e4567-e89b-12d3-a456-426614174000" },
+        .payload = dynamic(Payload{ .nested = "a\"b", .values = .{ 1, 2 } }),
+    });
+    defer properties.deinit(std.testing.allocator);
+    const json = try properties.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"Options\":{},\"Parameters\":{\"text\":\"\\\"a\\\\\\\"b\\\"\",\"literal\":\"\\\"literal\\\"\",\"bytes\":\"\\\"xyz\\\"\",\"signed\":\"int(-2)\",\"small_unsigned\":\"int(3)\",\"count\":\"long(4)\",\"wide_unsigned\":\"long(5)\",\"enabled\":\"bool(true)\",\"ratio\":\"real(1.5)\",\"ratio32\":\"real(2.5)\",\"when\":\"datetime(2026-01-02T03:04:05Z)\",\"span\":\"timespan(01:02:03)\",\"amount\":\"decimal(12.340)\",\"id\":\"guid(123e4567-e89b-12d3-a456-426614174000)\",\"payload\":\"dynamic({\\\"nested\\\":\\\"a\\\\\\\"b\\\",\\\"values\\\":[1,2]})\"}}",
+        json,
+    );
+    const query = try Binding.prepend(std.testing.allocator, "print ['count']");
+    defer std.testing.allocator.free(query);
+    try std.testing.expectEqualStrings(Binding.declaration ++ "print ['count']", query);
+}
+
+test "real parameter special values use valid Kusto literals" {
+    const Binding = QueryParameters(struct { value: f64 });
+    const values = [_]struct { input: f64, expected: []const u8 }{
+        .{ .input = std.math.nan(f64), .expected = "real(nan)" },
+        .{ .input = std.math.inf(f64), .expected = "real(+inf)" },
+        .{ .input = -std.math.inf(f64), .expected = "real(-inf)" },
+    };
+    for (values) |item| {
+        var properties = try Binding.bind(std.testing.allocator, .{ .value = item.input });
+        defer properties.deinit(std.testing.allocator);
+        try std.testing.expectEqualStrings(item.expected, switch (properties.parameters.items[0].value) {
+            .string => |wire| wire,
+            else => return error.TestUnexpectedResult,
+        });
+    }
+}
+
+test "string parameter values reject invalid UTF-8" {
+    const Binding = QueryParameters(struct { value: []const u8 });
+    try std.testing.expectError(
+        error.InvalidKustoStringParameter,
+        Binding.bind(std.testing.allocator, .{ .value = &[_]u8{0xff} }),
+    );
+}
+
+test "safe KQL builder escapes runtime values and transfers ownership" {
+    const Binding = QueryParameters(struct { value: i64 });
+    var builder = try Builder(Binding).init(std.testing.allocator);
+    defer builder.deinit();
+    try builder.literal("T | where ");
+    try builder.identifier("x'] | take 1 //\\\n");
+    try builder.literal(" == ");
+    try builder.string("a'\\\n\t\x01é");
+    try builder.literal(" and x == ");
+    try builder.parameter(.value);
+    try builder.unsafeRaw(" | take 1");
+    try builder.literal(" | project ");
+    try builder.identifier("表");
+    try std.testing.expectEqualStrings(
+        "declare query_parameters (['value']:long);\nT | where ['x\\'] | take 1 //\\\\\\n'] == 'a\\'\\\\\\n\\t\\001é' and x == ['value'] | take 1 | project ['表']",
+        builder.bytes(),
+    );
+    const owned = try builder.takeBytes();
+    defer std.testing.allocator.free(owned);
+    try std.testing.expectEqualStrings(
+        "declare query_parameters (['value']:long);\nT | where ['x\\'] | take 1 //\\\\\\n'] == 'a\\'\\\\\\n\\t\\001é' and x == ['value'] | take 1 | project ['表']",
+        owned,
+    );
+    try std.testing.expectEqual(@as(usize, 0), builder.bytes().len);
+    try std.testing.expectError(error.InvalidKustoIdentifier, builder.identifier(""));
+    try std.testing.expectError(error.InvalidKustoIdentifier, builder.identifier(&[_]u8{0xff}));
+    try std.testing.expectError(error.InvalidKustoString, builder.string(&[_]u8{0xff}));
+}
+
+test "empty parameter bindings omit the declaration" {
+    const Binding = QueryParameters(struct {});
+    try std.testing.expectEqualStrings("", Binding.declaration);
+    var properties = try Binding.bind(std.testing.allocator, .{});
+    defer properties.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), properties.parameters.items.len);
+
+    var builder = try Builder(Binding).init(std.testing.allocator);
+    defer builder.deinit();
+    try builder.literal("print 1");
+    try std.testing.expectEqualStrings("print 1", builder.bytes());
+}
+
+fn bindAllocationFixture(allocator: std.mem.Allocator) !void {
+    const Payload = struct { values: [2]i32 };
+    const Binding = QueryParameters(struct {
+        text: []const u8,
+        payload: Dynamic(Payload),
+    });
+    var properties = try Binding.bind(allocator, .{
+        .text = "value",
+        .payload = dynamic(Payload{ .values = .{ 1, 2 } }),
+    });
+    defer properties.deinit(allocator);
+    const query = try Binding.prepend(allocator, "print text");
+    defer allocator.free(query);
+}
+
+test "query binding releases every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        bindAllocationFixture,
+        .{},
+    );
+}
+
+fn builderAllocationFixture(allocator: std.mem.Allocator) !void {
+    const Binding = QueryParameters(struct { value: i64 });
+    var builder = try Builder(Binding).init(allocator);
+    defer builder.deinit();
+    try builder.identifier("quotes' slash\\ and newline\n");
+    try builder.string("text\x01");
+}
+
+test "KQL builder releases every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        builderAllocationFixture,
+        .{},
+    );
+}

--- a/sdk/kusto/data/result.zig
+++ b/sdk/kusto/data/result.zig
@@ -72,6 +72,26 @@ pub const KustoValue = union(enum) {
         self.* = .null;
     }
 
+    /// Duplicates every allocator-owned payload so the result survives its
+    /// source dataset's `deinit`.
+    pub fn clone(self: KustoValue, allocator: std.mem.Allocator) !KustoValue {
+        return switch (self) {
+            .null => .null,
+            .string => |value| .{ .string = try allocator.dupe(u8, value) },
+            .bool => |value| .{ .bool = value },
+            .int => |value| .{ .int = value },
+            .long => |value| .{ .long = value },
+            .real => |value| .{ .real = value },
+            .real_raw => |value| .{ .real_raw = try allocator.dupe(u8, value) },
+            .decimal => |value| .{ .decimal = try allocator.dupe(u8, value) },
+            .datetime => |value| .{ .datetime = try allocator.dupe(u8, value) },
+            .timespan => |value| .{ .timespan = try allocator.dupe(u8, value) },
+            .guid => |value| .{ .guid = try allocator.dupe(u8, value) },
+            .dynamic => |value| .{ .dynamic = try allocator.dupe(u8, value) },
+            .unknown => |value| .{ .unknown = try allocator.dupe(u8, value) },
+        };
+    }
+
     pub fn asString(self: KustoValue) ?[]const u8 {
         return switch (self) {
             .string => |value| value,
@@ -139,6 +159,13 @@ pub const KustoValue = union(enum) {
     pub fn asGuid(self: KustoValue) ?[]const u8 {
         return switch (self) {
             .guid => |value| value,
+            else => null,
+        };
+    }
+
+    pub fn asDynamic(self: KustoValue) ?[]const u8 {
+        return switch (self) {
+            .dynamic => |value| value,
             else => null,
         };
     }
@@ -245,7 +272,461 @@ pub const KustoResultTable = struct {
     pub fn rowIterator(self: *const KustoResultTable) RowIterator {
         return .{ .rows = self.rows };
     }
+
+    /// Creates a decoder which resolves the requested schema once.
+    pub fn rowDecoder(self: *const KustoResultTable, comptime T: type) !KustoRowDecoder(T) {
+        return KustoRowDecoder(T).init(self);
+    }
+
+    /// Returns an iterator which borrows this table and yields owned rows.
+    pub fn typedRows(
+        self: *const KustoResultTable,
+        comptime T: type,
+        allocator: std.mem.Allocator,
+    ) !KustoTypedRowIterator(T) {
+        return .{
+            .decoder = try self.rowDecoder(T),
+            .rows = self.rows,
+            .allocator = allocator,
+        };
+    }
 };
+
+/// An owned decoded datetime lexical value. Unlike `kql.DateTime`, this owns
+/// its bytes and therefore remains valid after the source dataset is freed.
+pub const KustoDateTime = struct {
+    value: []u8,
+
+    pub fn deinit(self: *KustoDateTime, allocator: std.mem.Allocator) void {
+        allocator.free(self.value);
+        self.* = undefined;
+    }
+};
+
+/// An owned decoded timespan lexical value.
+pub const KustoTimespan = struct {
+    value: []u8,
+
+    pub fn deinit(self: *KustoTimespan, allocator: std.mem.Allocator) void {
+        allocator.free(self.value);
+        self.* = undefined;
+    }
+};
+
+/// An owned decoded decimal lexical value.
+pub const KustoDecimal = struct {
+    value: []u8,
+
+    pub fn deinit(self: *KustoDecimal, allocator: std.mem.Allocator) void {
+        allocator.free(self.value);
+        self.* = undefined;
+    }
+};
+
+/// An owned decoded GUID lexical value.
+pub const KustoGuid = struct {
+    value: []u8,
+
+    pub fn deinit(self: *KustoGuid, allocator: std.mem.Allocator) void {
+        allocator.free(self.value);
+        self.* = undefined;
+    }
+};
+
+/// Exact owned JSON for a Kusto `dynamic` cell.
+pub const KustoDynamic = struct {
+    raw_json: []u8,
+
+    pub fn deinit(self: *KustoDynamic, allocator: std.mem.Allocator) void {
+        allocator.free(self.raw_json);
+        self.* = undefined;
+    }
+};
+
+/// A schema-validated, allocation-free mapping from Zig fields to table cells.
+pub fn KustoRowDecoder(comptime T: type) type {
+    validateRowType(T);
+    const fields = std.meta.fields(T);
+
+    return struct {
+        const Self = @This();
+
+        columns: []const KustoResultColumn,
+        mapping: [fields.len]usize,
+
+        /// Resolves all requested columns once and rejects ambiguous schemas.
+        pub fn init(table: *const KustoResultTable) !Self {
+            const missing_column = std.math.maxInt(usize);
+            var mapping: [fields.len]usize = [_]usize{missing_column} ** fields.len;
+            for (table.columns, 0..) |column, column_index| {
+                inline for (fields, 0..) |meta_field, field_index| {
+                    if (std.mem.eql(u8, column.name, rowColumnName(T, meta_field.name))) {
+                        if (mapping[field_index] != missing_column)
+                            return error.DuplicateKustoColumn;
+                        mapping[field_index] = column_index;
+                    }
+                }
+            }
+            inline for (mapping) |column_index| {
+                if (column_index == missing_column)
+                    return error.MissingKustoColumn;
+            }
+            return .{ .columns = table.columns, .mapping = mapping };
+        }
+
+        /// Converts a borrowed result row into a wholly allocator-owned `T`.
+        pub fn rowAs(
+            self: *const Self,
+            row: *const KustoResultRow,
+            allocator: std.mem.Allocator,
+        ) !T {
+            if (row.columns.ptr != self.columns.ptr or row.columns.len != self.columns.len)
+                return error.KustoRowSchemaMismatch;
+
+            var result: T = undefined;
+            var initialized: [fields.len]bool = [_]bool{false} ** fields.len;
+            errdefer {
+                inline for (fields, 0..) |meta_field, field_index| {
+                    if (initialized[field_index])
+                        deinitDecodedField(meta_field.type, &@field(result, meta_field.name), allocator);
+                }
+            }
+
+            inline for (fields, 0..) |meta_field, field_index| {
+                const column_index = self.mapping[field_index];
+                if (column_index >= row.values.len) return error.MissingKustoCell;
+                @field(result, meta_field.name) = try decodeField(
+                    meta_field.type,
+                    allocator,
+                    &row.values[column_index],
+                );
+                initialized[field_index] = true;
+            }
+            return result;
+        }
+
+        pub fn deinitRow(value: *T, allocator: std.mem.Allocator) void {
+            deinitDecodedRow(T, value, allocator);
+        }
+    };
+}
+
+/// Deinitializes all allocations owned by an owned typed result row.
+pub fn deinitRow(value: anytype, allocator: std.mem.Allocator) void {
+    const pointer = @typeInfo(@TypeOf(value));
+    const T = switch (pointer) {
+        .pointer => |item| item.child,
+        else => @compileError("result.deinitRow requires a pointer to a row struct"),
+    };
+    validateRowType(T);
+    deinitDecodedRow(T, value, allocator);
+}
+
+/// An iterator that owns its precomputed decoder and borrows table rows.
+pub fn KustoTypedRowIterator(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        decoder: KustoRowDecoder(T),
+        rows: []const KustoResultRow,
+        allocator: std.mem.Allocator,
+        index: usize = 0,
+
+        /// Returns one owned row at a time; call `deinitRow` for every result.
+        pub fn next(self: *Self) !?T {
+            if (self.index >= self.rows.len) return null;
+            defer self.index += 1;
+            return try self.decoder.rowAs(&self.rows[self.index], self.allocator);
+        }
+
+        pub fn deinitRow(value: *T, allocator: std.mem.Allocator) void {
+            deinitDecodedRow(T, value, allocator);
+        }
+    };
+}
+
+fn validateRowType(comptime T: type) void {
+    const info = switch (@typeInfo(T)) {
+        .@"struct" => |item| item,
+        else => @compileError("KustoRowDecoder requires a non-tuple struct row type"),
+    };
+    if (info.is_tuple)
+        @compileError("KustoRowDecoder requires a non-tuple struct row type");
+    validateKustoColumnMappings(T);
+    inline for (std.meta.fields(T), 0..) |meta_field, field_index| {
+        validateDecodedFieldType(T, meta_field.name, meta_field.type);
+        const requested_name = rowColumnName(T, meta_field.name);
+        inline for (std.meta.fields(T)[field_index + 1 ..]) |other| {
+            if (std.mem.eql(u8, requested_name, rowColumnName(T, other.name))) {
+                @compileError(std.fmt.comptimePrint(
+                    "Kusto row fields '{s}' and '{s}' both request column '{s}'",
+                    .{ meta_field.name, other.name, requested_name },
+                ));
+            }
+        }
+    }
+}
+
+fn validateKustoColumnMappings(comptime T: type) void {
+    if (!@hasDecl(T, "kusto_columns")) return;
+    const Mapping = @TypeOf(@field(T, "kusto_columns"));
+    const mapping_info = switch (@typeInfo(Mapping)) {
+        .@"struct" => |item| item,
+        else => @compileError("kusto_columns must be a non-tuple struct literal"),
+    };
+    if (mapping_info.is_tuple)
+        @compileError("kusto_columns must be a non-tuple struct literal");
+    inline for (std.meta.fields(Mapping)) |mapping_field| {
+        if (!hasRowField(T, mapping_field.name)) {
+            @compileError(std.fmt.comptimePrint(
+                "kusto_columns contains unknown Zig field '{s}'",
+                .{mapping_field.name},
+            ));
+        }
+        const name = comptimeByteString(@field(T.kusto_columns, mapping_field.name));
+        if (name.len == 0) {
+            @compileError(std.fmt.comptimePrint(
+                "kusto_columns target for '{s}' must not be empty",
+                .{mapping_field.name},
+            ));
+        }
+    }
+}
+
+fn hasRowField(comptime T: type, comptime name: []const u8) bool {
+    inline for (std.meta.fields(T)) |meta_field| {
+        if (std.mem.eql(u8, meta_field.name, name)) return true;
+    }
+    return false;
+}
+
+fn rowColumnName(comptime T: type, comptime field_name: []const u8) []const u8 {
+    if (!@hasDecl(T, "kusto_columns")) return field_name;
+    inline for (std.meta.fields(@TypeOf(T.kusto_columns))) |mapping_field| {
+        if (std.mem.eql(u8, mapping_field.name, field_name))
+            return comptimeByteString(@field(T.kusto_columns, mapping_field.name));
+    }
+    return field_name;
+}
+
+fn comptimeByteString(comptime value: anytype) []const u8 {
+    const T = @TypeOf(value);
+    return switch (@typeInfo(T)) {
+        .array => |array| if (array.child == u8)
+            value[0..]
+        else
+            @compileError("kusto_columns targets must be byte strings"),
+        .pointer => |pointer| switch (pointer.size) {
+            .slice => if (pointer.child == u8)
+                value
+            else
+                @compileError("kusto_columns targets must be byte strings"),
+            .one => switch (@typeInfo(pointer.child)) {
+                .array => |array| if (array.child == u8)
+                    value[0..]
+                else
+                    @compileError("kusto_columns targets must be byte strings"),
+                else => @compileError("kusto_columns targets must be byte strings"),
+            },
+            else => @compileError("kusto_columns targets must be byte strings"),
+        },
+        else => @compileError("kusto_columns targets must be byte strings"),
+    };
+}
+
+fn validateDecodedFieldType(
+    comptime Row: type,
+    comptime field_name: []const u8,
+    comptime T: type,
+) void {
+    switch (@typeInfo(T)) {
+        .optional => |item| {
+            if (@typeInfo(item.child) == .optional) {
+                @compileError(std.fmt.comptimePrint(
+                    "Kusto row field '{s}.{s}' cannot use nested optional type {s}",
+                    .{ @typeName(Row), field_name, @typeName(T) },
+                ));
+            }
+            validateDecodedFieldType(Row, field_name, item.child);
+            return;
+        },
+        else => {},
+    }
+    if (hasCustomDecode(T)) {
+        validateCustomDecode(T);
+        validateCustomDeinit(T);
+        return;
+    }
+    if (T == bool or T == i32 or T == i64 or T == f64 or
+        T == []u8 or T == []const u8 or T == KustoValue or
+        T == KustoDateTime or T == KustoTimespan or T == KustoDecimal or
+        T == KustoGuid or T == KustoDynamic)
+        return;
+    @compileError(std.fmt.comptimePrint(
+        "Kusto row field '{s}.{s}' has unsupported type {s}; supported types are bool, i32, i64, f64, []u8, []const u8, KustoValue, KustoDateTime, KustoTimespan, KustoDecimal, KustoGuid, KustoDynamic, optional forms, or a kustoDecode hook",
+        .{ @typeName(Row), field_name, @typeName(T) },
+    ));
+}
+
+fn hasCustomDecode(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .@"struct" => @hasDecl(T, "kustoDecode"),
+        .@"union" => @hasDecl(T, "kustoDecode"),
+        .@"enum" => @hasDecl(T, "kustoDecode"),
+        .@"opaque" => @hasDecl(T, "kustoDecode"),
+        else => false,
+    };
+}
+
+fn hasCustomDeinit(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .@"struct" => @hasDecl(T, "deinit"),
+        .@"union" => @hasDecl(T, "deinit"),
+        .@"enum" => @hasDecl(T, "deinit"),
+        .@"opaque" => @hasDecl(T, "deinit"),
+        else => false,
+    };
+}
+
+fn validateCustomDecode(comptime T: type) void {
+    const function_info = switch (@typeInfo(@TypeOf(T.kustoDecode))) {
+        .@"fn" => |item| item,
+        else => @compileError("kustoDecode must be a function"),
+    };
+    if (function_info.params.len != 2 or
+        function_info.params[0].type != std.mem.Allocator or
+        function_info.params[1].type != *const KustoValue)
+    {
+        @compileError(std.fmt.comptimePrint(
+            "{s}.kustoDecode must have signature fn (std.mem.Allocator, *const KustoValue) !@This()",
+            .{@typeName(T)},
+        ));
+    }
+    const return_type = function_info.return_type orelse @compileError("kustoDecode must return an error union");
+    const error_union = switch (@typeInfo(return_type)) {
+        .error_union => |item| item,
+        else => @compileError("kustoDecode must return an error union"),
+    };
+    if (error_union.payload != T) {
+        @compileError(std.fmt.comptimePrint(
+            "{s}.kustoDecode must return !@This()",
+            .{@typeName(T)},
+        ));
+    }
+}
+
+fn validateCustomDeinit(comptime T: type) void {
+    if (!hasCustomDeinit(T)) return;
+    const function_info = switch (@typeInfo(@TypeOf(T.deinit))) {
+        .@"fn" => |item| item,
+        else => @compileError("deinit must be a function"),
+    };
+    if (function_info.params.len != 2 or
+        function_info.params[0].type != *T or
+        function_info.params[1].type != std.mem.Allocator or
+        function_info.return_type != void)
+    {
+        @compileError(std.fmt.comptimePrint(
+            "{s}.deinit must have signature fn (*@This(), std.mem.Allocator) void",
+            .{@typeName(T)},
+        ));
+    }
+}
+
+fn decodeField(comptime T: type, allocator: std.mem.Allocator, value: *const KustoValue) !T {
+    return switch (@typeInfo(T)) {
+        .optional => |item| if (value.isNull())
+            null
+        else
+            try decodeNonOptional(item.child, allocator, value),
+        else => blk: {
+            if (value.isNull()) return error.RequiredKustoValueIsNull;
+            break :blk try decodeNonOptional(T, allocator, value);
+        },
+    };
+}
+
+fn decodeNonOptional(comptime T: type, allocator: std.mem.Allocator, value: *const KustoValue) !T {
+    if (comptime hasCustomDecode(T))
+        return T.kustoDecode(allocator, value);
+    if (T == bool) return value.asBool() orelse error.IncompatibleKustoValue;
+    if (T == i32) return value.asI32() orelse error.IncompatibleKustoValue;
+    if (T == i64) return value.asI64() orelse error.IncompatibleKustoValue;
+    if (T == f64) return typedReal(value.*) orelse error.IncompatibleKustoValue;
+    if (T == []u8 or T == []const u8) {
+        const text = value.asString() orelse return error.IncompatibleKustoValue;
+        return try allocator.dupe(u8, text);
+    }
+    if (T == KustoValue) return try value.clone(allocator);
+    if (T == KustoDateTime) {
+        const text = value.asDateTime() orelse return error.IncompatibleKustoValue;
+        return .{ .value = try allocator.dupe(u8, text) };
+    }
+    if (T == KustoTimespan) {
+        const text = value.asTimespan() orelse return error.IncompatibleKustoValue;
+        return .{ .value = try allocator.dupe(u8, text) };
+    }
+    if (T == KustoDecimal) {
+        const text = value.asDecimal() orelse return error.IncompatibleKustoValue;
+        return .{ .value = try allocator.dupe(u8, text) };
+    }
+    if (T == KustoGuid) {
+        const text = value.asGuid() orelse return error.IncompatibleKustoValue;
+        return .{ .value = try allocator.dupe(u8, text) };
+    }
+    if (T == KustoDynamic) {
+        const raw = value.asDynamic() orelse return error.IncompatibleKustoValue;
+        return .{ .raw_json = try allocator.dupe(u8, raw) };
+    }
+    unreachable;
+}
+
+fn typedReal(value: KustoValue) ?f64 {
+    return switch (value) {
+        .real => |number| number,
+        .real_raw => |raw| {
+            if (std.mem.eql(u8, raw, "\"NaN\"")) return std.math.nan(f64);
+            if (std.mem.eql(u8, raw, "\"Infinity\"") or
+                std.mem.eql(u8, raw, "\"+Infinity\""))
+                return std.math.inf(f64);
+            if (std.mem.eql(u8, raw, "\"-Infinity\""))
+                return -std.math.inf(f64);
+            return null;
+        },
+        else => null,
+    };
+}
+
+fn deinitDecodedRow(comptime T: type, value: *T, allocator: std.mem.Allocator) void {
+    inline for (std.meta.fields(T)) |meta_field| {
+        deinitDecodedField(meta_field.type, &@field(value.*, meta_field.name), allocator);
+    }
+}
+
+fn deinitDecodedField(comptime T: type, value: *T, allocator: std.mem.Allocator) void {
+    switch (@typeInfo(T)) {
+        .optional => {
+            if (value.*) |*child| deinitDecodedField(@typeInfo(T).optional.child, child, allocator);
+            return;
+        },
+        else => {},
+    }
+    if (T == []u8 or T == []const u8) {
+        allocator.free(value.*);
+        return;
+    }
+    if (T == KustoValue) {
+        value.deinit(allocator);
+        return;
+    }
+    if (T == KustoDateTime or T == KustoTimespan or T == KustoDecimal or
+        T == KustoGuid or T == KustoDynamic)
+    {
+        value.deinit(allocator);
+        return;
+    }
+    if (comptime hasCustomDeinit(T)) value.deinit(allocator);
+}
 
 /// The raw JSON and ordinal for a buffered response frame. `raw_json` borrows
 /// the containing dataset's `raw_response`; it is not a second response copy.
@@ -2469,6 +2950,259 @@ test "complex result parsing releases all allocation failures" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         parseAllocationFixture,
+        .{},
+    );
+}
+
+const TypedHook = struct {
+    text: []u8,
+
+    pub fn kustoDecode(allocator: std.mem.Allocator, value: *const KustoValue) !@This() {
+        const text = value.asString() orelse return error.TypedHookExpectedString;
+        return .{ .text = try allocator.dupe(u8, text) };
+    }
+
+    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+        allocator.free(self.text);
+        self.* = undefined;
+    }
+};
+
+const FailingTypedHook = struct {
+    pub fn kustoDecode(_: std.mem.Allocator, _: *const KustoValue) !@This() {
+        return error.TypedHookRejected;
+    }
+};
+
+fn decodeTypedFixture(allocator: std.mem.Allocator) !DecodeOutcome {
+    return decode(
+        allocator,
+        \\{"Tables":[{"TableName":"Rows","Columns":[
+        \\ {"ColumnName":"Name","ColumnType":"string"},{"ColumnName":"Count","ColumnType":"long"},{"ColumnName":"Flag","ColumnType":"bool"},{"ColumnName":"Small","ColumnType":"int"},{"ColumnName":"Rate","ColumnType":"real"},{"ColumnName":"When","ColumnType":"datetime"},{"ColumnName":"Span","ColumnType":"timespan"},{"ColumnName":"Amount","ColumnType":"decimal"},{"ColumnName":"Id","ColumnType":"guid"},{"ColumnName":"Payload","ColumnType":"dynamic"},{"ColumnName":"NullName","ColumnType":"string"}
+        \\],"Rows":[["Ada",42,true,7,1.25,"2026-01-02T03:04:05Z","01:02:03","12.340","123e4567-e89b-12d3-a456-426614174000",{"nested":[1,2]},null],["Grace",43,false,8,2.5,"2026-01-03T03:04:05Z","02:03:04","13.340","123e4567-e89b-12d3-a456-426614174001",{"nested":[3]},null]]}]}
+    ,
+        .{},
+        .query,
+    );
+}
+
+test "typed rows map reordered and renamed columns into owned values" {
+    const Row = struct {
+        count: i64,
+        name: []u8,
+        enabled: bool,
+        optional_name: ?[]const u8,
+
+        pub const kusto_columns = .{
+            .count = "Count",
+            .name = "Name",
+            .enabled = "Flag",
+            .optional_name = "NullName",
+        };
+    };
+    const Decoder = KustoRowDecoder(Row);
+    var decoded = try decodeTypedFixture(std.testing.allocator);
+    defer decoded.deinit(std.testing.allocator);
+    const table = &decoded.dataset.tables[0];
+    const decoder = try table.rowDecoder(Row);
+    var row = try decoder.rowAs(&table.rows[0], std.testing.allocator);
+    defer Decoder.deinitRow(&row, std.testing.allocator);
+    try std.testing.expectEqual(@as(i64, 42), row.count);
+    try std.testing.expectEqualStrings("Ada", row.name);
+    try std.testing.expect(row.enabled);
+    try std.testing.expect(row.optional_name == null);
+
+    const IntRow = struct { Small: i32 };
+    const int_decoder = try table.rowDecoder(IntRow);
+    var int_row = try int_decoder.rowAs(&table.rows[0], std.testing.allocator);
+    defer KustoRowDecoder(IntRow).deinitRow(&int_row, std.testing.allocator);
+    try std.testing.expectEqual(@as(i32, 7), int_row.Small);
+}
+
+test "typed rows support scalars semantic values and KustoValue cloning" {
+    const Row = struct {
+        Name: KustoValue,
+        Small: i64,
+        Rate: f64,
+        When: KustoDateTime,
+        Span: KustoTimespan,
+        Amount: KustoDecimal,
+        Id: KustoGuid,
+        Payload: KustoDynamic,
+    };
+    const Decoder = KustoRowDecoder(Row);
+    var decoded = try decodeTypedFixture(std.testing.allocator);
+    const table = &decoded.dataset.tables[0];
+    const decoder = try table.rowDecoder(Row);
+    var row = try decoder.rowAs(&table.rows[0], std.testing.allocator);
+    decoded.deinit(std.testing.allocator);
+    defer Decoder.deinitRow(&row, std.testing.allocator);
+    try std.testing.expectEqualStrings("Ada", row.Name.asString().?);
+    try std.testing.expectEqual(@as(i64, 7), row.Small);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.25), row.Rate, 0.001);
+    try std.testing.expectEqualStrings("2026-01-02T03:04:05Z", row.When.value);
+    try std.testing.expectEqualStrings("01:02:03", row.Span.value);
+    try std.testing.expectEqualStrings("12.340", row.Amount.value);
+    try std.testing.expectEqualStrings("123e4567-e89b-12d3-a456-426614174000", row.Id.value);
+    try std.testing.expectEqualStrings("{\"nested\":[1,2]}", row.Payload.raw_json);
+}
+
+test "typed rows decode documented non-finite real values" {
+    const Row = struct { Value: f64 };
+    const Decoder = KustoRowDecoder(Row);
+    var decoded = try decode(
+        std.testing.allocator,
+        \\{"Tables":[{"TableName":"Reals","Columns":[{"ColumnName":"Value","ColumnType":"real"}],"Rows":[["NaN"],["Infinity"],["-Infinity"],[1e999]]}]}
+    ,
+        .{},
+        .query,
+    );
+    defer decoded.deinit(std.testing.allocator);
+    const table = &decoded.dataset.tables[0];
+    const decoder = try table.rowDecoder(Row);
+
+    var nan_row = try decoder.rowAs(&table.rows[0], std.testing.allocator);
+    defer Decoder.deinitRow(&nan_row, std.testing.allocator);
+    try std.testing.expect(std.math.isNan(nan_row.Value));
+
+    var positive_row = try decoder.rowAs(&table.rows[1], std.testing.allocator);
+    defer Decoder.deinitRow(&positive_row, std.testing.allocator);
+    try std.testing.expect(std.math.isPositiveInf(positive_row.Value));
+
+    var negative_row = try decoder.rowAs(&table.rows[2], std.testing.allocator);
+    defer Decoder.deinitRow(&negative_row, std.testing.allocator);
+    try std.testing.expect(std.math.isNegativeInf(negative_row.Value));
+
+    try std.testing.expectError(
+        error.IncompatibleKustoValue,
+        decoder.rowAs(&table.rows[3], std.testing.allocator),
+    );
+}
+
+test "typed rows reject missing duplicate null and incompatible cells" {
+    const Missing = struct { Absent: []u8 };
+    var decoded = try decodeTypedFixture(std.testing.allocator);
+    defer decoded.deinit(std.testing.allocator);
+    const table = &decoded.dataset.tables[0];
+    try std.testing.expectError(error.MissingKustoColumn, table.rowDecoder(Missing));
+
+    const RequiredNull = struct { NullName: []u8 };
+    const null_decoder = try table.rowDecoder(RequiredNull);
+    try std.testing.expectError(
+        error.RequiredKustoValueIsNull,
+        null_decoder.rowAs(&table.rows[0], std.testing.allocator),
+    );
+
+    const Incompatible = struct { Count: bool };
+    const incompatible_decoder = try table.rowDecoder(Incompatible);
+    try std.testing.expectError(
+        error.IncompatibleKustoValue,
+        incompatible_decoder.rowAs(&table.rows[0], std.testing.allocator),
+    );
+
+    const NotDynamic = struct { Name: KustoDynamic };
+    const not_dynamic_decoder = try table.rowDecoder(NotDynamic);
+    try std.testing.expectError(
+        error.IncompatibleKustoValue,
+        not_dynamic_decoder.rowAs(&table.rows[0], std.testing.allocator),
+    );
+
+    const LaterFailure = struct {
+        Name: []u8,
+        Count: bool,
+    };
+    const later_failure_decoder = try table.rowDecoder(LaterFailure);
+    try std.testing.expectError(
+        error.IncompatibleKustoValue,
+        later_failure_decoder.rowAs(&table.rows[0], std.testing.allocator),
+    );
+
+    var duplicate = try decode(
+        std.testing.allocator,
+        \\{"Tables":[{"TableName":"Duplicate","Columns":[{"ColumnName":"Name","ColumnType":"string"},{"ColumnName":"Name","ColumnType":"string"}],"Rows":[["one","two"]]}]}
+    ,
+        .{},
+        .query,
+    );
+    defer duplicate.deinit(std.testing.allocator);
+    try std.testing.expectError(
+        error.DuplicateKustoColumn,
+        duplicate.dataset.tables[0].rowDecoder(struct { Name: []u8 }),
+    );
+}
+
+test "typed rows reject missing varying-width cells and schema mismatches" {
+    const Row = struct { B: i64 };
+    var varying = try decode(
+        std.testing.allocator,
+        \\{"Tables":[{"TableName":"Rows","Columns":[{"ColumnName":"A","ColumnType":"string"},{"ColumnName":"B","ColumnType":"long"}],"Rows":[["only-a"]]}]}
+    ,
+        .{ .allow_varying_row_widths = true },
+        .query,
+    );
+    defer varying.deinit(std.testing.allocator);
+    const decoder = try varying.dataset.tables[0].rowDecoder(Row);
+    try std.testing.expectError(
+        error.MissingKustoCell,
+        decoder.rowAs(&varying.dataset.tables[0].rows[0], std.testing.allocator),
+    );
+
+    var another = try decodeTypedFixture(std.testing.allocator);
+    defer another.deinit(std.testing.allocator);
+    const name_decoder = try varying.dataset.tables[0].rowDecoder(struct { A: []u8 });
+    try std.testing.expectError(
+        error.KustoRowSchemaMismatch,
+        name_decoder.rowAs(&another.dataset.tables[0].rows[0], std.testing.allocator),
+    );
+}
+
+test "typed rows support custom conversion hooks and typed iteration" {
+    const Row = struct { Name: TypedHook };
+    const Decoder = KustoRowDecoder(Row);
+    var decoded = try decodeTypedFixture(std.testing.allocator);
+    defer decoded.deinit(std.testing.allocator);
+    const table = &decoded.dataset.tables[0];
+    const decoder = try table.rowDecoder(Row);
+    var row = try decoder.rowAs(&table.rows[0], std.testing.allocator);
+    defer Decoder.deinitRow(&row, std.testing.allocator);
+    try std.testing.expectEqualStrings("Ada", row.Name.text);
+
+    const Failing = struct { Name: FailingTypedHook };
+    const failing_decoder = try table.rowDecoder(Failing);
+    try std.testing.expectError(
+        error.TypedHookRejected,
+        failing_decoder.rowAs(&table.rows[0], std.testing.allocator),
+    );
+
+    const IteratorRow = struct { Count: i64 };
+    const Iterator = KustoTypedRowIterator(IteratorRow);
+    var rows = try table.typedRows(IteratorRow, std.testing.allocator);
+    var first = (try rows.next()).?;
+    defer Iterator.deinitRow(&first, std.testing.allocator);
+    var second = (try rows.next()).?;
+    defer Iterator.deinitRow(&second, std.testing.allocator);
+    try std.testing.expectEqual(@as(i64, 42), first.Count);
+    try std.testing.expectEqual(@as(i64, 43), second.Count);
+    try std.testing.expect((try rows.next()) == null);
+}
+
+fn typedRowAllocationFixture(allocator: std.mem.Allocator) !void {
+    const Row = struct {
+        Name: []u8,
+        Payload: KustoDynamic,
+    };
+    const Decoder = KustoRowDecoder(Row);
+    var decoded = try decodeTypedFixture(allocator);
+    defer decoded.deinit(allocator);
+    const decoder = try decoded.dataset.tables[0].rowDecoder(Row);
+    var row = try decoder.rowAs(&decoded.dataset.tables[0].rows[0], allocator);
+    defer Decoder.deinitRow(&row, allocator);
+}
+
+test "typed row conversion releases every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        typedRowAllocationFixture,
         .{},
     );
 }

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const core = @import("azure_core");
 const serde = @import("serde");
 const kusto_common = @import("azure_kusto_common");
+pub const kql = @import("kql.zig");
 const result = @import("result.zig");
 
 pub const ConnectionProperties = kusto_common.ConnectionProperties;
@@ -34,6 +35,14 @@ pub const KustoValue = result.KustoValue;
 pub const KustoResultColumn = result.KustoResultColumn;
 pub const KustoResultRow = result.KustoResultRow;
 pub const KustoResultTable = result.KustoResultTable;
+pub const KustoDateTime = result.KustoDateTime;
+pub const KustoTimespan = result.KustoTimespan;
+pub const KustoDecimal = result.KustoDecimal;
+pub const KustoGuid = result.KustoGuid;
+pub const KustoDynamic = result.KustoDynamic;
+pub const KustoRowDecoder = result.KustoRowDecoder;
+pub const KustoTypedRowIterator = result.KustoTypedRowIterator;
+pub const deinitRow = result.deinitRow;
 pub const KustoFramePayload = result.KustoFramePayload;
 pub const KustoUnknownFrame = result.KustoUnknownFrame;
 pub const KustoFrame = result.KustoFrame;
@@ -43,6 +52,13 @@ pub const FrameIterator = result.FrameIterator;
 pub const KustoResponseDataSet = result.KustoResponseDataSet;
 pub const DecodeOutcome = result.DecodeOutcome;
 pub const decodeResponseDataSet = result.decode;
+pub const QueryParameters = kql.QueryParameters;
+pub const KqlBuilder = kql.Builder;
+pub const KqlDateTime = kql.DateTime;
+pub const KqlTimespan = kql.Timespan;
+pub const KqlDecimal = kql.Decimal;
+pub const KqlGuid = kql.Guid;
+pub const dynamic = kql.dynamic;
 
 pub const KustoClientOptions = struct {
     application_name: []const u8 = "azure-sdk-zig",
@@ -872,6 +888,54 @@ test "KustoClient honors varying-result-width request property" {
         mock.last_body.?,
         "\"client_results_reader_allow_varying_row_widths\":true",
     ) != null);
+}
+
+test "typed parameter bindings stay in properties rather than query text" {
+    const Params = struct {
+        secret: []const u8,
+        limit: i64,
+    };
+    const Binding = QueryParameters(Params);
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    var properties = try Binding.bind(allocator, .{
+        .secret = "'; .drop table T //",
+        .limit = 7,
+    });
+    defer properties.deinit(allocator);
+    var query = try kql.Builder(Binding).init(allocator);
+    defer query.deinit();
+    try query.literal("StormEvents | where Secret == ");
+    try query.parameter(.secret);
+    try query.literal(" | take ");
+    try query.parameter(.limit);
+    var dataset = try client.executeQuery(allocator, "db", query.bytes(), properties);
+    defer dataset.deinit(allocator);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const wire = try serde.json.fromSlice(
+        struct { csl: []const u8 },
+        arena.allocator(),
+        mock.last_body.?,
+    );
+    try std.testing.expectEqualStrings(
+        "declare query_parameters (['secret']:string, ['limit']:long);\nStormEvents | where Secret == ['secret'] | take ['limit']",
+        wire.csl,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, wire.csl, "drop table") == null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        mock.last_body.?,
+        "\"secret\":\"\\\"'; .drop table T //\\\"\"",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"limit\":\"long(7)\"") != null);
 }
 
 test {


### PR DESCRIPTION
Closes #51

Adds comptime `QueryParameters(T)` bindings whose generated declarations, typed references, and KQL-literal wire values share one type classifier. The new allocator-owned KQL builder safely escapes runtime identifiers and strings, brackets parameter names, supports trusted comptime fragments, and keeps `unsafeRaw` explicit.

Adds table-bound `KustoRowDecoder(T)` and typed iteration with one precomputed column mapping, field renames, optional nulls, owned scalar wrappers, cloned dynamic values, custom conversion hooks, deterministic cleanup, and allocator-failure coverage. Raw KQL, `KustoValue`, raw frames, and existing request properties remain available.

Validation: `zig fmt --check sdk/ build.zig` and `zig build test --summary all` (361/361 tests).