### PR TITLE
core: add bidirectional streaming HTTP operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 
 | Module | Description |
 |--------|-------------|
-| `http.StdHttpTransport` | HTTP client via `std.http.Client` with response header capture |
-| `http.MockTransport` | Canned responses for unit tests |
+| `http.StdHttpTransport` | Buffered and bounded-memory streaming HTTP via `std.http.Client`, with incremental gzip/deflate/zstd response decoding |
+| `http.MockTransport` | Canned buffered and streaming responses for unit tests |
 | `http.SequenceMockTransport` | Multi-response sequences for retry testing |
 | `pipeline.HttpPipeline` | Ordered chain of policies → transport |
 | `pipeline.TelemetryPolicy` | Injects `User-Agent` header |
@@ -76,6 +76,8 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 | `errors` | Azure error envelope parsing + `logErrorResponse` |
 | `lro` | Long-running operation poller (poll until Succeeded/Failed) |
 | `pager` | Generic paged-result iterator (`PipelinePager`) |
+
+`HttpTransport.open` and `HttpPipeline.open` return a heap-backed, single-owner `HttpOperation`. Pass a borrowed `StreamingRequestBody` with `content_length` for `Content-Length`, or omit the length for chunked upload; the source reader only needs to remain alive until `open` returns. Consume the response through `operation.reader()`, then call `finish` to drain and permit connection reuse, or `abort`/`cancel` to close without draining. Always call `deinit`; it aborts any still-active operation. Streaming policy preparation runs once and never retries a consumed reader. `CancellationToken` is checked between upload reads and cannot interrupt an already-blocking reader or socket call.
 
 ### Identity (`azure_identity`)
 
@@ -163,10 +165,10 @@ Metadata can expose the login authority for a sovereign or private cloud, but `T
 
 - Typed helper areas cover timeout, truncation, progressive results, cache, consistency, resources, and security. Unknown options preserve their JSON types; raw JSON fragments are not accepted. Query parameter values must be strings or Kusto `long` values; encode other scalar types as KQL literal strings such as `datetime(...)` or `dynamic(...)`.
 - Query requests default to a 4-minute server timeout and management requests to 10 minutes. Explicit server timeouts range from 1 second through 1 hour with millisecond precision; the client budget defaults to the server timeout plus 30 seconds. `no_request_timeout` requests the maximum server timeout.
-- In the current synchronous buffered transport, the client timeout bounds retries and backoff only; it cannot interrupt an in-flight `std.http` request. Hard cancellation is deferred to future streaming and cancellation transport work.
+- The client timeout still bounds retries and backoff only; it cannot interrupt an in-flight blocking `std.http` call. Azure Core now exposes explicit streaming-operation cancellation, but Kusto deadline and request-ID cancellation integration remains future work.
 - Explicit application, user, version, and request-ID headers override defaults. Results expose owned `client_request_id` and `activity_id`; dataset `deinit` frees them.
 - Buffered result rows are strict about matching the declared column width by default. Set `ClientRequestProperties.setClientResultsReaderAllowVaryingRowWidths` only for services that intentionally emit uneven rows; missing cells remain absent and extra cells are preserved as unknown raw JSON.
-- V2 buffered decoding requires a `DataSetHeader` first and `DataSetCompletion` last. It reconstructs progressive or fragmented `DataAppend`/`DataReplace` frames by table ID, treats row-embedded OneAPI errors as partial results, retains unknown frames, and exposes table/row iterators plus ID, kind, primary, properties, and status selectors. Network streaming and cancellation remain future work.
+- V2 buffered decoding requires a `DataSetHeader` first and `DataSetCompletion` last. It reconstructs progressive or fragmented `DataAppend`/`DataReplace` frames by table ID, treats row-embedded OneAPI errors as partial results, retains unknown frames, and exposes table/row iterators plus ID, kind, primary, properties, and status selectors. Kusto frame streaming and query cancellation remain future work.
 - Queries may retry; management operations and streaming ingestion remain non-retryable.
 - Kusto `*Result` APIs return `KustoResult(T)`: `.ok`, `.partial` (possibly unreliable decoded buffered tables plus an owned `KustoError`), or `.err`; call `deinit`. A streaming `.err` records `.known_not_accepted` for a received non-2xx response and `.unknown` with the transport cause after transport entry fails, while pre-transport credential/policy errors stay in the outer Zig error union. Permanent and partial failures are never retryable.
 

--- a/sdk/core/http/decompression.zig
+++ b/sdk/core/http/decompression.zig
@@ -25,7 +25,7 @@ pub const DecompressionPolicy = struct {
     policy: HttpPolicy,
 
     pub fn init() DecompressionPolicy {
-        return .{ .policy = .{ .processFn = &processImpl } };
+        return .{ .policy = .{ .processFn = &processImpl, .prepareFn = &prepareImpl } };
     }
 
     pub fn asPolicy(self: *DecompressionPolicy) *HttpPolicy {
@@ -33,13 +33,17 @@ pub const DecompressionPolicy = struct {
     }
 
     fn processImpl(
-        _: *HttpPolicy,
+        policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        try request.setHeader("Accept-Encoding", "gzip, deflate");
+        try prepareImpl(policy, request);
         return callNext(request, next, final_transport);
+    }
+
+    fn prepareImpl(_: *HttpPolicy, request: *Request) !void {
+        try request.setHeader("Accept-Encoding", "gzip, deflate");
     }
 };
 
@@ -65,4 +69,25 @@ test "DecompressionPolicy sets Accept-Encoding" {
     var resp = try pip.send(&req);
     defer resp.deinit();
     try std.testing.expectEqualStrings("gzip, deflate", req.headers.get("Accept-Encoding").?);
+}
+
+test "DecompressionPolicy prepares streaming request" {
+    const allocator = std.testing.allocator;
+    var mock = transport.MockTransport.init(allocator, 200, "body");
+    defer mock.deinit();
+    var decomp = DecompressionPolicy.init();
+    var policy_ptrs = [_]*HttpPolicy{decomp.asPolicy()};
+    var pip = pipeline_mod.HttpPipeline{
+        .policies = &policy_ptrs,
+        .transport_impl = mock.asTransport(),
+    };
+    var req = Request.init(allocator, .GET, "https://example.com");
+    defer req.deinit();
+    var operation = try pip.open(&req, .{});
+    defer operation.deinit();
+    try std.testing.expectEqualStrings(
+        "gzip, deflate",
+        mock.last_headers.get("Accept-Encoding").?,
+    );
+    try operation.finish();
 }

--- a/sdk/core/http/pipeline.zig
+++ b/sdk/core/http/pipeline.zig
@@ -4,6 +4,8 @@ const transport = @import("transport.zig");
 const Request = transport.Request;
 const Response = transport.Response;
 const HttpTransport = transport.HttpTransport;
+const HttpOperation = transport.HttpOperation;
+const OpenOptions = transport.OpenOptions;
 
 fn nanoTimestamp() i128 {
     var threaded: std.Io.Threaded = .init_single_threaded;
@@ -36,6 +38,10 @@ pub const HttpPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) anyerror!Response,
+    prepareFn: ?*const fn (
+        self: *HttpPolicy,
+        request: *Request,
+    ) anyerror!void = null,
 
     pub fn process(
         self: *HttpPolicy,
@@ -44,6 +50,11 @@ pub const HttpPolicy = struct {
         final_transport: *HttpTransport,
     ) !Response {
         return self.processFn(self, request, next, final_transport);
+    }
+
+    pub fn prepare(self: *HttpPolicy, request: *Request) !void {
+        const prepareFn = self.prepareFn orelse return error.StreamingPolicyUnsupported;
+        return prepareFn(self, request);
     }
 };
 
@@ -56,7 +67,29 @@ pub const HttpPipeline = struct {
         request.transport_started = false;
         return callNext(request, self.policies, self.transport_impl);
     }
+
+    /// Prepares each policy once, then opens a non-retrying streaming
+    /// operation. A policy must explicitly support request-only preparation.
+    pub fn open(
+        self: *HttpPipeline,
+        request: *Request,
+        options: OpenOptions,
+    ) !*HttpOperation {
+        request.transport_started = false;
+        try checkOpenCancelled(options);
+        for (self.policies) |policy| {
+            try policy.prepare(request);
+            try checkOpenCancelled(options);
+        }
+        return self.transport_impl.open(request, options);
+    }
 };
+
+fn checkOpenCancelled(options: OpenOptions) !void {
+    if (options.cancellation) |token| {
+        if (token.isCancelled()) return error.OperationCancelled;
+    }
+}
 
 /// Advance through the remaining policies, calling the transport at the end.
 fn callNext(request: *Request, next: []*HttpPolicy, final_transport: *HttpTransport) !Response {
@@ -76,7 +109,7 @@ pub const TelemetryPolicy = struct {
     pub fn init(user_agent: []const u8) TelemetryPolicy {
         return .{
             .user_agent = user_agent,
-            .policy = .{ .processFn = &processImpl },
+            .policy = .{ .processFn = &processImpl, .prepareFn = &prepareImpl },
         };
     }
 
@@ -90,9 +123,13 @@ pub const TelemetryPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
+        try prepareImpl(policy, request);
+        return callNext(request, next, final_transport);
+    }
+
+    fn prepareImpl(policy: *HttpPolicy, request: *Request) !void {
         const self: *TelemetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
         try request.setHeader("User-Agent", self.user_agent);
-        return callNext(request, next, final_transport);
     }
 };
 
@@ -101,7 +138,7 @@ pub const LoggingPolicy = struct {
     policy: HttpPolicy,
 
     pub fn init() LoggingPolicy {
-        return .{ .policy = .{ .processFn = &processImpl } };
+        return .{ .policy = .{ .processFn = &processImpl, .prepareFn = &prepareImpl } };
     }
 
     pub fn asPolicy(self: *LoggingPolicy) *HttpPolicy {
@@ -109,15 +146,19 @@ pub const LoggingPolicy = struct {
     }
 
     fn processImpl(
-        _: *HttpPolicy,
+        policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        std.log.info("azure-sdk: {s} {s}", .{ @tagName(request.method), request.url });
+        try prepareImpl(policy, request);
         const response = try callNext(request, next, final_transport);
         std.log.info("azure-sdk: {d} {s}", .{ response.status_code, request.url });
         return response;
+    }
+
+    fn prepareImpl(_: *HttpPolicy, request: *Request) !void {
+        std.log.info("azure-sdk: {s} {s}", .{ @tagName(request.method), request.url });
     }
 };
 
@@ -136,7 +177,7 @@ pub const RetryPolicy = struct {
 
     pub fn init() RetryPolicy {
         return .{
-            .policy = .{ .processFn = &processImpl },
+            .policy = .{ .processFn = &processImpl, .prepareFn = &prepareImpl },
         };
     }
 
@@ -148,6 +189,8 @@ pub const RetryPolicy = struct {
         return status == 429 or status == 408 or status == 500 or
             status == 502 or status == 503 or status == 504;
     }
+
+    fn prepareImpl(_: *HttpPolicy, _: *Request) !void {}
 
     fn processImpl(
         policy: *HttpPolicy,
@@ -281,7 +324,7 @@ pub const BearerTokenAuthPolicy = struct {
             .allocator = allocator,
             .credential = credential,
             .scopes = scopes,
-            .policy = .{ .processFn = &processImpl },
+            .policy = .{ .processFn = &processImpl, .prepareFn = &prepareImpl },
         };
     }
 
@@ -300,6 +343,11 @@ pub const BearerTokenAuthPolicy = struct {
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
+        try prepareImpl(policy, request);
+        return callNext(request, next, final_transport);
+    }
+
+    fn prepareImpl(policy: *HttpPolicy, request: *Request) !void {
         const self: *BearerTokenAuthPolicy = @alignCast(@fieldParentPtr("policy", policy));
         const now = unixTimestampSeconds();
         const refresh_buffer: i64 = 300; // 5 minutes before expiry
@@ -333,7 +381,6 @@ pub const BearerTokenAuthPolicy = struct {
         }
         if (old_auth_value) |old| self.allocator.free(old);
         try request.setHeader("Authorization", self.cached_auth_value.?);
-        return callNext(request, next, final_transport);
     }
 };
 
@@ -353,7 +400,7 @@ pub const RequestIdPolicy = struct {
     policy: HttpPolicy,
 
     pub fn init() RequestIdPolicy {
-        return .{ .policy = .{ .processFn = &processImpl } };
+        return .{ .policy = .{ .processFn = &processImpl, .prepareFn = &prepareImpl } };
     }
 
     pub fn asPolicy(self: *RequestIdPolicy) *HttpPolicy {
@@ -361,13 +408,17 @@ pub const RequestIdPolicy = struct {
     }
 
     fn processImpl(
-        _: *HttpPolicy,
+        policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
         final_transport: *HttpTransport,
     ) !Response {
-        try ensureRequestId(request);
+        try prepareImpl(policy, request);
         return callNext(request, next, final_transport);
+    }
+
+    fn prepareImpl(_: *HttpPolicy, request: *Request) !void {
+        try ensureRequestId(request);
     }
 };
 
@@ -452,6 +503,73 @@ test "pipeline with telemetry and mock transport" {
     defer resp.deinit();
     try std.testing.expectEqual(@as(u16, 200), resp.status_code);
     try std.testing.expectEqualStrings("azsdk-zig-test/0.1.0", req.headers.get("User-Agent").?);
+}
+
+test "pipeline prepares streaming policies without retrying" {
+    const allocator = std.testing.allocator;
+    var mock = transport.MockTransport.init(allocator, 200, "stream");
+    defer mock.deinit();
+    var telemetry = TelemetryPolicy.init("stream-agent");
+    var request_id = RequestIdPolicy.init();
+    var retry = RetryPolicy.init();
+    var policy_ptrs = [_]*HttpPolicy{
+        telemetry.asPolicy(),
+        request_id.asPolicy(),
+        retry.asPolicy(),
+    };
+    var pipeline_inst = HttpPipeline{
+        .policies = &policy_ptrs,
+        .transport_impl = mock.asTransport(),
+    };
+    var request = Request.init(allocator, .GET, "https://example.com");
+    defer request.deinit();
+    var operation = try pipeline_inst.open(&request, .{});
+    defer operation.deinit();
+    try std.testing.expectEqualStrings("stream-agent", mock.last_headers.get("User-Agent").?);
+    try std.testing.expect(mock.last_headers.get("x-ms-client-request-id") != null);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try operation.finish();
+
+    var token = transport.CancellationToken{};
+    token.cancel();
+    var cancelled_request = Request.init(allocator, .GET, "https://example.com/cancelled");
+    defer cancelled_request.deinit();
+    try std.testing.expectError(
+        error.OperationCancelled,
+        pipeline_inst.open(&cancelled_request, .{ .cancellation = &token }),
+    );
+    try std.testing.expect(cancelled_request.getHeader("User-Agent") == null);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
+test "pipeline rejects policies without streaming preparation" {
+    const UnsupportedPolicy = struct {
+        fn process(
+            _: *HttpPolicy,
+            _: *Request,
+            _: []*HttpPolicy,
+            _: *HttpTransport,
+        ) anyerror!Response {
+            return error.UnexpectedPolicyCall;
+        }
+    };
+
+    const allocator = std.testing.allocator;
+    var mock = transport.MockTransport.init(allocator, 200, "stream");
+    defer mock.deinit();
+    var unsupported = HttpPolicy{ .processFn = &UnsupportedPolicy.process };
+    var policies = [_]*HttpPolicy{&unsupported};
+    var pipeline_inst = HttpPipeline{
+        .policies = &policies,
+        .transport_impl = mock.asTransport(),
+    };
+    var request = Request.init(allocator, .GET, "https://example.com");
+    defer request.deinit();
+    try std.testing.expectError(
+        error.StreamingPolicyUnsupported,
+        pipeline_inst.open(&request, .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
 }
 
 test "pipeline with no policies" {

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -133,6 +133,115 @@ pub const Response = struct {
     }
 };
 
+/// A thread-safe signal checked between streamed upload reads.
+///
+/// Calling `cancel` does not interrupt a blocking reader or socket operation.
+pub const CancellationToken = struct {
+    cancelled: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    pub fn cancel(self: *CancellationToken) void {
+        self.cancelled.store(true, .release);
+    }
+
+    pub fn isCancelled(self: *const CancellationToken) bool {
+        return self.cancelled.load(.acquire);
+    }
+};
+
+/// A borrowed request-body reader. A known length uses `Content-Length`;
+/// otherwise the transport uses chunked transfer encoding.
+///
+/// The reader must remain valid until `HttpTransport.open` returns.
+pub const StreamingRequestBody = struct {
+    reader: *std.Io.Reader,
+    content_length: ?u64 = null,
+};
+
+pub const OpenOptions = struct {
+    /// When null, `Request.body` is used as a known-length body.
+    body: ?StreamingRequestBody = null,
+    cancellation: ?*const CancellationToken = null,
+};
+
+const BodyFraming = union(enum) {
+    none,
+    content_length: u64,
+    chunked,
+};
+
+pub const OperationState = enum {
+    active,
+    finished,
+    aborted,
+    cancelled,
+};
+
+/// Single-owner handle for an incremental HTTP response.
+pub const HttpOperation = struct {
+    status_code: u16,
+    headers: std.StringHashMap([]const u8),
+    body_reader: *std.Io.Reader,
+    state: OperationState = .active,
+    finishFn: *const fn (self: *HttpOperation) anyerror!void,
+    abortFn: *const fn (self: *HttpOperation) void,
+    cancelFn: *const fn (self: *HttpOperation) void,
+    deinitFn: *const fn (self: *HttpOperation) void,
+    bodyErrorFn: ?*const fn (self: *const HttpOperation) ?anyerror = null,
+
+    pub fn isSuccess(self: *const HttpOperation) bool {
+        return self.status_code >= 200 and self.status_code < 300;
+    }
+
+    pub fn getHeader(self: *const HttpOperation, name: []const u8) ?[]const u8 {
+        var iter = self.headers.iterator();
+        while (iter.next()) |entry| {
+            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, name)) return entry.value_ptr.*;
+        }
+        return null;
+    }
+
+    pub fn reader(self: *HttpOperation) !*std.Io.Reader {
+        if (self.state != .active) return error.HttpOperationNotActive;
+        return self.body_reader;
+    }
+
+    pub fn bodyError(self: *const HttpOperation) ?anyerror {
+        if (self.state != .active) return null;
+        const bodyErrorFn = self.bodyErrorFn orelse return null;
+        return bodyErrorFn(self);
+    }
+
+    /// Drains the response and releases the underlying connection.
+    pub fn finish(self: *HttpOperation) !void {
+        if (self.state != .active) return error.HttpOperationNotActive;
+        self.finishFn(self) catch |err| {
+            self.abortFn(self);
+            self.state = .aborted;
+            return err;
+        };
+        self.state = .finished;
+    }
+
+    /// Stops without draining the response.
+    pub fn abort(self: *HttpOperation) void {
+        if (self.state != .active) return;
+        self.abortFn(self);
+        self.state = .aborted;
+    }
+
+    pub fn cancel(self: *HttpOperation) void {
+        if (self.state != .active) return;
+        self.cancelFn(self);
+        self.state = .cancelled;
+    }
+
+    /// Aborts an active operation, then releases all operation storage.
+    pub fn deinit(self: *HttpOperation) void {
+        if (self.state == .active) self.abort();
+        self.deinitFn(self);
+    }
+};
+
 /// Pluggable HTTP transport interface.
 ///
 /// Default implementation uses `std.http.Client` (TLS via `std.crypto.tls`).
@@ -141,10 +250,74 @@ pub const Response = struct {
 /// contract for bootstrap calls.
 pub const HttpTransport = struct {
     sendFn: *const fn (self: *HttpTransport, request: *Request) anyerror!Response,
+    openFn: ?*const fn (
+        self: *HttpTransport,
+        request: *Request,
+        options: OpenOptions,
+    ) anyerror!*HttpOperation = null,
 
     pub fn send(self: *HttpTransport, request: *Request) !Response {
         request.transport_started = true;
         return self.sendFn(self, request);
+    }
+
+    pub fn open(
+        self: *HttpTransport,
+        request: *Request,
+        options: OpenOptions,
+    ) !*HttpOperation {
+        request.transport_started = true;
+        if (self.openFn) |openFn| return openFn(self, request, options);
+        if (options.body != null) return error.StreamingRequestUnsupported;
+        if (options.cancellation) |token| {
+            if (token.isCancelled()) return error.OperationCancelled;
+        }
+        return BufferedOperation.open(self, request);
+    }
+};
+
+const BufferedOperation = struct {
+    operation: HttpOperation,
+    allocator: std.mem.Allocator,
+    response: Response,
+    reader_impl: std.Io.Reader,
+
+    fn open(transport: *HttpTransport, request: *Request) !*HttpOperation {
+        var response = try transport.send(request);
+        errdefer response.deinit();
+
+        const self = try response.allocator.create(BufferedOperation);
+        self.* = .{
+            .operation = undefined,
+            .allocator = response.allocator,
+            .response = response,
+            .reader_impl = std.Io.Reader.fixed(response.body),
+        };
+        self.operation = .{
+            .status_code = response.status_code,
+            .headers = response.headers,
+            .body_reader = &self.reader_impl,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &abortImpl,
+            .deinitFn = &deinitImpl,
+        };
+        self.response.headers = std.StringHashMap([]const u8).init(response.allocator);
+        return &self.operation;
+    }
+
+    fn finishImpl(operation: *HttpOperation) !void {
+        const self: *BufferedOperation = @alignCast(@fieldParentPtr("operation", operation));
+        _ = try self.reader_impl.discardRemaining();
+    }
+
+    fn abortImpl(_: *HttpOperation) void {}
+
+    fn deinitImpl(operation: *HttpOperation) void {
+        const self: *BufferedOperation = @alignCast(@fieldParentPtr("operation", operation));
+        deinitOwnedHeaders(self.allocator, &self.operation.headers);
+        self.response.deinit();
+        self.allocator.destroy(self);
     }
 };
 
@@ -163,7 +336,7 @@ pub const StdHttpTransport = struct {
         return .{
             .allocator = allocator,
             .client = .{ .allocator = allocator, .io = io },
-            .transport = .{ .sendFn = &sendImpl },
+            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
 
@@ -179,101 +352,365 @@ pub const StdHttpTransport = struct {
         const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
         const allocator = self.allocator;
 
-        // Convert request headers to std.http.Header slices.
-        //
-        // Authenticated requests must not follow redirects because
-        // `extra_headers` are retained across cross-origin redirects.
-        var extra = std.ArrayList(std.http.Header).empty;
-        defer extra.deinit(allocator);
-        var authenticated = false;
+        var operation = try openImpl(transport, request, .{});
+        defer operation.deinit();
 
-        var it = request.headers.iterator();
-        while (it.next()) |entry| {
-            const header = std.http.Header{ .name = entry.key_ptr.*, .value = entry.value_ptr.* };
-            try extra.append(allocator, header);
-            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Authorization")) {
-                authenticated = true;
-            }
+        const body = operation.body_reader.allocRemaining(
+            allocator,
+            .limited(16 * 1024 * 1024),
+        ) catch |err| switch (err) {
+            error.ReadFailed => return operation.bodyError() orelse error.ReadFailed,
+            else => |other| return other,
+        };
+        errdefer allocator.free(body);
+        try operation.finish();
+
+        var headers = try cloneOwnedHeaders(allocator, &operation.headers);
+        errdefer deinitOwnedHeaders(allocator, &headers);
+
+        return .{
+            .status_code = operation.status_code,
+            .headers = headers,
+            .body = body,
+            .allocator = allocator,
+        };
+    }
+
+    fn openImpl(
+        transport: *HttpTransport,
+        request: *Request,
+        options: OpenOptions,
+    ) !*HttpOperation {
+        const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
+        return StdStreamingOperation.open(self, request, options);
+    }
+};
+
+const StdStreamingOperation = struct {
+    operation: HttpOperation,
+    allocator: std.mem.Allocator,
+    request_headers: std.StringHashMap([]const u8),
+    extra_headers: []std.http.Header,
+    redirect_buffer: []u8,
+    decompress_buffer: []u8,
+    request: std.http.Client.Request,
+    request_active: bool,
+    response: std.http.Client.Response,
+    transfer_reader: *std.Io.Reader,
+    transfer_buffer: [64]u8,
+    upload_read_buffer: [16 * 1024]u8,
+    upload_write_buffer: [16 * 1024]u8,
+    decompress: std.http.Decompress,
+
+    fn open(
+        transport: *StdHttpTransport,
+        request: *Request,
+        options: OpenOptions,
+    ) !*HttpOperation {
+        if (options.body != null and request.body != null) {
+            return error.MultipleRequestBodies;
+        }
+        if (options.cancellation) |token| {
+            if (token.isCancelled()) return error.OperationCancelled;
         }
 
-        const uri = try std.Uri.parse(request.url);
+        const allocator = transport.allocator;
+        const self = try allocator.create(StdStreamingOperation);
+        self.* = .{
+            .operation = undefined,
+            .allocator = allocator,
+            .request_headers = std.StringHashMap([]const u8).init(allocator),
+            .extra_headers = &.{},
+            .redirect_buffer = &.{},
+            .decompress_buffer = &.{},
+            .request = undefined,
+            .request_active = false,
+            .response = undefined,
+            .transfer_reader = undefined,
+            .transfer_buffer = undefined,
+            .upload_read_buffer = undefined,
+            .upload_write_buffer = undefined,
+            .decompress = undefined,
+        };
+        errdefer {
+            self.releaseRequest(true);
+            self.cleanupStorage();
+            allocator.destroy(self);
+        }
 
-        // Use lower-level API to access response headers.
-        var req = try self.client.request(request.method.toStd(), uri, .{
-            .extra_headers = extra.items,
+        const framing = requestBodyFraming(request, options);
+        try copyRequestHeaders(self, request, framing);
+        self.redirect_buffer = try allocator.alloc(u8, 8 * 1024);
+
+        const uri = try std.Uri.parse(request.url);
+        const authenticated = request.getHeader("Authorization") != null;
+        self.request = try transport.client.request(request.method.toStd(), uri, .{
+            .extra_headers = self.extra_headers,
             .redirect_behavior = if (authenticated or request.redirect_policy == .not_allowed)
                 .not_allowed
             else
                 @enumFromInt(3),
         });
-        defer req.deinit();
+        self.request_active = true;
+        self.request.accept_encoding[@intFromEnum(std.http.ContentEncoding.zstd)] = true;
 
-        // Send body if present.
-        if (request.body) |payload| {
-            req.transfer_encoding = .{ .content_length = payload.len };
-            var body_writer = try req.sendBodyUnflushed(&.{});
-            try body_writer.writer.writeAll(payload);
-            try body_writer.end();
-            try req.connection.?.flush();
+        if (options.body) |body| {
+            try self.sendStream(body, options.cancellation);
+        } else if (request.body) |body| {
+            try self.sendBytes(body);
+        } else if (request.method.toStd().requestHasBody()) {
+            try self.sendBytes("");
         } else {
-            try req.sendBodiless();
+            try self.request.sendBodiless();
         }
 
-        // Receive response head.
-        const redirect_buf = try allocator.alloc(u8, 8 * 1024);
-        defer allocator.free(redirect_buf);
-        var response = try req.receiveHead(redirect_buf);
+        self.response = try self.request.receiveHead(self.redirect_buffer);
+        const status_code: u16 = @intFromEnum(self.response.head.status);
+        var headers = try copyResponseHeaders(allocator, &self.response.head);
+        errdefer deinitOwnedHeaders(allocator, &headers);
 
-        // Capture response headers before reading body (body invalidates head strings).
-        var resp_headers = std.StringHashMap([]const u8).init(allocator);
-        errdefer deinitOwnedHeaders(allocator, &resp_headers);
-        var header_it = response.head.iterateHeaders();
-        while (header_it.next()) |hdr| {
-            const name = try allocator.dupe(u8, hdr.name);
-            errdefer allocator.free(name);
-            const value = try allocator.dupe(u8, hdr.value);
-            errdefer allocator.free(value);
-
-            // ARM may return the same header twice (e.g. ratelimit counters).
-            // `put` would silently leak the prior key+value pair, so use
-            // `getOrPut` and free our duplicate ourselves.
-            const gop = try resp_headers.getOrPut(name);
-            if (gop.found_existing) {
-                allocator.free(name);
-                allocator.free(gop.value_ptr.*);
-                gop.value_ptr.* = value;
-            } else {
-                gop.key_ptr.* = name;
-                gop.value_ptr.* = value;
-            }
-        }
-
-        // Read body with decompression support.
-        var body_allocating: std.Io.Writer.Allocating = .init(allocator);
-        errdefer body_allocating.deinit();
-        var transfer_buffer: [64]u8 = undefined;
-        var decompress: std.http.Decompress = undefined;
-        const decompress_buffer: []u8 = switch (response.head.content_encoding) {
+        self.decompress_buffer = switch (self.response.head.content_encoding) {
             .identity => &.{},
-            .zstd => try allocator.alloc(u8, std.compress.zstd.default_window_len),
+            .zstd => try allocator.alloc(
+                u8,
+                std.compress.zstd.default_window_len + std.compress.zstd.block_size_max,
+            ),
             .deflate, .gzip => try allocator.alloc(u8, std.compress.flate.max_window_len),
             .compress => return error.UnsupportedCompressionMethod,
         };
-        defer if (decompress_buffer.len > 0) allocator.free(decompress_buffer);
-        const reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
-        _ = reader.streamRemaining(&body_allocating.writer) catch |err| switch (err) {
-            error.ReadFailed => return response.bodyErr().?,
-            error.WriteFailed => return error.OutOfMemory,
+        self.transfer_reader =
+            if (self.response.head.transfer_encoding != .none or
+            self.response.head.content_length != null)
+                &self.request.reader.interface
+            else
+                self.request.reader.in;
+        const body_reader = self.response.readerDecompressing(
+            &self.transfer_buffer,
+            &self.decompress,
+            self.decompress_buffer,
+        );
+        self.operation = .{
+            .status_code = status_code,
+            .headers = headers,
+            .body_reader = body_reader,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &abortImpl,
+            .deinitFn = &deinitImpl,
+            .bodyErrorFn = &bodyErrorImpl,
         };
+        return &self.operation;
+    }
 
-        return .{
-            .status_code = @intFromEnum(response.head.status),
-            .headers = resp_headers,
-            .body = try body_allocating.toOwnedSlice(),
-            .allocator = allocator,
+    fn copyRequestHeaders(
+        self: *StdStreamingOperation,
+        request: *const Request,
+        framing: BodyFraming,
+    ) !void {
+        var extra = std.ArrayList(std.http.Header).empty;
+        defer extra.deinit(self.allocator);
+
+        var iterator = request.headers.iterator();
+        while (iterator.next()) |entry| {
+            if (try validateFramingHeader(entry.key_ptr.*, entry.value_ptr.*, framing)) {
+                continue;
+            }
+            const name = try self.allocator.dupe(u8, entry.key_ptr.*);
+            errdefer self.allocator.free(name);
+            const value = try self.allocator.dupe(u8, entry.value_ptr.*);
+            errdefer self.allocator.free(value);
+            try extra.append(self.allocator, .{ .name = name, .value = value });
+            try self.request_headers.put(name, value);
+        }
+        self.extra_headers = try extra.toOwnedSlice(self.allocator);
+    }
+
+    fn sendBytes(self: *StdStreamingOperation, bytes: []const u8) !void {
+        self.request.transfer_encoding = .{ .content_length = bytes.len };
+        var writer = try self.request.sendBodyUnflushed(&self.upload_write_buffer);
+        try writer.writer.writeAll(bytes);
+        try writer.end();
+    }
+
+    fn sendStream(
+        self: *StdStreamingOperation,
+        body: StreamingRequestBody,
+        cancellation: ?*const CancellationToken,
+    ) !void {
+        self.request.transfer_encoding = if (body.content_length) |length|
+            .{ .content_length = length }
+        else
+            .chunked;
+        var writer = try self.request.sendBodyUnflushed(&self.upload_write_buffer);
+
+        if (body.content_length) |length| {
+            var remaining = length;
+            while (remaining > 0) {
+                try checkCancelled(cancellation);
+                const limit: usize = @intCast(@min(remaining, self.upload_read_buffer.len));
+                const count = try body.reader.readSliceShort(self.upload_read_buffer[0..limit]);
+                if (count == 0) return error.RequestBodyTooShort;
+                try checkCancelled(cancellation);
+                try writer.writer.writeAll(self.upload_read_buffer[0..count]);
+                remaining -= count;
+            }
+            try checkCancelled(cancellation);
+            var extra: [1]u8 = undefined;
+            const extra_count = try body.reader.readSliceShort(&extra);
+            try checkCancelled(cancellation);
+            if (extra_count != 0) return error.RequestBodyTooLong;
+        } else {
+            while (true) {
+                try checkCancelled(cancellation);
+                const count = try body.reader.readSliceShort(&self.upload_read_buffer);
+                try checkCancelled(cancellation);
+                if (count == 0) break;
+                try writer.writer.writeAll(self.upload_read_buffer[0..count]);
+            }
+        }
+        try checkCancelled(cancellation);
+        try writer.end();
+    }
+
+    fn finishImpl(operation: *HttpOperation) !void {
+        const self: *StdStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        _ = self.operation.body_reader.discardRemaining() catch |err| {
+            const body_error = self.response.bodyErr();
+            self.releaseRequest(true);
+            return body_error orelse err;
         };
+        if (self.transfer_reader != self.operation.body_reader) {
+            _ = self.transfer_reader.discardRemaining() catch |err| {
+                const body_error = self.response.bodyErr();
+                self.releaseRequest(true);
+                return body_error orelse err;
+            };
+        }
+        self.releaseRequest(false);
+    }
+
+    fn abortImpl(operation: *HttpOperation) void {
+        const self: *StdStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        self.releaseRequest(true);
+    }
+
+    fn bodyErrorImpl(operation: *const HttpOperation) ?anyerror {
+        const self: *const StdStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        return self.response.bodyErr();
+    }
+
+    fn deinitImpl(operation: *HttpOperation) void {
+        const self: *StdStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        deinitOwnedHeaders(self.allocator, &self.operation.headers);
+        self.cleanupStorage();
+        self.allocator.destroy(self);
+    }
+
+    fn releaseRequest(self: *StdStreamingOperation, close: bool) void {
+        if (self.request_active) {
+            if (close) {
+                if (self.request.connection) |connection| connection.closing = true;
+            }
+            self.request.deinit();
+            self.request_active = false;
+        }
+    }
+
+    fn cleanupStorage(self: *StdStreamingOperation) void {
+        if (self.decompress_buffer.len > 0) self.allocator.free(self.decompress_buffer);
+        if (self.redirect_buffer.len > 0) self.allocator.free(self.redirect_buffer);
+        if (self.extra_headers.len > 0) self.allocator.free(self.extra_headers);
+        deinitOwnedHeaders(self.allocator, &self.request_headers);
     }
 };
+
+fn checkCancelled(cancellation: ?*const CancellationToken) !void {
+    if (cancellation) |token| {
+        if (token.isCancelled()) return error.OperationCancelled;
+    }
+}
+
+fn requestBodyFraming(request: *const Request, options: OpenOptions) BodyFraming {
+    if (options.body) |body| {
+        return if (body.content_length) |length|
+            .{ .content_length = length }
+        else
+            .chunked;
+    }
+    if (request.body) |body| return .{ .content_length = body.len };
+    if (request.method.toStd().requestHasBody()) return .{ .content_length = 0 };
+    return .none;
+}
+
+/// Returns true when the validated header must be omitted because std.http
+/// emits it from `BodyFraming`.
+fn validateFramingHeader(
+    name: []const u8,
+    value: []const u8,
+    framing: BodyFraming,
+) !bool {
+    if (std.ascii.eqlIgnoreCase(name, "Content-Length")) {
+        const expected = switch (framing) {
+            .content_length => |length| length,
+            .none, .chunked => return error.ConflictingRequestFraming,
+        };
+        const actual = std.fmt.parseInt(u64, std.mem.trim(u8, value, " \t"), 10) catch
+            return error.ConflictingRequestFraming;
+        if (actual != expected) return error.ConflictingRequestFraming;
+        return true;
+    }
+    if (std.ascii.eqlIgnoreCase(name, "Transfer-Encoding")) {
+        if (framing != .chunked or
+            !std.ascii.eqlIgnoreCase(std.mem.trim(u8, value, " \t"), "chunked"))
+        {
+            return error.ConflictingRequestFraming;
+        }
+        return true;
+    }
+    return false;
+}
+
+fn cloneOwnedHeaders(
+    allocator: std.mem.Allocator,
+    source: *const std.StringHashMap([]const u8),
+) !std.StringHashMap([]const u8) {
+    var result = std.StringHashMap([]const u8).init(allocator);
+    errdefer deinitOwnedHeaders(allocator, &result);
+    var iterator = source.iterator();
+    while (iterator.next()) |entry| {
+        const name = try allocator.dupe(u8, entry.key_ptr.*);
+        errdefer allocator.free(name);
+        const value = try allocator.dupe(u8, entry.value_ptr.*);
+        errdefer allocator.free(value);
+        try result.put(name, value);
+    }
+    return result;
+}
+
+fn copyResponseHeaders(
+    allocator: std.mem.Allocator,
+    head: *const std.http.Client.Response.Head,
+) !std.StringHashMap([]const u8) {
+    var headers = std.StringHashMap([]const u8).init(allocator);
+    errdefer deinitOwnedHeaders(allocator, &headers);
+    var iterator = head.iterateHeaders();
+    while (iterator.next()) |header| {
+        const name = try allocator.dupe(u8, header.name);
+        errdefer allocator.free(name);
+        const value = try allocator.dupe(u8, header.value);
+        errdefer allocator.free(value);
+        const gop = try headers.getOrPut(name);
+        if (gop.found_existing) {
+            allocator.free(name);
+            allocator.free(gop.value_ptr.*);
+            gop.value_ptr.* = value;
+        } else {
+            gop.key_ptr.* = name;
+            gop.value_ptr.* = value;
+        }
+    }
+    return headers;
+}
 
 /// A transport that returns canned responses — for unit tests.
 pub const MockTransport = struct {
@@ -292,13 +729,21 @@ pub const MockTransport = struct {
     last_operation_timeout_ms: ?u64 = null,
     call_count: usize = 0,
     response_headers_list: []const HeaderPair = &.{},
+    stream_upload_chunk_size: usize = 4 * 1024,
+    stream_response_chunk_size: usize = 4 * 1024,
+    stream_fail_upload_after: ?usize = null,
+    stream_fail_response_after: ?usize = null,
+    stream_finish_count: usize = 0,
+    stream_abort_count: usize = 0,
+    stream_cancel_count: usize = 0,
+    stream_deinit_count: usize = 0,
 
     pub fn init(allocator: std.mem.Allocator, status: u16, body: []const u8) MockTransport {
         return .{
             .response_status = status,
             .response_body = body,
             .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl },
+            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
             .last_method = null,
             .last_url = null,
             .last_headers = std.StringHashMap([]const u8).init(allocator),
@@ -319,6 +764,92 @@ pub const MockTransport = struct {
 
     fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
         const self: *MockTransport = @alignCast(@fieldParentPtr("transport", transport));
+        try self.captureRequest(request, request.body);
+
+        const response_body_copy = try self.allocator.dupe(u8, self.response_body);
+        errdefer self.allocator.free(response_body_copy);
+        const headers = try self.copyResponseHeaders();
+        return .{
+            .status_code = self.response_status,
+            .headers = headers,
+            .body = response_body_copy,
+            .allocator = self.allocator,
+        };
+    }
+
+    fn openImpl(
+        transport: *HttpTransport,
+        request: *Request,
+        options: OpenOptions,
+    ) !*HttpOperation {
+        const self: *MockTransport = @alignCast(@fieldParentPtr("transport", transport));
+        if (options.body != null and request.body != null) return error.MultipleRequestBodies;
+        try checkCancelled(options.cancellation);
+        const framing = requestBodyFraming(request, options);
+        var framing_headers = request.headers.iterator();
+        while (framing_headers.next()) |header| {
+            _ = try validateFramingHeader(header.key_ptr.*, header.value_ptr.*, framing);
+        }
+
+        if (options.body) |body| {
+            var captured: std.Io.Writer.Allocating = .init(self.allocator);
+            errdefer captured.deinit();
+            var buffer: [4 * 1024]u8 = undefined;
+            var total: usize = 0;
+            if (body.content_length) |length| {
+                var remaining = length;
+                while (remaining > 0) {
+                    try checkCancelled(options.cancellation);
+                    if (self.stream_fail_upload_after) |fail_after| {
+                        if (total >= fail_after) return error.InjectedUploadFailure;
+                    }
+                    const read_limit: usize = @intCast(@min(
+                        remaining,
+                        @min(@max(self.stream_upload_chunk_size, 1), buffer.len),
+                    ));
+                    const count = try body.reader.readSliceShort(buffer[0..read_limit]);
+                    try checkCancelled(options.cancellation);
+                    if (count == 0) return error.RequestBodyTooShort;
+                    captured.writer.writeAll(buffer[0..count]) catch return error.OutOfMemory;
+                    total += count;
+                    remaining -= count;
+                }
+                var extra: [1]u8 = undefined;
+                const extra_count = try body.reader.readSliceShort(&extra);
+                try checkCancelled(options.cancellation);
+                if (extra_count != 0) return error.RequestBodyTooLong;
+            } else {
+                while (true) {
+                    try checkCancelled(options.cancellation);
+                    if (self.stream_fail_upload_after) |fail_after| {
+                        if (total >= fail_after) return error.InjectedUploadFailure;
+                    }
+                    const read_limit = @min(
+                        @max(self.stream_upload_chunk_size, 1),
+                        buffer.len,
+                    );
+                    const count = try body.reader.readSliceShort(buffer[0..read_limit]);
+                    try checkCancelled(options.cancellation);
+                    if (count == 0) break;
+                    captured.writer.writeAll(buffer[0..count]) catch return error.OutOfMemory;
+                    total += count;
+                }
+            }
+            const bytes = try captured.toOwnedSlice();
+            defer self.allocator.free(bytes);
+            try self.captureRequest(request, bytes);
+        } else {
+            try self.captureRequest(request, request.body);
+        }
+
+        return MockStreamingOperation.open(self);
+    }
+
+    fn captureRequest(
+        self: *MockTransport,
+        request: *Request,
+        body: ?[]const u8,
+    ) !void {
         self.call_count += 1;
         self.last_method = request.method;
         if (self.last_url) |old| self.allocator.free(old);
@@ -326,8 +857,8 @@ pub const MockTransport = struct {
         self.last_url = try self.allocator.dupe(u8, request.url);
         if (self.last_body) |old| self.allocator.free(old);
         self.last_body = null;
-        self.last_body = if (request.body) |body|
-            try self.allocator.dupe(u8, body)
+        self.last_body = if (body) |bytes|
+            try self.allocator.dupe(u8, bytes)
         else
             null;
         clearOwnedHeaders(self.allocator, &self.last_headers);
@@ -342,9 +873,9 @@ pub const MockTransport = struct {
         self.last_retryable = request.retryable;
         self.last_redirect_policy = request.redirect_policy;
         self.last_operation_timeout_ms = request.operation_timeout_ms;
+    }
 
-        const response_body_copy = try self.allocator.dupe(u8, self.response_body);
-        errdefer self.allocator.free(response_body_copy);
+    fn copyResponseHeaders(self: *MockTransport) !std.StringHashMap([]const u8) {
         var headers = std.StringHashMap([]const u8).init(self.allocator);
         errdefer deinitOwnedHeaders(self.allocator, &headers);
         for (self.response_headers_list) |hdr| {
@@ -361,12 +892,118 @@ pub const MockTransport = struct {
             }
             entry.value_ptr.* = v;
         }
-        return .{
-            .status_code = self.response_status,
-            .headers = headers,
-            .body = response_body_copy,
-            .allocator = self.allocator,
+        return headers;
+    }
+};
+
+const MockStreamingOperation = struct {
+    operation: HttpOperation,
+    allocator: std.mem.Allocator,
+    owner: *MockTransport,
+    response_body: []u8,
+    response_reader: MockResponseReader,
+
+    fn open(owner: *MockTransport) !*HttpOperation {
+        const self = try owner.allocator.create(MockStreamingOperation);
+        errdefer owner.allocator.destroy(self);
+        const response_body = try owner.allocator.dupe(u8, owner.response_body);
+        errdefer owner.allocator.free(response_body);
+        var headers = try owner.copyResponseHeaders();
+        errdefer deinitOwnedHeaders(owner.allocator, &headers);
+
+        self.* = .{
+            .operation = undefined,
+            .allocator = owner.allocator,
+            .owner = owner,
+            .response_body = response_body,
+            .response_reader = undefined,
         };
+        self.response_reader = MockResponseReader.init(
+            response_body,
+            owner.stream_response_chunk_size,
+            owner.stream_fail_response_after,
+        );
+        self.operation = .{
+            .status_code = owner.response_status,
+            .headers = headers,
+            .body_reader = &self.response_reader.interface,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &cancelImpl,
+            .deinitFn = &deinitImpl,
+        };
+        return &self.operation;
+    }
+
+    fn finishImpl(operation: *HttpOperation) !void {
+        const self: *MockStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.stream_finish_count += 1;
+        _ = try self.response_reader.interface.discardRemaining();
+    }
+
+    fn abortImpl(operation: *HttpOperation) void {
+        const self: *MockStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.stream_abort_count += 1;
+    }
+
+    fn cancelImpl(operation: *HttpOperation) void {
+        const self: *MockStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.stream_cancel_count += 1;
+    }
+
+    fn deinitImpl(operation: *HttpOperation) void {
+        const self: *MockStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.stream_deinit_count += 1;
+        deinitOwnedHeaders(self.allocator, &self.operation.headers);
+        self.allocator.free(self.response_body);
+        self.allocator.destroy(self);
+    }
+};
+
+const MockResponseReader = struct {
+    interface: std.Io.Reader,
+    body: []const u8,
+    offset: usize,
+    chunk_size: usize,
+    fail_after: ?usize,
+
+    fn init(body: []const u8, chunk_size: usize, fail_after: ?usize) MockResponseReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .body = body,
+            .offset = 0,
+            .chunk_size = @max(chunk_size, 1),
+            .fail_after = fail_after,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *MockResponseReader = @alignCast(@fieldParentPtr("interface", interface));
+        if (self.fail_after) |fail_after| {
+            if (self.offset >= fail_after) return error.ReadFailed;
+        }
+        if (self.offset >= self.body.len) return error.EndOfStream;
+
+        var count = @min(
+            self.body.len - self.offset,
+            limit.minInt(self.chunk_size),
+        );
+        if (self.fail_after) |fail_after| {
+            count = @min(count, fail_after - self.offset);
+        }
+        if (count == 0) return 0;
+        try writer.writeAll(self.body[self.offset .. self.offset + count]);
+        self.offset += count;
+        return count;
     }
 };
 
@@ -497,4 +1134,395 @@ test "mock transport" {
     try std.testing.expectEqual(RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
     try std.testing.expectEqual(@as(?u64, 12_345), mock.last_operation_timeout_ms);
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
+test "mock streaming transport accepts known and chunked uploads" {
+    const allocator = std.testing.allocator;
+    var mock = MockTransport.init(allocator, 201, "response-data");
+    defer mock.deinit();
+    mock.stream_upload_chunk_size = 3;
+    mock.stream_response_chunk_size = 2;
+
+    {
+        var known_source = std.Io.Reader.fixed("known-body");
+        var known_request = Request.init(allocator, .POST, "https://example.com/known");
+        defer known_request.deinit();
+        var known = try mock.asTransport().open(&known_request, .{
+            .body = .{ .reader = &known_source, .content_length = 10 },
+        });
+        defer known.deinit();
+        try std.testing.expectEqual(@as(u16, 201), known.status_code);
+        try std.testing.expectEqualStrings("known-body", mock.last_body.?);
+        var response_buffer: [32]u8 = undefined;
+        const first_count = try (try known.reader()).readSliceShort(response_buffer[0..3]);
+        try std.testing.expect(first_count > 0);
+        try known.finish();
+    }
+
+    {
+        var chunked_source = std.Io.Reader.fixed("chunked-body");
+        var chunked_request = Request.init(allocator, .POST, "https://example.com/chunked");
+        defer chunked_request.deinit();
+        var chunked = try mock.asTransport().open(&chunked_request, .{
+            .body = .{ .reader = &chunked_source },
+        });
+        defer chunked.deinit();
+        try std.testing.expectEqualStrings("chunked-body", mock.last_body.?);
+        chunked.abort();
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), mock.call_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_finish_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
+    try std.testing.expectEqual(@as(usize, 2), mock.stream_deinit_count);
+}
+
+test "mock streaming transport validates upload lengths and failures" {
+    const allocator = std.testing.allocator;
+    var mock = MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+
+    var short_source = std.Io.Reader.fixed("short");
+    var request = Request.init(allocator, .POST, "https://example.com");
+    defer request.deinit();
+    try std.testing.expectError(
+        error.RequestBodyTooShort,
+        mock.asTransport().open(&request, .{
+            .body = .{ .reader = &short_source, .content_length = 6 },
+        }),
+    );
+
+    var long_source = std.Io.Reader.fixed("long");
+    try std.testing.expectError(
+        error.RequestBodyTooLong,
+        mock.asTransport().open(&request, .{
+            .body = .{ .reader = &long_source, .content_length = 3 },
+        }),
+    );
+
+    mock.stream_fail_upload_after = 2;
+    mock.stream_upload_chunk_size = 2;
+    var failing_source = std.Io.Reader.fixed("failure");
+    try std.testing.expectError(
+        error.InjectedUploadFailure,
+        mock.asTransport().open(&request, .{
+            .body = .{ .reader = &failing_source },
+        }),
+    );
+
+    try request.setHeader("Content-Length", "99");
+    var conflicting_source = std.Io.Reader.fixed("body");
+    try std.testing.expectError(
+        error.ConflictingRequestFraming,
+        mock.asTransport().open(&request, .{
+            .body = .{ .reader = &conflicting_source, .content_length = 4 },
+        }),
+    );
+}
+
+test "mock streaming response failure cancellation and cleanup" {
+    const allocator = std.testing.allocator;
+    var mock = MockTransport.init(allocator, 200, "response");
+    defer mock.deinit();
+    mock.stream_response_chunk_size = 2;
+    mock.stream_fail_response_after = 4;
+
+    var request = Request.init(allocator, .GET, "https://example.com");
+    defer request.deinit();
+    var operation = try mock.asTransport().open(&request, .{});
+    defer operation.deinit();
+    var buffer: [8]u8 = undefined;
+    try std.testing.expectError(
+        error.ReadFailed,
+        (try operation.reader()).readSliceShort(&buffer),
+    );
+    operation.cancel();
+    try std.testing.expectEqual(OperationState.cancelled, operation.state);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_cancel_count);
+
+    var failed_finish = try mock.asTransport().open(&request, .{});
+    defer failed_finish.deinit();
+    try std.testing.expectError(error.ReadFailed, failed_finish.finish());
+    try std.testing.expectEqual(OperationState.aborted, failed_finish.state);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
+
+    var token = CancellationToken{};
+    token.cancel();
+    try std.testing.expectError(
+        error.OperationCancelled,
+        mock.asTransport().open(&request, .{ .cancellation = &token }),
+    );
+
+    var active_token = CancellationToken{};
+    var cancelling_source = CancellingReader.init(&active_token);
+    var upload_request = Request.init(allocator, .POST, "https://example.com/upload");
+    defer upload_request.deinit();
+    try std.testing.expectError(
+        error.OperationCancelled,
+        mock.asTransport().open(&upload_request, .{
+            .body = .{ .reader = &cancelling_source.interface },
+            .cancellation = &active_token,
+        }),
+    );
+}
+
+test "buffered transport adapts to response streaming" {
+    const allocator = std.testing.allocator;
+    const responses = [_]SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = "buffered" },
+    };
+    var mock = SequenceMockTransport.init(allocator, &responses);
+    var request = Request.init(allocator, .GET, "https://example.com");
+    defer request.deinit();
+    var operation = try mock.asTransport().open(&request, .{});
+    defer operation.deinit();
+    const body = try (try operation.reader()).allocRemaining(allocator, .unlimited);
+    defer allocator.free(body);
+    try std.testing.expectEqualStrings("buffered", body);
+    try operation.finish();
+}
+
+test "standard transport streams known and chunked uploads with decompression" {
+    const cases = [_]struct {
+        content_length: ?u64,
+        encoding: []const u8,
+        encoded_response: []const u8,
+        chunked_response: bool,
+    }{
+        .{
+            .content_length = 21,
+            .encoding = "gzip",
+            .encoded_response = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03\x2b\x2e\x29\x4a\x4d\xcc\x4d\x4d\x51\x48\xce\xcf\x2d\x28\x4a\x2d\x2e\x06\x32\x81\x54\x41\x7e\x5e\x71\x2a\x00\xa6\x80\xb4\x50\x1c\x00\x00\x00",
+            .chunked_response = true,
+        },
+        .{
+            .content_length = null,
+            .encoding = "deflate",
+            .encoded_response = "\x78\x9c\x2b\x2e\x29\x4a\x4d\xcc\x4d\x4d\x51\x48\xce\xcf\x2d\x28\x4a\x2d\x2e\x06\x32\x81\x54\x41\x7e\x5e\x71\x2a\x00\xa2\x5a\x0b\x3a",
+            .chunked_response = false,
+        },
+        .{
+            .content_length = null,
+            .encoding = "zstd",
+            .encoded_response = "\x28\xb5\x2f\xfd\x04\x58\xe1\x00\x00\x73\x74\x72\x65\x61\x6d\x65\x64\x20\x63\x6f\x6d\x70\x72\x65\x73\x73\x65\x64\x20\x72\x65\x73\x70\x6f\x6e\x73\x65\xa9\xca\xdc\xf0",
+            .chunked_response = false,
+        },
+    };
+    for (cases) |case| {
+        try runStdStreamingCase(
+            case.content_length,
+            case.encoding,
+            case.encoded_response,
+            case.chunked_response,
+        );
+    }
+}
+
+fn runStdStreamingCase(
+    content_length: ?u64,
+    encoding: []const u8,
+    encoded_response: []const u8,
+    chunked_response: bool,
+) !void {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    var address: std.Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var server = try address.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+
+    var context = LocalHttpServer{
+        .io = io,
+        .server = &server,
+        .encoding = encoding,
+        .encoded_response = encoded_response,
+        .chunked_response = chunked_response,
+    };
+    const thread = try std.Thread.spawn(.{}, LocalHttpServer.run, .{&context});
+
+    const url = try std.fmt.allocPrint(
+        allocator,
+        "http://127.0.0.1:{d}/stream",
+        .{server.socket.address.getPort()},
+    );
+    defer allocator.free(url);
+
+    var transport = StdHttpTransport.init(allocator, io);
+    defer transport.deinit();
+    var request = Request.init(allocator, .POST, url);
+    defer request.deinit();
+    var source = std.Io.Reader.fixed("streaming upload body");
+    var operation = transport.asTransport().open(&request, .{
+        .body = .{ .reader = &source, .content_length = content_length },
+    }) catch |err| {
+        thread.join();
+        if (context.failure) |failure| return failure;
+        return err;
+    };
+    defer operation.deinit();
+
+    var response: std.Io.Writer.Allocating = .init(allocator);
+    defer response.deinit();
+    _ = try (try operation.reader()).streamRemaining(&response.writer);
+    try std.testing.expectEqualStrings(
+        "streamed compressed response",
+        response.writer.buffered(),
+    );
+    try operation.finish();
+    thread.join();
+    if (context.failure) |failure| return failure;
+    try std.testing.expectEqualStrings("streaming upload body", context.received[0..context.received_len]);
+    try std.testing.expectEqual(content_length == null, context.saw_chunked);
+}
+
+const LocalHttpServer = struct {
+    io: std.Io,
+    server: *std.Io.net.Server,
+    encoding: []const u8,
+    encoded_response: []const u8,
+    chunked_response: bool,
+    received: [128]u8 = undefined,
+    received_len: usize = 0,
+    saw_chunked: bool = false,
+    failure: ?anyerror = null,
+
+    fn run(self: *LocalHttpServer) void {
+        self.serve() catch |err| {
+            self.failure = err;
+        };
+    }
+
+    fn serve(self: *LocalHttpServer) !void {
+        const stream = try self.server.accept(self.io);
+        defer stream.close(self.io);
+        var read_buffer: [1024]u8 = undefined;
+        var reader = std.Io.net.Stream.Reader.init(stream, self.io, &read_buffer);
+        var write_buffer: [1024]u8 = undefined;
+        var writer = std.Io.net.Stream.Writer.init(stream, self.io, &write_buffer);
+
+        var content_length: ?usize = null;
+        while (true) {
+            const raw_line = (reader.interface.takeDelimiter('\n') catch
+                return error.ServerHeaderReadFailed) orelse
+                return error.ServerHeaderReadFailed;
+            const line = std.mem.trimEnd(u8, raw_line, "\r");
+            if (line.len == 0) break;
+            if (std.ascii.startsWithIgnoreCase(line, "content-length:")) {
+                const value = std.mem.trim(u8, line["content-length:".len..], " ");
+                content_length = try std.fmt.parseInt(usize, value, 10);
+            } else if (std.ascii.startsWithIgnoreCase(line, "transfer-encoding:")) {
+                const value = std.mem.trim(u8, line["transfer-encoding:".len..], " ");
+                self.saw_chunked = std.ascii.eqlIgnoreCase(value, "chunked");
+            }
+        }
+
+        if (self.saw_chunked) {
+            while (true) {
+                const raw_size = (reader.interface.takeDelimiter('\n') catch
+                    return error.ServerChunkHeaderReadFailed) orelse
+                    return error.ServerChunkHeaderReadFailed;
+                const size_text = std.mem.trim(u8, raw_size, "\r ");
+                const size = try std.fmt.parseInt(usize, size_text, 16);
+                if (size == 0) {
+                    _ = (reader.interface.takeDelimiter('\n') catch
+                        return error.ServerChunkTrailerReadFailed) orelse
+                        return error.ServerChunkTrailerReadFailed;
+                    break;
+                }
+                if (self.received_len + size > self.received.len) return error.UploadTooLarge;
+                reader.interface.readSliceAll(
+                    self.received[self.received_len .. self.received_len + size],
+                ) catch return error.ServerChunkBodyReadFailed;
+                self.received_len += size;
+                var crlf: [2]u8 = undefined;
+                reader.interface.readSliceAll(&crlf) catch
+                    return error.ServerChunkTerminatorReadFailed;
+                if (!std.mem.eql(u8, &crlf, "\r\n")) return error.InvalidChunk;
+            }
+        } else {
+            const length = content_length orelse return error.MissingContentLength;
+            if (length > self.received.len) return error.UploadTooLarge;
+            reader.interface.readSliceAll(self.received[0..length]) catch
+                return error.ServerBodyReadFailed;
+            self.received_len = length;
+        }
+
+        const midpoint = self.encoded_response.len / 2;
+        if (self.chunked_response) {
+            try writer.interface.print(
+                "HTTP/1.1 200 OK\r\nContent-Encoding: {s}\r\nTransfer-Encoding: chunked\r\n\r\n{x}\r\n",
+                .{ self.encoding, midpoint },
+            );
+            try writer.interface.writeAll(self.encoded_response[0..midpoint]);
+            try writer.interface.print(
+                "\r\n{x}\r\n",
+                .{self.encoded_response.len - midpoint},
+            );
+            try writer.interface.writeAll(self.encoded_response[midpoint..]);
+            try writer.interface.writeAll("\r\n0\r\n\r\n");
+        } else {
+            try writer.interface.print(
+                "HTTP/1.1 200 OK\r\nContent-Encoding: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n",
+                .{ self.encoding, self.encoded_response.len },
+            );
+            try writer.interface.writeAll(self.encoded_response[0..midpoint]);
+            try writer.interface.flush();
+            try writer.interface.writeAll(self.encoded_response[midpoint..]);
+        }
+        try writer.interface.flush();
+    }
+};
+
+const CancellingReader = struct {
+    interface: std.Io.Reader,
+    token: *CancellationToken,
+    emitted: bool = false,
+
+    fn init(token: *CancellationToken) CancellingReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .token = token,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *CancellingReader = @alignCast(@fieldParentPtr("interface", interface));
+        if (self.emitted) return error.EndOfStream;
+        const bytes = limit.sliceConst("part");
+        try writer.writeAll(bytes);
+        self.emitted = true;
+        self.token.cancel();
+        return bytes.len;
+    }
+};
+
+fn mockStreamingAllocationFixture(allocator: std.mem.Allocator) !void {
+    var mock = MockTransport.init(allocator, 200, "response");
+    defer mock.deinit();
+    mock.response_headers_list = &.{.{ .name = "x-test", .value = "value" }};
+    var request = Request.init(allocator, .POST, "https://example.com");
+    defer request.deinit();
+    try request.setHeader("content-type", "application/octet-stream");
+    var source = std.Io.Reader.fixed("request");
+    var operation = try mock.asTransport().open(&request, .{
+        .body = .{ .reader = &source, .content_length = 7 },
+    });
+    defer operation.deinit();
+    try operation.finish();
+}
+
+test "mock streaming operation releases every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        mockStreamingAllocationFixture,
+        .{},
+    );
 }


### PR DESCRIPTION
Closes #52.

Adds a heap-backed single-owner HTTP operation API for known-length and chunked request streams plus incremental response readers. The standard transport keeps request, response, decompression, header, redirect, and buffer state stable until deterministic finish, abort, cancel, or deinit; buffered send remains compatible.

Pipeline policies now support one-time streaming preparation without replaying consumed readers. Mock and loopback coverage exercises upload framing, cancellation, failures, cleanup, allocation failures, and incremental gzip, deflate, and zstd responses.