### PR TITLE
core: add ACR header and URL primitives

### DIFF
--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -106,18 +106,94 @@ fn isHttpTokenByte(byte: u8) bool {
     };
 }
 
+pub const ResponseHeader = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// Allocator-owned response headers in wire order.
+///
+/// Unlike `Response.headers`, this collection preserves duplicate field
+/// values. Use `getFirst` for the first value or `getAll` for every value.
+pub const ResponseHeaders = struct {
+    entries: std.ArrayList(ResponseHeader) = .empty,
+    allocator: ?std.mem.Allocator = null,
+
+    pub fn init(allocator: std.mem.Allocator) ResponseHeaders {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn append(self: *ResponseHeaders, name: []const u8, value: []const u8) !void {
+        const allocator = self.allocator orelse return error.ResponseHeadersNotInitialized;
+        const owned_name = try allocator.dupe(u8, name);
+        errdefer allocator.free(owned_name);
+        const owned_value = try allocator.dupe(u8, value);
+        errdefer allocator.free(owned_value);
+        try self.entries.append(allocator, .{ .name = owned_name, .value = owned_value });
+    }
+
+    pub fn getFirst(self: *const ResponseHeaders, name: []const u8) ?[]const u8 {
+        for (self.entries.items) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, name)) return header.value;
+        }
+        return null;
+    }
+
+    /// Return an allocator-owned slice containing borrowed header values.
+    pub fn getAll(
+        self: *const ResponseHeaders,
+        allocator: std.mem.Allocator,
+        name: []const u8,
+    ) ![][]const u8 {
+        var count: usize = 0;
+        for (self.entries.items) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, name)) count += 1;
+        }
+        const values = try allocator.alloc([]const u8, count);
+        var index: usize = 0;
+        for (self.entries.items) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, name)) {
+                values[index] = header.value;
+                index += 1;
+            }
+        }
+        return values;
+    }
+
+    pub fn clone(self: *const ResponseHeaders, allocator: std.mem.Allocator) !ResponseHeaders {
+        var result = ResponseHeaders.init(allocator);
+        errdefer result.deinit();
+        for (self.entries.items) |header| {
+            try result.append(header.name, header.value);
+        }
+        return result;
+    }
+
+    pub fn deinit(self: *ResponseHeaders) void {
+        const allocator = self.allocator orelse return;
+        for (self.entries.items) |header| {
+            allocator.free(header.name);
+            allocator.free(header.value);
+        }
+        self.entries.deinit(allocator);
+        self.* = .{};
+    }
+};
+
 /// An HTTP response.
 pub const Response = struct {
     status_code: u16,
     headers: std.StringHashMap([]const u8),
     body: []const u8,
     allocator: std.mem.Allocator,
+    response_headers: ResponseHeaders = .{},
 
     pub fn isSuccess(self: Response) bool {
         return self.status_code >= 200 and self.status_code < 300;
     }
 
     pub fn getHeader(self: *const Response, key: []const u8) ?[]const u8 {
+        if (self.response_headers.getFirst(key)) |value| return value;
         var iterator = self.headers.iterator();
         while (iterator.next()) |entry| {
             if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, key)) {
@@ -127,8 +203,29 @@ pub const Response = struct {
         return null;
     }
 
+    /// Return all values for a response header, preserving wire order.
+    ///
+    /// The returned outer slice is allocator-owned; its values borrow from
+    /// this response and remain valid until `deinit`.
+    pub fn getHeaderValues(
+        self: *const Response,
+        allocator: std.mem.Allocator,
+        key: []const u8,
+    ) ![][]const u8 {
+        const values = try self.response_headers.getAll(allocator, key);
+        if (values.len > 0) return values;
+        allocator.free(values);
+
+        const value = getHeaderFromMap(&self.headers, key) orelse
+            return allocator.alloc([]const u8, 0);
+        const fallback = try allocator.alloc([]const u8, 1);
+        fallback[0] = value;
+        return fallback;
+    }
+
     pub fn deinit(self: *Response) void {
         self.allocator.free(self.body);
+        self.response_headers.deinit();
         deinitOwnedHeaders(self.allocator, &self.headers);
     }
 };
@@ -180,6 +277,7 @@ pub const OperationState = enum {
 pub const HttpOperation = struct {
     status_code: u16,
     headers: std.StringHashMap([]const u8),
+    response_headers: ResponseHeaders = .{},
     body_reader: *std.Io.Reader,
     state: OperationState = .active,
     finishFn: *const fn (self: *HttpOperation) anyerror!void,
@@ -193,11 +291,29 @@ pub const HttpOperation = struct {
     }
 
     pub fn getHeader(self: *const HttpOperation, name: []const u8) ?[]const u8 {
+        if (self.response_headers.getFirst(name)) |value| return value;
         var iter = self.headers.iterator();
         while (iter.next()) |entry| {
             if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, name)) return entry.value_ptr.*;
         }
         return null;
+    }
+
+    /// Return all values for a response header, preserving wire order.
+    pub fn getHeaderValues(
+        self: *const HttpOperation,
+        allocator: std.mem.Allocator,
+        name: []const u8,
+    ) ![][]const u8 {
+        const values = try self.response_headers.getAll(allocator, name);
+        if (values.len > 0) return values;
+        allocator.free(values);
+
+        const value = getHeaderFromMap(&self.headers, name) orelse
+            return allocator.alloc([]const u8, 0);
+        const fallback = try allocator.alloc([]const u8, 1);
+        fallback[0] = value;
+        return fallback;
     }
 
     pub fn reader(self: *HttpOperation) !*std.Io.Reader {
@@ -298,6 +414,7 @@ const BufferedOperation = struct {
         self.operation = .{
             .status_code = response.status_code,
             .headers = response.headers,
+            .response_headers = response.response_headers,
             .body_reader = &self.reader_impl,
             .finishFn = &finishImpl,
             .abortFn = &abortImpl,
@@ -305,6 +422,7 @@ const BufferedOperation = struct {
             .deinitFn = &deinitImpl,
         };
         self.response.headers = std.StringHashMap([]const u8).init(response.allocator);
+        self.response.response_headers = .{};
         return &self.operation;
     }
 
@@ -317,6 +435,7 @@ const BufferedOperation = struct {
 
     fn deinitImpl(operation: *HttpOperation) void {
         const self: *BufferedOperation = @alignCast(@fieldParentPtr("operation", operation));
+        self.operation.response_headers.deinit();
         deinitOwnedHeaders(self.allocator, &self.operation.headers);
         self.response.deinit();
         self.allocator.destroy(self);
@@ -367,14 +486,19 @@ pub const StdHttpTransport = struct {
         errdefer allocator.free(body);
         try operation.finish();
 
-        var headers = try cloneOwnedHeaders(allocator, &operation.headers);
-        errdefer deinitOwnedHeaders(allocator, &headers);
+        var header_set = try cloneOwnedResponseHeaderSet(
+            allocator,
+            &operation.headers,
+            &operation.response_headers,
+        );
+        errdefer header_set.deinit(allocator);
 
         return .{
             .status_code = operation.status_code,
-            .headers = headers,
+            .headers = header_set.map,
             .body = body,
             .allocator = allocator,
+            .response_headers = header_set.values,
         };
     }
 
@@ -468,8 +592,8 @@ const StdStreamingOperation = struct {
 
         self.response = try self.request.receiveHead(self.redirect_buffer);
         const status_code: u16 = @intFromEnum(self.response.head.status);
-        var headers = try copyResponseHeaders(allocator, &self.response.head);
-        errdefer deinitOwnedHeaders(allocator, &headers);
+        var header_set = try copyResponseHeaders(allocator, &self.response.head);
+        errdefer header_set.deinit(allocator);
 
         self.decompress_buffer = switch (self.response.head.content_encoding) {
             .identity => &.{},
@@ -493,7 +617,8 @@ const StdStreamingOperation = struct {
         );
         self.operation = .{
             .status_code = status_code,
-            .headers = headers,
+            .headers = header_set.map,
+            .response_headers = header_set.values,
             .body_reader = body_reader,
             .finishFn = &finishImpl,
             .abortFn = &abortImpl,
@@ -603,6 +728,7 @@ const StdStreamingOperation = struct {
 
     fn deinitImpl(operation: *HttpOperation) void {
         const self: *StdStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        self.operation.response_headers.deinit();
         deinitOwnedHeaders(self.allocator, &self.operation.headers);
         self.cleanupStorage();
         self.allocator.destroy(self);
@@ -672,10 +798,21 @@ fn validateFramingHeader(
     return false;
 }
 
-fn cloneOwnedHeaders(
+const OwnedResponseHeaderSet = struct {
+    map: std.StringHashMap([]const u8),
+    values: ResponseHeaders,
+
+    fn deinit(self: *OwnedResponseHeaderSet, allocator: std.mem.Allocator) void {
+        self.values.deinit();
+        deinitOwnedHeaders(allocator, &self.map);
+    }
+};
+
+fn cloneOwnedResponseHeaderSet(
     allocator: std.mem.Allocator,
     source: *const std.StringHashMap([]const u8),
-) !std.StringHashMap([]const u8) {
+    response_headers: *const ResponseHeaders,
+) !OwnedResponseHeaderSet {
     var result = std.StringHashMap([]const u8).init(allocator);
     errdefer deinitOwnedHeaders(allocator, &result);
     var iterator = source.iterator();
@@ -686,17 +823,23 @@ fn cloneOwnedHeaders(
         errdefer allocator.free(value);
         try result.put(name, value);
     }
-    return result;
+    return .{
+        .map = result,
+        .values = try response_headers.clone(allocator),
+    };
 }
 
 fn copyResponseHeaders(
     allocator: std.mem.Allocator,
     head: *const std.http.Client.Response.Head,
-) !std.StringHashMap([]const u8) {
+) !OwnedResponseHeaderSet {
     var headers = std.StringHashMap([]const u8).init(allocator);
     errdefer deinitOwnedHeaders(allocator, &headers);
+    var values = ResponseHeaders.init(allocator);
+    errdefer values.deinit();
     var iterator = head.iterateHeaders();
     while (iterator.next()) |header| {
+        try values.append(header.name, header.value);
         const name = try allocator.dupe(u8, header.name);
         errdefer allocator.free(name);
         const value = try allocator.dupe(u8, header.value);
@@ -711,7 +854,7 @@ fn copyResponseHeaders(
             gop.value_ptr.* = value;
         }
     }
-    return headers;
+    return .{ .map = headers, .values = values };
 }
 
 /// A transport that returns canned responses — for unit tests.
@@ -770,12 +913,14 @@ pub const MockTransport = struct {
 
         const response_body_copy = try self.allocator.dupe(u8, self.response_body);
         errdefer self.allocator.free(response_body_copy);
-        const headers = try self.copyResponseHeaders();
+        var header_set = try self.copyResponseHeaders();
+        errdefer header_set.deinit(self.allocator);
         return .{
             .status_code = self.response_status,
-            .headers = headers,
+            .headers = header_set.map,
             .body = response_body_copy,
             .allocator = self.allocator,
+            .response_headers = header_set.values,
         };
     }
 
@@ -877,10 +1022,13 @@ pub const MockTransport = struct {
         self.last_operation_timeout_ms = request.operation_timeout_ms;
     }
 
-    fn copyResponseHeaders(self: *MockTransport) !std.StringHashMap([]const u8) {
+    fn copyResponseHeaders(self: *MockTransport) !OwnedResponseHeaderSet {
         var headers = std.StringHashMap([]const u8).init(self.allocator);
         errdefer deinitOwnedHeaders(self.allocator, &headers);
+        var values = ResponseHeaders.init(self.allocator);
+        errdefer values.deinit();
         for (self.response_headers_list) |hdr| {
+            try values.append(hdr.name, hdr.value);
             const k = try self.allocator.dupe(u8, hdr.name);
             errdefer self.allocator.free(k);
             const v = try self.allocator.dupe(u8, hdr.value);
@@ -894,7 +1042,7 @@ pub const MockTransport = struct {
             }
             entry.value_ptr.* = v;
         }
-        return headers;
+        return .{ .map = headers, .values = values };
     }
 };
 
@@ -910,8 +1058,8 @@ const MockStreamingOperation = struct {
         errdefer owner.allocator.destroy(self);
         const response_body = try owner.allocator.dupe(u8, owner.response_body);
         errdefer owner.allocator.free(response_body);
-        var headers = try owner.copyResponseHeaders();
-        errdefer deinitOwnedHeaders(owner.allocator, &headers);
+        var header_set = try owner.copyResponseHeaders();
+        errdefer header_set.deinit(owner.allocator);
 
         self.* = .{
             .operation = undefined,
@@ -927,7 +1075,8 @@ const MockStreamingOperation = struct {
         );
         self.operation = .{
             .status_code = owner.response_status,
-            .headers = headers,
+            .headers = header_set.map,
+            .response_headers = header_set.values,
             .body_reader = &self.response_reader.interface,
             .finishFn = &finishImpl,
             .abortFn = &abortImpl,
@@ -956,6 +1105,7 @@ const MockStreamingOperation = struct {
     fn deinitImpl(operation: *HttpOperation) void {
         const self: *MockStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
         self.owner.stream_deinit_count += 1;
+        self.operation.response_headers.deinit();
         deinitOwnedHeaders(self.allocator, &self.operation.headers);
         self.allocator.free(self.response_body);
         self.allocator.destroy(self);
@@ -1019,6 +1169,17 @@ fn clearOwnedHeaders(
         allocator.free(entry.value_ptr.*);
     }
     headers.clearRetainingCapacity();
+}
+
+fn getHeaderFromMap(
+    headers: *const std.StringHashMap([]const u8),
+    name: []const u8,
+) ?[]const u8 {
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, name)) return entry.value_ptr.*;
+    }
+    return null;
 }
 
 fn deinitOwnedHeaders(
@@ -1097,23 +1258,27 @@ test "response isSuccess" {
     try std.testing.expect(resp.isSuccess());
 }
 
-test "response header lookup is case-insensitive" {
+test "response header lookup preserves mixed-case duplicates" {
     const allocator = std.testing.allocator;
-    var headers = std.StringHashMap([]const u8).init(allocator);
-    const name = try allocator.dupe(u8, "X-MS-Activity-Id");
-    errdefer allocator.free(name);
-    const value = try allocator.dupe(u8, "activity-id");
-    errdefer allocator.free(value);
-    try headers.put(name, value);
+    var response_headers = ResponseHeaders.init(allocator);
+    errdefer response_headers.deinit();
+    try response_headers.append("Link", "</page/2>; rel=next");
+    try response_headers.append("lInK", "</page/3>; rel=last");
 
     var resp = Response{
         .status_code = 200,
-        .headers = headers,
+        .headers = std.StringHashMap([]const u8).init(allocator),
         .body = try allocator.dupe(u8, "ok"),
         .allocator = allocator,
+        .response_headers = response_headers,
     };
     defer resp.deinit();
-    try std.testing.expectEqualStrings("activity-id", resp.getHeader("x-ms-activity-id").?);
+    try std.testing.expectEqualStrings("</page/2>; rel=next", resp.getHeader("LINK").?);
+    const links = try resp.getHeaderValues(allocator, "link");
+    defer allocator.free(links);
+    try std.testing.expectEqual(@as(usize, 2), links.len);
+    try std.testing.expectEqualStrings("</page/2>; rel=next", links[0]);
+    try std.testing.expectEqualStrings("</page/3>; rel=last", links[1]);
     try std.testing.expect(resp.getHeader("missing") == null);
 }
 
@@ -1121,6 +1286,10 @@ test "mock transport" {
     const allocator = std.testing.allocator;
     var mock = MockTransport.init(allocator, 200, "{\"status\":\"ok\"}");
     defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Docker-Content-Digest", .value = "sha256:first" },
+        .{ .name = "docker-content-digest", .value = "sha256:second" },
+    };
     var req = Request.init(allocator, .POST, "https://vault.azure.net/secrets/mysecret");
     defer req.deinit();
     req.body = "{\"value\":\"secret-value\"}";
@@ -1136,6 +1305,12 @@ test "mock transport" {
     try std.testing.expectEqual(RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
     try std.testing.expectEqual(@as(?u64, 12_345), mock.last_operation_timeout_ms);
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try std.testing.expectEqualStrings("sha256:first", resp.getHeader("DOCKER-CONTENT-DIGEST").?);
+    const digests = try resp.getHeaderValues(allocator, "docker-content-digest");
+    defer allocator.free(digests);
+    try std.testing.expectEqual(@as(usize, 2), digests.len);
+    try std.testing.expectEqualStrings("sha256:first", digests[0]);
+    try std.testing.expectEqualStrings("sha256:second", digests[1]);
 }
 
 test "mock streaming transport accepts known and chunked uploads" {
@@ -1361,6 +1536,12 @@ fn runStdStreamingCase(
         return err;
     };
     defer operation.deinit();
+    try std.testing.expectEqualStrings("first", operation.getHeader("x-test").?);
+    const test_headers = try operation.getHeaderValues(allocator, "X-Test");
+    defer allocator.free(test_headers);
+    try std.testing.expectEqual(@as(usize, 2), test_headers.len);
+    try std.testing.expectEqualStrings("first", test_headers[0]);
+    try std.testing.expectEqualStrings("second", test_headers[1]);
 
     var response: std.Io.Writer.Allocating = .init(allocator);
     defer response.deinit();
@@ -1451,7 +1632,7 @@ const LocalHttpServer = struct {
         const midpoint = self.encoded_response.len / 2;
         if (self.chunked_response) {
             try writer.interface.print(
-                "HTTP/1.1 200 OK\r\nContent-Encoding: {s}\r\nTransfer-Encoding: chunked\r\n\r\n{x}\r\n",
+                "HTTP/1.1 200 OK\r\nContent-Encoding: {s}\r\nX-Test: first\r\nx-test: second\r\nTransfer-Encoding: chunked\r\n\r\n{x}\r\n",
                 .{ self.encoding, midpoint },
             );
             try writer.interface.writeAll(self.encoded_response[0..midpoint]);
@@ -1463,7 +1644,7 @@ const LocalHttpServer = struct {
             try writer.interface.writeAll("\r\n0\r\n\r\n");
         } else {
             try writer.interface.print(
-                "HTTP/1.1 200 OK\r\nContent-Encoding: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n",
+                "HTTP/1.1 200 OK\r\nContent-Encoding: {s}\r\nX-Test: first\r\nx-test: second\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n",
                 .{ self.encoding, self.encoded_response.len },
             );
             try writer.interface.writeAll(self.encoded_response[0..midpoint]);

--- a/sdk/core/lro.zig
+++ b/sdk/core/lro.zig
@@ -118,9 +118,9 @@ pub const Poller = struct {
     ) !Poller {
         const strategy = options.strategy orelse try detectStrategy(initial_response);
         const poll_url_str = switch (strategy) {
-            .operation_location => getHeaderIgnoreCase(initial_response.headers, "operation-location"),
-            .azure_async_operation => getHeaderIgnoreCase(initial_response.headers, "azure-asyncoperation"),
-            .location => getHeaderIgnoreCase(initial_response.headers, "location"),
+            .operation_location => initial_response.getHeader("operation-location"),
+            .azure_async_operation => initial_response.getHeader("azure-asyncoperation"),
+            .location => initial_response.getHeader("location"),
             .provisioning_state => original_url,
         } orelse return error.NoPollUrl;
 
@@ -177,7 +177,7 @@ pub const Poller = struct {
         self.last_body = try self.allocator.dupe(u8, resp.body);
 
         // Check for Retry-After header and update interval.
-        if (getHeaderIgnoreCase(resp.headers, "retry-after")) |ra| {
+        if (resp.getHeader("retry-after")) |ra| {
             if (std.fmt.parseInt(u64, ra, 10)) |secs| {
                 // Clamp to max 120 seconds.
                 self.poll_interval_ms = @min(secs * 1000, 120_000);
@@ -312,11 +312,11 @@ pub fn TypedPoller(comptime T: type) type {
 // ─────────────────── Strategy Detection ────────────────────
 
 fn detectStrategy(response: http.Response) !PollingStrategy {
-    if (getHeaderIgnoreCase(response.headers, "operation-location") != null)
+    if (response.getHeader("operation-location") != null)
         return .operation_location;
-    if (getHeaderIgnoreCase(response.headers, "azure-asyncoperation") != null)
+    if (response.getHeader("azure-asyncoperation") != null)
         return .azure_async_operation;
-    if (getHeaderIgnoreCase(response.headers, "location") != null and response.status_code == 202)
+    if (response.getHeader("location") != null and response.status_code == 202)
         return .location;
     return error.UnsupportedLroPattern;
 }
@@ -362,19 +362,6 @@ fn statusFromHttpCode(code: u16) OperationStatus {
     if (code == 202) return .in_progress;
     if (code >= 400) return .failed;
     return .in_progress;
-}
-
-// ─────────────────── Header Helpers ────────────────────────
-
-fn getHeaderIgnoreCase(headers: std.StringHashMap([]const u8), key: []const u8) ?[]const u8 {
-    // Direct lookup first.
-    if (headers.get(key)) |v| return v;
-    // Case-insensitive scan.
-    var it = headers.iterator();
-    while (it.next()) |entry| {
-        if (eqlIgnoreCase(entry.key_ptr.*, key)) return entry.value_ptr.*;
-    }
-    return null;
 }
 
 fn eqlIgnoreCase(a: []const u8, b: []const u8) bool {

--- a/sdk/core/url.zig
+++ b/sdk/core/url.zig
@@ -53,12 +53,106 @@ pub const Url = struct {
 /// Encodes all characters except unreserved chars (A-Z, a-z, 0-9, '-', '.', '_', '~')
 /// per RFC 3986 §2.3.
 pub fn percentEncode(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    return encodeWithMode(allocator, input, .segment);
+}
+
+/// Percent-encode one path segment.
+pub fn encodePathSegment(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    return encodeWithMode(allocator, input, .segment);
+}
+
+/// Percent-encode an ACR repository name while preserving `/` separators.
+pub fn encodeRepositoryName(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    return encodeWithMode(allocator, input, .repository);
+}
+
+/// Expand a greedy path value, preserving URI reserved characters and valid
+/// existing percent escapes.
+pub fn expandGreedyPathValue(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    return encodeWithMode(allocator, input, .greedy);
+}
+
+/// Resolve an absolute or relative URL reference against an endpoint.
+pub fn resolveUrl(
+    allocator: std.mem.Allocator,
+    endpoint: []const u8,
+    reference: []const u8,
+) ![]u8 {
+    const base = std.Uri.parse(endpoint) catch return error.InvalidUrl;
+    if (base.host == null) return error.InvalidUrl;
+
+    var storage = try allocator.alloc(u8, reference.len + endpoint.len + 2);
+    defer allocator.free(storage);
+    @memcpy(storage[0..reference.len], reference);
+    var available = storage;
+    const resolved = std.Uri.resolveInPlace(base, reference.len, &available) catch
+        return error.InvalidUrl;
+
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    try std.Uri.format(&resolved, &output.writer);
+    return output.toOwnedSlice();
+}
+
+/// Validate that a URL is HTTPS and uses one of the expected hosts.
+///
+/// Host matching is exact and case-insensitive. An empty expected-host list
+/// accepts any HTTPS host.
+pub fn validateHttpsUrl(raw: []const u8, expected_hosts: []const []const u8) !void {
+    const uri = std.Uri.parse(raw) catch return error.InvalidUrl;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) return error.HttpsRequired;
+    if (uri.host == null or uri.user != null or uri.password != null or uri.fragment != null)
+        return error.InvalidUrl;
+
+    var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const host = uri.getHost(&host_buffer) catch return error.InvalidUrl;
+    if (expected_hosts.len == 0) return;
+    for (expected_hosts) |expected| {
+        if (std.ascii.eqlIgnoreCase(host.bytes, expected)) return;
+    }
+    return error.UnexpectedHost;
+}
+
+/// Resolve a URL reference and validate the resulting HTTPS host.
+pub fn resolveAndValidateUrl(
+    allocator: std.mem.Allocator,
+    endpoint: []const u8,
+    reference: []const u8,
+    expected_hosts: []const []const u8,
+) ![]u8 {
+    const resolved = try resolveUrl(allocator, endpoint, reference);
+    errdefer allocator.free(resolved);
+    try validateHttpsUrl(resolved, expected_hosts);
+    return resolved;
+}
+
+const EncodeMode = enum {
+    segment,
+    repository,
+    greedy,
+};
+
+fn encodeWithMode(
+    allocator: std.mem.Allocator,
+    input: []const u8,
+    mode: EncodeMode,
+) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
     const hex = "0123456789ABCDEF";
-    for (input) |c| {
-        if (isUnreserved(c)) {
+    var index: usize = 0;
+    while (index < input.len) : (index += 1) {
+        const c = input[index];
+        if (isUnreserved(c) or
+            (mode == .repository and c == '/') or
+            (mode == .greedy and isReserved(c)))
+        {
             try buf.append(allocator, c);
+        } else if (mode == .greedy and c == '%' and index + 2 < input.len and
+            hexVal(input[index + 1]) != null and hexVal(input[index + 2]) != null)
+        {
+            try buf.appendSlice(allocator, input[index .. index + 3]);
+            index += 2;
         } else {
             try buf.append(allocator, '%');
             try buf.append(allocator, hex[c >> 4]);
@@ -105,6 +199,13 @@ fn isUnreserved(c: u8) bool {
         c == '-' or c == '.' or c == '_' or c == '~';
 }
 
+fn isReserved(c: u8) bool {
+    return switch (c) {
+        ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=' => true,
+        else => false,
+    };
+}
+
 fn hexVal(c: u8) ?u4 {
     if (c >= '0' and c <= '9') return @intCast(c - '0');
     if (c >= 'A' and c <= 'F') return @intCast(c - 'A' + 10);
@@ -138,6 +239,111 @@ test "percentEncode unreserved passthrough" {
     const encoded = try percentEncode(allocator, "abc-123_XYZ.~");
     defer allocator.free(encoded);
     try std.testing.expectEqualStrings("abc-123_XYZ.~", encoded);
+}
+
+test "path segment repository and greedy encoding" {
+    const allocator = std.testing.allocator;
+
+    const digest = try encodePathSegment(allocator, "sha256:abc/def");
+    defer allocator.free(digest);
+    try std.testing.expectEqualStrings("sha256%3Aabc%2Fdef", digest);
+
+    const repository = try encodeRepositoryName(allocator, "team/my image");
+    defer allocator.free(repository);
+    try std.testing.expectEqualStrings("team/my%20image", repository);
+
+    const upload = try expandGreedyPathValue(
+        allocator,
+        "/v2/team/app/blobs/uploads/id?_state=a%2Fb&digest=sha256:abc",
+    );
+    defer allocator.free(upload);
+    try std.testing.expectEqualStrings(
+        "/v2/team/app/blobs/uploads/id?_state=a%2Fb&digest=sha256:abc",
+        upload,
+    );
+}
+
+test "resolve relative and absolute URLs" {
+    const allocator = std.testing.allocator;
+
+    const relative = try resolveUrl(
+        allocator,
+        "https://registry.example/v2/team/app/",
+        "../tags/list?n=10",
+    );
+    defer allocator.free(relative);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/v2/team/tags/list?n=10",
+        relative,
+    );
+
+    const root_relative = try resolveUrl(
+        allocator,
+        "https://registry.example/v2/",
+        "/oauth2/token?service=registry.example",
+    );
+    defer allocator.free(root_relative);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/oauth2/token?service=registry.example",
+        root_relative,
+    );
+
+    const absolute = try resolveUrl(
+        allocator,
+        "https://registry.example/v2/",
+        "https://auth.example/oauth2/token",
+    );
+    defer allocator.free(absolute);
+    try std.testing.expectEqualStrings("https://auth.example/oauth2/token", absolute);
+}
+
+test "validate HTTPS URL expected hosts" {
+    const allocator = std.testing.allocator;
+    const expected = [_][]const u8{ "registry.example", "auth.example" };
+
+    const relative = try resolveAndValidateUrl(
+        allocator,
+        "https://registry.example/v2/",
+        "/v2/team/app/tags/list",
+        &expected,
+    );
+    defer allocator.free(relative);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/v2/team/app/tags/list",
+        relative,
+    );
+
+    try validateHttpsUrl("https://AUTH.EXAMPLE/oauth2/token", &expected);
+    try std.testing.expectError(
+        error.HttpsRequired,
+        validateHttpsUrl("http://registry.example/v2/", &expected),
+    );
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        validateHttpsUrl("https://registry.example.evil.test/v2/", &expected),
+    );
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        resolveAndValidateUrl(
+            allocator,
+            "https://registry.example/v2/",
+            "//evil.test/v2/",
+            &expected,
+        ),
+    );
+    try std.testing.expectError(
+        error.HttpsRequired,
+        resolveAndValidateUrl(
+            allocator,
+            "https://registry.example/v2/",
+            "http://registry.example/v2/",
+            &expected,
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidUrl,
+        validateHttpsUrl("https://user@registry.example/v2/", &expected),
+    );
 }
 
 test "percentDecode round-trip" {

--- a/sdk/kusto/data/root.zig
+++ b/sdk/kusto/data/root.zig
@@ -466,12 +466,15 @@ fn responseFromOperation(
             return err;
         };
     }
+    var response_headers = try operation.response_headers.clone(allocator);
+    errdefer response_headers.deinit();
     try operation.finish();
     return .{
         .status_code = operation.status_code,
         .headers = headers,
         .body = owned_body,
         .allocator = allocator,
+        .response_headers = response_headers,
     };
 }
 

--- a/sdk/kusto/ingest/streaming.zig
+++ b/sdk/kusto/ingest/streaming.zig
@@ -881,11 +881,14 @@ fn responseFromOperation(
         }
         entry.value_ptr.* = value;
     }
+    var response_headers = try operation.response_headers.clone(allocator);
+    errdefer response_headers.deinit();
     return .{
         .status_code = operation.status_code,
         .headers = headers,
         .body = try output.toOwnedSlice(allocator),
         .allocator = allocator,
+        .response_headers = response_headers,
     };
 }
 

--- a/sdk/storage/blobs/root.zig
+++ b/sdk/storage/blobs/root.zig
@@ -284,7 +284,7 @@ pub const BlobClient = struct {
             return error.AzureRequestFailed;
         }
 
-        const etag = if (resp.headers.get("ETag")) |e| try allocator.dupe(u8, e) else null;
+        const etag = if (resp.getHeader("ETag")) |e| try allocator.dupe(u8, e) else null;
         return .{ .ok = .{ .etag = etag } };
     }
 
@@ -337,8 +337,8 @@ pub const BlobClient = struct {
         }
 
         return .{ .ok = .{
-            .etag = if (resp.headers.get("ETag")) |e| try allocator.dupe(u8, e) else null,
-            .last_modified = if (resp.headers.get("Last-Modified")) |lm| try allocator.dupe(u8, lm) else null,
+            .etag = if (resp.getHeader("ETag")) |e| try allocator.dupe(u8, e) else null,
+            .last_modified = if (resp.getHeader("Last-Modified")) |lm| try allocator.dupe(u8, lm) else null,
         } };
     }
 


### PR DESCRIPTION
## Summary

- add duplicate-preserving, case-insensitive HTTP headers
- add ACR path encoding, greedy expansion, URL resolution, and endpoint validation
- update transports, mocks, and consumers with focused coverage

Closes #80.