### PR TITLE
kusto: add examples, live tests, and compatibility documentation

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -20,7 +20,7 @@ jobs:
           version: 0.16.0
 
       - name: Format Check
-        run: zig fmt --check sdk/ build.zig
+        run: zig fmt --check sdk/ examples/ build.zig
 
       - name: Build
         run: zig build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ This document provides guidance for AI agents (Copilot, etc.) working on this re
 ```bash
 zig build                     # compile SDK + example
 zig build test --summary all  # run all tests (must pass before committing)
-zig fmt sdk/ build.zig        # format code (CI enforces this)
-zig fmt --check sdk/ build.zig # check formatting without modifying
+zig fmt sdk/ examples/ build.zig        # format code (CI enforces this)
+zig fmt --check sdk/ examples/ build.zig # check formatting without modifying
 ```
 
 ## Repository Structure

--- a/README.md
+++ b/README.md
@@ -15,20 +15,43 @@ Pure Zig implementation of Azure service clients with **zero C dependencies**.
 ```zig
 const std = @import("std");
 const core = @import("azure_core");
-const identity = @import("azure_identity");
+const identity = core.identity;
+const kusto_common = @import("azure_kusto_common");
+const kusto_data = @import("azure_kusto_data");
 
-// Authenticate with DefaultAzureCredential (env vars, managed identity, or CLI).
-var transport = core.http.StdHttpTransport.init(allocator, io);
-var cred = identity.DefaultAzureCredential.init(allocator, transport.asTransport(), std.posix.environ);
+pub fn main(init: std.process.Init) !void {
+    // Authenticate with environment, workload identity, managed identity, or Azure CLI.
+    var transport = core.http.StdHttpTransport.init(init.gpa, init.io);
+    defer transport.deinit();
+    var credential = try identity.DefaultAzureCredential.init(
+        init.gpa,
+        init.io,
+        transport.asTransport(),
+        init.environ_map,
+    );
+    defer credential.deinit();
 
-// Use any service client.
-var client = @import("azure_keyvault_secrets").SecretClient.init(
-    "https://myvault.vault.azure.net",
-    cred.asCredential(),
-    transport.asTransport(),
-    .{},
-);
-const secret = try client.getSecret(allocator, "my-secret");
+    var builder = kusto_common.KustoConnectionStringBuilder.init(
+        "https://mycluster.kusto.windows.net",
+    );
+    _ = builder.withTokenCredential(credential.asCredential());
+    const connection = try kusto_common.KustoConnection.init(
+        init.gpa,
+        builder.build(),
+        transport.asTransport(),
+        .{},
+    );
+    defer connection.deinit();
+
+    var client = kusto_data.KustoClient.initWithConnection(connection, .{});
+    var result = try client.executeQueryResult(
+        init.gpa,
+        "MyDatabase",
+        "print SDK='azure-sdk-for-zig'",
+        null,
+    );
+    defer result.deinit(init.gpa);
+}
 ```
 
 ## Build & Test
@@ -39,6 +62,8 @@ Requires [Zig 0.16.0](https://ziglang.org/download/) or later.
 zig build           # compile SDK + example
 zig build test      # run all tests
 zig build run       # run the example app
+zig build run-kusto-examples -- default-query
+zig build kusto-live-test     # skips unless Kusto is configured
 ```
 
 ## Architecture
@@ -144,6 +169,50 @@ resource discovery, queued-ingestion schema, retry, or status handling is
 included.
 
 Kusto datasets and non-null ingestion IDs are allocator-owned; call their `deinit` methods when finished. Buffered Kusto datasets retain the raw response and tagged `KustoFrame` slices (including unknown V2 frames), decode V1 plus normal, progressive, and fragmented V2 tables into owned `KustoValue` values (null, strings, booleans, integers, reals, and Kusto lexical types), and preserve dynamic or unknown cells as raw JSON. Progressive query events instead own one exact raw V2 frame at a time and retain only table schemas and row counts in stream state.
+
+### Kusto feature matrix
+
+| Capability | Primary API | Result and ownership | Important constraints |
+|------------|-------------|----------------------|-----------------------|
+| Buffered query | `KustoClient.executeQueryResult` | `KustoResult(KustoResponseDataSet)`; call `deinit` | Retries received retryable query failures within the request budget |
+| Typed parameters and rows | `kql.QueryParameters`, `kql.Builder`, `KustoRowDecoder` | Bound properties and builders own allocations; typed rows require `deinitRow` | Runtime values are parameters, never interpolated KQL |
+| Progressive query | `KustoClient.executeProgressiveQuery` | Heap-owned `ProgressiveQueryStream`; finish or abort, then `deinit` | One exclusive frame/table/row consumer; bounded frames and table state |
+| Management | `KustoClient.executeMgmtResult` | `KustoResult(KustoResponseDataSet)`; call `deinit` | Management commands are deliberately non-retryable |
+| Direct streaming ingestion | `StreamingIngestClient.ingestResult` | `KustoResult(IngestionResult)`; call `deinit` | At most 4 MiB raw; JSON/MultiJSON/Avro require a named mapping |
+| Queued ingestion | `QueuedIngestClient.ingest` | `QueuedIngestionResult`; call `deinit` | Queue acceptance is submission only; resource discovery and complete-SAS storage are required |
+| Managed routing and fallback | `ManagedIngestClient.ingestResult` | `KustoResult(ManagedIngestionResult)`; call `deinit` | Fallback occurs only after a replayable retryable known-not-accepted direct failure |
+| Queued status | `StatusTrackingHandle.poll` | Owned `StatusPollOutcome`; call `deinit` | Requires table reporting; only `succeeded` is terminal success |
+
+### Executable Kusto examples and live tests
+
+`examples/kusto/main.zig` is one executable runner whose subcommands cover default-credential query, typed parameter query, management, progressive iteration, direct streaming ingestion, queued submission, managed routing/fallback policy, and status polling:
+
+```bash
+export KUSTO_CLUSTER_URL='https://<cluster>.<region>.kusto.windows.net'
+export KUSTO_DATABASE='<database>'
+
+zig build run-kusto-examples -- default-query
+zig build run-kusto-examples -- typed-query
+zig build run-kusto-examples -- management
+zig build run-kusto-examples -- progressive
+```
+
+Ingestion scenarios additionally require `KUSTO_TARGET_TABLE` and `KUSTO_TARGET_MAPPING`. The default NDJSON payload contains one `Message` string field; override it with `KUSTO_INGEST_DATA` when the mapping expects another shape. `KUSTO_STATUS_TIMEOUT_MS` optionally changes the two-minute polling budget.
+
+```bash
+export KUSTO_TARGET_TABLE='<table>'
+export KUSTO_TARGET_MAPPING='<json-ingestion-mapping>'
+
+zig build run-kusto-examples -- streaming
+zig build run-kusto-examples -- queued
+zig build run-kusto-examples -- managed
+zig build run-kusto-examples -- status
+zig build run-kusto-examples -- all
+```
+
+`zig build kusto-live-test` runs the same functions serially and returns successful Zig skips when the query or ingestion environment is absent. It is an explicit step and is not part of deterministic `zig build test`. `DefaultAzureCredential` still requires one usable environment, workload-identity, managed-identity, or Azure CLI source. The managed example deterministically selects Queue with a queued-only extent tag; safely forcing a real service to return the retryable direct rejection needed for live fallback is not possible, so that exact branch remains covered by mock protocol tests.
+
+The examples print only counts and enum outcomes. They do not print credentials, authorization headers, ingestion payloads, service-issued SAS URIs, or raw error bodies.
 
 ### Kusto authentication and connections
 
@@ -436,6 +505,28 @@ const decoder = try table.rowDecoder(Row);
 var row = try decoder.rowAs(&table.rows[0], allocator);
 defer Decoder.deinitRow(&row, allocator);
 ```
+
+### Kusto compatibility and migration
+
+Valid legacy entry points remain for the current compatibility release, but authenticated applications should migrate now:
+
+| Previous entry point or assumption | Current migration |
+|------------------------------------|-------------------|
+| `KustoClient.init`, `StreamingIngestClient.init`, `QueuedIngestClient.init`, or `ManagedIngestClient.init` with authentication fields | Create one owned `KustoConnection`, then use each client's `initWithConnection` constructor |
+| `withAadAppKey` | Supply a `TokenCredential` through `withTokenCredential`; app-key connection creation returns `AadAppKeyAuthenticationUnsupported` |
+| `executeQuery`, `executeMgmt`, or `execute` generic failures | Prefer the corresponding `*Result` API to retain structured `.ok`, `.partial`, and `.err` outcomes |
+| `ingestFromSlice*` and `ingestFromBlob*` compatibility wrappers | Prefer runtime-source `ingestResult`/`ingest`; flattening wrappers intentionally discard queued attempts and status tracking |
+| Any string as a queued or managed source ID | Supply a nonzero canonical UUID or omit it for secure generation; uppercase UUIDs normalize to lowercase |
+| Queue acceptance as completed ingestion | Treat it only as submission; request table reporting and poll a transferred `StatusTrackingHandle` for terminal status |
+| Borrowed response strings or implicit cleanup | Treat datasets, errors, ingestion IDs, frames, status values, and typed rows as owned according to their documented `deinit` method |
+
+`KustoConnection` and clients derived from it are serialized-use only; externally synchronize shared calls. Cancellation and deadlines are best-effort boundaries between reads, retries, and storage phases and cannot interrupt an already-blocking system call. Unknown streaming or Queue outcomes are deliberately not replayed. Endpoint discovery accepts only trusted Kusto origins unless an exact additional host is configured. Complete-SAS Blob, Queue, and Table clients never receive the Kusto bearer credential, reject redirects, and redact SAS query values from formatting.
+
+These compatibility wrappers are retained for one release so valid older call sites can migrate without an immediate source break. Unavoidable behavior changes remain: legacy app-key authentication is rejected, real queued submission distinguishes rejected/unknown/pre-Queue outcomes, and allocator-owned result graphs require explicit cleanup.
+
+### Kusto parity references
+
+Kusto behavior and protocol choices were compared against the [Rust SDK](https://github.com/Azure/azure-kusto-rust), [Go SDK](https://github.com/Azure/azure-kusto-go), [Java SDK](https://github.com/Azure/azure-kusto-java), the [Kusto REST API](https://learn.microsoft.com/azure/data-explorer/kusto/api/rest/), and the [Kusto ingestion client reference](https://learn.microsoft.com/azure/data-explorer/kusto/api/netfx/kusto-ingest-client-reference). Zig intentionally stays stricter where replay or acceptance is ambiguous.
 
 ### Infrastructure
 

--- a/build.zig
+++ b/build.zig
@@ -165,7 +165,7 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    _ = b.addModule("azure_kusto_ingest", .{
+    const kusto_ingest_mod = b.addModule("azure_kusto_ingest", .{
         .root_source_file = b.path("sdk/kusto/ingest/root.zig"),
         .target = target,
         .imports = &.{
@@ -535,6 +535,51 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run", "Run the example");
     run_step.dependOn(&run_example.step);
+
+    const kusto_example = b.addExecutable(.{
+        .name = "azure_kusto_examples",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/kusto/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = core_mod },
+                .{ .name = "azure_kusto_common", .module = kusto_common_mod },
+                .{ .name = "azure_kusto_data", .module = kusto_data_mod },
+                .{ .name = "azure_kusto_ingest", .module = kusto_ingest_mod },
+            },
+        }),
+    });
+    b.installArtifact(kusto_example);
+
+    const run_kusto_example = b.addRunArtifact(kusto_example);
+    run_kusto_example.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_kusto_example.addArgs(args);
+    const run_kusto_step = b.step(
+        "run-kusto-examples",
+        "Run an opt-in Kusto example",
+    );
+    run_kusto_step.dependOn(&run_kusto_example.step);
+
+    const kusto_live_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/kusto/live_test.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = core_mod },
+                .{ .name = "azure_kusto_common", .module = kusto_common_mod },
+                .{ .name = "azure_kusto_data", .module = kusto_data_mod },
+                .{ .name = "azure_kusto_ingest", .module = kusto_ingest_mod },
+            },
+        }),
+    });
+    const run_kusto_live_tests = b.addRunArtifact(kusto_live_tests);
+    const kusto_live_test_step = b.step(
+        "kusto-live-test",
+        "Run opt-in Kusto live tests; unconfigured tests skip",
+    );
+    kusto_live_test_step.dependOn(&run_kusto_live_tests.step);
 
     // -- tspconfigs tool --
     //

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,6 +17,7 @@
         "build.zig",
         "build.zig.zon",
         "sdk",
+        "examples",
         "LICENSE.txt",
         "README.md",
     },

--- a/examples/kusto/live_test.zig
+++ b/examples/kusto/live_test.zig
@@ -1,0 +1,81 @@
+//! Explicit opt-in Kusto live tests.
+//!
+//! `zig build kusto-live-test` skips cleanly unless the documented Kusto
+//! environment is present. It is not part of the deterministic default suite.
+const std = @import("std");
+const examples = @import("main.zig");
+const ingest = @import("azure_kusto_ingest");
+
+test "live Kusto query management and progressive examples" {
+    const allocator = std.testing.allocator;
+    var env = try std.process.Environ.createMap(std.testing.environ, allocator);
+    defer env.deinit();
+    const config = (try examples.Config.fromEnvironment(&env)) orelse
+        return error.SkipZigTest;
+    const session = try examples.Session.create(
+        allocator,
+        std.testing.io,
+        &env,
+        config.cluster_url,
+    );
+    defer session.deinit();
+
+    try std.testing.expect(try examples.runDefaultCredentialQuery(
+        allocator,
+        session,
+        config,
+    ) != 0);
+    try std.testing.expect(try examples.runTypedQuery(
+        allocator,
+        session,
+        config,
+    ) != 0);
+    try std.testing.expect(try examples.runManagement(
+        allocator,
+        session,
+        config,
+    ) != 0);
+    try std.testing.expect(try examples.runProgressiveQuery(
+        allocator,
+        session,
+        config,
+    ) != 0);
+}
+
+test "live Kusto ingestion and status examples" {
+    const allocator = std.testing.allocator;
+    var env = try std.process.Environ.createMap(std.testing.environ, allocator);
+    defer env.deinit();
+    const config = (try examples.Config.fromEnvironment(&env)) orelse
+        return error.SkipZigTest;
+    if (config.target_table == null or config.target_mapping == null)
+        return error.SkipZigTest;
+    const session = try examples.Session.create(
+        allocator,
+        std.testing.io,
+        &env,
+        config.cluster_url,
+    );
+    defer session.deinit();
+
+    try std.testing.expectEqual(
+        ingest.IngestionStatus.success,
+        try examples.runStreamingIngestion(allocator, session, config),
+    );
+    try std.testing.expectEqual(
+        ingest.QueuedSubmissionOutcome.queue_accepted,
+        try examples.runQueuedIngestion(allocator, session, config),
+    );
+    try std.testing.expectEqual(
+        ingest.ManagedIngestionRoute.queued,
+        try examples.runManagedIngestion(allocator, session, config),
+    );
+    const polled = try examples.runStatusPolling(allocator, session, config);
+    switch (polled) {
+        .status => |status_value| try std.testing.expectEqual(
+            ingest.QueuedIngestionStatus.succeeded,
+            status_value,
+        ),
+        .stopped => return error.KustoStatusPollingStopped,
+    }
+}

--- a/examples/kusto/main.zig
+++ b/examples/kusto/main.zig
@@ -1,0 +1,504 @@
+//! Opt-in live examples for Azure Data Explorer (Kusto).
+//!
+//! Run `zig build run-kusto-examples -- <scenario>` after configuring the
+//! environment variables printed by `usage`.
+const std = @import("std");
+const core = @import("azure_core");
+const common = @import("azure_kusto_common");
+const data = @import("azure_kusto_data");
+const ingest = @import("azure_kusto_ingest");
+
+const default_ingest_data =
+    \\{"Message":"azure-sdk-for-zig live example"}
+    \\
+;
+
+pub const Scenario = enum {
+    default_query,
+    typed_query,
+    management,
+    progressive,
+    streaming,
+    queued,
+    managed,
+    status,
+    all,
+
+    fn requiresIngestion(self: Scenario) bool {
+        return switch (self) {
+            .streaming, .queued, .managed, .status, .all => true,
+            else => false,
+        };
+    }
+};
+
+pub const Config = struct {
+    cluster_url: []const u8,
+    database: []const u8,
+    target_table: ?[]const u8,
+    target_mapping: ?[]const u8,
+    ingest_data: []const u8,
+    status_timeout_ms: u64,
+
+    pub fn fromEnvironment(env: *const std.process.Environ.Map) !?Config {
+        const cluster_url = nonEmpty(env.get("KUSTO_CLUSTER_URL")) orelse return null;
+        const database = nonEmpty(env.get("KUSTO_DATABASE")) orelse return null;
+        const timeout_ms = if (nonEmpty(env.get("KUSTO_STATUS_TIMEOUT_MS"))) |value|
+            std.fmt.parseInt(u64, value, 10) catch return error.InvalidKustoStatusTimeout
+        else
+            2 * 60 * 1_000;
+        if (timeout_ms == 0) return error.InvalidKustoStatusTimeout;
+        return .{
+            .cluster_url = cluster_url,
+            .database = database,
+            .target_table = nonEmpty(env.get("KUSTO_TARGET_TABLE")),
+            .target_mapping = nonEmpty(env.get("KUSTO_TARGET_MAPPING")),
+            .ingest_data = nonEmpty(env.get("KUSTO_INGEST_DATA")) orelse default_ingest_data,
+            .status_timeout_ms = timeout_ms,
+        };
+    }
+
+    pub fn ingestionTarget(self: Config) !ingest.StreamingIngestTarget {
+        return .{
+            .database = self.database,
+            .table = self.target_table orelse return error.KustoTargetTableRequired,
+        };
+    }
+
+    pub fn ingestionMapping(self: Config) ![]const u8 {
+        return self.target_mapping orelse error.KustoTargetMappingRequired;
+    }
+};
+
+/// Stable heap allocation is required because credentials and connections
+/// borrow the transport stored in this session.
+pub const Session = struct {
+    allocator: std.mem.Allocator,
+    transport: core.http.StdHttpTransport,
+    credential: core.identity.DefaultAzureCredential,
+    connection: *common.KustoConnection,
+
+    pub fn create(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        env: *const std.process.Environ.Map,
+        cluster_url: []const u8,
+    ) !*Session {
+        const self = try allocator.create(Session);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+        self.transport = core.http.StdHttpTransport.init(allocator, io);
+        errdefer self.transport.deinit();
+        self.credential = try core.identity.DefaultAzureCredential.init(
+            allocator,
+            io,
+            self.transport.asTransport(),
+            env,
+        );
+        errdefer self.credential.deinit();
+        var builder = common.KustoConnectionStringBuilder.init(cluster_url);
+        _ = builder.withTokenCredential(self.credential.asCredential());
+        self.connection = try common.KustoConnection.init(
+            allocator,
+            builder.build(),
+            self.transport.asTransport(),
+            .{},
+        );
+        return self;
+    }
+
+    pub fn deinit(self: *Session) void {
+        self.connection.deinit();
+        self.credential.deinit();
+        self.transport.deinit();
+        const allocator = self.allocator;
+        allocator.destroy(self);
+    }
+};
+
+pub const PollSummary = union(enum) {
+    status: ingest.QueuedIngestionStatus,
+    stopped: ingest.StatusPollingStopReason,
+};
+
+pub fn runDefaultCredentialQuery(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !usize {
+    var client = data.KustoClient.initWithConnection(session.connection, .{});
+    var result = try client.executeQueryResult(
+        allocator,
+        config.database,
+        "print SDK='azure-sdk-for-zig'",
+        null,
+    );
+    defer result.deinit(allocator);
+    return completedTableCount(&result);
+}
+
+pub fn runTypedQuery(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !usize {
+    const Binding = data.kql.QueryParameters(struct {
+        sdk_name: []const u8,
+        minimum: i64,
+    });
+    var properties = try Binding.bind(allocator, .{
+        .sdk_name = "azure-sdk-for-zig",
+        .minimum = 1,
+    });
+    defer properties.deinit(allocator);
+    var query = try data.kql.Builder(Binding).init(allocator);
+    defer query.deinit();
+    try query.literal("print SDK=");
+    try query.parameter(.sdk_name);
+    try query.literal(", Minimum=");
+    try query.parameter(.minimum);
+
+    var client = data.KustoClient.initWithConnection(session.connection, .{});
+    var result = try client.executeQueryResult(
+        allocator,
+        config.database,
+        query.bytes(),
+        properties,
+    );
+    defer result.deinit(allocator);
+    return completedTableCount(&result);
+}
+
+pub fn runManagement(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !usize {
+    var client = data.KustoClient.initWithConnection(session.connection, .{});
+    var result = try client.executeMgmtResult(
+        allocator,
+        config.database,
+        ".show version",
+        null,
+    );
+    defer result.deinit(allocator);
+    return completedTableCount(&result);
+}
+
+pub fn runProgressiveQuery(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !usize {
+    var client = data.KustoClient.initWithConnection(session.connection, .{});
+    var opened = try client.executeProgressiveQuery(
+        allocator,
+        config.database,
+        "range ExampleValue from 1 to 3 step 1",
+        null,
+        .{ .deadline_ms = 30_000 },
+    );
+    return switch (opened) {
+        .ok => |stream| blk: {
+            defer stream.deinit();
+            var count: usize = 0;
+            while (try stream.next()) |frame| {
+                var owned = frame;
+                const failed = progressiveFrameFailed(&owned);
+                owned.deinit(allocator);
+                if (failed) return error.KustoProgressiveQueryFailed;
+                count += 1;
+            }
+            try stream.finish();
+            break :blk count;
+        },
+        .partial => unreachable,
+        .err => |*failure| {
+            failure.deinit();
+            return error.KustoProgressiveQueryFailed;
+        },
+    };
+}
+
+pub fn runStreamingIngestion(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !ingest.IngestionStatus {
+    const target = try config.ingestionTarget();
+    const mapping = try config.ingestionMapping();
+    var client = ingest.StreamingIngestClient.initWithConnection(session.connection);
+    var result = try client.ingestResult(
+        allocator,
+        target,
+        .{ .bytes = config.ingest_data },
+        .{ .format = .json, .mapping_name = mapping },
+    );
+    defer result.deinit(allocator);
+    return switch (result) {
+        .ok => |value| value.status,
+        .partial => unreachable,
+        .err => error.KustoStreamingIngestionFailed,
+    };
+}
+
+pub fn runQueuedIngestion(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !ingest.QueuedSubmissionOutcome {
+    const target = try config.ingestionTarget();
+    const mapping = try config.ingestionMapping();
+    var client = ingest.QueuedIngestClient.initWithConnection(session.connection);
+    var result = try client.ingest(
+        allocator,
+        target,
+        .{ .bytes = config.ingest_data },
+        .{ .format = .json, .mapping_name = mapping },
+    );
+    defer result.deinit(allocator);
+    return result.outcome;
+}
+
+pub fn runManagedIngestion(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !ingest.ManagedIngestionRoute {
+    const target = try config.ingestionTarget();
+    const mapping = try config.ingestionMapping();
+    var client = ingest.ManagedIngestClient.initWithConnection(session.connection);
+    var result = try client.ingestResult(
+        allocator,
+        target,
+        .{ .bytes = config.ingest_data },
+        .{
+            .format = .json,
+            .mapping_name = mapping,
+            // Extent tags are Queue-only, so this deterministically
+            // demonstrates managed preflight routing. Sources without
+            // Queue-only properties remain eligible for safe direct fallback.
+            .tags = &.{"azure-sdk-for-zig-managed-example"},
+        },
+    );
+    defer result.deinit(allocator);
+    return switch (result) {
+        .ok => |*managed_result| switch (managed_result.*) {
+            .streaming => .streaming,
+            .queued => |submission| if (submission.outcome == .queue_accepted)
+                .queued
+            else
+                error.KustoManagedQueueSubmissionFailed,
+        },
+        .partial => unreachable,
+        .err => error.KustoManagedIngestionFailed,
+    };
+}
+
+pub fn runStatusPolling(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+) !PollSummary {
+    const target = try config.ingestionTarget();
+    const mapping = try config.ingestionMapping();
+    var client = ingest.QueuedIngestClient.initWithConnection(session.connection);
+    var submission = try client.ingest(
+        allocator,
+        target,
+        .{ .bytes = config.ingest_data },
+        .{
+            .format = .json,
+            .mapping_name = mapping,
+            .report_level = .failures_and_successes,
+            .report_method = .queue_and_table,
+        },
+    );
+    defer submission.deinit(allocator);
+    if (submission.outcome != .queue_accepted)
+        return error.KustoStatusSubmissionFailed;
+    var tracking = submission.takeTracking() orelse
+        return error.KustoStatusTrackingUnavailable;
+    defer tracking.deinit();
+    var polled = try tracking.poll(allocator, .{
+        .poll_interval_ms = 5_000,
+        .timeout_ms = config.status_timeout_ms,
+    });
+    defer polled.deinit(allocator);
+    return switch (polled) {
+        .status => |status_result| .{ .status = status_result.status },
+        .stopped => |stopped| .{ .stopped = stopped.reason },
+    };
+}
+
+pub fn main(init: std.process.Init) !void {
+    var args = try init.minimal.args.iterateAllocator(init.gpa);
+    defer args.deinit();
+    _ = args.next();
+    const scenario_text = args.next() orelse {
+        usage();
+        return error.KustoExampleScenarioRequired;
+    };
+    if (args.next() != null) {
+        usage();
+        return error.UnexpectedKustoExampleArgument;
+    }
+    const scenario = parseScenario(scenario_text) orelse {
+        usage();
+        return error.UnknownKustoExampleScenario;
+    };
+    const config = (try Config.fromEnvironment(init.environ_map)) orelse {
+        environmentUsage(false);
+        return error.KustoLiveEnvironmentRequired;
+    };
+    if (scenario.requiresIngestion() and
+        (config.target_table == null or config.target_mapping == null))
+    {
+        environmentUsage(true);
+        return error.KustoIngestionEnvironmentRequired;
+    }
+
+    const session = try Session.create(
+        init.gpa,
+        init.io,
+        init.environ_map,
+        config.cluster_url,
+    );
+    defer session.deinit();
+    try runAndPrint(init.gpa, session, config, scenario);
+}
+
+fn completedTableCount(
+    result: *data.KustoResult(data.KustoResponseDataSet),
+) !usize {
+    return switch (result.*) {
+        .ok => |dataset| dataset.tables.len,
+        .partial => error.KustoPartialResult,
+        .err => error.KustoRequestFailed,
+    };
+}
+
+fn progressiveFrameFailed(frame: *const data.ProgressiveFrame) bool {
+    return switch (frame.payload) {
+        .data_table, .table_fragment => |batch| batch.failure != null,
+        .table_completion => |completion| completion.failure != null or
+            completion.has_errors or completion.cancelled,
+        .data_set_completion => |completion| completion.failure != null or
+            completion.has_errors or completion.cancelled,
+        else => false,
+    };
+}
+
+fn runAndPrint(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    config: Config,
+    scenario: Scenario,
+) !void {
+    switch (scenario) {
+        .default_query => std.debug.print(
+            "default-query: {d} result table(s)\n",
+            .{try runDefaultCredentialQuery(allocator, session, config)},
+        ),
+        .typed_query => std.debug.print(
+            "typed-query: {d} result table(s)\n",
+            .{try runTypedQuery(allocator, session, config)},
+        ),
+        .management => std.debug.print(
+            "management: {d} result table(s)\n",
+            .{try runManagement(allocator, session, config)},
+        ),
+        .progressive => std.debug.print(
+            "progressive: {d} frame(s)\n",
+            .{try runProgressiveQuery(allocator, session, config)},
+        ),
+        .streaming => std.debug.print(
+            "streaming: {s}\n",
+            .{@tagName(try runStreamingIngestion(allocator, session, config))},
+        ),
+        .queued => std.debug.print(
+            "queued: {s}\n",
+            .{@tagName(try runQueuedIngestion(allocator, session, config))},
+        ),
+        .managed => std.debug.print(
+            "managed: {s}\n",
+            .{@tagName(try runManagedIngestion(allocator, session, config))},
+        ),
+        .status => printPollSummary(
+            try runStatusPolling(allocator, session, config),
+        ),
+        .all => {
+            inline for ([_]Scenario{
+                .default_query,
+                .typed_query,
+                .management,
+                .progressive,
+                .streaming,
+                .queued,
+                .managed,
+                .status,
+            }) |item| try runAndPrint(allocator, session, config, item);
+        },
+    }
+}
+
+fn printPollSummary(summary: PollSummary) void {
+    switch (summary) {
+        .status => |status_value| std.debug.print(
+            "status: terminal {s}\n",
+            .{@tagName(status_value)},
+        ),
+        .stopped => |reason| std.debug.print(
+            "status: stopped ({s})\n",
+            .{@tagName(reason)},
+        ),
+    }
+}
+
+fn parseScenario(value: []const u8) ?Scenario {
+    if (std.mem.eql(u8, value, "default-query")) return .default_query;
+    if (std.mem.eql(u8, value, "typed-query")) return .typed_query;
+    if (std.mem.eql(u8, value, "management")) return .management;
+    if (std.mem.eql(u8, value, "progressive")) return .progressive;
+    if (std.mem.eql(u8, value, "streaming")) return .streaming;
+    if (std.mem.eql(u8, value, "queued")) return .queued;
+    if (std.mem.eql(u8, value, "managed")) return .managed;
+    if (std.mem.eql(u8, value, "status")) return .status;
+    if (std.mem.eql(u8, value, "all")) return .all;
+    return null;
+}
+
+fn nonEmpty(value: ?[]const u8) ?[]const u8 {
+    const present = value orelse return null;
+    return if (present.len == 0) null else present;
+}
+
+fn usage() void {
+    std.debug.print(
+        \\Usage: zig build run-kusto-examples -- <scenario>
+        \\Scenarios: default-query, typed-query, management, progressive,
+        \\           streaming, queued, managed, status, all
+        \\
+    , .{});
+    environmentUsage(true);
+}
+
+fn environmentUsage(include_ingestion: bool) void {
+    std.debug.print(
+        \\Required environment:
+        \\  KUSTO_CLUSTER_URL
+        \\  KUSTO_DATABASE
+        \\
+    , .{});
+    if (include_ingestion) {
+        std.debug.print(
+            \\Ingestion scenarios also require:
+            \\  KUSTO_TARGET_TABLE
+            \\  KUSTO_TARGET_MAPPING
+            \\Optional:
+            \\  KUSTO_INGEST_DATA
+            \\  KUSTO_STATUS_TIMEOUT_MS
+            \\
+        , .{});
+    }
+}

--- a/sdk/kusto/data/stream.zig
+++ b/sdk/kusto/data/stream.zig
@@ -169,7 +169,10 @@ pub const ProgressiveQueryStream = struct {
     /// completion state, and finishes the HTTP operation. Drained events are
     /// discarded; use `next` when individual partial failures are required.
     pub fn finish(self: *ProgressiveQueryStream) !void {
-        while (try self.nextInternal()) |*frame| frame.deinit(self.allocator);
+        while (try self.nextInternal()) |frame| {
+            var owned = frame;
+            owned.deinit(self.allocator);
+        }
     }
 
     /// Does not auto-drain. An active operation is aborted before its storage


### PR DESCRIPTION
## Summary

- add a packaged Kusto runner covering authenticated, typed, management, progressive, streaming, queued, managed, and status paths
- add explicit environment-gated live tests that reuse the executable examples and skip cleanly when unconfigured
- document the feature matrix, migration and ownership rules, endpoint/SAS safety, and Rust/Go/Java/protocol parity sources
- fix progressive stream draining and validate the examples on Linux, Windows, and macOS targets

## Testing

- `zig fmt --check sdk/ examples/ build.zig`
- `zig build test --summary all` (481/481)
- `zig build kusto-live-test --summary all` (2 clean skips when unconfigured)
- `zig build -Dtarget=x86_64-windows`
- `zig build -Dtarget=aarch64-macos`

Closes #60