### PR TITLE
storage: add credential-isolated SAS Blob and Queue operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 
 | Package | Clients |
 |---------|---------|
-| `azure_storage_blobs` | `BlobClient`, `BlobContainerClient` |
-| `azure_storage_queues` | `QueueClient`, `QueueServiceClient` |
+| `azure_storage_blobs` | `BlobClient`, `BlobContainerClient`, `SasBlobClient` |
+| `azure_storage_queues` | `QueueClient`, `QueueServiceClient`, `SasQueueClient` |
 | `azure_storage_files_shares` | `ShareClient`, `ShareDirectoryClient`, `ShareFileClient` |
 | `azure_storage_files_datalake` | `DataLakeFileSystemClient`, `DataLakeFileClient` |
-| `azure_storage_common` | `StorageSharedKeyCredential`, `SasBuilder` |
+| `azure_storage_common` | `StorageSharedKeyCredential`, `SasBuilder`, complete-SAS helpers |
 | `azure_keyvault_secrets` | `SecretClient` |
 | `azure_keyvault_keys` | `KeyClient`, `CryptographyClient` |
 | `azure_keyvault_certificates` | `CertificateClient` |
@@ -113,6 +113,35 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 | `azure_messaging_servicebus` | `ServiceBusSenderClient`, `ServiceBusReceiverClient`, `ServiceBusAdministrationClient` |
 | `azure_kusto_data` | `KustoClient` (experimental buffered and progressive query plus management support) |
 | `azure_kusto_ingest` | `StreamingIngestClient` for direct, bounded-memory streaming ingestion; queued ingestion and managed queued fallback are not implemented |
+
+### Complete SAS Blob and Queue operations
+
+`SasBlobClient` and `SasQueueClient` take an allocator, a complete
+service-issued HTTPS SAS URI, and an `HttpTransport`—never a credential or a
+caller-supplied pipeline. Existing SAS queries remain opaque and are redacted
+by formatting. Requests have no `Authorization` header, disable retries, and
+reject redirects.
+
+```zig
+var blob = try blobs.SasBlobClient.init(allocator, blob_sas_uri, transport);
+defer blob.deinit();
+const upload = try blob.uploadFile("data.ndjson", .{});
+
+var queue = try queues.SasQueueClient.init(allocator, queue_sas_uri, transport);
+defer queue.deinit();
+const submitted = try queue.sendMessage(ingestion_message_bytes);
+```
+
+Blob sources have exact sizes: byte slices derive theirs, files are checked
+before and after opening, and `uploadReader` requires a supplied size. Sources
+are consumed once. Uploads up to 256 MiB stream as `Put Blob`; larger uploads
+stream 4 MiB blocks by default. A single request is capped at 5,000 MiB;
+blocks are capped at 100 MiB and 50,000 blocks (about 4.77 TiB total) before
+an ordered block-list commit. Queue messages are Base64-encoded inside the
+Azure Queue XML envelope. Outcomes are `.accepted`, `.rejected` after a
+received non-2xx status, or `.unknown` after transport failure; no Kusto
+resource discovery, queued-ingestion schema, retry, or status handling is
+included.
 
 Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished. Buffered Kusto datasets retain the raw response and tagged `KustoFrame` slices (including unknown V2 frames), decode V1 plus normal, progressive, and fragmented V2 tables into owned `KustoValue` values (null, strings, booleans, integers, reals, and Kusto lexical types), and preserve dynamic or unknown cells as raw JSON. Progressive query events instead own one exact raw V2 frame at a time and retain only table schemas and row counts in stream state.
 

--- a/build.zig
+++ b/build.zig
@@ -28,8 +28,8 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    const blobs_mod = b.addModule("azure_storage_blobs", .{
-        .root_source_file = b.path("sdk/storage/blobs/root.zig"),
+    const storage_common_mod = b.addModule("azure_storage_common", .{
+        .root_source_file = b.path("sdk/storage/common/root.zig"),
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
@@ -37,11 +37,12 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    _ = b.addModule("azure_storage_common", .{
-        .root_source_file = b.path("sdk/storage/common/root.zig"),
+    const blobs_mod = b.addModule("azure_storage_blobs", .{
+        .root_source_file = b.path("sdk/storage/blobs/root.zig"),
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
+            .{ .name = "azure_storage_common", .module = storage_common_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -104,6 +105,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
+            .{ .name = "azure_storage_common", .module = storage_common_mod },
             .{ .name = "serde", .module = serde_mod },
         },
     });
@@ -316,6 +318,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .imports = &.{
                     .{ .name = "azure_core", .module = core_mod },
+                    .{ .name = "azure_storage_common", .module = storage_common_mod },
                     .{ .name = "serde", .module = serde_mod },
                 },
             }),

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -266,8 +266,10 @@ pub const HttpTransport = struct {
         request: *Request,
         options: OpenOptions,
     ) !*HttpOperation {
-        request.transport_started = true;
-        if (self.openFn) |openFn| return openFn(self, request, options);
+        if (self.openFn) |openFn| {
+            request.transport_started = true;
+            return openFn(self, request, options);
+        }
         if (options.body != null) return error.StreamingRequestUnsupported;
         if (options.cancellation) |token| {
             if (token.isCancelled()) return error.OperationCancelled;
@@ -447,7 +449,7 @@ const StdStreamingOperation = struct {
         self.request = try transport.client.request(request.method.toStd(), uri, .{
             .extra_headers = self.extra_headers,
             .redirect_behavior = if (authenticated or request.redirect_policy == .not_allowed)
-                .not_allowed
+                .unhandled
             else
                 @enumFromInt(3),
         });

--- a/sdk/storage/blobs/root.zig
+++ b/sdk/storage/blobs/root.zig
@@ -1,6 +1,27 @@
 const std = @import("std");
 const core = @import("azure_core");
 
+const sas = @import("sas.zig");
+
+pub const SasBlobClient = sas.SasBlobClient;
+pub const CompleteSasBlobClient = sas.CompleteSasBlobClient;
+pub const BlobUploadSource = sas.BlobUploadSource;
+pub const BlobUploadSourceKind = sas.BlobUploadSourceKind;
+pub const BorrowedReaderSource = sas.BorrowedReaderSource;
+pub const BlobUploadOptions = sas.BlobUploadOptions;
+pub const BlobUploadOutcome = sas.BlobUploadOutcome;
+pub const BlobUploadPhase = sas.BlobUploadPhase;
+pub const default_single_upload_max_bytes = sas.default_single_upload_max_bytes;
+pub const max_single_upload_bytes = sas.max_single_upload_bytes;
+pub const default_block_size = sas.default_block_size;
+pub const max_block_size = sas.max_block_size;
+pub const max_block_count = sas.max_block_count;
+pub const max_upload_bytes = sas.max_upload_bytes;
+
+test {
+    std.testing.refAllDecls(sas);
+}
+
 // ─────────────────────────── Models ───────────────────────────
 
 pub const BlobProperties = struct {

--- a/sdk/storage/blobs/sas.zig
+++ b/sdk/storage/blobs/sas.zig
@@ -1,0 +1,882 @@
+//! Complete-URL SAS Blob uploads without credentials or retry policies.
+const std = @import("std");
+const core = @import("azure_core");
+const storage_common = @import("azure_storage_common");
+
+const sas = storage_common.sas;
+
+/// The default cutoff for one `Put Blob` request. Larger sources use ordered
+/// `Put Block` requests followed by a `Put Block List` commit.
+pub const default_single_upload_max_bytes: u64 = 256 * 1024 * 1024;
+/// The largest single-request `Put Blob` upload this client permits.
+pub const max_single_upload_bytes: u64 = 5_000 * 1024 * 1024;
+/// The default bounded block size for uploads above the single-request limit.
+pub const default_block_size: u64 = 4 * 1024 * 1024;
+/// The largest block size accepted by this client.
+pub const max_block_size: u64 = 100 * 1024 * 1024;
+/// Azure Blob Storage permits at most this many uncommitted blocks per blob.
+pub const max_block_count: u64 = 50_000;
+pub const max_upload_bytes: u64 = max_block_size * max_block_count;
+pub const storage_api_version = "2024-11-04";
+
+/// A borrowed reader with an exact byte length. The reader is consumed once;
+/// this client never retries or rewinds it.
+pub const BorrowedReaderSource = struct {
+    reader: *std.Io.Reader,
+    size: u64,
+};
+
+/// An upload source. Byte slices and paths are borrowed for the duration of
+/// `upload`; a file is opened once and streamed, never whole-buffered.
+pub const BlobUploadSource = union(enum) {
+    bytes: []const u8,
+    file: []const u8,
+    reader: BorrowedReaderSource,
+
+    pub fn kind(self: BlobUploadSource) BlobUploadSourceKind {
+        return switch (self) {
+            .bytes => .bytes,
+            .file => .file,
+            .reader => .reader,
+        };
+    }
+};
+
+pub const BlobUploadSourceKind = enum {
+    bytes,
+    file,
+    reader,
+};
+
+pub const BlobUploadOptions = struct {
+    content_type: []const u8 = "application/octet-stream",
+    /// Sources at or below this size use one streaming `Put Blob` request.
+    /// Set to zero to always use blocks.
+    single_upload_max_bytes: u64 = default_single_upload_max_bytes,
+    /// Used only for block uploads. The client validates `1..max_block_size`
+    /// and the resulting `max_block_count` before any transport operation.
+    block_size: u64 = default_block_size,
+};
+
+pub const BlobUploadPhase = enum {
+    put_blob,
+    put_block,
+    put_block_list,
+};
+
+/// A final Blob upload outcome. Received non-2xx responses are known not
+/// accepted; errors after transport entry have unknown server-side outcome.
+pub const BlobUploadOutcome = union(enum) {
+    accepted: struct { status_code: u16 },
+    rejected: struct {
+        status_code: u16,
+        phase: BlobUploadPhase,
+    },
+    unknown: struct {
+        cause: anyerror,
+        phase: BlobUploadPhase,
+    },
+    /// One or more blocks were accepted, but no block-list commit was sent.
+    /// Retrying with the same deterministic block IDs is safe.
+    incomplete: struct {
+        cause: anyerror,
+        phase: BlobUploadPhase,
+        staged_blocks: u64,
+    },
+
+    pub fn isAccepted(self: BlobUploadOutcome) bool {
+        return self == .accepted;
+    }
+
+    pub fn format(self: BlobUploadOutcome, writer: anytype) !void {
+        switch (self) {
+            .accepted => |value| try writer.print(
+                "BlobUploadOutcome(accepted, status={d})",
+                .{value.status_code},
+            ),
+            .rejected => |value| try writer.print(
+                "BlobUploadOutcome(rejected, phase={s}, status={d})",
+                .{ @tagName(value.phase), value.status_code },
+            ),
+            .unknown => |value| try writer.print(
+                "BlobUploadOutcome(unknown, phase={s}, cause={s})",
+                .{ @tagName(value.phase), @errorName(value.cause) },
+            ),
+            .incomplete => |value| try writer.print(
+                "BlobUploadOutcome(incomplete, phase={s}, staged_blocks={d}, cause={s})",
+                .{ @tagName(value.phase), value.staged_blocks, @errorName(value.cause) },
+            ),
+        }
+    }
+};
+
+/// A Blob client constructed only from an allocator, a complete SAS URL, and
+/// a transport. It deliberately has no credential or caller-supplied
+/// pipeline: every request uses an empty-policy, no-redirect pipeline.
+pub const SasBlobClient = struct {
+    allocator: std.mem.Allocator,
+    uri: sas.CompleteSasUri,
+    transport: *core.http.HttpTransport,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        complete_sas_uri: []const u8,
+        transport: *core.http.HttpTransport,
+    ) !SasBlobClient {
+        var uri = try sas.CompleteSasUri.init(allocator, complete_sas_uri);
+        errdefer uri.deinit();
+        if (!uri.hasAzureStorageServiceHost("blob"))
+            return error.UnexpectedBlobSasHost;
+        return .{
+            .allocator = allocator,
+            .uri = uri,
+            .transport = transport,
+        };
+    }
+
+    pub fn deinit(self: *SasBlobClient) void {
+        self.uri.deinit();
+        self.* = undefined;
+    }
+
+    /// Renders a query-redacted SAS URL only.
+    pub fn format(self: SasBlobClient, writer: anytype) !void {
+        try writer.print("SasBlobClient({f})", .{self.uri});
+    }
+
+    /// Uploads a known-size source. The method does not retry: a borrowed
+    /// reader is one-shot, and file/byte sources are not replayed implicitly.
+    pub fn upload(
+        self: *SasBlobClient,
+        source: BlobUploadSource,
+        options: BlobUploadOptions,
+    ) !BlobUploadOutcome {
+        const source_size = try sourceSize(source);
+        try validateOptions(source_size, options);
+
+        if (source_size <= options.single_upload_max_bytes) {
+            if (source == .bytes)
+                return self.putBlobBytes(source.bytes, options);
+            var opened = try OpenedSource.init(self.allocator, source, source_size);
+            defer opened.deinit();
+            return self.putBlob(opened.reader(), source_size, options);
+        }
+
+        // Allocate the complete ordered commit body before staging any block.
+        // This avoids a local allocation failure after successful block puts.
+        const commit_body = try makeBlockList(self.allocator, source_size, options.block_size);
+        defer self.allocator.free(commit_body);
+
+        var opened = try OpenedSource.init(self.allocator, source, source_size);
+        defer opened.deinit();
+        var remaining = source_size;
+        var block_index: u64 = 0;
+        while (remaining != 0) : (block_index += 1) {
+            const block_length = @min(remaining, options.block_size);
+            var block_reader = LimitedReader.init(opened.reader(), block_length);
+            const block_id = blockId(block_index);
+            const block_url = self.uri.appendProtocolQuery(self.allocator, &.{
+                .{ .name = "comp", .value = "block" },
+                .{ .name = "blockid", .value = &block_id },
+            }) catch |err| return localFailureAfterBlocks(err, .put_block, block_index);
+            defer self.allocator.free(block_url);
+
+            var request = core.http.Request.init(self.allocator, .PUT, block_url);
+            defer request.deinit();
+            request.setHeader("Content-Type", "application/octet-stream") catch |err|
+                return localFailureAfterBlocks(err, .put_block, block_index);
+            request.setHeader("x-ms-version", storage_api_version) catch |err|
+                return localFailureAfterBlocks(err, .put_block, block_index);
+            const streaming_body: ?core.http.StreamingRequestBody = switch (source) {
+                .bytes => |bytes| blk: {
+                    const start: usize = @intCast(source_size - remaining);
+                    const length: usize = @intCast(block_length);
+                    request.body = bytes[start .. start + length];
+                    break :blk null;
+                },
+                .file, .reader => .{
+                    .reader = &block_reader.interface,
+                    .content_length = block_length,
+                },
+            };
+            const outcome = sas.send(self.transport, &request, streaming_body) catch |err|
+                return localFailureAfterBlocks(err, .put_block, block_index);
+            switch (outcome) {
+                .accepted => {},
+                else => return mapOutcome(outcome, .put_block),
+            }
+            remaining -= block_length;
+        }
+
+        // Each limited block reader hides its following source bytes from the
+        // transport's exact-length probe. Verify the source's advertised
+        // length once all blocks have been consumed.
+        if (source != .bytes) {
+            ensureExhausted(opened.reader()) catch |err|
+                return localFailureAfterBlocks(err, .put_block_list, block_index);
+        }
+
+        const commit_url = self.uri.appendProtocolQuery(self.allocator, &.{
+            .{ .name = "comp", .value = "blocklist" },
+        }) catch |err| return localFailureAfterBlocks(err, .put_block_list, block_index);
+        defer self.allocator.free(commit_url);
+        var request = core.http.Request.init(self.allocator, .PUT, commit_url);
+        defer request.deinit();
+        request.setHeader("Content-Type", "application/xml") catch |err|
+            return localFailureAfterBlocks(err, .put_block_list, block_index);
+        request.setHeader("x-ms-version", storage_api_version) catch |err|
+            return localFailureAfterBlocks(err, .put_block_list, block_index);
+        request.setHeader("x-ms-blob-content-type", options.content_type) catch |err|
+            return localFailureAfterBlocks(err, .put_block_list, block_index);
+        request.body = commit_body;
+        const outcome = sas.send(self.transport, &request, null) catch |err|
+            return localFailureAfterBlocks(err, .put_block_list, block_index);
+        return mapOutcome(outcome, .put_block_list);
+    }
+
+    pub fn uploadBytes(
+        self: *SasBlobClient,
+        bytes: []const u8,
+        options: BlobUploadOptions,
+    ) !BlobUploadOutcome {
+        return self.upload(.{ .bytes = bytes }, options);
+    }
+
+    pub fn uploadFile(
+        self: *SasBlobClient,
+        path: []const u8,
+        options: BlobUploadOptions,
+    ) !BlobUploadOutcome {
+        return self.upload(.{ .file = path }, options);
+    }
+
+    pub fn uploadReader(
+        self: *SasBlobClient,
+        reader: *std.Io.Reader,
+        size: u64,
+        options: BlobUploadOptions,
+    ) !BlobUploadOutcome {
+        return self.upload(.{ .reader = .{ .reader = reader, .size = size } }, options);
+    }
+
+    fn putBlob(
+        self: *SasBlobClient,
+        reader: *std.Io.Reader,
+        size: u64,
+        options: BlobUploadOptions,
+    ) !BlobUploadOutcome {
+        var request = core.http.Request.init(self.allocator, .PUT, self.uri.bytes);
+        defer request.deinit();
+        try request.setHeader("Content-Type", options.content_type);
+        try request.setHeader("x-ms-blob-type", "BlockBlob");
+        try request.setHeader("x-ms-version", storage_api_version);
+        return mapOutcome(
+            try sas.send(
+                self.transport,
+                &request,
+                .{ .reader = reader, .content_length = size },
+            ),
+            .put_blob,
+        );
+    }
+
+    fn putBlobBytes(
+        self: *SasBlobClient,
+        bytes: []const u8,
+        options: BlobUploadOptions,
+    ) !BlobUploadOutcome {
+        var request = core.http.Request.init(self.allocator, .PUT, self.uri.bytes);
+        defer request.deinit();
+        try request.setHeader("Content-Type", options.content_type);
+        try request.setHeader("x-ms-blob-type", "BlockBlob");
+        try request.setHeader("x-ms-version", storage_api_version);
+        request.body = bytes;
+        return mapOutcome(try sas.send(self.transport, &request, null), .put_blob);
+    }
+};
+
+/// Compatibility spelling emphasizing that `init` accepts a complete SAS URL.
+pub const CompleteSasBlobClient = SasBlobClient;
+
+fn mapOutcome(outcome: sas.RequestOutcome, phase: BlobUploadPhase) BlobUploadOutcome {
+    return switch (outcome) {
+        .accepted => |value| .{ .accepted = .{
+            .status_code = value.status_code,
+        } },
+        .rejected => |value| .{ .rejected = .{
+            .status_code = value.status_code,
+            .phase = phase,
+        } },
+        .unknown => |value| .{ .unknown = .{
+            .cause = value.cause,
+            .phase = phase,
+        } },
+    };
+}
+
+fn localFailureAfterBlocks(
+    cause: anyerror,
+    phase: BlobUploadPhase,
+    staged_blocks: u64,
+) anyerror!BlobUploadOutcome {
+    if (staged_blocks == 0) return cause;
+    return .{ .incomplete = .{
+        .cause = cause,
+        .phase = phase,
+        .staged_blocks = staged_blocks,
+    } };
+}
+
+fn validateOptions(size: u64, options: BlobUploadOptions) !void {
+    if (options.block_size == 0 or options.block_size > max_block_size)
+        return error.InvalidBlobBlockSize;
+    if (options.single_upload_max_bytes > max_single_upload_bytes)
+        return error.InvalidBlobSingleUploadLimit;
+    if (size > max_upload_bytes)
+        return error.BlobUploadTooLarge;
+    if (size > options.single_upload_max_bytes) {
+        const blocks = blockCount(size, options.block_size);
+        if (blocks > max_block_count)
+            return error.BlobUploadTooLarge;
+    }
+}
+
+fn blockCount(size: u64, block_size: u64) u64 {
+    return (size / block_size) + @intFromBool(size % block_size != 0);
+}
+
+fn blockId(index: u64) [12]u8 {
+    var decimal: [8]u8 = undefined;
+    _ = std.fmt.bufPrint(&decimal, "{d:0>8}", .{index}) catch unreachable;
+    var encoded: [12]u8 = undefined;
+    _ = std.base64.standard.Encoder.encode(&encoded, &decimal);
+    return encoded;
+}
+
+fn makeBlockList(
+    allocator: std.mem.Allocator,
+    size: u64,
+    block_size: u64,
+) ![]u8 {
+    var output = std.ArrayList(u8).empty;
+    errdefer output.deinit(allocator);
+    try output.appendSlice(allocator, "<BlockList>");
+    const count = blockCount(size, block_size);
+    var index: u64 = 0;
+    while (index < count) : (index += 1) {
+        const id = blockId(index);
+        try output.appendSlice(allocator, "<Latest>");
+        try output.appendSlice(allocator, &id);
+        try output.appendSlice(allocator, "</Latest>");
+    }
+    try output.appendSlice(allocator, "</BlockList>");
+    return output.toOwnedSlice(allocator);
+}
+
+fn sourceSize(source: BlobUploadSource) !u64 {
+    return switch (source) {
+        .bytes => |bytes| @intCast(bytes.len),
+        .file => |path| fileSize(path),
+        .reader => |reader| reader.size,
+    };
+}
+
+fn fileSize(path: []const u8) !u64 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io = threaded.io();
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    if (stat.kind != .file) return error.BlobUploadSourceNotFile;
+    return stat.size;
+}
+
+const FileSourceHandle = struct {
+    allocator: std.mem.Allocator,
+    threaded: std.Io.Threaded,
+    file: std.Io.File,
+    reader_impl: std.Io.File.Reader,
+    buffer: [16 * 1024]u8 = undefined,
+
+    fn deinit(self: *FileSourceHandle) void {
+        self.file.close(self.threaded.io());
+        self.allocator.destroy(self);
+    }
+};
+
+const OpenedSource = union(enum) {
+    bytes: struct { reader_impl: std.Io.Reader },
+    file: *FileSourceHandle,
+    borrowed: *std.Io.Reader,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        source: BlobUploadSource,
+        expected_size: u64,
+    ) !OpenedSource {
+        return switch (source) {
+            .bytes => |bytes| .{ .bytes = .{
+                .reader_impl = std.Io.Reader.fixed(bytes),
+            } },
+            .reader => |source_reader| .{ .borrowed = source_reader.reader },
+            .file => |path| blk: {
+                const handle = try allocator.create(FileSourceHandle);
+                errdefer allocator.destroy(handle);
+                handle.* = .{
+                    .allocator = allocator,
+                    .threaded = .init_single_threaded,
+                    .file = undefined,
+                    .reader_impl = undefined,
+                };
+                const io = handle.threaded.io();
+                handle.file = try std.Io.Dir.cwd().openFile(io, path, .{});
+                errdefer handle.file.close(io);
+                const stat = try handle.file.stat(io);
+                if (stat.kind != .file) return error.BlobUploadSourceNotFile;
+                if (stat.size != expected_size) return error.BlobUploadSourceChanged;
+                handle.reader_impl = handle.file.readerStreaming(io, &handle.buffer);
+                break :blk .{ .file = handle };
+            },
+        };
+    }
+
+    fn reader(self: *OpenedSource) *std.Io.Reader {
+        return switch (self.*) {
+            .bytes => |*bytes| &bytes.reader_impl,
+            .file => |file| &file.reader_impl.interface,
+            .borrowed => |source_reader| source_reader,
+        };
+    }
+
+    fn deinit(self: *OpenedSource) void {
+        switch (self.*) {
+            .file => |file| file.deinit(),
+            .bytes, .borrowed => {},
+        }
+    }
+};
+
+/// Restricts one `Put Block` request to its assigned bytes without consuming
+/// the first byte of the next block during the transport's length check.
+const LimitedReader = struct {
+    interface: std.Io.Reader,
+    source: *std.Io.Reader,
+    remaining: u64,
+    buffer: [16 * 1024]u8 = undefined,
+    buffered_start: usize = 0,
+    buffered_end: usize = 0,
+
+    fn init(source: *std.Io.Reader, remaining: u64) LimitedReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .source = source,
+            .remaining = remaining,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *LimitedReader = @alignCast(@fieldParentPtr("interface", interface));
+        if (self.buffered_start == self.buffered_end) {
+            if (self.remaining == 0) return error.EndOfStream;
+            const wanted: usize = @intCast(@min(self.remaining, self.buffer.len));
+            const count = self.source.readSliceShort(self.buffer[0..wanted]) catch
+                return error.ReadFailed;
+            if (count == 0) return error.EndOfStream;
+            self.remaining -= count;
+            self.buffered_start = 0;
+            self.buffered_end = count;
+        }
+        const written = writer.write(
+            limit.slice(self.buffer[self.buffered_start..self.buffered_end]),
+        ) catch return error.WriteFailed;
+        self.buffered_start += written;
+        return written;
+    }
+};
+
+fn ensureExhausted(reader: *std.Io.Reader) !void {
+    var extra: [1]u8 = undefined;
+    if (try reader.readSliceShort(&extra) != 0)
+        return error.RequestBodyTooLong;
+}
+
+const CommitFailureTransport = struct {
+    allocator: std.mem.Allocator,
+    transport: core.http.HttpTransport,
+    fail_on_call: usize,
+    call_count: usize = 0,
+    operation: core.http.HttpOperation = undefined,
+    response_reader: std.Io.Reader = undefined,
+
+    fn init(allocator: std.mem.Allocator, fail_on_call: usize) CommitFailureTransport {
+        return .{
+            .allocator = allocator,
+            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
+            .fail_on_call = fail_on_call,
+        };
+    }
+
+    fn asTransport(self: *CommitFailureTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn sendImpl(
+        _: *core.http.HttpTransport,
+        _: *core.http.Request,
+    ) !core.http.Response {
+        return error.TestUnexpectedSend;
+    }
+
+    fn openImpl(
+        transport: *core.http.HttpTransport,
+        _: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *CommitFailureTransport = @alignCast(@fieldParentPtr("transport", transport));
+        self.call_count += 1;
+        if (self.call_count == self.fail_on_call)
+            return error.InjectedCommitFailure;
+
+        if (options.body) |body| {
+            var buffer: [4 * 1024]u8 = undefined;
+            while (try body.reader.readSliceShort(&buffer) != 0) {}
+        }
+        self.response_reader = std.Io.Reader.fixed("");
+        self.operation = .{
+            .status_code = 201,
+            .headers = std.StringHashMap([]const u8).init(self.allocator),
+            .body_reader = &self.response_reader,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &abortImpl,
+            .deinitFn = &deinitImpl,
+        };
+        return &self.operation;
+    }
+
+    fn finishImpl(_: *core.http.HttpOperation) !void {}
+
+    fn abortImpl(_: *core.http.HttpOperation) void {}
+
+    fn deinitImpl(operation: *core.http.HttpOperation) void {
+        const self: *CommitFailureTransport = @alignCast(@fieldParentPtr("operation", operation));
+        self.operation.headers.deinit();
+    }
+};
+
+const BoundedReadSource = struct {
+    reader: std.Io.Reader,
+    bytes: []const u8,
+    offset: usize = 0,
+    max_read_request: usize = 0,
+
+    fn init(bytes: []const u8) BoundedReadSource {
+        return .{
+            .reader = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .bytes = bytes,
+        };
+    }
+
+    fn stream(
+        reader: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *BoundedReadSource = @alignCast(@fieldParentPtr("reader", reader));
+        const requested = limit.minInt(std.math.maxInt(usize));
+        self.max_read_request = @max(self.max_read_request, requested);
+        if (self.offset == self.bytes.len) return error.EndOfStream;
+        const count = @min(self.bytes.len - self.offset, requested);
+        const written = writer.write(
+            self.bytes[self.offset..][0..count],
+        ) catch return error.WriteFailed;
+        self.offset += written;
+        return written;
+    }
+};
+
+test "SAS blob upload preserves query, isolates credentials, and drains response" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 201, "done");
+    defer transport.deinit();
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=a%2Bb%3D&sp=rw",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const outcome = try client.uploadBytes("payload", .{ .content_type = "text/plain" });
+    try std.testing.expect(outcome.isAccepted());
+    try std.testing.expectEqualStrings(
+        "https://account.blob.core.windows.net/container/blob?sig=a%2Bb%3D&sp=rw",
+        transport.last_url.?,
+    );
+    try std.testing.expect(transport.last_headers.get("Authorization") == null);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, transport.last_redirect_policy.?);
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_finish_count);
+    try std.testing.expectEqualStrings("payload", transport.last_body.?);
+}
+
+test "SAS blob byte uploads support buffered-only transports" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    transport.transport.openFn = null;
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=opaque",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const single = try client.uploadBytes("payload", .{});
+    try std.testing.expect(single.isAccepted());
+    try std.testing.expectEqualStrings("payload", transport.last_body.?);
+
+    const blocked = try client.uploadBytes("abcdefgh", .{
+        .single_upload_max_bytes = 3,
+        .block_size = 3,
+    });
+    try std.testing.expect(blocked.isAccepted());
+    try std.testing.expectEqual(@as(usize, 5), transport.call_count);
+    try std.testing.expectEqualStrings(
+        "<BlockList><Latest>MDAwMDAwMDA=</Latest><Latest>MDAwMDAwMDE=</Latest><Latest>MDAwMDAwMDI=</Latest></BlockList>",
+        transport.last_body.?,
+    );
+}
+
+test "SAS blob block upload orders deterministic IDs and bounds reads" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    transport.stream_upload_chunk_size = 2;
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sp=w&sig=opaque%2Bvalue",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    var reader = std.Io.Reader.fixed("abcdefgh");
+    const outcome = try client.uploadReader(&reader, 8, .{
+        .single_upload_max_bytes = 3,
+        .block_size = 3,
+    });
+    try std.testing.expect(outcome.isAccepted());
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+    try std.testing.expectEqualStrings(
+        "https://account.blob.core.windows.net/container/blob?sp=w&sig=opaque%2Bvalue&comp=blocklist",
+        transport.last_url.?,
+    );
+    try std.testing.expectEqualStrings(
+        "<BlockList><Latest>MDAwMDAwMDA=</Latest><Latest>MDAwMDAwMDE=</Latest><Latest>MDAwMDAwMDI=</Latest></BlockList>",
+        transport.last_body.?,
+    );
+    try std.testing.expect(transport.last_headers.get("Authorization") == null);
+}
+
+test "SAS blob returns known rejections and unknown transport outcomes" {
+    const allocator = std.testing.allocator;
+    var rejected_transport = core.http.MockTransport.init(allocator, 403, "denied");
+    defer rejected_transport.deinit();
+    var rejected_client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=opaque",
+        rejected_transport.asTransport(),
+    );
+    defer rejected_client.deinit();
+    const rejected = try rejected_client.uploadBytes("x", .{});
+    switch (rejected) {
+        .rejected => |value| {
+            try std.testing.expectEqual(@as(u16, 403), value.status_code);
+            try std.testing.expectEqual(BlobUploadPhase.put_blob, value.phase);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    var unknown_transport = core.http.MockTransport.init(allocator, 201, "");
+    defer unknown_transport.deinit();
+    unknown_transport.stream_fail_upload_after = 0;
+    var unknown_client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=opaque",
+        unknown_transport.asTransport(),
+    );
+    defer unknown_client.deinit();
+    var unknown_reader = std.Io.Reader.fixed("x");
+    const unknown = try unknown_client.uploadReader(&unknown_reader, 1, .{});
+    switch (unknown) {
+        .unknown => |value| try std.testing.expectEqual(BlobUploadPhase.put_blob, value.phase),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "SAS blob rejects a host-changing redirect without another request" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 302, "");
+    defer transport.deinit();
+    transport.response_headers_list = &.{
+        .{ .name = "Location", .value = "https://attacker.example/collect-sas" },
+    };
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=opaque",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const outcome = try client.uploadBytes("x", .{});
+    switch (outcome) {
+        .rejected => |value| try std.testing.expectEqual(@as(u16, 302), value.status_code),
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, transport.last_redirect_policy.?);
+    try std.testing.expect(transport.last_headers.get("Authorization") == null);
+}
+
+test "SAS blob does not commit after an unknown commit transport failure" {
+    const allocator = std.testing.allocator;
+    var transport = CommitFailureTransport.init(allocator, 4);
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=opaque",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const outcome = try client.uploadBytes("abcdefgh", .{
+        .single_upload_max_bytes = 3,
+        .block_size = 3,
+    });
+    switch (outcome) {
+        .unknown => |value| {
+            try std.testing.expectEqual(BlobUploadPhase.put_block_list, value.phase);
+            try std.testing.expectEqual(error.InjectedCommitFailure, value.cause);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+}
+
+test "SAS blob block reader stays bounded and short sources are unknown" {
+    const allocator = std.testing.allocator;
+    const bytes = [_]u8{'x'} ** (64 * 1024 + 1);
+    var source = BoundedReadSource.init(&bytes);
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=opaque",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const outcome = try client.uploadReader(&source.reader, bytes.len, .{
+        .single_upload_max_bytes = 0,
+        .block_size = 32 * 1024,
+    });
+    try std.testing.expect(outcome.isAccepted());
+    try std.testing.expect(source.max_read_request <= 16 * 1024);
+    try std.testing.expectEqual(bytes.len, source.offset);
+
+    var short_reader = std.Io.Reader.fixed("short");
+    const short = try client.uploadReader(&short_reader, 6, .{});
+    switch (short) {
+        .unknown => |value| try std.testing.expectEqual(BlobUploadPhase.put_blob, value.phase),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "SAS blob reports extra source data after staging as incomplete" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=opaque",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    var reader = std.Io.Reader.fixed("1234567");
+    const outcome = try client.uploadReader(&reader, 6, .{
+        .single_upload_max_bytes = 0,
+        .block_size = 3,
+    });
+    switch (outcome) {
+        .incomplete => |value| {
+            try std.testing.expectEqual(@as(u64, 2), value.staged_blocks);
+            try std.testing.expectEqual(error.RequestBodyTooLong, value.cause);
+            try std.testing.expectEqual(BlobUploadPhase.put_block_list, value.phase);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+}
+
+test "SAS blob validates limits and redacts diagnostics" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    var client = try SasBlobClient.init(
+        allocator,
+        "https://account.blob.core.windows.net/container/blob?sig=secret",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    try std.testing.expectError(
+        error.InvalidBlobBlockSize,
+        client.uploadBytes("x", .{ .block_size = 0 }),
+    );
+    try std.testing.expectError(
+        error.InvalidBlobSingleUploadLimit,
+        client.uploadBytes("x", .{
+            .single_upload_max_bytes = max_single_upload_bytes + 1,
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+
+    var buffer: [256]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buffer);
+    try writer.print("{f}", .{client});
+    try std.testing.expect(std.mem.indexOf(u8, buffer[0..writer.end], "secret") == null);
+    try std.testing.expect(std.mem.indexOf(u8, buffer[0..writer.end], "?***") != null);
+    try std.testing.expectError(
+        error.UnexpectedBlobSasHost,
+        SasBlobClient.init(
+            allocator,
+            "https://account.queue.core.windows.net/queue?sig=opaque",
+            transport.asTransport(),
+        ),
+    );
+}
+
+fn blockListAllocationTest(allocator: std.mem.Allocator) !void {
+    const body = try makeBlockList(allocator, 16 * 1024, 4 * 1024);
+    defer allocator.free(body);
+}
+
+test "SAS blob block-list allocation failures clean up" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        blockListAllocationTest,
+        .{},
+    );
+}

--- a/sdk/storage/common/root.zig
+++ b/sdk/storage/common/root.zig
@@ -2,6 +2,12 @@ const std = @import("std");
 const core = @import("azure_core");
 const base64 = core.base64;
 
+pub const sas = @import("sas.zig");
+
+test {
+    std.testing.refAllDecls(sas);
+}
+
 const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
 
 /// Shared Key credential for Azure Storage.
@@ -166,11 +172,11 @@ test "StorageSharedKeyCredential signRequest produces real HMAC" {
 
 test "SasBuilder sign produces HMAC signature" {
     const allocator = std.testing.allocator;
-    const sas = SasBuilder{
+    const builder = SasBuilder{
         .permissions = "rl",
         .expiry = "2026-12-31T23:59:59Z",
     };
-    const qs = try sas.sign(allocator, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+    const qs = try builder.sign(allocator, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
     defer allocator.free(qs);
     // Must contain sig= with a base64 value.
     try std.testing.expect(std.mem.find(u8, qs, "&sig=") != null);
@@ -179,11 +185,11 @@ test "SasBuilder sign produces HMAC signature" {
 
 test "SasBuilder toQueryString unsigned" {
     const allocator = std.testing.allocator;
-    const sas = SasBuilder{
+    const builder = SasBuilder{
         .permissions = "rl",
         .expiry = "2026-12-31T23:59:59Z",
     };
-    const qs = try sas.toQueryString(allocator);
+    const qs = try builder.toQueryString(allocator);
     defer allocator.free(qs);
     try std.testing.expect(std.mem.find(u8, qs, "sp=rl") != null);
     try std.testing.expect(std.mem.find(u8, qs, "se=2026-12-31T23:59:59Z") != null);

--- a/sdk/storage/common/sas.zig
+++ b/sdk/storage/common/sas.zig
@@ -1,0 +1,384 @@
+//! Credential-isolated helpers for operations on complete, service-issued
+//! Azure Storage SAS URLs.
+const std = @import("std");
+const core = @import("azure_core");
+
+/// An owned complete HTTPS SAS URL.
+///
+/// The URL's existing query is deliberately opaque: it is copied exactly as
+/// supplied and is never parsed, decoded, reordered, or rendered by
+/// `format`. Protocol parameters added by an operation are appended only
+/// after the original query.
+pub const CompleteSasUri = struct {
+    allocator: std.mem.Allocator,
+    bytes: []u8,
+    query_start: usize,
+
+    pub fn init(allocator: std.mem.Allocator, value: []const u8) !CompleteSasUri {
+        try validate(value);
+        return .{
+            .allocator = allocator,
+            .bytes = try allocator.dupe(u8, value),
+            .query_start = std.mem.indexOfScalar(u8, value, '?').?,
+        };
+    }
+
+    pub fn deinit(self: *CompleteSasUri) void {
+        self.allocator.free(self.bytes);
+        self.* = undefined;
+    }
+
+    /// Renders the public origin and path only. The SAS query is never
+    /// included in diagnostic output.
+    pub fn format(self: CompleteSasUri, writer: anytype) !void {
+        try writer.print("CompleteSasUri({s}?***)", .{self.bytes[0..self.query_start]});
+    }
+
+    /// Returns whether this URI targets a recognized Azure Storage service
+    /// hostname for `service` (`"blob"` or `"queue"`). This intentionally
+    /// accepts public, US Government, China, and Private Link service names,
+    /// but not an arbitrary host that could receive a SAS token.
+    pub fn hasAzureStorageServiceHost(
+        self: *const CompleteSasUri,
+        service: []const u8,
+    ) bool {
+        const scheme_end = std.mem.indexOfScalar(u8, self.bytes, ':') orelse return false;
+        const authority_start = scheme_end + 3;
+        const authority_end = authority_start + (std.mem.indexOfAny(
+            u8,
+            self.bytes[authority_start..],
+            "/?",
+        ) orelse self.bytes.len - authority_start);
+        const authority = self.bytes[authority_start..authority_end];
+        const host = if (std.mem.lastIndexOfScalar(u8, authority, ':')) |port_start|
+            authority[0..port_start]
+        else
+            authority;
+
+        const suffixes = [_][]const u8{
+            ".core.windows.net",
+            ".core.usgovcloudapi.net",
+            ".core.chinacloudapi.cn",
+            ".core.cloudapi.de",
+        };
+        for (suffixes) |suffix| {
+            var service_suffix_buffer: [64]u8 = undefined;
+            const service_suffix = std.fmt.bufPrint(
+                &service_suffix_buffer,
+                ".{s}{s}",
+                .{ service, suffix },
+            ) catch return false;
+            if (endsWithIgnoreCase(host, service_suffix)) return true;
+        }
+        return false;
+    }
+
+    /// Returns an owned URL with protocol parameters appended after the
+    /// original opaque query. Only `QueryParameter.value` is percent encoded.
+    pub fn appendProtocolQuery(
+        self: *const CompleteSasUri,
+        allocator: std.mem.Allocator,
+        parameters: []const QueryParameter,
+    ) ![]u8 {
+        var result = std.ArrayList(u8).empty;
+        errdefer result.deinit(allocator);
+        try result.appendSlice(allocator, self.bytes);
+        for (parameters) |parameter| {
+            if (!isProtocolParameterName(parameter.name))
+                return error.InvalidSasProtocolParameter;
+            try result.append(allocator, '&');
+            try result.appendSlice(allocator, parameter.name);
+            try result.append(allocator, '=');
+            try appendPercentEncoded(&result, allocator, parameter.value);
+        }
+        return result.toOwnedSlice(allocator);
+    }
+
+    /// Returns an owned URL with a path segment inserted before the original
+    /// opaque query. Queue SAS URLs use this to address `/messages`.
+    pub fn appendPathSegment(
+        self: *const CompleteSasUri,
+        allocator: std.mem.Allocator,
+        segment: []const u8,
+    ) ![]u8 {
+        if (segment.len == 0 or
+            std.mem.indexOfAny(u8, segment, "/?#") != null)
+            return error.InvalidSasPathSegment;
+
+        var result = std.ArrayList(u8).empty;
+        errdefer result.deinit(allocator);
+        const path_end = self.query_start;
+        try result.appendSlice(allocator, self.bytes[0..path_end]);
+        if (path_end == 0 or self.bytes[path_end - 1] != '/')
+            try result.append(allocator, '/');
+        try result.appendSlice(allocator, segment);
+        try result.appendSlice(allocator, self.bytes[path_end..]);
+        return result.toOwnedSlice(allocator);
+    }
+
+    fn validate(value: []const u8) !void {
+        for (value) |byte| {
+            if (byte <= 0x20 or byte >= 0x7f)
+                return error.InvalidSasUri;
+        }
+        // Parse solely to reject malformed URLs. Rendering and query handling
+        // below always use the original byte slice, not parsed components.
+        _ = std.Uri.parse(value) catch return error.InvalidSasUri;
+
+        const scheme_end = std.mem.indexOfScalar(u8, value, ':') orelse
+            return error.InvalidSasUri;
+        if (!std.ascii.eqlIgnoreCase(value[0..scheme_end], "https"))
+            return error.SasUriMustUseHttps;
+        if (value.len < scheme_end + 3 or
+            !std.mem.eql(u8, value[scheme_end..][0..3], "://"))
+            return error.InvalidSasUri;
+        if (std.mem.indexOfScalar(u8, value, '#') != null)
+            return error.SasUriFragmentNotAllowed;
+
+        const authority_start = scheme_end + 3;
+        const authority_end = authority_start + (std.mem.indexOfAny(
+            u8,
+            value[authority_start..],
+            "/?",
+        ) orelse value.len - authority_start);
+        if (authority_start == authority_end)
+            return error.InvalidSasUri;
+        if (std.mem.indexOfScalar(u8, value[authority_start..authority_end], '@') != null)
+            return error.SasUriUserInfoNotAllowed;
+
+        const query_start = std.mem.indexOfScalar(u8, value, '?') orelse
+            return error.SasQueryRequired;
+        if (query_start + 1 == value.len)
+            return error.SasQueryRequired;
+    }
+};
+
+pub const QueryParameter = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// The outcome of a request sent through a credential-free SAS pipeline.
+///
+/// A received non-2xx status is known not accepted. A failure while opening
+/// after transport entry is unknown because no response status was received.
+/// Once a 2xx response head is received, the request is accepted even if
+/// draining the response body fails.
+pub const RequestOutcome = union(enum) {
+    accepted: struct { status_code: u16 },
+    rejected: struct { status_code: u16 },
+    unknown: struct { cause: anyerror },
+
+    pub fn isAccepted(self: RequestOutcome) bool {
+        return self == .accepted;
+    }
+
+    pub fn format(self: RequestOutcome, writer: anytype) !void {
+        switch (self) {
+            .accepted => |value| try writer.print(
+                "SasRequestOutcome(accepted, status={d})",
+                .{value.status_code},
+            ),
+            .rejected => |value| try writer.print(
+                "SasRequestOutcome(rejected, status={d})",
+                .{value.status_code},
+            ),
+            .unknown => |value| try writer.print(
+                "SasRequestOutcome(unknown, cause={s})",
+                .{@errorName(value.cause)},
+            ),
+        }
+    }
+};
+
+/// Opens one non-retrying, no-redirect request through an empty-policy
+/// pipeline. No caller-supplied pipeline is accepted, so a bearer policy
+/// cannot be attached to this request class.
+pub fn send(
+    transport: *core.http.HttpTransport,
+    request: *core.http.Request,
+    body: ?core.http.StreamingRequestBody,
+) !RequestOutcome {
+    request.retryable = false;
+    request.redirect_policy = .not_allowed;
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &.{},
+        .transport_impl = transport,
+    };
+    const operation = pipeline.open(request, .{ .body = body }) catch |err| {
+        if (request.transport_started)
+            return .{ .unknown = .{ .cause = err } };
+        return err;
+    };
+    defer operation.deinit();
+
+    const status_code = operation.status_code;
+    if (!operation.isSuccess()) {
+        // The response head establishes a known rejection. A body-drain
+        // failure cannot turn that status into an accepted operation.
+        _ = operation.finish() catch {};
+        return .{ .rejected = .{ .status_code = status_code } };
+    }
+
+    _ = operation.finish() catch {};
+    return .{ .accepted = .{ .status_code = status_code } };
+}
+
+fn isProtocolParameterName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    for (name) |byte| {
+        if (!((byte >= 'a' and byte <= 'z') or
+            (byte >= 'A' and byte <= 'Z') or
+            (byte >= '0' and byte <= '9') or
+            byte == '-' or byte == '_' or byte == '.'))
+            return false;
+    }
+    return true;
+}
+
+fn appendPercentEncoded(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !void {
+    const hex = "0123456789ABCDEF";
+    for (value) |byte| {
+        if (isUnreserved(byte)) {
+            try output.append(allocator, byte);
+        } else {
+            try output.append(allocator, '%');
+            try output.append(allocator, hex[byte >> 4]);
+            try output.append(allocator, hex[byte & 0x0f]);
+        }
+    }
+}
+
+fn isUnreserved(byte: u8) bool {
+    return (byte >= 'a' and byte <= 'z') or
+        (byte >= 'A' and byte <= 'Z') or
+        (byte >= '0' and byte <= '9') or
+        byte == '-' or byte == '.' or byte == '_' or byte == '~';
+}
+
+fn endsWithIgnoreCase(value: []const u8, suffix: []const u8) bool {
+    if (value.len < suffix.len) return false;
+    return std.ascii.eqlIgnoreCase(value[value.len - suffix.len ..], suffix);
+}
+
+test "complete SAS URI preserves opaque query when adding parameters" {
+    const allocator = std.testing.allocator;
+    var uri = try CompleteSasUri.init(
+        allocator,
+        "https://account.blob.core.windows.net/c/b?sp=rw&sig=a%2Bb%3D&empty=&x=1+2",
+    );
+    defer uri.deinit();
+    const updated = try uri.appendProtocolQuery(allocator, &.{
+        .{ .name = "comp", .value = "block" },
+        .{ .name = "blockid", .value = "A+/=" },
+    });
+    defer allocator.free(updated);
+    try std.testing.expectEqualStrings(
+        "https://account.blob.core.windows.net/c/b?sp=rw&sig=a%2Bb%3D&empty=&x=1+2&comp=block&blockid=A%2B%2F%3D",
+        updated,
+    );
+}
+
+test "complete SAS URI inserts queue path before opaque query" {
+    const allocator = std.testing.allocator;
+    var uri = try CompleteSasUri.init(
+        allocator,
+        "https://account.queue.core.windows.net/q?sig=a%2Fb&sv=2024-11-04",
+    );
+    defer uri.deinit();
+    const messages = try uri.appendPathSegment(allocator, "messages");
+    defer allocator.free(messages);
+    try std.testing.expectEqualStrings(
+        "https://account.queue.core.windows.net/q/messages?sig=a%2Fb&sv=2024-11-04",
+        messages,
+    );
+}
+
+test "complete SAS URI rejects unsafe URL forms and redacts formatting" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(
+        error.SasUriMustUseHttps,
+        CompleteSasUri.init(allocator, "http://account.blob.core.windows.net/c?sig=x"),
+    );
+    try std.testing.expectError(
+        error.SasUriUserInfoNotAllowed,
+        CompleteSasUri.init(allocator, "https://user@account.blob.core.windows.net/c?sig=x"),
+    );
+    try std.testing.expectError(
+        error.SasUriFragmentNotAllowed,
+        CompleteSasUri.init(allocator, "https://account.blob.core.windows.net/c?sig=x#fragment"),
+    );
+    try std.testing.expectError(
+        error.InvalidSasUri,
+        CompleteSasUri.init(
+            allocator,
+            "https://account.blob.core.windows.net/c?sig=x\r\nX-Injected:%20yes",
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidSasUri,
+        CompleteSasUri.init(allocator, "https://account.blob.core.windows.net/raw path?sig=x"),
+    );
+    try std.testing.expectError(
+        error.SasQueryRequired,
+        CompleteSasUri.init(allocator, "https://account.blob.core.windows.net/c"),
+    );
+
+    var uri = try CompleteSasUri.init(
+        allocator,
+        "https://account.blob.core.windows.net/c?sig=secret-value",
+    );
+    defer uri.deinit();
+    var buffer: [256]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buffer);
+    try writer.print("{f}", .{uri});
+    try std.testing.expectEqualStrings(
+        "CompleteSasUri(https://account.blob.core.windows.net/c?***)",
+        buffer[0..writer.end],
+    );
+}
+
+test "complete SAS URI recognizes only the intended Azure Storage service host" {
+    const allocator = std.testing.allocator;
+    var blob = try CompleteSasUri.init(
+        allocator,
+        "https://account.privatelink.blob.core.windows.net/c?sig=x",
+    );
+    defer blob.deinit();
+    try std.testing.expect(blob.hasAzureStorageServiceHost("blob"));
+    try std.testing.expect(!blob.hasAzureStorageServiceHost("queue"));
+
+    var attacker = try CompleteSasUri.init(
+        allocator,
+        "https://account.blob.core.windows.net.attacker.example/c?sig=x",
+    );
+    defer attacker.deinit();
+    try std.testing.expect(!attacker.hasAzureStorageServiceHost("blob"));
+}
+
+fn uriAllocationTest(allocator: std.mem.Allocator) !void {
+    var uri = try CompleteSasUri.init(
+        allocator,
+        "https://account.blob.core.windows.net/c/b?sig=a%2Bb%3D&sp=rw",
+    );
+    defer uri.deinit();
+    const block = try uri.appendProtocolQuery(allocator, &.{
+        .{ .name = "comp", .value = "block" },
+        .{ .name = "blockid", .value = "MDAwMDAwMDA=" },
+    });
+    defer allocator.free(block);
+    const messages = try uri.appendPathSegment(allocator, "messages");
+    defer allocator.free(messages);
+}
+
+test "complete SAS URI cleans up on every URL allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        uriAllocationTest,
+        .{},
+    );
+}

--- a/sdk/storage/queues/root.zig
+++ b/sdk/storage/queues/root.zig
@@ -1,6 +1,17 @@
 const std = @import("std");
 const core = @import("azure_core");
 
+const sas = @import("sas.zig");
+
+pub const SasQueueClient = sas.SasQueueClient;
+pub const CompleteSasQueueClient = sas.CompleteSasQueueClient;
+pub const QueueMessageOutcome = sas.QueueMessageOutcome;
+pub const max_queue_message_bytes = sas.max_queue_message_bytes;
+
+test {
+    std.testing.refAllDecls(sas);
+}
+
 // ─────────────────────────── Models ───────────────────────────
 
 pub const QueueMessage = struct {

--- a/sdk/storage/queues/sas.zig
+++ b/sdk/storage/queues/sas.zig
@@ -1,0 +1,212 @@
+//! Complete-URL SAS Queue message submission without credentials or retries.
+const std = @import("std");
+const core = @import("azure_core");
+const storage_common = @import("azure_storage_common");
+
+const sas = storage_common.sas;
+
+/// Azure Queue permits a 64 KiB encoded `MessageText`; standard Base64 makes
+/// 48 KiB the largest raw message that can always fit.
+pub const max_queue_message_bytes: usize = 48 * 1024;
+pub const storage_api_version = "2024-11-04";
+
+/// A Queue client constructed only from an allocator, a complete queue SAS
+/// URL, and a transport. It never accepts a credential or an external
+/// pipeline, so Kusto bearer authentication cannot reach Queue Storage.
+pub const SasQueueClient = struct {
+    allocator: std.mem.Allocator,
+    uri: sas.CompleteSasUri,
+    transport: *core.http.HttpTransport,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        complete_queue_sas_uri: []const u8,
+        transport: *core.http.HttpTransport,
+    ) !SasQueueClient {
+        var uri = try sas.CompleteSasUri.init(allocator, complete_queue_sas_uri);
+        errdefer uri.deinit();
+        if (!uri.hasAzureStorageServiceHost("queue"))
+            return error.UnexpectedQueueSasHost;
+        return .{
+            .allocator = allocator,
+            .uri = uri,
+            .transport = transport,
+        };
+    }
+
+    pub fn deinit(self: *SasQueueClient) void {
+        self.uri.deinit();
+        self.* = undefined;
+    }
+
+    /// Renders a query-redacted SAS URL only.
+    pub fn format(self: SasQueueClient, writer: anytype) !void {
+        try writer.print("SasQueueClient({f})", .{self.uri});
+    }
+
+    /// POSTs a raw message as standard Base64 inside Azure Queue's required
+    /// XML `MessageText` envelope. All local allocations finish before the
+    /// transport starts, so an accepted response cannot later be replaced by
+    /// an allocation failure in this method.
+    pub fn sendMessage(
+        self: *SasQueueClient,
+        message: []const u8,
+    ) !sas.RequestOutcome {
+        if (message.len > max_queue_message_bytes)
+            return error.QueueMessageTooLarge;
+
+        const encoded = try core.base64.encode(self.allocator, message);
+        defer self.allocator.free(encoded);
+        const body = try messageXml(self.allocator, encoded);
+        defer self.allocator.free(body);
+        const url = try self.uri.appendPathSegment(self.allocator, "messages");
+        defer self.allocator.free(url);
+
+        var request = core.http.Request.init(self.allocator, .POST, url);
+        defer request.deinit();
+        try request.setHeader("Content-Type", "application/xml");
+        try request.setHeader("x-ms-version", storage_api_version);
+        request.body = body;
+        return sas.send(self.transport, &request, null);
+    }
+};
+
+/// Compatibility spelling emphasizing that `init` accepts a complete SAS URL.
+pub const CompleteSasQueueClient = SasQueueClient;
+pub const QueueMessageOutcome = sas.RequestOutcome;
+
+fn messageXml(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 {
+    var output = std.ArrayList(u8).empty;
+    errdefer output.deinit(allocator);
+    try output.appendSlice(allocator, "<QueueMessage><MessageText>");
+    try appendXmlEscaped(&output, allocator, encoded);
+    try output.appendSlice(allocator, "</MessageText></QueueMessage>");
+    return output.toOwnedSlice(allocator);
+}
+
+fn appendXmlEscaped(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !void {
+    for (value) |byte| {
+        switch (byte) {
+            '&' => try output.appendSlice(allocator, "&amp;"),
+            '<' => try output.appendSlice(allocator, "&lt;"),
+            '>' => try output.appendSlice(allocator, "&gt;"),
+            '"' => try output.appendSlice(allocator, "&quot;"),
+            '\'' => try output.appendSlice(allocator, "&apos;"),
+            else => try output.append(allocator, byte),
+        }
+    }
+}
+
+test "SAS queue message preserves SAS, base64 encodes special bytes, and isolates credentials" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    var client = try SasQueueClient.init(
+        allocator,
+        "https://account.queue.core.windows.net/queue?sig=a%2Bb%3D&sp=a",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const outcome = try client.sendMessage("<&>\"'\x00");
+    try std.testing.expect(outcome.isAccepted());
+    try std.testing.expectEqual(core.http.Method.POST, transport.last_method.?);
+    try std.testing.expectEqualStrings(
+        "https://account.queue.core.windows.net/queue/messages?sig=a%2Bb%3D&sp=a",
+        transport.last_url.?,
+    );
+    try std.testing.expectEqualStrings(
+        "<QueueMessage><MessageText>PCY+IicA</MessageText></QueueMessage>",
+        transport.last_body.?,
+    );
+    try std.testing.expect(transport.last_headers.get("Authorization") == null);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, transport.last_redirect_policy.?);
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_finish_count);
+}
+
+test "SAS queue reports received rejection and validates message size" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 403, "denied");
+    defer transport.deinit();
+    var client = try SasQueueClient.init(
+        allocator,
+        "https://account.queue.core.windows.net/queue?sig=opaque",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const rejected = try client.sendMessage("message");
+    switch (rejected) {
+        .rejected => |value| try std.testing.expectEqual(@as(u16, 403), value.status_code),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const too_large = [_]u8{0} ** (max_queue_message_bytes + 1);
+    try std.testing.expectError(error.QueueMessageTooLarge, client.sendMessage(&too_large));
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+}
+
+test "SAS queue preserves accepted status when response draining fails" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 201, "response");
+    defer transport.deinit();
+    transport.stream_fail_response_after = 0;
+    var client = try SasQueueClient.init(
+        allocator,
+        "https://account.queue.core.windows.net/queue?sig=opaque",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+
+    const outcome = try client.sendMessage("message");
+    try std.testing.expect(outcome.isAccepted());
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_abort_count);
+}
+
+test "Queue XML escaping and client diagnostics redact sensitive queries" {
+    const allocator = std.testing.allocator;
+    var escaped = std.ArrayList(u8).empty;
+    defer escaped.deinit(allocator);
+    try appendXmlEscaped(&escaped, allocator, "<&>\"'");
+    try std.testing.expectEqualStrings("&lt;&amp;&gt;&quot;&apos;", escaped.items);
+
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    var client = try SasQueueClient.init(
+        allocator,
+        "https://account.queue.core.windows.net/queue?sig=secret",
+        transport.asTransport(),
+    );
+    defer client.deinit();
+    var buffer: [256]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buffer);
+    try writer.print("{f}", .{client});
+    try std.testing.expect(std.mem.indexOf(u8, buffer[0..writer.end], "secret") == null);
+    try std.testing.expectError(
+        error.UnexpectedQueueSasHost,
+        SasQueueClient.init(
+            allocator,
+            "https://account.blob.core.windows.net/container/blob?sig=opaque",
+            transport.asTransport(),
+        ),
+    );
+}
+
+fn queueBodyAllocationTest(allocator: std.mem.Allocator) !void {
+    const encoded = try core.base64.encode(allocator, "allocation test");
+    defer allocator.free(encoded);
+    const body = try messageXml(allocator, encoded);
+    defer allocator.free(body);
+}
+
+test "SAS queue cleans up on every pre-transport allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        queueBodyAllocationTest,
+        .{},
+    );
+}


### PR DESCRIPTION
Closes #55

Adds reusable complete-SAS Blob and Queue clients with opaque query preservation, structural credential isolation, no-follow requests, redacted diagnostics, bounded Put Blob/Put Block uploads, deterministic block-list commits, protocol-correct Base64 Queue XML, and explicit accepted/rejected/unknown/incomplete outcomes.

Kusto resource discovery, queued-ingestion message schema, retries, and status handling remain out of scope.