### PR TITLE
kusto: stream progressive query frames and support cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 | `azure_messaging_eventhubs` | `ProducerClient`, `ConsumerClient` |
 | `azure_messaging_eventhubs_checkpointstore_blob` | Blob-backed checkpoint store |
 | `azure_messaging_servicebus` | `ServiceBusSenderClient`, `ServiceBusReceiverClient`, `ServiceBusAdministrationClient` |
-| `azure_kusto_data` | `KustoClient` (experimental buffered query and management support) |
+| `azure_kusto_data` | `KustoClient` (experimental buffered and progressive query plus management support) |
 | `azure_kusto_ingest` | `StreamingIngestClient` (experimental direct streaming ingestion); queued ingestion and managed queued fallback are planned, not implemented |
 
-Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished. Buffered Kusto datasets retain the raw response and tagged `KustoFrame` slices (including unknown V2 frames), decode V1 plus normal, progressive, and fragmented V2 tables into owned `KustoValue` values (null, strings, booleans, integers, reals, and Kusto lexical types), and preserve dynamic or unknown cells as raw JSON.
+Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished. Buffered Kusto datasets retain the raw response and tagged `KustoFrame` slices (including unknown V2 frames), decode V1 plus normal, progressive, and fragmented V2 tables into owned `KustoValue` values (null, strings, booleans, integers, reals, and Kusto lexical types), and preserve dynamic or unknown cells as raw JSON. Progressive query events instead own one exact raw V2 frame at a time and retain only table schemas and row counts in stream state.
 
 ### Kusto authentication and connections
 
@@ -165,12 +165,52 @@ Metadata can expose the login authority for a sovereign or private cloud, but `T
 
 - Typed helper areas cover timeout, truncation, progressive results, cache, consistency, resources, and security. Unknown options preserve their JSON types; raw JSON fragments are not accepted. Query parameter values must be strings or Kusto `long` values; encode other scalar types as KQL literal strings such as `datetime(...)` or `dynamic(...)`.
 - Query requests default to a 4-minute server timeout and management requests to 10 minutes. Explicit server timeouts range from 1 second through 1 hour with millisecond precision; the client budget defaults to the server timeout plus 30 seconds. `no_request_timeout` requests the maximum server timeout.
-- The client timeout still bounds retries and backoff only; it cannot interrupt an in-flight blocking `std.http` call. Azure Core now exposes explicit streaming-operation cancellation, but Kusto deadline and request-ID cancellation integration remains future work.
+- Buffered client timeouts still bound retries and backoff only; they cannot interrupt an in-flight blocking `std.http` call. `ProgressiveQueryOptions.deadline_ms` is checked before and after each pull, and a supplied `CancellationToken` is checked between pulls and during open. Neither can interrupt an already-blocking reader or socket call.
 - Explicit application, user, version, and request-ID headers override defaults. Results expose owned `client_request_id` and `activity_id`; dataset `deinit` frees them.
 - Buffered result rows are strict about matching the declared column width by default. Set `ClientRequestProperties.setClientResultsReaderAllowVaryingRowWidths` only for services that intentionally emit uneven rows; missing cells remain absent and extra cells are preserved as unknown raw JSON.
-- V2 buffered decoding requires a `DataSetHeader` first and `DataSetCompletion` last. It reconstructs progressive or fragmented `DataAppend`/`DataReplace` frames by table ID, treats row-embedded OneAPI errors as partial results, retains unknown frames, and exposes table/row iterators plus ID, kind, primary, properties, and status selectors. Kusto frame streaming and query cancellation remain future work.
+- V2 buffered decoding requires a `DataSetHeader` first and `DataSetCompletion` last. It reconstructs progressive or fragmented `DataAppend`/`DataReplace` frames by table ID, treats row-embedded OneAPI errors as partial results, retains unknown frames, and exposes table/row iterators plus ID, kind, primary, properties, and status selectors.
+- `executeProgressiveQuery` forces the V2 progressive result options, consumes one complete object from the top-level JSON array at a time, and enforces `max_frame_bytes` plus `max_table_count`. Its `ProgressiveFrame` values own exact raw JSON until `deinit`; `DataAppend` and `DataReplace` remain explicit rather than being flattened. Frame, table, and row pull adapters are exclusive. The row adapter emits one null-row `replace` reset before every replacement batch, followed by append row events, and retains table/dataset completion events so partial failures and cancellation remain visible. All row-adapter payloads are borrowed until its next call.
+- Call `ProgressiveQueryStream.finish` to drain and validate the full response. Calling `deinit` without `finish` intentionally aborts without draining. `cancel` first cancels the local operation, then sends a non-retryable management `.cancel query` command targeting the original query `x-ms-client-request-id`; its management result is structured as `KustoResult(KustoResponseDataSet)`.
 - Queries may retry; management operations and streaming ingestion remain non-retryable.
 - Kusto `*Result` APIs return `KustoResult(T)`: `.ok`, `.partial` (possibly unreliable decoded buffered tables plus an owned `KustoError`), or `.err`; call `deinit`. A streaming `.err` records `.known_not_accepted` for a received non-2xx response and `.unknown` with the transport cause after transport entry fails, while pre-transport credential/policy errors stay in the outer Zig error union. Permanent and partial failures are never retryable.
+
+### Progressive Kusto queries
+
+```zig
+var opened = try client.executeProgressiveQuery(
+    allocator,
+    "db",
+    "StormEvents | take 100",
+    null,
+    .{ .max_frame_bytes = 1024 * 1024, .deadline_ms = 30_000 },
+);
+const query_stream = switch (opened) {
+    .ok => |value| value,
+    .err => |*failure| {
+        defer failure.deinit();
+        return error.KustoQueryFailed;
+    },
+    .partial => unreachable,
+};
+defer query_stream.deinit(); // aborts if finish was not called
+
+while (try query_stream.next()) |frame| {
+    var owned = frame;
+    defer owned.deinit(allocator);
+    switch (owned.payload) {
+        .table_fragment => |batch| {
+            // `batch.action` is .append or .replace; do not flatten replaces.
+            _ = batch.table.rows;
+        },
+        .table_completion => |completion| if (completion.failure) |failure| {
+            // In-band partial failure, owned by this frame.
+            _ = failure;
+        },
+        else => {},
+    }
+}
+try query_stream.finish();
+```
 
 ### Typed KQL and result rows
 

--- a/sdk/kusto/common.zig
+++ b/sdk/kusto/common.zig
@@ -417,6 +417,25 @@ pub const KustoConnection = struct {
     }
 
     pub fn send(self: *KustoConnection, request: *core.http.Request) !core.http.Response {
+        try self.validateRequestEndpoint(request);
+        request.redirect_policy = .not_allowed;
+        return self.pipeline.send(request);
+    }
+
+    /// Opens a single-owner streaming operation using the authenticated
+    /// pipeline. Streaming preparation runs each policy once and never retries
+    /// a consumed request body.
+    pub fn open(
+        self: *KustoConnection,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        try self.validateRequestEndpoint(request);
+        request.redirect_policy = .not_allowed;
+        return self.pipeline.open(request, options);
+    }
+
+    fn validateRequestEndpoint(self: *const KustoConnection, request: *const core.http.Request) !void {
         const targets_engine = sameHttpsOrigin(self.cluster_url, request.url);
         const targets_data_management = if (self.data_management_url) |url|
             sameHttpsOrigin(url, request.url)
@@ -425,8 +444,6 @@ pub const KustoConnection = struct {
         if (!targets_engine and !targets_data_management) {
             return error.UntrustedKustoRequestEndpoint;
         }
-        request.redirect_policy = .not_allowed;
-        return self.pipeline.send(request);
     }
 
     pub fn clusterUrl(self: *const KustoConnection) []const u8 {
@@ -739,6 +756,26 @@ pub const ClientRequestProperties = struct {
     pub fn deinit(self: *ClientRequestProperties, allocator: std.mem.Allocator) void {
         deinitPropertyList(&self.options, allocator);
         deinitPropertyList(&self.parameters, allocator);
+    }
+
+    /// Deep-copies the option and parameter bags. Borrowed header strings
+    /// remain borrowed, matching the source property bag.
+    pub fn clone(self: *const ClientRequestProperties, allocator: std.mem.Allocator) !ClientRequestProperties {
+        var result = ClientRequestProperties{
+            .client_request_id = self.client_request_id,
+            .application = self.application,
+            .server_timeout_ms = self.server_timeout_ms,
+            .user = self.user,
+            .client_version = self.client_version,
+            .client_timeout_ms = self.client_timeout_ms,
+            .no_request_timeout = self.no_request_timeout,
+        };
+        errdefer result.deinit(allocator);
+        for (self.options.items) |property|
+            try appendClonedProperty(&result.options, allocator, property);
+        for (self.parameters.items) |property|
+            try appendClonedProperty(&result.parameters, allocator, property);
+        return result;
     }
 
     /// Set an arbitrary Kusto request option. The name and value are copied.
@@ -1062,6 +1099,21 @@ fn deinitPropertyList(items: *std.ArrayListUnmanaged(RequestProperty), allocator
     for (items.items) |*property| property.deinit(allocator);
     items.deinit(allocator);
     items.* = .empty;
+}
+
+fn appendClonedProperty(
+    destination: *std.ArrayListUnmanaged(RequestProperty),
+    allocator: std.mem.Allocator,
+    source: RequestProperty,
+) !void {
+    const name = try allocator.dupe(u8, source.name);
+    errdefer allocator.free(name);
+    const value = try cloneSerdeValue(source.value, allocator);
+    errdefer {
+        var owned_value = value;
+        owned_value.deinit(allocator);
+    }
+    try destination.append(allocator, .{ .name = name, .value = value });
 }
 
 fn setProperty(items: *std.ArrayListUnmanaged(RequestProperty), allocator: std.mem.Allocator, name: []const u8, value: anytype) !void {

--- a/sdk/kusto/data/result.zig
+++ b/sdk/kusto/data/result.zig
@@ -907,6 +907,426 @@ pub const KustoResponseDataSet = struct {
     }
 };
 
+/// How a progressive table batch changes its table's current rows. Consumers
+/// must treat `replace` as a reset, including when the batch has zero rows.
+pub const ProgressiveTableAction = enum {
+    append,
+    replace,
+};
+
+/// Allocator-owned V2 data-set metadata emitted by a progressive stream.
+pub const ProgressiveDataSetHeader = struct {
+    version: []u8,
+    is_progressive: bool,
+    is_fragmented: ?bool = null,
+    error_reporting_placement: ?[]u8 = null,
+
+    pub fn deinit(self: *ProgressiveDataSetHeader, allocator: std.mem.Allocator) void {
+        allocator.free(self.version);
+        if (self.error_reporting_placement) |value| allocator.free(value);
+        self.* = undefined;
+    }
+};
+
+/// An owned table-shaped progressive batch. A `data_table` event is always a
+/// replacement, while a table fragment preserves the server's explicit action.
+pub const ProgressiveTableBatch = struct {
+    action: ProgressiveTableAction,
+    table: KustoResultTable,
+    failure: ?kusto_common.KustoError = null,
+
+    pub fn deinit(self: *ProgressiveTableBatch, allocator: std.mem.Allocator) void {
+        self.table.deinit(allocator);
+        if (self.failure) |*failure| failure.deinit();
+        self.* = undefined;
+    }
+};
+
+pub const ProgressiveTableProgress = struct {
+    table_id: i64,
+    progress: f64,
+};
+
+pub const ProgressiveTableCompletion = struct {
+    table_id: i64,
+    row_count: i64,
+    has_errors: bool,
+    cancelled: bool,
+    failure: ?kusto_common.KustoError = null,
+
+    pub fn deinit(self: *ProgressiveTableCompletion) void {
+        if (self.failure) |*failure| failure.deinit();
+        self.* = undefined;
+    }
+};
+
+pub const ProgressiveDataSetCompletion = struct {
+    has_errors: bool,
+    cancelled: bool,
+    failure: ?kusto_common.KustoError = null,
+
+    pub fn deinit(self: *ProgressiveDataSetCompletion) void {
+        if (self.failure) |*failure| failure.deinit();
+        self.* = undefined;
+    }
+};
+
+pub const ProgressiveUnknownFrame = struct {
+    frame_type: []u8,
+
+    pub fn deinit(self: *ProgressiveUnknownFrame, allocator: std.mem.Allocator) void {
+        allocator.free(self.frame_type);
+        self.* = undefined;
+    }
+};
+
+/// One owned V2 response event. `raw_json` is the exact complete JSON object
+/// received from the wire and remains valid until `deinit`.
+pub const ProgressiveFrame = struct {
+    index: usize,
+    raw_json: []u8,
+    payload: Payload,
+
+    pub const Payload = union(enum) {
+        data_set_header: ProgressiveDataSetHeader,
+        data_table: ProgressiveTableBatch,
+        table_header: KustoResultTable,
+        table_fragment: ProgressiveTableBatch,
+        table_progress: ProgressiveTableProgress,
+        table_completion: ProgressiveTableCompletion,
+        data_set_completion: ProgressiveDataSetCompletion,
+        unknown: ProgressiveUnknownFrame,
+    };
+
+    pub fn deinit(self: *ProgressiveFrame, allocator: std.mem.Allocator) void {
+        switch (self.payload) {
+            .data_set_header => |*header| header.deinit(allocator),
+            .data_table, .table_fragment => |*batch| batch.deinit(allocator),
+            .table_header => |*table| table.deinit(allocator),
+            .table_completion => |*completion| completion.deinit(),
+            .data_set_completion => |*completion| completion.deinit(),
+            .unknown => |*unknown| unknown.deinit(allocator),
+            .table_progress => {},
+        }
+        allocator.free(self.raw_json);
+        self.* = undefined;
+    }
+
+    pub fn frameType(self: *const ProgressiveFrame) []const u8 {
+        return switch (self.payload) {
+            .data_set_header => "DataSetHeader",
+            .data_table => "DataTable",
+            .table_header => "TableHeader",
+            .table_fragment => "TableFragment",
+            .table_progress => "TableProgress",
+            .table_completion => "TableCompletion",
+            .data_set_completion => "DataSetCompletion",
+            .unknown => |unknown| unknown.frame_type,
+        };
+    }
+};
+
+const ProgressiveTableState = struct {
+    table: ?KustoResultTable,
+    row_count: i64,
+    completed: bool,
+
+    fn deinit(self: *ProgressiveTableState, allocator: std.mem.Allocator) void {
+        if (self.table) |*table| table.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+/// Incrementally validates V2 frames while retaining only schemas, row counts,
+/// and table state. Every input slice passed to `decodeOwnedFrame` transfers
+/// ownership, whether decoding succeeds or fails.
+pub const ProgressiveDecoder = struct {
+    allocator: std.mem.Allocator,
+    options: DecodeOptions,
+    operation: kusto_common.KustoOperation,
+    tables: std.ArrayList(ProgressiveTableState) = .empty,
+    table_indexes: std.AutoHashMap(i64, usize),
+    saw_header: bool = false,
+    saw_completion: bool = false,
+    is_progressive: bool = false,
+    is_fragmented: bool = false,
+    next_index: usize = 0,
+    max_table_count: usize = 1024,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        options: DecodeOptions,
+        operation: kusto_common.KustoOperation,
+    ) ProgressiveDecoder {
+        return .{
+            .allocator = allocator,
+            .options = options,
+            .operation = operation,
+            .table_indexes = std.AutoHashMap(i64, usize).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *ProgressiveDecoder) void {
+        for (self.tables.items) |*table| table.deinit(self.allocator);
+        self.tables.deinit(self.allocator);
+        self.table_indexes.deinit();
+        self.* = undefined;
+    }
+
+    /// Decodes one complete JSON object and transfers ownership of `raw_json`
+    /// to the returned event. The decoder never accumulates event rows.
+    pub fn decodeOwnedFrame(self: *ProgressiveDecoder, raw_json: []u8) !ProgressiveFrame {
+        errdefer self.allocator.free(raw_json);
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+        const fields = try parseObjectFields(arena.allocator(), raw_json);
+        const frame_type_raw = requiredField(fields, "FrameType") orelse return error.MalformedKustoResponse;
+        const frame_type = try decodeStringTemp(arena.allocator(), frame_type_raw);
+        if (self.saw_completion) return error.MalformedKustoResponse;
+        if (!self.saw_header and !std.mem.eql(u8, frame_type, "DataSetHeader"))
+            return error.MalformedKustoResponse;
+
+        var payload: ProgressiveFrame.Payload = undefined;
+        if (std.mem.eql(u8, frame_type, "DataSetHeader")) {
+            if (self.saw_header) return error.MalformedKustoResponse;
+            payload = .{ .data_set_header = try self.decodeHeader(fields) };
+        } else if (std.mem.eql(u8, frame_type, "DataTable")) {
+            payload = .{ .data_table = try self.decodeDataTable(fields) };
+        } else if (std.mem.eql(u8, frame_type, "TableHeader")) {
+            payload = .{ .table_header = try self.decodeTableHeader(fields) };
+        } else if (std.mem.eql(u8, frame_type, "TableFragment")) {
+            payload = .{ .table_fragment = try self.decodeTableFragment(fields) };
+        } else if (std.mem.eql(u8, frame_type, "TableProgress")) {
+            payload = .{ .table_progress = try self.decodeTableProgress(fields) };
+        } else if (std.mem.eql(u8, frame_type, "TableCompletion")) {
+            payload = .{ .table_completion = try self.decodeTableCompletion(fields) };
+        } else if (std.mem.eql(u8, frame_type, "DataSetCompletion")) {
+            payload = .{ .data_set_completion = try self.decodeDataSetCompletion(fields) };
+        } else {
+            payload = .{ .unknown = .{
+                .frame_type = try self.allocator.dupe(u8, frame_type),
+            } };
+        }
+        const frame = ProgressiveFrame{
+            .index = self.next_index,
+            .raw_json = raw_json,
+            .payload = payload,
+        };
+        self.next_index += 1;
+        return frame;
+    }
+
+    /// Verifies that the top-level array ended after a header and completion.
+    pub fn finish(self: *const ProgressiveDecoder) !void {
+        if (!self.saw_header or !self.saw_completion)
+            return error.MalformedKustoResponse;
+    }
+
+    fn decodeHeader(self: *ProgressiveDecoder, fields: []const Field) !ProgressiveDataSetHeader {
+        const version_raw = requiredField(fields, "Version") orelse return error.MalformedKustoResponse;
+        const progressive_raw = requiredField(fields, "IsProgressive") orelse return error.MalformedKustoResponse;
+        const version = try decodeStringOwned(self.allocator, version_raw);
+        errdefer self.allocator.free(version);
+        var header = ProgressiveDataSetHeader{
+            .version = version,
+            .is_progressive = try decodeBool(progressive_raw),
+        };
+        errdefer header.deinit(self.allocator);
+        if (field(fields, "IsFragmented")) |raw|
+            header.is_fragmented = try decodeBool(raw);
+        if (field(fields, "ErrorReportingPlacement")) |raw|
+            header.error_reporting_placement = try decodeStringOwned(self.allocator, raw);
+        self.saw_header = true;
+        self.is_progressive = header.is_progressive;
+        self.is_fragmented = header.is_fragmented orelse false;
+        return header;
+    }
+
+    fn decodeDataTable(self: *ProgressiveDecoder, fields: []const Field) !ProgressiveTableBatch {
+        const id = try parseRequiredId(fields, "TableId");
+        if (self.table_indexes.contains(id)) return error.MalformedKustoResponse;
+        var failure: ?kusto_common.KustoError = null;
+        errdefer if (failure) |*value| value.deinit();
+        var builder = try parseDataTable(
+            self.allocator,
+            fields,
+            id,
+            self.options,
+            self.operation,
+            &failure,
+        );
+        errdefer builder.deinit(self.allocator);
+        var table = try builder.take(self.allocator);
+        errdefer table.deinit(self.allocator);
+        try self.addTableState(&table, @intCast(table.rows.len), true);
+        const owned_failure = failure;
+        failure = null;
+        return .{ .action = .replace, .table = table, .failure = owned_failure };
+    }
+
+    fn decodeTableHeader(self: *ProgressiveDecoder, fields: []const Field) !KustoResultTable {
+        if (!self.allowsTableFrames()) return error.MalformedKustoResponse;
+        const id = try parseRequiredId(fields, "TableId");
+        if (self.table_indexes.contains(id)) return error.MalformedKustoResponse;
+        var builder = try parseTableHeader(self.allocator, fields, id);
+        errdefer builder.deinit(self.allocator);
+        var table = try builder.take(self.allocator);
+        errdefer table.deinit(self.allocator);
+        try self.addTableState(&table, 0, false);
+        return table;
+    }
+
+    fn decodeTableFragment(self: *ProgressiveDecoder, fields: []const Field) !ProgressiveTableBatch {
+        if (!self.allowsTableFrames()) return error.MalformedKustoResponse;
+        const id = try parseRequiredId(fields, "TableId");
+        const table_index = self.table_indexes.get(id) orelse return error.MalformedKustoResponse;
+        const state = &self.tables.items[table_index];
+        if (state.completed) return error.MalformedKustoResponse;
+        const state_table = if (state.table) |*table| table else return error.MalformedKustoResponse;
+        if (field(fields, "FieldCount")) |raw| {
+            const field_count = try decodeNonNegativeI64(raw);
+            if (field_count != state_table.columns.len) return error.MalformedKustoResponse;
+        }
+        const type_raw = requiredField(fields, "TableFragmentType") orelse return error.MalformedKustoResponse;
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+        const type_name = try decodeStringTemp(arena.allocator(), type_raw);
+        const action: ProgressiveTableAction = if (std.mem.eql(u8, type_name, "DataAppend"))
+            .append
+        else if (std.mem.eql(u8, type_name, "DataReplace"))
+            .replace
+        else
+            return error.UnsupportedTableFragmentType;
+        const rows_raw = requiredField(fields, "Rows") orelse return error.MalformedKustoResponse;
+        var batch_table = try cloneTableMetadata(self.allocator, state_table, false);
+        errdefer batch_table.deinit(self.allocator);
+        var failure: ?kusto_common.KustoError = null;
+        errdefer if (failure) |*value| value.deinit();
+        const rows = try parseRows(
+            self.allocator,
+            rows_raw,
+            batch_table.columns,
+            self.options,
+            self.operation,
+            &failure,
+        );
+        batch_table.rows = rows;
+        batch_table.reported_row_count = @intCast(rows.len);
+        const batch_count: i64 = @intCast(rows.len);
+        state.row_count = switch (action) {
+            .append => std.math.add(i64, state.row_count, batch_count) catch return error.MalformedKustoResponse,
+            .replace => batch_count,
+        };
+        const owned_failure = failure;
+        failure = null;
+        return .{ .action = action, .table = batch_table, .failure = owned_failure };
+    }
+
+    fn decodeTableProgress(self: *ProgressiveDecoder, fields: []const Field) !ProgressiveTableProgress {
+        if (!self.allowsTableFrames()) return error.MalformedKustoResponse;
+        const id = try parseRequiredId(fields, "TableId");
+        const table_index = self.table_indexes.get(id) orelse return error.MalformedKustoResponse;
+        const state = &self.tables.items[table_index];
+        if (state.completed) return error.MalformedKustoResponse;
+        const progress_raw = requiredField(fields, "TableProgress") orelse return error.MalformedKustoResponse;
+        const progress = try decodeFiniteNumber(progress_raw);
+        if (progress < 0 or progress > 100) return error.MalformedKustoResponse;
+        const table = if (state.table) |*value| value else return error.MalformedKustoResponse;
+        table.progress = progress;
+        return .{ .table_id = id, .progress = progress };
+    }
+
+    fn decodeTableCompletion(self: *ProgressiveDecoder, fields: []const Field) !ProgressiveTableCompletion {
+        const id = try parseRequiredId(fields, "TableId");
+        const table_index = self.table_indexes.get(id) orelse return error.MalformedKustoResponse;
+        const state = &self.tables.items[table_index];
+        if (state.completed) return error.MalformedKustoResponse;
+        const row_count_raw = requiredField(fields, "RowCount") orelse return error.MalformedKustoResponse;
+        const row_count = try decodeNonNegativeI64(row_count_raw);
+        if (row_count != state.row_count) return error.MalformedKustoResponse;
+        const has_errors = if (field(fields, "HasErrors")) |raw| try decodeBool(raw) else false;
+        const cancelled = if (field(fields, "Cancelled")) |raw| try decodeBool(raw) else false;
+        const failure = try completionFailure(
+            self.allocator,
+            self.operation,
+            .table_completion,
+            field(fields, "OneApiErrors"),
+            has_errors,
+            cancelled,
+        );
+        state.completed = true;
+        if (state.table) |*table| {
+            table.deinit(self.allocator);
+            state.table = null;
+        }
+        return .{
+            .table_id = id,
+            .row_count = row_count,
+            .has_errors = has_errors,
+            .cancelled = cancelled,
+            .failure = failure,
+        };
+    }
+
+    fn decodeDataSetCompletion(self: *ProgressiveDecoder, fields: []const Field) !ProgressiveDataSetCompletion {
+        for (self.tables.items) |state| {
+            if (!state.completed) return error.MalformedKustoResponse;
+        }
+        const has_errors_raw = requiredField(fields, "HasErrors") orelse return error.MalformedKustoResponse;
+        const cancelled_raw = requiredField(fields, "Cancelled") orelse return error.MalformedKustoResponse;
+        const has_errors = try decodeBool(has_errors_raw);
+        const cancelled = try decodeBool(cancelled_raw);
+        const failure = try completionFailure(
+            self.allocator,
+            self.operation,
+            .dataset_completion,
+            field(fields, "OneApiErrors"),
+            has_errors,
+            cancelled,
+        );
+        self.saw_completion = true;
+        return .{
+            .has_errors = has_errors,
+            .cancelled = cancelled,
+            .failure = failure,
+        };
+    }
+
+    fn addTableState(
+        self: *ProgressiveDecoder,
+        source: *const KustoResultTable,
+        row_count: i64,
+        completed: bool,
+    ) !void {
+        const id = source.id orelse return error.MalformedKustoResponse;
+        if (self.tables.items.len >= self.max_table_count)
+            return error.KustoProgressiveTableLimitExceeded;
+        var table: ?KustoResultTable = if (completed)
+            null
+        else
+            try cloneTableMetadata(self.allocator, source, false);
+        errdefer if (table) |*value| value.deinit(self.allocator);
+        if (table) |*value| {
+            value.completed = false;
+            value.reported_row_count = row_count;
+        }
+        try self.table_indexes.put(id, self.tables.items.len);
+        errdefer {
+            _ = self.table_indexes.remove(id);
+        }
+        try self.tables.append(self.allocator, .{
+            .table = table,
+            .row_count = row_count,
+            .completed = completed,
+        });
+        table = null;
+    }
+
+    fn allowsTableFrames(self: *const ProgressiveDecoder) bool {
+        return self.is_progressive or self.is_fragmented;
+    }
+};
+
 pub const DecodeOutcome = struct {
     dataset: KustoResponseDataSet,
     failure: ?kusto_common.KustoError = null,
@@ -1898,6 +2318,67 @@ fn deinitTableMetadata(table: *KustoResultTable, allocator: std.mem.Allocator) v
     if (table.toc_name) |value| allocator.free(value);
     if (table.toc_id) |value| allocator.free(value);
     if (table.pretty_name) |value| allocator.free(value);
+}
+
+fn cloneTableMetadata(
+    allocator: std.mem.Allocator,
+    source: *const KustoResultTable,
+    completed: bool,
+) !KustoResultTable {
+    const name = try allocator.dupe(u8, source.name);
+    errdefer allocator.free(name);
+    const kind = if (source.kind) |value| try allocator.dupe(u8, value) else null;
+    errdefer if (kind) |value| allocator.free(value);
+    const toc_name = if (source.toc_name) |value| try allocator.dupe(u8, value) else null;
+    errdefer if (toc_name) |value| allocator.free(value);
+    const toc_id = if (source.toc_id) |value| try allocator.dupe(u8, value) else null;
+    errdefer if (toc_id) |value| allocator.free(value);
+    const pretty_name = if (source.pretty_name) |value| try allocator.dupe(u8, value) else null;
+    errdefer if (pretty_name) |value| allocator.free(value);
+    const columns = try cloneColumns(allocator, source.columns);
+    errdefer {
+        for (columns) |*column| column.deinit(allocator);
+        allocator.free(columns);
+    }
+    return .{
+        .id = source.id,
+        .ordinal = source.ordinal,
+        .name = name,
+        .kind = kind,
+        .known_kind = source.known_kind,
+        .toc_name = toc_name,
+        .toc_id = toc_id,
+        .pretty_name = pretty_name,
+        .columns = columns,
+        .rows = &.{},
+        .progress = source.progress,
+        .reported_row_count = source.reported_row_count,
+        .completed = completed,
+    };
+}
+
+fn cloneColumns(
+    allocator: std.mem.Allocator,
+    source: []const KustoResultColumn,
+) ![]KustoResultColumn {
+    var columns = try allocator.alloc(KustoResultColumn, source.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (columns[0..initialized]) |*column| column.deinit(allocator);
+        allocator.free(columns);
+    }
+    for (source, 0..) |column, index| {
+        columns[index] = .{
+            .name = try allocator.dupe(u8, column.name),
+            .column_type = undefined,
+            .scalar_kind = column.scalar_kind,
+            .has_declared_type = column.has_declared_type,
+        };
+        errdefer allocator.free(columns[index].name);
+        columns[index].column_type = try allocator.dupe(u8, column.column_type);
+        initialized += 1;
+    }
+    return columns;
 }
 
 fn parseObjectFields(allocator: std.mem.Allocator, raw: []const u8) ![]Field {
@@ -2954,6 +3435,24 @@ test "complex result parsing releases all allocation failures" {
     );
 }
 
+test "progressive decoder does not retain completed DataTable schemas" {
+    const allocator = std.testing.allocator;
+    var decoder = ProgressiveDecoder.init(allocator, .{}, .query);
+    defer decoder.deinit();
+
+    var header = try decoder.decodeOwnedFrame(try allocator.dupe(u8,
+        \\{"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false}
+    ));
+    defer header.deinit(allocator);
+    var table = try decoder.decodeOwnedFrame(try allocator.dupe(u8,
+        \\{"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"T","Columns":[{"ColumnName":"Value","ColumnType":"long"}],"Rows":[[1]]}
+    ));
+    defer table.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), decoder.tables.items.len);
+    try std.testing.expect(decoder.tables.items[0].table == null);
+}
+
 const TypedHook = struct {
     text: []u8,
 
@@ -3204,5 +3703,103 @@ test "typed row conversion releases every allocation failure path" {
         std.testing.allocator,
         typedRowAllocationFixture,
         .{},
+    );
+}
+
+test "ProgressiveDecoder retains only state and preserves append replace completion errors" {
+    const allocator = std.testing.allocator;
+    var decoder = ProgressiveDecoder.init(allocator, .{}, .query);
+    defer decoder.deinit();
+
+    var header = try decoder.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"DataSetHeader\",\"Version\":\"v2.0\",\"IsProgressive\":true}",
+    ));
+    defer header.deinit(allocator);
+    try std.testing.expectEqualStrings("DataSetHeader", header.frameType());
+
+    var table_header = try decoder.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"TableHeader\",\"TableId\":7,\"TableKind\":\"PrimaryResult\",\"TableName\":\"T\",\"Columns\":[{\"ColumnName\":\"n\",\"ColumnType\":\"long\"}]}",
+    ));
+    defer table_header.deinit(allocator);
+
+    var append = try decoder.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"TableFragment\",\"TableId\":7,\"FieldCount\":1,\"TableFragmentType\":\"DataAppend\",\"Rows\":[[1]]}",
+    ));
+    defer append.deinit(allocator);
+    switch (append.payload) {
+        .table_fragment => |batch| {
+            try std.testing.expectEqual(ProgressiveTableAction.append, batch.action);
+            try std.testing.expectEqual(@as(?i64, 1), batch.table.rows[0].get(0).?.asI64());
+        },
+        else => return error.TestUnexpectedFrame,
+    }
+
+    var replace = try decoder.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"TableFragment\",\"TableId\":7,\"FieldCount\":1,\"TableFragmentType\":\"DataReplace\",\"Rows\":[]}",
+    ));
+    defer replace.deinit(allocator);
+    switch (replace.payload) {
+        .table_fragment => |batch| {
+            try std.testing.expectEqual(ProgressiveTableAction.replace, batch.action);
+            try std.testing.expectEqual(@as(usize, 0), batch.table.rows.len);
+        },
+        else => return error.TestUnexpectedFrame,
+    }
+
+    var completion = try decoder.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"TableCompletion\",\"TableId\":7,\"RowCount\":0,\"HasErrors\":true,\"Cancelled\":false,\"OneApiErrors\":[{\"error\":{\"code\":\"Partial\",\"message\":\"partial table\"}}]}",
+    ));
+    defer completion.deinit(allocator);
+    switch (completion.payload) {
+        .table_completion => |item| {
+            try std.testing.expect(item.failure != null);
+            try std.testing.expectEqual(KustoErrorSource.table_completion, item.failure.?.source);
+        },
+        else => return error.TestUnexpectedFrame,
+    }
+
+    var dataset_completion = try decoder.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"DataSetCompletion\",\"HasErrors\":false,\"Cancelled\":false}",
+    ));
+    defer dataset_completion.deinit(allocator);
+    try decoder.finish();
+}
+
+test "ProgressiveDecoder rejects out of order and invalid row counts" {
+    const allocator = std.testing.allocator;
+    var decoder = ProgressiveDecoder.init(allocator, .{}, .query);
+    defer decoder.deinit();
+    try std.testing.expectError(
+        error.MalformedKustoResponse,
+        decoder.decodeOwnedFrame(try allocator.dupe(
+            u8,
+            "{\"FrameType\":\"TableProgress\",\"TableId\":1,\"TableProgress\":50}",
+        )),
+    );
+
+    var second = ProgressiveDecoder.init(allocator, .{}, .query);
+    defer second.deinit();
+    var header = try second.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"DataSetHeader\",\"Version\":\"v2.0\",\"IsProgressive\":true}",
+    ));
+    defer header.deinit(allocator);
+    var table = try second.decodeOwnedFrame(try allocator.dupe(
+        u8,
+        "{\"FrameType\":\"TableHeader\",\"TableId\":1,\"TableKind\":\"PrimaryResult\",\"TableName\":\"T\",\"Columns\":[]}",
+    ));
+    defer table.deinit(allocator);
+    try std.testing.expectError(
+        error.MalformedKustoResponse,
+        second.decodeOwnedFrame(try allocator.dupe(
+            u8,
+            "{\"FrameType\":\"TableCompletion\",\"TableId\":1,\"RowCount\":1}",
+        )),
     );
 }

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -8,6 +8,7 @@ const serde = @import("serde");
 const kusto_common = @import("azure_kusto_common");
 pub const kql = @import("kql.zig");
 const result = @import("result.zig");
+const stream = @import("stream.zig");
 
 pub const ConnectionProperties = kusto_common.ConnectionProperties;
 pub const ClientRequestProperties = kusto_common.ClientRequestProperties;
@@ -52,6 +53,21 @@ pub const FrameIterator = result.FrameIterator;
 pub const KustoResponseDataSet = result.KustoResponseDataSet;
 pub const DecodeOutcome = result.DecodeOutcome;
 pub const decodeResponseDataSet = result.decode;
+pub const ProgressiveDecoder = result.ProgressiveDecoder;
+pub const ProgressiveFrame = stream.ProgressiveFrame;
+pub const ProgressiveDataSetHeader = result.ProgressiveDataSetHeader;
+pub const ProgressiveTableAction = stream.ProgressiveTableAction;
+pub const ProgressiveTableBatch = stream.ProgressiveTableBatch;
+pub const ProgressiveTableProgress = stream.ProgressiveTableProgress;
+pub const ProgressiveTableCompletion = stream.ProgressiveTableCompletion;
+pub const ProgressiveDataSetCompletion = stream.ProgressiveDataSetCompletion;
+pub const ProgressiveUnknownFrame = result.ProgressiveUnknownFrame;
+pub const ProgressiveQueryOptions = stream.ProgressiveQueryOptions;
+pub const ProgressiveQueryStream = stream.ProgressiveQueryStream;
+pub const ProgressiveFrameIterator = stream.ProgressiveFrameIterator;
+pub const ProgressiveTableIterator = stream.ProgressiveTableIterator;
+pub const ProgressiveRowIterator = stream.ProgressiveRowIterator;
+pub const ProgressiveRowEvent = stream.ProgressiveRowEvent;
 pub const QueryParameters = kql.QueryParameters;
 pub const KqlBuilder = kql.Builder;
 pub const KqlDateTime = kql.DateTime;
@@ -119,6 +135,75 @@ pub const KustoClient = struct {
         const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
         defer allocator.free(url);
         return self.executeInternal(allocator, url, database, query, properties, .query);
+    }
+
+    /// Opens a pull-based V2 progressive query stream. The returned stream is
+    /// heap-owned; call `deinit` exactly once, or `finish` first to drain and
+    /// validate the response. A non-2xx open returns a structured `.err`.
+    pub fn executeProgressiveQuery(
+        self: *KustoClient,
+        allocator: std.mem.Allocator,
+        database: []const u8,
+        query: []const u8,
+        properties: ?ClientRequestProperties,
+        options: ProgressiveQueryOptions,
+    ) !KustoResult(*ProgressiveQueryStream) {
+        if (options.max_frame_bytes == 0) return error.InvalidProgressiveFrameLimit;
+        if (options.max_table_count == 0) return error.InvalidProgressiveTableLimit;
+        const provided_properties = properties orelse ClientRequestProperties{};
+        var props = try provided_properties.clone(allocator);
+        defer props.deinit(allocator);
+        try props.setOption(allocator, "results_progressive_enabled", true);
+        try props.setOption(allocator, "results_v2_fragment_primary_tables", true);
+        try props.setOption(allocator, "results_v2_newlines_between_frames", true);
+        try props.setOption(allocator, "results_error_reporting_placement", "end_of_table");
+        try props.validate(.query);
+
+        const url = try std.fmt.allocPrint(allocator, "{s}/v2/rest/query", .{self.engineUrl()});
+        defer allocator.free(url);
+        const body = try serializeRequest(allocator, database, query, props, .query);
+        defer allocator.free(body);
+
+        var request = core.http.Request.init(allocator, .POST, url);
+        defer request.deinit();
+        try self.configureRequest(&request, props, .query);
+        request.body = body;
+        request.retryable = false;
+        const original_request_id = request.getHeader("x-ms-client-request-id") orelse
+            return error.MissingKustoRequestId;
+
+        const operation = try self.open(&request, .{ .cancellation = options.cancellation });
+        if (!operation.isSuccess()) {
+            defer operation.deinit();
+            var response = try responseFromOperation(allocator, operation, 16 * 1024 * 1024);
+            defer response.deinit();
+            var failure = try kusto_common.errors.fromHttpResponse(
+                allocator,
+                .query,
+                &response,
+                .known_not_accepted,
+            );
+            errdefer failure.deinit();
+            try kusto_common.errors.applyResponseCorrelation(
+                &failure,
+                &response,
+                original_request_id,
+            );
+            return .{ .err = failure };
+        }
+
+        errdefer operation.deinit();
+        const query_stream = try ProgressiveQueryStream.create(
+            allocator,
+            operation,
+            options,
+            .{ .allow_varying_row_widths = try props.allowVaryingRowWidths() },
+            original_request_id,
+            database,
+            @ptrCast(self),
+            &cancelProgressiveQuery,
+        );
+        return .{ .ok = query_stream };
     }
 
     /// Execute a management command (starts with `.`). Uses the V1 REST endpoint.
@@ -225,17 +310,7 @@ pub const KustoClient = struct {
 
         var request = core.http.Request.init(allocator, .POST, url);
         defer request.deinit();
-        try request.setHeader("Content-Type", "application/json; charset=utf-8");
-        try request.setHeader("Accept", "application/json");
-        try request.setHeader("Accept-Encoding", "gzip, deflate");
-        try request.setHeader("x-ms-app", props.application orelse self.application_name);
-        if (props.user) |user| try request.setHeader("x-ms-user", user);
-        try request.setHeader("x-ms-client-version", props.client_version orelse self.client_version);
-        try request.setHeader("x-ms-version", "2024-12-12");
-        if (props.client_request_id) |request_id|
-            try request.setHeader("x-ms-client-request-id", request_id);
-        try core.pipeline.ensureRequestId(&request);
-        request.operation_timeout_ms = try props.effectiveClientTimeoutMs(kind);
+        try self.configureRequest(&request, props, kind);
         request.body = body;
         request.retryable = kind == .query;
 
@@ -293,6 +368,25 @@ pub const KustoClient = struct {
         };
     }
 
+    fn configureRequest(
+        self: *const KustoClient,
+        request: *core.http.Request,
+        props: ClientRequestProperties,
+        kind: KustoRequestKind,
+    ) !void {
+        try request.setHeader("Content-Type", "application/json; charset=utf-8");
+        try request.setHeader("Accept", "application/json");
+        try request.setHeader("Accept-Encoding", "gzip, deflate");
+        try request.setHeader("x-ms-app", props.application orelse self.application_name);
+        if (props.user) |user| try request.setHeader("x-ms-user", user);
+        try request.setHeader("x-ms-client-version", props.client_version orelse self.client_version);
+        try request.setHeader("x-ms-version", "2024-12-12");
+        if (props.client_request_id) |request_id|
+            try request.setHeader("x-ms-client-request-id", request_id);
+        try core.pipeline.ensureRequestId(request);
+        request.operation_timeout_ms = try props.effectiveClientTimeoutMs(kind);
+    }
+
     fn send(self: *KustoClient, request: *core.http.Request) !core.http.Response {
         return switch (self.runtime) {
             .shared => |connection| connection.send(request),
@@ -309,7 +403,108 @@ pub const KustoClient = struct {
             },
         };
     }
+
+    fn open(
+        self: *KustoClient,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        return switch (self.runtime) {
+            .shared => |connection| connection.open(request, options),
+            .legacy => |*legacy| {
+                const connection = legacy.connection;
+                if (connection.credential != null or
+                    connection.authority_id != null or
+                    connection.application_client_id != null or
+                    connection.application_key != null)
+                {
+                    return error.AuthenticatedConnectionRequired;
+                }
+                return legacy.pipeline.open(request, options);
+            },
+        };
+    }
 };
+
+fn responseFromOperation(
+    allocator: std.mem.Allocator,
+    operation: *core.http.HttpOperation,
+    max_bytes: usize,
+) !core.http.Response {
+    if (max_bytes == 0) return error.InvalidProgressiveFrameLimit;
+    const reader = try operation.reader();
+    var body = std.ArrayList(u8).empty;
+    errdefer body.deinit(allocator);
+    var buffer: [4 * 1024]u8 = undefined;
+    while (true) {
+        const count = reader.readSliceShort(&buffer) catch |err| return err;
+        if (count == 0) break;
+        const remaining = max_bytes - body.items.len;
+        try body.appendSlice(allocator, buffer[0..@min(remaining, count)]);
+    }
+    const owned_body = try body.toOwnedSlice(allocator);
+    errdefer allocator.free(owned_body);
+    var headers = std.StringHashMap([]const u8).init(allocator);
+    errdefer {
+        var iterator = headers.iterator();
+        while (iterator.next()) |header| {
+            allocator.free(header.key_ptr.*);
+            allocator.free(header.value_ptr.*);
+        }
+        headers.deinit();
+    }
+    var iterator = operation.headers.iterator();
+    while (iterator.next()) |header| {
+        const name = try allocator.dupe(u8, header.key_ptr.*);
+        const value = allocator.dupe(u8, header.value_ptr.*) catch |err| {
+            allocator.free(name);
+            return err;
+        };
+        headers.put(name, value) catch |err| {
+            allocator.free(name);
+            allocator.free(value);
+            return err;
+        };
+    }
+    try operation.finish();
+    return .{
+        .status_code = operation.status_code,
+        .headers = headers,
+        .body = owned_body,
+        .allocator = allocator,
+    };
+}
+
+fn cancelProgressiveQuery(
+    context: *anyopaque,
+    allocator: std.mem.Allocator,
+    database: []const u8,
+    request_id: []const u8,
+) !KustoResult(KustoResponseDataSet) {
+    const client: *KustoClient = @ptrCast(@alignCast(context));
+    const command = try cancelCommand(allocator, request_id);
+    defer allocator.free(command);
+    return client.executeMgmtResult(allocator, database, command, null);
+}
+
+fn cancelCommand(allocator: std.mem.Allocator, request_id: []const u8) ![]u8 {
+    if (!std.unicode.utf8ValidateSlice(request_id))
+        return error.InvalidKustoClientRequestId;
+    var command = std.ArrayList(u8).empty;
+    errdefer command.deinit(allocator);
+    try command.appendSlice(allocator, ".cancel query \"");
+    for (request_id) |byte| {
+        if (byte < 0x20 or byte == 0x7f)
+            return error.InvalidKustoClientRequestId;
+        switch (byte) {
+            '"', '\\' => try command.append(allocator, '\\'),
+            else => {},
+        }
+        try command.append(allocator, byte);
+    }
+    try command.append(allocator, '"');
+    return command.toOwnedSlice(allocator);
+}
 
 fn serializeRequest(
     allocator: std.mem.Allocator,
@@ -936,6 +1131,584 @@ test "typed parameter bindings stay in properties rather than query text" {
         "\"secret\":\"\\\"'; .drop table T //\\\"\"",
     ) != null);
     try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"limit\":\"long(7)\"") != null);
+}
+
+const progressive_v2_response =
+    \\[
+    \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true,"ErrorReportingPlacement":"EndOfTable"},
+    \\ {"FrameType":"TableHeader","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"Value","ColumnType":"long"}]},
+    \\ {"FrameType":"TableFragment","TableId":0,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[[1]]},
+    \\ {"FrameType":"TableProgress","TableId":0,"TableProgress":50},
+    \\ {"FrameType":"TableFragment","TableId":0,"FieldCount":1,"TableFragmentType":"DataReplace","Rows":[]},
+    \\ {"FrameType":"TableCompletion","TableId":0,"RowCount":0,"HasErrors":true,"Cancelled":false,"OneApiErrors":[{"error":{"code":"Partial","message":"table partial"}}]},
+    \\ {"FrameType":"DataSetCompletion","HasErrors":true,"Cancelled":false,"OneApiErrors":[{"error":{"code":"Partial","message":"dataset partial"}}]}
+    \\]
+;
+
+test "KustoClient progressively pulls tiny chunks with explicit replace and completion errors" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer mock.deinit();
+    mock.stream_response_chunk_size = 1;
+    mock.response_headers_list = &.{
+        .{ .name = "x-ms-client-request-id", .value = "service-request-id" },
+        .{ .name = "x-ms-activity-id", .value = "service-activity-id" },
+    };
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    var properties = ClientRequestProperties{};
+    defer properties.deinit(allocator);
+    try properties.setProgressiveRowCount(allocator, 10);
+
+    var opened = try client.executeProgressiveQuery(
+        allocator,
+        "db",
+        "range x from 1 to 1 step 1",
+        properties,
+        .{ .max_frame_bytes = 1024 },
+    );
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        .err => |*failure| {
+            defer failure.deinit();
+            return error.TestUnexpectedResult;
+        },
+        .partial => return error.TestUnexpectedResult,
+    };
+    defer query_stream.deinit();
+
+    try std.testing.expectEqual(@as(?bool, false), mock.last_retryable);
+    for ([_][]const u8{
+        "\"results_progressive_enabled\":true",
+        "\"results_v2_fragment_primary_tables\":true",
+        "\"results_v2_newlines_between_frames\":true",
+        "\"results_error_reporting_placement\":\"end_of_table\"",
+        "\"query_results_progressive_row_count\":10",
+    }) |expected|
+        try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, expected) != null);
+
+    var saw_append = false;
+    var saw_replace = false;
+    var saw_progress = false;
+    var saw_partial = false;
+    while (try query_stream.next()) |frame| {
+        var owned = frame;
+        defer owned.deinit(allocator);
+        switch (owned.payload) {
+            .table_fragment => |batch| {
+                if (batch.action == .append) {
+                    saw_append = true;
+                    try std.testing.expectEqual(@as(?i64, 1), batch.table.rows[0].get(0).?.asI64());
+                } else {
+                    saw_replace = true;
+                    try std.testing.expectEqual(@as(usize, 0), batch.table.rows.len);
+                }
+            },
+            .table_progress => |progress| {
+                saw_progress = true;
+                try std.testing.expectEqual(@as(f64, 50), progress.progress);
+            },
+            .table_completion => |completion| {
+                try std.testing.expect(completion.failure != null);
+                try std.testing.expectEqualStrings(
+                    "service-request-id",
+                    completion.failure.?.client_request_id.?,
+                );
+                try std.testing.expectEqualStrings(
+                    "service-activity-id",
+                    completion.failure.?.activity_id.?,
+                );
+                saw_partial = true;
+            },
+            .data_set_completion => |completion| {
+                try std.testing.expect(completion.failure != null);
+                saw_partial = true;
+            },
+            else => {},
+        }
+    }
+    try std.testing.expect(saw_append and saw_replace and saw_progress and saw_partial);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_finish_count);
+}
+
+test "shared KustoClient opens progressive queries through authenticated no-redirect pipeline" {
+    const allocator = std.testing.allocator;
+    var credential = TestTokenCredential{};
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer mock.deinit();
+    const connection = try KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = "https://cluster.kusto.windows.net",
+            .credential = credential.asCredential(),
+        },
+        mock.asTransport(),
+        .{ .metadata_mode = .disabled },
+    );
+    defer connection.deinit();
+    var client = KustoClient.initWithConnection(connection, .{});
+    const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer query_stream.deinit();
+    try std.testing.expect(mock.last_headers.get("Authorization") != null);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
+    try std.testing.expectEqual(@as(usize, 1), credential.call_count);
+}
+
+test "progressive query reports non-success opens as structured errors" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(
+        allocator,
+        429,
+        "{\"error\":{\"code\":\"Throttled\",\"message\":\"retry later\"}}",
+    );
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    var opened = try client.executeProgressiveQuery(
+        allocator,
+        "db",
+        "print 1",
+        null,
+        .{ .max_frame_bytes = 8 },
+    );
+    defer opened.deinit(allocator);
+    switch (opened) {
+        .err => |failure| {
+            try std.testing.expectEqual(@as(?u16, 429), failure.http_status);
+            try std.testing.expectEqual(KustoErrorSource.http, failure.source);
+            try std.testing.expect(failure.retryable);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_finish_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_deinit_count);
+}
+
+test "progressive row iterator exposes zero row replacement reset" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer mock.deinit();
+    mock.stream_response_chunk_size = 2;
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer query_stream.deinit();
+    var rows = try query_stream.rowIterator();
+    defer rows.deinit();
+
+    const appended = (try rows.next()).?.batch;
+    try std.testing.expectEqual(ProgressiveTableAction.append, appended.action);
+    try std.testing.expectEqual(@as(?i64, 1), appended.row.?.get(0).?.asI64());
+    const reset = (try rows.next()).?.batch;
+    try std.testing.expectEqual(ProgressiveTableAction.replace, reset.action);
+    try std.testing.expect(reset.row == null);
+    try std.testing.expect((try rows.next()).?.table_completion.failure != null);
+    try std.testing.expect((try rows.next()).?.data_set_completion.failure != null);
+    try std.testing.expect((try rows.next()) == null);
+}
+
+const progressive_replace_response =
+    \\[
+    \\ {"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+    \\ {"FrameType":"TableHeader","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"Value","ColumnType":"long"}]},
+    \\ {"FrameType":"TableFragment","TableId":0,"FieldCount":1,"TableFragmentType":"DataReplace","Rows":[[1],[2]]},
+    \\ {"FrameType":"TableFragment","TableId":0,"FieldCount":1,"TableFragmentType":"DataAppend","Rows":[{"OneApiErrors":[{"error":{"code":"Partial","message":"append partial"}}]}]},
+    \\ {"FrameType":"TableCompletion","TableId":0,"RowCount":2,"HasErrors":true,"Cancelled":false,"OneApiErrors":[{"error":{"code":"Partial","message":"table partial"}}]},
+    \\ {"FrameType":"DataSetCompletion","HasErrors":true,"Cancelled":false,"OneApiErrors":[{"error":{"code":"Partial","message":"dataset partial"}}]}
+    \\]
+;
+
+test "progressive row iterator resets once and preserves every partial failure" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_replace_response);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer query_stream.deinit();
+    var rows = try query_stream.rowIterator();
+    defer rows.deinit();
+
+    const reset = (try rows.next()).?.batch;
+    try std.testing.expectEqual(ProgressiveTableAction.replace, reset.action);
+    try std.testing.expect(reset.row == null);
+    const first = (try rows.next()).?.batch;
+    const second = (try rows.next()).?.batch;
+    try std.testing.expectEqual(ProgressiveTableAction.append, first.action);
+    try std.testing.expectEqual(ProgressiveTableAction.append, second.action);
+    try std.testing.expectEqual(@as(?i64, 1), first.row.?.getByName("Value").?.asI64());
+    try std.testing.expectEqual(@as(?i64, 2), second.row.?.getByName("Value").?.asI64());
+    const append_failure = (try rows.next()).?.batch;
+    try std.testing.expectEqual(ProgressiveTableAction.append, append_failure.action);
+    try std.testing.expect(append_failure.row == null);
+    try std.testing.expect(append_failure.failure != null);
+    try std.testing.expect((try rows.next()).?.table_completion.failure != null);
+    try std.testing.expect((try rows.next()).?.data_set_completion.failure != null);
+    try std.testing.expect((try rows.next()) == null);
+}
+
+test "progressive fragment events own their row schema" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_replace_response);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+
+    for (0..2) |_| {
+        var frame = (try query_stream.next()).?;
+        frame.deinit(allocator);
+    }
+    var fragment = (try query_stream.next()).?;
+    query_stream.deinit();
+    defer fragment.deinit(allocator);
+
+    const table = &fragment.payload.table_fragment.table;
+    try std.testing.expectEqual(@as(?i64, 1), table.rows[0].getByName("Value").?.asI64());
+    const Row = struct { Value: i64 };
+    const decoder = try table.rowDecoder(Row);
+    var typed = try decoder.rowAs(&table.rows[1], allocator);
+    defer KustoRowDecoder(Row).deinitRow(&typed, allocator);
+    try std.testing.expectEqual(@as(i64, 2), typed.Value);
+}
+
+test "KustoResult deinitializes an owned progressive stream pointer" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    var opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    opened.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_deinit_count);
+}
+
+test "progressive query cannot send remote cancellation after dataset completion" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer query_stream.deinit();
+
+    while (try query_stream.next()) |frame| {
+        const completed = std.meta.activeTag(frame.payload) == .data_set_completion;
+        var owned = frame;
+        owned.deinit(allocator);
+        if (completed) break;
+    }
+    try std.testing.expectError(error.ProgressiveQueryNotActive, query_stream.cancel());
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try std.testing.expect((try query_stream.next()) == null);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_finish_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_deinit_count);
+}
+
+test "progressive stream releases early operations and does not retain many frames" {
+    const allocator = std.testing.allocator;
+    var early_mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer early_mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        early_mock.asTransport(),
+        .{},
+    );
+    const early_opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const early_stream = switch (early_opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    early_stream.deinit();
+    try std.testing.expectEqual(@as(usize, 1), early_mock.stream_abort_count);
+    try std.testing.expectEqual(@as(usize, 1), early_mock.stream_deinit_count);
+
+    var response = std.ArrayList(u8).empty;
+    defer response.deinit(allocator);
+    try response.appendSlice(allocator,
+        \\[{"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":true},
+    );
+    for (0..256) |index| {
+        const frame = try std.fmt.allocPrint(
+            allocator,
+            "{{\"FrameType\":\"Future\",\"Index\":{d},\"Nested\":{{\"text\":\"x\"}}}},",
+            .{index},
+        );
+        defer allocator.free(frame);
+        try response.appendSlice(allocator, frame);
+    }
+    try response.appendSlice(allocator,
+        \\{"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}]
+    );
+
+    var mock = core.http.MockTransport.init(allocator, 200, response.items);
+    defer mock.deinit();
+    mock.stream_response_chunk_size = 3;
+    client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    const opened = try client.executeProgressiveQuery(
+        allocator,
+        "db",
+        "print 1",
+        null,
+        .{ .max_frame_bytes = 128 },
+    );
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer query_stream.deinit();
+    var count: usize = 0;
+    while (try query_stream.next()) |frame| {
+        var owned = frame;
+        defer owned.deinit(allocator);
+        try std.testing.expect(owned.raw_json.len <= 128);
+        count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 258), count);
+    try std.testing.expect(query_stream.frame_buffer.items.len <= 128);
+}
+
+test "progressive stream bounds frames and rejects malformed order or reader failures" {
+    const allocator = std.testing.allocator;
+    var too_large = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer too_large.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        too_large.asTransport(),
+        .{},
+    );
+    var opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{ .max_frame_bytes = 8 });
+    const limited = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer limited.deinit();
+    try std.testing.expectError(error.KustoProgressiveFrameTooLarge, limited.next());
+    try std.testing.expectEqual(@as(usize, 1), too_large.stream_abort_count);
+
+    const malformed =
+        \\[{"FrameType":"TableHeader","TableId":0,"TableKind":"PrimaryResult","TableName":"T","Columns":[]}]
+    ;
+    var bad_mock = core.http.MockTransport.init(allocator, 200, malformed);
+    defer bad_mock.deinit();
+    client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        bad_mock.asTransport(),
+        .{},
+    );
+    opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const bad_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer bad_stream.deinit();
+    try std.testing.expectError(error.MalformedKustoResponse, bad_stream.next());
+
+    const trailing_comma =
+        \\[{"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\{"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false},]
+    ;
+    var comma_mock = core.http.MockTransport.init(allocator, 200, trailing_comma);
+    defer comma_mock.deinit();
+    client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        comma_mock.asTransport(),
+        .{},
+    );
+    opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const comma_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer comma_stream.deinit();
+    for (0..2) |_| {
+        var frame = (try comma_stream.next()).?;
+        frame.deinit(allocator);
+    }
+    try std.testing.expectError(error.MalformedKustoResponse, comma_stream.next());
+
+    const invalid_header =
+        \\[{"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":"yes"}]
+    ;
+    var header_mock = core.http.MockTransport.init(allocator, 200, invalid_header);
+    defer header_mock.deinit();
+    client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        header_mock.asTransport(),
+        .{},
+    );
+    opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const header_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer header_stream.deinit();
+    try std.testing.expectError(error.MalformedKustoResponse, header_stream.next());
+
+    const too_many_tables =
+        \\[{"FrameType":"DataSetHeader","Version":"v2.0","IsProgressive":false},
+        \\{"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"A","Columns":[],"Rows":[]},
+        \\{"FrameType":"DataTable","TableId":1,"TableKind":"PrimaryResult","TableName":"B","Columns":[],"Rows":[]},
+        \\{"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}]
+    ;
+    var table_mock = core.http.MockTransport.init(allocator, 200, too_many_tables);
+    defer table_mock.deinit();
+    client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        table_mock.asTransport(),
+        .{},
+    );
+    opened = try client.executeProgressiveQuery(
+        allocator,
+        "db",
+        "print 1",
+        null,
+        .{ .max_table_count = 1 },
+    );
+    const table_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer table_stream.deinit();
+    for (0..2) |_| {
+        var frame = (try table_stream.next()).?;
+        frame.deinit(allocator);
+    }
+    try std.testing.expectError(
+        error.KustoProgressiveTableLimitExceeded,
+        table_stream.next(),
+    );
+
+    var failed_mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer failed_mock.deinit();
+    failed_mock.stream_fail_response_after = 0;
+    client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        failed_mock.asTransport(),
+        .{},
+    );
+    opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
+    const failed_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer failed_stream.deinit();
+    try std.testing.expectError(error.ReadFailed, failed_stream.next());
+}
+
+test "progressive query cancellation uses original request ID and management request semantics" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    const target_id = "query-request-id";
+    const properties = ClientRequestProperties{ .client_request_id = target_id };
+    const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", properties, .{});
+    const query_stream = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer query_stream.deinit();
+    try std.testing.expectEqualStrings(target_id, query_stream.clientRequestId());
+
+    var cancelled = try query_stream.cancel();
+    defer cancelled.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_cancel_count);
+    try std.testing.expect(std.mem.endsWith(u8, mock.last_url.?, "/v1/rest/mgmt"));
+    try std.testing.expectEqual(@as(?bool, false), mock.last_retryable);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        mock.last_body.?,
+        ".cancel query \\\"query-request-id\\\"",
+    ) != null);
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        target_id,
+        mock.last_headers.get("x-ms-client-request-id").?,
+    ));
+}
+
+test "progressive query checks pre-cancellation and deadlines between pulls" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
+    defer mock.deinit();
+    var client = KustoClient.init(
+        .{ .cluster_url = "https://cluster.kusto.windows.net" },
+        mock.asTransport(),
+        .{},
+    );
+    var token = core.http.CancellationToken{};
+    token.cancel();
+    try std.testing.expectError(
+        error.OperationCancelled,
+        client.executeProgressiveQuery(allocator, "db", "print 1", null, .{ .cancellation = &token }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+
+    const opened = try client.executeProgressiveQuery(
+        allocator,
+        "db",
+        "print 1",
+        null,
+        .{ .deadline_ms = 0 },
+    );
+    const timed = switch (opened) {
+        .ok => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+    defer timed.deinit();
+    try std.testing.expectError(error.OperationTimedOut, timed.next());
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
 }
 
 test {

--- a/sdk/kusto/data/stream.zig
+++ b/sdk/kusto/data/stream.zig
@@ -1,0 +1,526 @@
+//! Pull-based, bounded-memory progressive Kusto query streaming.
+const std = @import("std");
+const core = @import("azure_core");
+const kusto_common = @import("azure_kusto_common");
+const result = @import("result.zig");
+
+/// Controls progressive response parsing. `deadline_ms` is a best-effort
+/// budget checked before and after pulls; it cannot interrupt a blocking
+/// `std.Io.Reader` read.
+pub const ProgressiveQueryOptions = struct {
+    /// Maximum bytes in one complete V2 frame object. The stream reuses a
+    /// buffer of at most this size and an outstanding event owns one frame.
+    max_frame_bytes: usize = 4 * 1024 * 1024,
+    /// Maximum distinct table IDs retained for frame-order validation.
+    max_table_count: usize = 1024,
+    /// Best-effort duration from successful stream creation until a pull fails
+    /// with `OperationTimedOut`.
+    deadline_ms: ?u64 = null,
+    /// Checked by core while opening and by this stream between pulls. It
+    /// cannot interrupt a reader already blocked in the transport.
+    cancellation: ?*const core.http.CancellationToken = null,
+};
+
+pub const ProgressiveFrame = result.ProgressiveFrame;
+pub const ProgressiveTableAction = result.ProgressiveTableAction;
+pub const ProgressiveTableBatch = result.ProgressiveTableBatch;
+pub const ProgressiveTableProgress = result.ProgressiveTableProgress;
+pub const ProgressiveTableCompletion = result.ProgressiveTableCompletion;
+pub const ProgressiveDataSetCompletion = result.ProgressiveDataSetCompletion;
+
+const CancelFn = *const fn (
+    context: *anyopaque,
+    allocator: std.mem.Allocator,
+    database: []const u8,
+    request_id: []const u8,
+) anyerror!kusto_common.KustoResult(result.KustoResponseDataSet);
+
+const ArrayState = enum {
+    begin,
+    expect_first_value,
+    expect_next_value,
+    after_value,
+    after_array,
+    complete,
+    closed,
+};
+
+const Consumer = enum {
+    none,
+    frames,
+    tables,
+    rows,
+};
+
+/// A heap-owned, single-consumer progressive V2 query stream.
+///
+/// The stream owns the HTTP operation, decoder state, query database, and
+/// original `x-ms-client-request-id`. It borrows the client context supplied
+/// by the data client, which must outlive the stream. Call `finish` to drain
+/// and validate a response, or `deinit` to deterministically abort without
+/// draining.
+pub const ProgressiveQueryStream = struct {
+    allocator: std.mem.Allocator,
+    operation: ?*core.http.HttpOperation,
+    reader: ?*std.Io.Reader,
+    decoder: result.ProgressiveDecoder,
+    options: ProgressiveQueryOptions,
+    deadline_ns: ?i128,
+    original_request_id: []u8,
+    database: []u8,
+    cancel_context: *anyopaque,
+    cancel_fn: CancelFn,
+    frame_buffer: std.ArrayList(u8) = .empty,
+    array_state: ArrayState = .begin,
+    consumer: Consumer = .none,
+
+    pub fn create(
+        allocator: std.mem.Allocator,
+        operation: *core.http.HttpOperation,
+        options: ProgressiveQueryOptions,
+        decode_options: result.DecodeOptions,
+        original_request_id: []const u8,
+        database: []const u8,
+        cancel_context: *anyopaque,
+        cancel_fn: CancelFn,
+    ) !*ProgressiveQueryStream {
+        if (options.max_frame_bytes == 0) return error.InvalidProgressiveFrameLimit;
+        if (options.max_table_count == 0) return error.InvalidProgressiveTableLimit;
+        const reader = try operation.reader();
+        const request_id = try allocator.dupe(u8, original_request_id);
+        errdefer allocator.free(request_id);
+        const database_copy = try allocator.dupe(u8, database);
+        errdefer allocator.free(database_copy);
+        const self = try allocator.create(ProgressiveQueryStream);
+        errdefer allocator.destroy(self);
+        var decoder = result.ProgressiveDecoder.init(allocator, decode_options, .query);
+        decoder.max_table_count = options.max_table_count;
+        self.* = .{
+            .allocator = allocator,
+            .operation = operation,
+            .reader = reader,
+            .decoder = decoder,
+            .options = options,
+            .deadline_ns = deadlineFromNow(options.deadline_ms),
+            .original_request_id = request_id,
+            .database = database_copy,
+            .cancel_context = cancel_context,
+            .cancel_fn = cancel_fn,
+        };
+        return self;
+    }
+
+    /// Stops without draining. This is the deterministic early-exit path and
+    /// does not submit a server-side cancellation command.
+    pub fn abort(self: *ProgressiveQueryStream) void {
+        self.closeOperation(.abort);
+    }
+
+    /// Cancels the active local operation first, then sends non-retryable
+    /// `.cancel query "<original request id>"` through the owning client.
+    pub fn cancel(self: *ProgressiveQueryStream) !kusto_common.KustoResult(result.KustoResponseDataSet) {
+        if (self.operation == null or self.decoder.saw_completion)
+            return error.ProgressiveQueryNotActive;
+        self.closeOperation(.cancel);
+        return self.cancel_fn(
+            self.cancel_context,
+            self.allocator,
+            self.database,
+            self.original_request_id,
+        );
+    }
+
+    /// Returns the original query request ID used as the server cancellation
+    /// target. It is not the response activity ID.
+    pub fn clientRequestId(self: *const ProgressiveQueryStream) []const u8 {
+        return self.original_request_id;
+    }
+
+    /// Pulls the next owned V2 event. The caller owns a non-null event and
+    /// must call `deinit`; no event remains retained by the stream.
+    pub fn next(self: *ProgressiveQueryStream) !?ProgressiveFrame {
+        try self.claim(.frames);
+        return self.nextInternal();
+    }
+
+    /// Returns a thin exclusive iterator over all frames.
+    pub fn frameIterator(self: *ProgressiveQueryStream) !ProgressiveFrameIterator {
+        try self.claim(.frames);
+        return .{ .stream = self };
+    }
+
+    /// Returns an exclusive iterator over table data, progress, and completion
+    /// events. Dataset completion is also retained so partial failure remains
+    /// visible. Other frames are deinitialized.
+    pub fn tableIterator(self: *ProgressiveQueryStream) !ProgressiveTableIterator {
+        try self.claim(.tables);
+        return .{ .stream = self };
+    }
+
+    /// Returns an exclusive iterator over rows and completion events. Borrowed
+    /// payloads become invalid on its next call or `deinit`. A `replace` batch
+    /// with a null row resets the table before subsequent append rows.
+    pub fn rowIterator(self: *ProgressiveQueryStream) !ProgressiveRowIterator {
+        try self.claim(.rows);
+        return .{ .stream = self };
+    }
+
+    /// Drains remaining frames, validates closing array punctuation and V2
+    /// completion state, and finishes the HTTP operation. Drained events are
+    /// discarded; use `next` when individual partial failures are required.
+    pub fn finish(self: *ProgressiveQueryStream) !void {
+        while (try self.nextInternal()) |*frame| frame.deinit(self.allocator);
+    }
+
+    /// Does not auto-drain. An active operation is aborted before its storage
+    /// is released, and the stream allocation must be deinitialized exactly
+    /// once by its owner.
+    pub fn deinit(self: *ProgressiveQueryStream) void {
+        self.closeOperation(.abort);
+        self.decoder.deinit();
+        self.frame_buffer.deinit(self.allocator);
+        self.allocator.free(self.original_request_id);
+        self.allocator.free(self.database);
+        self.allocator.destroy(self);
+    }
+
+    fn nextInternal(self: *ProgressiveQueryStream) !?ProgressiveFrame {
+        errdefer self.closeOperation(.abort);
+        try self.checkInterruption();
+        while (true) {
+            switch (self.array_state) {
+                .begin => {
+                    const byte = (try self.nextNonWhitespace()) orelse return error.MalformedKustoResponse;
+                    if (byte != '[') return error.MalformedKustoResponse;
+                    self.array_state = .expect_first_value;
+                },
+                .expect_first_value, .expect_next_value => {
+                    const byte = (try self.nextNonWhitespace()) orelse return error.MalformedKustoResponse;
+                    if (byte == ']') {
+                        if (self.array_state == .expect_next_value)
+                            return error.MalformedKustoResponse;
+                        self.array_state = .after_array;
+                        continue;
+                    }
+                    if (byte != '{') return error.MalformedKustoResponse;
+                    const raw_json = try self.readObject(byte);
+                    self.array_state = .after_value;
+                    var frame = try self.decoder.decodeOwnedFrame(raw_json);
+                    errdefer frame.deinit(self.allocator);
+                    try self.applyFrameCorrelation(&frame);
+                    try self.checkInterruption();
+                    return frame;
+                },
+                .after_value => {
+                    const byte = (try self.nextNonWhitespace()) orelse return error.MalformedKustoResponse;
+                    switch (byte) {
+                        ',' => self.array_state = .expect_next_value,
+                        ']' => self.array_state = .after_array,
+                        else => return error.MalformedKustoResponse,
+                    }
+                },
+                .after_array => {
+                    while (try self.readByte()) |byte| {
+                        if (!std.ascii.isWhitespace(byte))
+                            return error.MalformedKustoResponse;
+                    }
+                    try self.decoder.finish();
+                    const operation = self.operation orelse return error.ProgressiveQueryClosed;
+                    try operation.finish();
+                    operation.deinit();
+                    self.operation = null;
+                    self.reader = null;
+                    self.array_state = .complete;
+                    try self.checkInterruption();
+                    return null;
+                },
+                .complete => return null,
+                .closed => return error.ProgressiveQueryClosed,
+            }
+        }
+    }
+
+    fn readObject(self: *ProgressiveQueryStream, first: u8) ![]u8 {
+        self.frame_buffer.clearRetainingCapacity();
+        try self.appendFrameByte(first);
+        var depth: usize = 1;
+        var in_string = false;
+        var escaped = false;
+        while (true) {
+            const byte = (try self.readByte()) orelse return error.MalformedKustoResponse;
+            try self.appendFrameByte(byte);
+            if (in_string) {
+                if (escaped) {
+                    escaped = false;
+                } else if (byte == '\\') {
+                    escaped = true;
+                } else if (byte == '"') {
+                    in_string = false;
+                }
+                continue;
+            }
+            switch (byte) {
+                '"' => in_string = true,
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if (depth == 0)
+                        return self.allocator.dupe(u8, self.frame_buffer.items);
+                },
+                else => {},
+            }
+        }
+    }
+
+    fn appendFrameByte(self: *ProgressiveQueryStream, byte: u8) !void {
+        if (self.frame_buffer.items.len >= self.options.max_frame_bytes)
+            return error.KustoProgressiveFrameTooLarge;
+        try self.frame_buffer.append(self.allocator, byte);
+    }
+
+    fn nextNonWhitespace(self: *ProgressiveQueryStream) !?u8 {
+        while (try self.readByte()) |byte| {
+            if (!std.ascii.isWhitespace(byte)) return byte;
+        }
+        return null;
+    }
+
+    fn readByte(self: *ProgressiveQueryStream) !?u8 {
+        const reader = self.reader orelse return error.ProgressiveQueryClosed;
+        var byte: [1]u8 = undefined;
+        const count = reader.readSliceShort(&byte) catch |err| return err;
+        if (count == 0) return null;
+        return byte[0];
+    }
+
+    fn claim(self: *ProgressiveQueryStream, consumer: Consumer) !void {
+        if (self.consumer == .none) {
+            self.consumer = consumer;
+            return;
+        }
+        if (self.consumer != consumer) return error.ProgressiveIteratorInUse;
+    }
+
+    fn checkInterruption(self: *ProgressiveQueryStream) !void {
+        if (self.options.cancellation) |token| {
+            if (token.isCancelled()) {
+                self.closeOperation(.cancel);
+                return error.OperationCancelled;
+            }
+        }
+        if (self.deadline_ns) |deadline| {
+            if (monotonicNs() >= deadline) {
+                self.closeOperation(.abort);
+                return error.OperationTimedOut;
+            }
+        }
+    }
+
+    fn applyFrameCorrelation(
+        self: *ProgressiveQueryStream,
+        frame: *ProgressiveFrame,
+    ) !void {
+        const operation = self.operation orelse return error.ProgressiveQueryClosed;
+        const response_request_id = operation.getHeader("x-ms-client-request-id");
+        const response_activity_id = operation.getHeader("x-ms-activity-id");
+        const failure = switch (frame.payload) {
+            .data_table, .table_fragment => |*batch| if (batch.failure) |*value| value else null,
+            .table_completion => |*completion| if (completion.failure) |*value| value else null,
+            .data_set_completion => |*completion| if (completion.failure) |*value| value else null,
+            else => null,
+        };
+        if (failure) |value|
+            try kusto_common.errors.applyCorrelation(
+                value,
+                response_request_id,
+                response_activity_id,
+                self.original_request_id,
+            );
+    }
+
+    fn closeOperation(self: *ProgressiveQueryStream, action: enum { abort, cancel }) void {
+        const operation = self.operation orelse return;
+        switch (action) {
+            .abort => operation.abort(),
+            .cancel => operation.cancel(),
+        }
+        operation.deinit();
+        self.operation = null;
+        self.reader = null;
+        if (self.array_state != .complete)
+            self.array_state = .closed;
+    }
+};
+
+/// Pull wrapper for full owned progressive frames.
+pub const ProgressiveFrameIterator = struct {
+    stream: *ProgressiveQueryStream,
+
+    pub fn next(self: *ProgressiveFrameIterator) !?ProgressiveFrame {
+        return self.stream.next();
+    }
+};
+
+/// Pull wrapper that returns only table-shaped frames. The caller owns each
+/// returned frame and must deinitialize it.
+pub const ProgressiveTableIterator = struct {
+    stream: *ProgressiveQueryStream,
+
+    pub fn next(self: *ProgressiveTableIterator) !?ProgressiveFrame {
+        while (try self.stream.nextInternal()) |frame| {
+            switch (frame.payload) {
+                .data_table,
+                .table_header,
+                .table_fragment,
+                .table_progress,
+                .table_completion,
+                .data_set_completion,
+                => return frame,
+                else => {
+                    var discarded = frame;
+                    discarded.deinit(self.stream.allocator);
+                },
+            }
+        }
+        return null;
+    }
+};
+
+/// A borrowed row-level event. A batch with `replace` and a null row resets
+/// the table before subsequent append rows. Completion events keep partial
+/// failures and cancellation visible to row consumers.
+pub const ProgressiveRowEvent = union(enum) {
+    batch: struct {
+        action: ProgressiveTableAction,
+        table_id: i64,
+        row: ?*const result.KustoResultRow,
+        failure: ?*const kusto_common.KustoError = null,
+    },
+    table_completion: *const result.ProgressiveTableCompletion,
+    data_set_completion: *const result.ProgressiveDataSetCompletion,
+};
+
+/// Pulls row events while retaining no more than one table batch. Call
+/// `deinit` to release a current batch before destroying its source stream.
+pub const ProgressiveRowIterator = struct {
+    stream: *ProgressiveQueryStream,
+    current: ?ProgressiveFrame = null,
+    row_index: usize = 0,
+    marker_pending: bool = false,
+    failure_pending: bool = false,
+    completion_delivered: bool = false,
+
+    pub fn deinit(self: *ProgressiveRowIterator) void {
+        if (self.current) |*frame| frame.deinit(self.stream.allocator);
+        self.current = null;
+    }
+
+    pub fn next(self: *ProgressiveRowIterator) !?ProgressiveRowEvent {
+        while (true) {
+            if (self.current) |*frame| {
+                switch (frame.payload) {
+                    .data_table, .table_fragment => |*batch| {
+                        const id = batch.table.id orelse return error.MalformedKustoResponse;
+                        if (self.marker_pending) {
+                            self.marker_pending = false;
+                            const failure = if (self.failure_pending and batch.failure != null)
+                                &batch.failure.?
+                            else
+                                null;
+                            self.failure_pending = false;
+                            return .{ .batch = .{
+                                .action = batch.action,
+                                .table_id = id,
+                                .row = null,
+                                .failure = failure,
+                            } };
+                        }
+                        if (self.row_index < batch.table.rows.len) {
+                            defer self.row_index += 1;
+                            const failure = if (self.failure_pending and batch.failure != null)
+                                &batch.failure.?
+                            else
+                                null;
+                            self.failure_pending = false;
+                            return .{ .batch = .{
+                                .action = .append,
+                                .table_id = id,
+                                .row = &batch.table.rows[self.row_index],
+                                .failure = failure,
+                            } };
+                        }
+                        frame.deinit(self.stream.allocator);
+                        self.current = null;
+                        continue;
+                    },
+                    .table_completion => |*completion| {
+                        if (!self.completion_delivered) {
+                            self.completion_delivered = true;
+                            return .{ .table_completion = completion };
+                        }
+                        frame.deinit(self.stream.allocator);
+                        self.current = null;
+                        self.completion_delivered = false;
+                        continue;
+                    },
+                    .data_set_completion => |*completion| {
+                        if (!self.completion_delivered) {
+                            self.completion_delivered = true;
+                            return .{ .data_set_completion = completion };
+                        }
+                        frame.deinit(self.stream.allocator);
+                        self.current = null;
+                        self.completion_delivered = false;
+                        continue;
+                    },
+                    else => unreachable,
+                }
+            }
+
+            while (try self.stream.nextInternal()) |frame| {
+                switch (frame.payload) {
+                    .data_table, .table_fragment => |batch| {
+                        const marker_pending = batch.action == .replace or
+                            (batch.table.rows.len == 0 and batch.failure != null);
+                        const discard_empty_append = batch.action == .append and
+                            batch.table.rows.len == 0 and batch.failure == null;
+                        if (discard_empty_append) {
+                            var discarded = frame;
+                            discarded.deinit(self.stream.allocator);
+                            continue;
+                        }
+                        self.current = frame;
+                        self.row_index = 0;
+                        self.marker_pending = marker_pending;
+                        self.failure_pending = batch.failure != null;
+                        self.completion_delivered = false;
+                        break;
+                    },
+                    .table_completion, .data_set_completion => {
+                        self.current = frame;
+                        self.completion_delivered = false;
+                        break;
+                    },
+                    else => {
+                        var discarded = frame;
+                        discarded.deinit(self.stream.allocator);
+                    },
+                }
+            } else return null;
+        }
+    }
+};
+
+fn monotonicNs() i128 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    return std.Io.Timestamp.now(threaded.io(), .awake).toNanoseconds();
+}
+
+fn deadlineFromNow(timeout_ms: ?u64) ?i128 {
+    const timeout = timeout_ms orelse return null;
+    return std.math.add(
+        i128,
+        monotonicNs(),
+        @as(i128, timeout) * std.time.ns_per_ms,
+    ) catch std.math.maxInt(i128);
+}

--- a/sdk/kusto/error.zig
+++ b/sdk/kusto/error.zig
@@ -112,8 +112,24 @@ pub fn KustoResult(comptime T: type) type {
 }
 
 fn deinitValue(comptime T: type, value: *T, allocator: std.mem.Allocator) void {
-    if (comptime @typeInfo(T) == .@"struct" and @hasDecl(T, "deinit")) {
-        value.deinit(allocator);
+    switch (@typeInfo(T)) {
+        .@"struct" => {
+            if (comptime @hasDecl(T, "deinit"))
+                value.deinit(allocator);
+        },
+        .pointer => |pointer| {
+            if (comptime pointer.size == .one and @hasDecl(pointer.child, "deinit")) {
+                const deinit_info = @typeInfo(@TypeOf(pointer.child.deinit)).@"fn";
+                if (comptime deinit_info.params.len == 1) {
+                    value.*.deinit();
+                } else if (comptime deinit_info.params.len == 2) {
+                    value.*.deinit(allocator);
+                } else {
+                    @compileError("KustoResult pointer payload deinit must accept self and optionally an allocator");
+                }
+            }
+        },
+        else => {},
     }
 }
 
@@ -227,7 +243,23 @@ pub fn applyResponseCorrelation(
     response: *const http.Response,
     fallback_request_id: ?[]const u8,
 ) !void {
-    if (response.getHeader("x-ms-client-request-id")) |value| {
+    return applyCorrelation(
+        result,
+        response.getHeader("x-ms-client-request-id"),
+        response.getHeader("x-ms-activity-id"),
+        fallback_request_id,
+    );
+}
+
+/// Prefer correlation IDs carried by a streaming HTTP operation over values
+/// embedded in a OneAPI context.
+pub fn applyCorrelation(
+    result: *KustoError,
+    response_request_id: ?[]const u8,
+    response_activity_id: ?[]const u8,
+    fallback_request_id: ?[]const u8,
+) !void {
+    if (response_request_id) |value| {
         const owned = try result.allocator.dupe(u8, value);
         if (result.client_request_id) |old| result.allocator.free(old);
         result.client_request_id = owned;
@@ -235,7 +267,7 @@ pub fn applyResponseCorrelation(
         if (fallback_request_id) |value|
             result.client_request_id = try result.allocator.dupe(u8, value);
     }
-    if (response.getHeader("x-ms-activity-id")) |value| {
+    if (response_activity_id) |value| {
         const owned = try result.allocator.dupe(u8, value);
         if (result.activity_id) |old| result.allocator.free(old);
         result.activity_id = owned;


### PR DESCRIPTION
Closes #53

Adds bounded pull-based progressive V2 query streaming with owned frame events, table and row adapters, explicit append/replace semantics, partial-error correlation, deterministic operation cleanup, pull deadlines, cancellation tokens, and request-ID-based remote cancellation.

The stream bounds individual frame size and retained table state, preserves event-owned schemas and raw JSON, rejects malformed framing/order, and keeps management cancellation non-retryable.