### PR TITLE
core: add replayable streaming HTTP and redirect safety

### DIFF
--- a/sdk/core/http/pipeline.zig
+++ b/sdk/core/http/pipeline.zig
@@ -42,6 +42,13 @@ pub const HttpPolicy = struct {
         self: *HttpPolicy,
         request: *Request,
     ) anyerror!void = null,
+    openFn: ?*const fn (
+        self: *HttpPolicy,
+        request: *Request,
+        options: OpenOptions,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) anyerror!*HttpOperation = null,
 
     pub fn process(
         self: *HttpPolicy,
@@ -56,6 +63,18 @@ pub const HttpPolicy = struct {
         const prepareFn = self.prepareFn orelse return error.StreamingPolicyUnsupported;
         return prepareFn(self, request);
     }
+
+    pub fn open(
+        self: *HttpPolicy,
+        request: *Request,
+        options: OpenOptions,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !*HttpOperation {
+        if (self.openFn) |openFn| return openFn(self, request, options, next, final_transport);
+        try self.prepare(request);
+        return callNextOpen(request, options, next, final_transport);
+    }
 };
 
 /// Ordered chain of policy pointers that terminates at an `HttpTransport`.
@@ -68,8 +87,8 @@ pub const HttpPipeline = struct {
         return callNext(request, self.policies, self.transport_impl);
     }
 
-    /// Prepares each policy once, then opens a non-retrying streaming
-    /// operation. A policy must explicitly support request-only preparation.
+    /// Opens a streaming operation through the same ordered policy chain used
+    /// by buffered requests.
     pub fn open(
         self: *HttpPipeline,
         request: *Request,
@@ -77,11 +96,7 @@ pub const HttpPipeline = struct {
     ) !*HttpOperation {
         request.transport_started = false;
         try checkOpenCancelled(options);
-        for (self.policies) |policy| {
-            try policy.prepare(request);
-            try checkOpenCancelled(options);
-        }
-        return self.transport_impl.open(request, options);
+        return callNextOpen(request, options, self.policies, self.transport_impl);
     }
 };
 
@@ -97,6 +112,17 @@ fn callNext(request: *Request, next: []*HttpPolicy, final_transport: *HttpTransp
         return final_transport.send(request);
     }
     return next[0].process(request, next[1..], final_transport);
+}
+
+fn callNextOpen(
+    request: *Request,
+    options: OpenOptions,
+    next: []*HttpPolicy,
+    final_transport: *HttpTransport,
+) !*HttpOperation {
+    try checkOpenCancelled(options);
+    if (next.len == 0) return final_transport.open(request, options);
+    return next[0].open(request, options, next[1..], final_transport);
 }
 
 // ───────────────────────────── Policies ─────────────────────────────
@@ -168,7 +194,8 @@ pub const LoggingPolicy = struct {
 /// `Retry-After` response header when present. For retryable requests,
 /// `Request.operation_timeout_ms` limits attempts and backoff, but blocking
 /// transports cannot interrupt an in-flight send. Non-retryable requests
-/// always make one send, which is likewise not interruptible.
+/// always make one send, which is likewise not interruptible. Streaming
+/// requests are retried only when their body exposes an explicit rewind.
 pub const RetryPolicy = struct {
     max_retries: u32 = 3,
     initial_delay_ms: u64 = 800,
@@ -177,7 +204,11 @@ pub const RetryPolicy = struct {
 
     pub fn init() RetryPolicy {
         return .{
-            .policy = .{ .processFn = &processImpl, .prepareFn = &prepareImpl },
+            .policy = .{
+                .processFn = &processImpl,
+                .prepareFn = &prepareImpl,
+                .openFn = &openImpl,
+            },
         };
     }
 
@@ -253,6 +284,68 @@ pub const RetryPolicy = struct {
         }
     }
 
+    fn openImpl(
+        policy: *HttpPolicy,
+        request: *Request,
+        options: OpenOptions,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !*HttpOperation {
+        if (!request.retryable or !options.isReplayable())
+            return callNextOpen(request, options, next, final_transport);
+
+        const self: *RetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
+        const deadline_ns: ?i128 = if (request.operation_timeout_ms) |timeout_ms|
+            std.math.add(
+                i128,
+                monotonicNanoTimestamp(),
+                @as(i128, timeout_ms) * std.time.ns_per_ms,
+            ) catch std.math.maxInt(i128)
+        else
+            null;
+        var current_options = options;
+        var attempt: u32 = 0;
+        var prng = std.Random.DefaultPrng.init(@truncate(@as(u128, @bitCast(nanoTimestamp()))));
+
+        while (true) {
+            if (deadlineExpired(deadline_ns)) return error.OperationTimedOut;
+            if (attempt > 0) {
+                if (current_options.body) |*body| try body.rewind();
+            }
+
+            const result = callNextOpen(request, current_options, next, final_transport);
+            if (result) |operation| {
+                if (!isRetryable(operation.status_code) or attempt >= self.max_retries)
+                    return operation;
+
+                const retry_after_ms = retryAfterOperationDelayMs(operation);
+                operation.abort();
+                operation.deinit();
+                attempt += 1;
+                const delay = if (retry_after_ms > 0)
+                    @min(retry_after_ms, self.max_delay_ms)
+                else
+                    retryDelay(self, &prng, attempt);
+                if (!sleepWithinBudget(delay, deadline_ns)) return error.OperationTimedOut;
+            } else |err| {
+                if (attempt >= self.max_retries) return err;
+                attempt += 1;
+                const delay = retryDelay(self, &prng, attempt);
+                if (!sleepWithinBudget(delay, deadline_ns)) return error.OperationTimedOut;
+            }
+        }
+    }
+
+    fn retryDelay(self: *const RetryPolicy, prng: *std.Random.DefaultPrng, attempt: u32) u64 {
+        const base_delay = exponentialDelayMs(
+            self.initial_delay_ms,
+            self.max_delay_ms,
+            attempt,
+        );
+        const jitter = prng.random().uintLessThan(u64, @max(base_delay, 1));
+        return base_delay / 2 + jitter / 2;
+    }
+
     fn deadlineExpired(deadline_ns: ?i128) bool {
         const deadline = deadline_ns orelse return false;
         return monotonicNanoTimestamp() >= deadline;
@@ -297,6 +390,12 @@ pub const RetryPolicy = struct {
 
     fn retryAfterDelayMs(resp: Response) u64 {
         const seconds = parseRetryAfter(resp) orelse return 0;
+        return std.math.mul(u64, seconds, 1000) catch std.math.maxInt(u64);
+    }
+
+    fn retryAfterOperationDelayMs(operation: *const HttpOperation) u64 {
+        const value = operation.getHeader("Retry-After") orelse return 0;
+        const seconds = std.fmt.parseInt(u64, value, 10) catch return 0;
         return std.math.mul(u64, seconds, 1000) catch std.math.maxInt(u64);
     }
 };
@@ -439,7 +538,7 @@ pub const TracingPolicy = struct {
         return .{
             .tracer = tracer,
             .az_namespace = az_namespace,
-            .policy = .{ .processFn = &processImpl },
+            .policy = .{ .processFn = &processImpl, .openFn = &openImpl },
         };
     }
 
@@ -484,6 +583,29 @@ pub const TracingPolicy = struct {
 
         span.end();
         return response;
+    }
+
+    fn openImpl(
+        policy: *HttpPolicy,
+        request: *Request,
+        options: OpenOptions,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !*HttpOperation {
+        const self: *TracingPolicy = @alignCast(@fieldParentPtr("policy", policy));
+        const span = self.tracer.startSpan("HTTP", .client) catch
+            return callNextOpen(request, options, next, final_transport);
+        span.setAttribute("http.method", @tagName(request.method)) catch {};
+        span.setAttribute("url.full", request.url) catch {};
+        span.setAttribute("az.namespace", self.az_namespace) catch {};
+        const operation = callNextOpen(request, options, next, final_transport) catch |err| {
+            span.setStatus(.@"error");
+            span.end();
+            return err;
+        };
+        span.setStatus(if (operation.isSuccess()) .ok else .@"error");
+        span.end();
+        return operation;
     }
 };
 
@@ -540,6 +662,51 @@ test "pipeline prepares streaming policies without retrying" {
     );
     try std.testing.expect(cancelled_request.getHeader("User-Agent") == null);
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
+test "RetryPolicy replays only explicitly rewindable streaming bodies" {
+    const allocator = std.testing.allocator;
+    var retry = RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    var policies = [_]*HttpPolicy{retry.asPolicy()};
+
+    var replay_sequence = transport.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 503, .body = "retry" },
+        .{ .status = 200, .body = "ok" },
+    });
+    var replay_pipeline = HttpPipeline{
+        .policies = &policies,
+        .transport_impl = replay_sequence.asTransport(),
+    };
+    var replay_request = Request.init(allocator, .POST, "https://example.com/upload");
+    defer replay_request.deinit();
+    var replay = transport.ReplayableBytes.init("replayable");
+    var replay_operation = try replay_pipeline.open(&replay_request, .{ .body = replay.body() });
+    defer replay_operation.deinit();
+    try std.testing.expectEqual(@as(u16, 200), replay_operation.status_code);
+    try std.testing.expectEqual(@as(usize, 2), replay_sequence.call_count);
+    try std.testing.expectEqualStrings("replayable", replay_sequence.capturedBody(0));
+    try std.testing.expectEqualStrings("replayable", replay_sequence.capturedBody(1));
+    try replay_operation.finish();
+
+    var one_shot_sequence = transport.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 503, .body = "retry" },
+        .{ .status = 200, .body = "unexpected" },
+    });
+    var one_shot_pipeline = HttpPipeline{
+        .policies = &policies,
+        .transport_impl = one_shot_sequence.asTransport(),
+    };
+    var one_shot_request = Request.init(allocator, .POST, "https://example.com/upload");
+    defer one_shot_request.deinit();
+    var source = std.Io.Reader.fixed("one-shot");
+    var one_shot_operation = try one_shot_pipeline.open(&one_shot_request, .{
+        .body = transport.StreamingRequestBody.chunked(&source),
+    });
+    defer one_shot_operation.deinit();
+    try std.testing.expectEqual(@as(u16, 503), one_shot_operation.status_code);
+    try std.testing.expectEqual(@as(usize, 1), one_shot_sequence.call_count);
+    one_shot_operation.abort();
 }
 
 test "pipeline rejects policies without streaming preparation" {

--- a/sdk/core/http/pipeline.zig
+++ b/sdk/core/http/pipeline.zig
@@ -308,8 +308,10 @@ pub const RetryPolicy = struct {
         var prng = std.Random.DefaultPrng.init(@truncate(@as(u128, @bitCast(nanoTimestamp()))));
 
         while (true) {
+            try checkOpenCancelled(current_options);
             if (deadlineExpired(deadline_ns)) return error.OperationTimedOut;
             if (attempt > 0) {
+                try checkOpenCancelled(current_options);
                 if (current_options.body) |*body| try body.rewind();
             }
 
@@ -321,6 +323,7 @@ pub const RetryPolicy = struct {
                 const retry_after_ms = retryAfterOperationDelayMs(operation);
                 operation.abort();
                 operation.deinit();
+                try checkOpenCancelled(current_options);
                 attempt += 1;
                 const delay = if (retry_after_ms > 0)
                     @min(retry_after_ms, self.max_delay_ms)
@@ -328,6 +331,8 @@ pub const RetryPolicy = struct {
                     retryDelay(self, &prng, attempt);
                 if (!sleepWithinBudget(delay, deadline_ns)) return error.OperationTimedOut;
             } else |err| {
+                if (err == error.OperationCancelled) return err;
+                try checkOpenCancelled(current_options);
                 if (attempt >= self.max_retries) return err;
                 attempt += 1;
                 const delay = retryDelay(self, &prng, attempt);
@@ -707,6 +712,74 @@ test "RetryPolicy replays only explicitly rewindable streaming bodies" {
     try std.testing.expectEqual(@as(u16, 503), one_shot_operation.status_code);
     try std.testing.expectEqual(@as(usize, 1), one_shot_sequence.call_count);
     one_shot_operation.abort();
+}
+
+test "RetryPolicy propagates streaming cancellation without retry or rewind" {
+    const RewindSource = struct {
+        reader: std.Io.Reader,
+        bytes: []const u8,
+        rewind_count: usize = 0,
+
+        fn init(bytes: []const u8) @This() {
+            return .{ .reader = std.Io.Reader.fixed(bytes), .bytes = bytes };
+        }
+
+        fn rewind(context: *anyopaque) !*std.Io.Reader {
+            const self: *@This() = @ptrCast(@alignCast(context));
+            self.rewind_count += 1;
+            self.reader = std.Io.Reader.fixed(self.bytes);
+            return &self.reader;
+        }
+    };
+
+    const CancellingTransport = struct {
+        transport: HttpTransport = .{ .sendFn = &send, .openFn = &open },
+        call_count: usize = 0,
+
+        fn send(_: *HttpTransport, _: *Request) anyerror!Response {
+            return error.UnexpectedBufferedSend;
+        }
+
+        fn open(
+            transport_impl: *HttpTransport,
+            _: *Request,
+            options: OpenOptions,
+        ) anyerror!*HttpOperation {
+            const self: *@This() = @alignCast(@fieldParentPtr("transport", transport_impl));
+            self.call_count += 1;
+            if (options.body) |body| {
+                var byte: [1]u8 = undefined;
+                _ = try body.reader.readSliceShort(&byte);
+            }
+            if (options.cancellation) |token| @constCast(token).cancel();
+            return error.OperationCancelled;
+        }
+    };
+
+    const allocator = std.testing.allocator;
+    var cancelling = CancellingTransport{};
+    var retry = RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    var policies = [_]*HttpPolicy{retry.asPolicy()};
+    var pipeline_inst = HttpPipeline{
+        .policies = &policies,
+        .transport_impl = &cancelling.transport,
+    };
+    var request = Request.init(allocator, .POST, "https://example.com/upload");
+    defer request.deinit();
+    var token = transport.CancellationToken{};
+    var source = RewindSource.init("body");
+    const body = transport.StreamingRequestBody.knownLength(
+        &source.reader,
+        source.bytes.len,
+    ).withRewind(&source, &RewindSource.rewind);
+
+    try std.testing.expectError(
+        error.OperationCancelled,
+        pipeline_inst.open(&request, .{ .body = body, .cancellation = &token }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), cancelling.call_count);
+    try std.testing.expectEqual(@as(usize, 0), source.rewind_count);
 }
 
 test "pipeline rejects policies without streaming preparation" {

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -510,6 +510,7 @@ fn openFollowingRedirects(
 
     var redirect_count: usize = 0;
     while (true) {
+        try checkCancelled(current_options.cancellation);
         var operation = try rawOpen(transport, current, current_options);
         const action = redirectAction(
             operation.status_code,
@@ -535,6 +536,10 @@ fn openFollowingRedirects(
         };
         operation.abort();
         operation.deinit();
+        checkCancelled(current_options.cancellation) catch |err| {
+            target.allocator.free(target.url);
+            return err;
+        };
         if (action.drop_body) {
             current_options.body = null;
         } else if (current_options.body) |*body| {
@@ -1532,6 +1537,7 @@ pub const SequenceMockTransport = struct {
     captured_body_present: [16]bool = .{false} ** 16,
     captured_body_lengths: [16]usize = .{0} ** 16,
     captured_bodies: [16][512]u8 = undefined,
+    cancel_after_open: ?*CancellationToken = null,
 
     pub fn init(allocator: std.mem.Allocator, responses: []const CannedResponse) SequenceMockTransport {
         return .{
@@ -1593,6 +1599,7 @@ pub const SequenceMockTransport = struct {
         }
 
         const idx = try self.capture(request, body_bytes);
+        if (self.cancel_after_open) |token| token.cancel();
         return BufferedOperation.fromResponse(try self.response(idx));
     }
 
@@ -1940,6 +1947,54 @@ test "transport preserves buffered 301 302 and 303 redirect semantics" {
     try std.testing.expectEqual(Method.GET, one_shot_sequence.captured_methods[1].?);
     try std.testing.expect(!one_shot_sequence.captured_body_present[1]);
     try operation.finish();
+}
+
+test "streaming redirect cancellation does not rewind or follow" {
+    const CountingReplay = struct {
+        reader: std.Io.Reader,
+        bytes: []const u8,
+        rewind_count: usize = 0,
+
+        fn init(bytes: []const u8) @This() {
+            return .{ .reader = std.Io.Reader.fixed(bytes), .bytes = bytes };
+        }
+
+        fn rewind(context: *anyopaque) !*std.Io.Reader {
+            const self: *@This() = @ptrCast(@alignCast(context));
+            self.rewind_count += 1;
+            self.reader = std.Io.Reader.fixed(self.bytes);
+            return &self.reader;
+        }
+    };
+
+    const allocator = std.testing.allocator;
+    var token = CancellationToken{};
+    var sequence = SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "https://storage.example/blob" }},
+        },
+        .{ .status = 200, .body = "unexpected" },
+    });
+    sequence.cancel_after_open = &token;
+    var request = Request.init(allocator, .PUT, "https://registry.example/upload");
+    defer request.deinit();
+    var source = CountingReplay.init("payload");
+    const body = StreamingRequestBody.knownLength(
+        &source.reader,
+        source.bytes.len,
+    ).withRewind(&source, &CountingReplay.rewind);
+
+    try std.testing.expectError(
+        error.OperationCancelled,
+        sequence.asTransport().open(
+            &request,
+            .{ .body = body, .cancellation = &token },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), sequence.call_count);
+    try std.testing.expectEqual(@as(usize, 0), source.rewind_count);
 }
 
 test "transport does not replay one-shot bodies and rejects insecure redirects" {

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -463,7 +463,11 @@ fn sendFollowingRedirects(transport: *HttpTransport, request: *Request) !Respons
     var redirect_count: usize = 0;
     while (true) {
         var response = try transport.sendFn(transport, current);
-        const location = redirectLocation(response.status_code, response.getHeader("Location")) orelse
+        const action = redirectAction(
+            response.status_code,
+            current.method,
+            response.getHeader("Location"),
+        ) orelse
             return response;
         if (current.redirect_policy == .not_allowed) return response;
         if (redirect_count >= max_redirects) {
@@ -471,12 +475,18 @@ fn sendFollowingRedirects(transport: *HttpTransport, request: *Request) !Respons
             return error.TooManyRedirects;
         }
 
-        const target = resolveRedirect(current, location) catch |err| {
+        const target = resolveRedirect(current, action.location) catch |err| {
             response.deinit();
             return err;
         };
         response.deinit();
-        const next = OwnedRedirectRequest.create(current, target.url, target.cross_origin) catch |err| {
+        const next = OwnedRedirectRequest.create(
+            current,
+            target.url,
+            target.cross_origin,
+            action.method,
+            action.drop_body,
+        ) catch |err| {
             target.allocator.free(target.url);
             return err;
         };
@@ -501,28 +511,45 @@ fn openFollowingRedirects(
     var redirect_count: usize = 0;
     while (true) {
         var operation = try rawOpen(transport, current, current_options);
-        const location = redirectLocation(operation.status_code, operation.getHeader("Location")) orelse
+        const action = redirectAction(
+            operation.status_code,
+            current.method,
+            operation.getHeader("Location"),
+        ) orelse
             return operation;
-        if (current.redirect_policy == .not_allowed or !current_options.isReplayable())
+        if (current.redirect_policy == .not_allowed or
+            (!action.drop_body and !current_options.isReplayable()))
+        {
             return operation;
+        }
         if (redirect_count >= max_redirects) {
             operation.abort();
             operation.deinit();
             return error.TooManyRedirects;
         }
 
-        const target = resolveRedirect(current, location) catch |err| {
+        const target = resolveRedirect(current, action.location) catch |err| {
             operation.abort();
             operation.deinit();
             return err;
         };
         operation.abort();
         operation.deinit();
-        if (current_options.body) |*body| body.rewind() catch |err| {
-            target.allocator.free(target.url);
-            return err;
-        };
-        const next = OwnedRedirectRequest.create(current, target.url, target.cross_origin) catch |err| {
+        if (action.drop_body) {
+            current_options.body = null;
+        } else if (current_options.body) |*body| {
+            body.rewind() catch |err| {
+                target.allocator.free(target.url);
+                return err;
+            };
+        }
+        const next = OwnedRedirectRequest.create(
+            current,
+            target.url,
+            target.cross_origin,
+            action.method,
+            action.drop_body,
+        ) catch |err| {
             target.allocator.free(target.url);
             return err;
         };
@@ -545,9 +572,28 @@ fn rawOpen(
     return BufferedOperation.openRaw(transport, request);
 }
 
-fn redirectLocation(status_code: u16, location: ?[]const u8) ?[]const u8 {
-    if (status_code != 307 and status_code != 308) return null;
-    return location;
+const RedirectAction = struct {
+    location: []const u8,
+    method: Method,
+    drop_body: bool,
+};
+
+fn redirectAction(
+    status_code: u16,
+    method: Method,
+    location: ?[]const u8,
+) ?RedirectAction {
+    const target = location orelse return null;
+    // Match std.http.Client: 303 always becomes GET; 301/302 rewrite POST.
+    return switch (status_code) {
+        301, 302 => if (method == .POST)
+            .{ .location = target, .method = .GET, .drop_body = true }
+        else
+            .{ .location = target, .method = method, .drop_body = false },
+        303 => .{ .location = target, .method = .GET, .drop_body = true },
+        307, 308 => .{ .location = target, .method = method, .drop_body = false },
+        else => null,
+    };
 }
 
 const ResolvedRedirect = struct {
@@ -575,6 +621,8 @@ const OwnedRedirectRequest = struct {
         source: *const Request,
         target_url: []const u8,
         cross_origin: bool,
+        method: Method,
+        drop_body: bool,
     ) !*OwnedRedirectRequest {
         const self = try source.allocator.create(OwnedRedirectRequest);
         errdefer source.allocator.destroy(self);
@@ -582,7 +630,7 @@ const OwnedRedirectRequest = struct {
         errdefer source.allocator.free(owned_url);
         self.* = .{
             .allocator = source.allocator,
-            .request = Request.init(source.allocator, source.method, owned_url),
+            .request = Request.init(source.allocator, method, owned_url),
             .url = owned_url,
         };
         errdefer self.request.deinit();
@@ -590,9 +638,10 @@ const OwnedRedirectRequest = struct {
         while (headers.next()) |header| {
             if (cross_origin and std.ascii.eqlIgnoreCase(header.key_ptr.*, "Authorization"))
                 continue;
+            if (drop_body and isBodyHeader(header.key_ptr.*)) continue;
             try self.request.setHeader(header.key_ptr.*, header.value_ptr.*);
         }
-        self.request.body = source.body;
+        self.request.body = if (drop_body) null else source.body;
         self.request.retryable = source.retryable;
         self.request.transport_started = true;
         self.request.redirect_policy = source.redirect_policy;
@@ -606,6 +655,12 @@ const OwnedRedirectRequest = struct {
         self.allocator.destroy(self);
     }
 };
+
+fn isBodyHeader(name: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(name, "Content-Length") or
+        std.ascii.eqlIgnoreCase(name, "Transfer-Encoding") or
+        std.ascii.eqlIgnoreCase(name, "Content-Type");
+}
 
 const BufferedOperation = struct {
     operation: HttpOperation,
@@ -1469,8 +1524,12 @@ pub const SequenceMockTransport = struct {
     transport: HttpTransport,
     captured_methods: [16]?Method = .{null} ** 16,
     captured_authorization: [16]bool = .{false} ** 16,
+    captured_content_type: [16]bool = .{false} ** 16,
+    captured_content_length: [16]bool = .{false} ** 16,
+    captured_transfer_encoding: [16]bool = .{false} ** 16,
     captured_url_lengths: [16]usize = .{0} ** 16,
     captured_urls: [16][512]u8 = undefined,
+    captured_body_present: [16]bool = .{false} ** 16,
     captured_body_lengths: [16]usize = .{0} ** 16,
     captured_bodies: [16][512]u8 = undefined,
 
@@ -1583,8 +1642,12 @@ pub const SequenceMockTransport = struct {
         const call = self.call_count;
         self.captured_methods[call] = request.method;
         self.captured_authorization[call] = request.getHeader("Authorization") != null;
+        self.captured_content_type[call] = request.getHeader("Content-Type") != null;
+        self.captured_content_length[call] = request.getHeader("Content-Length") != null;
+        self.captured_transfer_encoding[call] = request.getHeader("Transfer-Encoding") != null;
         @memcpy(self.captured_urls[call][0..request.url.len], request.url);
         self.captured_url_lengths[call] = request.url.len;
+        self.captured_body_present[call] = body != null;
         @memcpy(self.captured_bodies[call][0..body_value.len], body_value);
         self.captured_body_lengths[call] = body_value.len;
         self.call_count += 1;
@@ -1787,6 +1850,96 @@ test "transport follows safe redirects and strips cross-origin authorization" {
         "https://registry.example/v2/continued",
         buffered_sequence.capturedUrl(1),
     );
+}
+
+test "transport preserves buffered 301 302 and 303 redirect semantics" {
+    const allocator = std.testing.allocator;
+    const cases = [_]struct {
+        status: u16,
+        method: Method,
+        location: []const u8,
+        expected_method: Method,
+        expected_body: ?[]const u8,
+        expected_authorization: bool,
+    }{
+        .{
+            .status = 301,
+            .method = .POST,
+            .location = "/moved",
+            .expected_method = .GET,
+            .expected_body = null,
+            .expected_authorization = true,
+        },
+        .{
+            .status = 302,
+            .method = .PUT,
+            .location = "/found",
+            .expected_method = .PUT,
+            .expected_body = "payload",
+            .expected_authorization = true,
+        },
+        .{
+            .status = 303,
+            .method = .PUT,
+            .location = "https://storage.example/result",
+            .expected_method = .GET,
+            .expected_body = null,
+            .expected_authorization = false,
+        },
+    };
+
+    for (cases) |case| {
+        const headers = [_]MockTransport.HeaderPair{
+            .{ .name = "Location", .value = case.location },
+        };
+        var sequence = SequenceMockTransport.init(allocator, &.{
+            .{ .status = case.status, .body = "", .headers = &headers },
+            .{ .status = 200, .body = "ok" },
+        });
+        var request = Request.init(allocator, case.method, "https://registry.example/start");
+        defer request.deinit();
+        request.body = "payload";
+        try request.setHeader("Authorization", "Bearer token");
+        try request.setHeader("Content-Type", "application/octet-stream");
+        try request.setHeader("Content-Length", "7");
+
+        var response = try sequence.asTransport().send(&request);
+        defer response.deinit();
+        try std.testing.expectEqual(@as(u16, 200), response.status_code);
+        try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
+        try std.testing.expectEqual(case.expected_method, sequence.captured_methods[1].?);
+        try std.testing.expectEqual(case.expected_body != null, sequence.captured_body_present[1]);
+        try std.testing.expectEqual(case.expected_authorization, sequence.captured_authorization[1]);
+        if (case.expected_body) |body| {
+            try std.testing.expectEqualStrings(body, sequence.capturedBody(1));
+            try std.testing.expect(sequence.captured_content_type[1]);
+            try std.testing.expect(sequence.captured_content_length[1]);
+        } else {
+            try std.testing.expect(!sequence.captured_content_type[1]);
+            try std.testing.expect(!sequence.captured_content_length[1]);
+            try std.testing.expect(!sequence.captured_transfer_encoding[1]);
+        }
+    }
+
+    var one_shot_sequence = SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 302,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "/after-post" }},
+        },
+        .{ .status = 200, .body = "ok" },
+    });
+    var one_shot_request = Request.init(allocator, .POST, "https://registry.example/start");
+    defer one_shot_request.deinit();
+    var source = std.Io.Reader.fixed("one-shot");
+    var operation = try one_shot_sequence.asTransport().open(&one_shot_request, .{
+        .body = StreamingRequestBody.knownLength(&source, 8),
+    });
+    defer operation.deinit();
+    try std.testing.expectEqual(@as(u16, 200), operation.status_code);
+    try std.testing.expectEqual(Method.GET, one_shot_sequence.captured_methods[1].?);
+    try std.testing.expect(!one_shot_sequence.captured_body_present[1]);
+    try operation.finish();
 }
 
 test "transport does not replay one-shot bodies and rejects insecure redirects" {

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -439,7 +439,6 @@ pub const HttpTransport = struct {
     ) anyerror!*HttpOperation = null,
 
     pub fn send(self: *HttpTransport, request: *Request) !Response {
-        request.transport_started = true;
         return sendFollowingRedirects(self, request);
     }
 
@@ -448,7 +447,6 @@ pub const HttpTransport = struct {
         request: *Request,
         options: OpenOptions,
     ) !*HttpOperation {
-        request.transport_started = true;
         return openFollowingRedirects(self, request, options);
     }
 };
@@ -462,6 +460,7 @@ fn sendFollowingRedirects(transport: *HttpTransport, request: *Request) !Respons
 
     var redirect_count: usize = 0;
     while (true) {
+        current.transport_started = true;
         var response = try transport.sendFn(transport, current);
         const action = redirectAction(
             response.status_code,
@@ -571,9 +570,13 @@ fn rawOpen(
     request: *Request,
     options: OpenOptions,
 ) !*HttpOperation {
-    if (transport.openFn) |openFn| return openFn(transport, request, options);
-    if (options.body != null) return error.StreamingRequestUnsupported;
     try checkCancelled(options.cancellation);
+    if (transport.openFn) |openFn| {
+        request.transport_started = true;
+        return openFn(transport, request, options);
+    }
+    if (options.body != null) return error.StreamingRequestUnsupported;
+    request.transport_started = true;
     return BufferedOperation.openRaw(transport, request);
 }
 
@@ -608,8 +611,14 @@ const ResolvedRedirect = struct {
 };
 
 fn resolveRedirect(request: *const Request, location: []const u8) !ResolvedRedirect {
-    const resolved = try url_mod.resolveAndValidateUrl(request.allocator, request.url, location, &.{});
+    var resolved = try url_mod.resolveUrl(request.allocator, request.url, location);
     errdefer request.allocator.free(resolved);
+    if (std.mem.indexOfScalar(u8, resolved, '#')) |fragment_start| {
+        const without_fragment = try request.allocator.dupe(u8, resolved[0..fragment_start]);
+        request.allocator.free(resolved);
+        resolved = without_fragment;
+    }
+    try url_mod.validateHttpsUrl(resolved, &.{});
     return .{
         .allocator = request.allocator,
         .url = resolved,
@@ -641,14 +650,12 @@ const OwnedRedirectRequest = struct {
         errdefer self.request.deinit();
         var headers = source.headers.iterator();
         while (headers.next()) |header| {
-            if (cross_origin and std.ascii.eqlIgnoreCase(header.key_ptr.*, "Authorization"))
-                continue;
+            if (isRedirectOmittedHeader(header.key_ptr.*, cross_origin)) continue;
             if (drop_body and isBodyHeader(header.key_ptr.*)) continue;
             try self.request.setHeader(header.key_ptr.*, header.value_ptr.*);
         }
         self.request.body = if (drop_body) null else source.body;
         self.request.retryable = source.retryable;
-        self.request.transport_started = true;
         self.request.redirect_policy = source.redirect_policy;
         self.request.operation_timeout_ms = source.operation_timeout_ms;
         return self;
@@ -660,6 +667,15 @@ const OwnedRedirectRequest = struct {
         self.allocator.destroy(self);
     }
 };
+
+fn isRedirectOmittedHeader(name: []const u8, cross_origin: bool) bool {
+    if (std.ascii.eqlIgnoreCase(name, "Host")) return true;
+    if (!cross_origin) return false;
+    return std.ascii.eqlIgnoreCase(name, "Authorization") or
+        std.ascii.eqlIgnoreCase(name, "Cookie") or
+        std.ascii.eqlIgnoreCase(name, "Cookie2") or
+        std.ascii.eqlIgnoreCase(name, "Proxy-Authorization");
+}
 
 fn isBodyHeader(name: []const u8) bool {
     return std.ascii.eqlIgnoreCase(name, "Content-Length") or
@@ -1529,6 +1545,9 @@ pub const SequenceMockTransport = struct {
     transport: HttpTransport,
     captured_methods: [16]?Method = .{null} ** 16,
     captured_authorization: [16]bool = .{false} ** 16,
+    captured_cookie: [16]bool = .{false} ** 16,
+    captured_proxy_authorization: [16]bool = .{false} ** 16,
+    captured_host: [16]bool = .{false} ** 16,
     captured_content_type: [16]bool = .{false} ** 16,
     captured_content_length: [16]bool = .{false} ** 16,
     captured_transfer_encoding: [16]bool = .{false} ** 16,
@@ -1649,6 +1668,10 @@ pub const SequenceMockTransport = struct {
         const call = self.call_count;
         self.captured_methods[call] = request.method;
         self.captured_authorization[call] = request.getHeader("Authorization") != null;
+        self.captured_cookie[call] = request.getHeader("Cookie") != null;
+        self.captured_proxy_authorization[call] =
+            request.getHeader("Proxy-Authorization") != null;
+        self.captured_host[call] = request.getHeader("Host") != null;
         self.captured_content_type[call] = request.getHeader("Content-Type") != null;
         self.captured_content_length[call] = request.getHeader("Content-Length") != null;
         self.captured_transfer_encoding[call] = request.getHeader("Transfer-Encoding") != null;
@@ -1687,6 +1710,35 @@ test "request init and set header" {
     try std.testing.expectEqualStrings("application/json", req.getHeader("ACCEPT").?);
     try std.testing.expectError(error.InvalidHttpHeaderName, req.setHeader("bad name", "value"));
     try std.testing.expectError(error.InvalidHttpHeaderValue, req.setHeader("x-value", "one\r\ntwo"));
+}
+
+test "streaming preflight failures do not mark transport as started" {
+    const allocator = std.testing.allocator;
+    var mock = MockTransport.init(allocator, 200, "ok");
+    defer mock.deinit();
+    mock.transport.openFn = null;
+
+    var unsupported_request = Request.init(allocator, .POST, "https://example.com/upload");
+    defer unsupported_request.deinit();
+    var source = std.Io.Reader.fixed("body");
+    try std.testing.expectError(
+        error.StreamingRequestUnsupported,
+        mock.asTransport().open(&unsupported_request, .{
+            .body = StreamingRequestBody.knownLength(&source, 4),
+        }),
+    );
+    try std.testing.expect(!unsupported_request.transport_started);
+
+    var cancelled_request = Request.init(allocator, .GET, "https://example.com/cancelled");
+    defer cancelled_request.deinit();
+    var cancellation = CancellationToken{};
+    cancellation.cancel();
+    try std.testing.expectError(
+        error.OperationCancelled,
+        mock.asTransport().open(&cancelled_request, .{ .cancellation = &cancellation }),
+    );
+    try std.testing.expect(!cancelled_request.transport_started);
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
 }
 
 test "response isSuccess" {
@@ -1807,18 +1859,21 @@ test "ReplayableBytes rewinds without copying" {
     try std.testing.expectEqualStrings("replay-body", buffer[0..second]);
 }
 
-test "transport follows safe redirects and strips cross-origin authorization" {
+test "transport follows safe redirects without forwarding origin credentials" {
     const allocator = std.testing.allocator;
     var sequence = SequenceMockTransport.init(allocator, &.{
         .{
             .status = 307,
             .body = "",
-            .headers = &.{.{ .name = "Location", .value = "https://storage.example/blob" }},
+            .headers = &.{.{ .name = "Location", .value = "https://storage.example/blob#section" }},
         },
         .{ .status = 200, .body = "ok" },
     });
     var request = Request.init(allocator, .POST, "https://registry.example/v2/upload");
     defer request.deinit();
+    try request.setHeader("Cookie", "session=test");
+    try request.setHeader("Proxy-Authorization", "Basic test");
+    try request.setHeader("Host", "registry.example");
     try request.setHeader("Authorization", "Bearer registry-token");
     var replay = ReplayableBytes.init("payload");
     var operation = try sequence.asTransport().open(&request, .{ .body = replay.body() });
@@ -1827,6 +1882,12 @@ test "transport follows safe redirects and strips cross-origin authorization" {
     try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
     try std.testing.expect(sequence.captured_authorization[0]);
     try std.testing.expect(!sequence.captured_authorization[1]);
+    try std.testing.expect(sequence.captured_cookie[0]);
+    try std.testing.expect(!sequence.captured_cookie[1]);
+    try std.testing.expect(sequence.captured_proxy_authorization[0]);
+    try std.testing.expect(!sequence.captured_proxy_authorization[1]);
+    try std.testing.expect(sequence.captured_host[0]);
+    try std.testing.expect(!sequence.captured_host[1]);
     try std.testing.expectEqual(Method.POST, sequence.captured_methods[1].?);
     try std.testing.expectEqualStrings("payload", sequence.capturedBody(0));
     try std.testing.expectEqualStrings("payload", sequence.capturedBody(1));
@@ -1844,6 +1905,8 @@ test "transport follows safe redirects and strips cross-origin authorization" {
     var buffered_request = Request.init(allocator, .PUT, "https://registry.example/v2/upload");
     defer buffered_request.deinit();
     buffered_request.body = "buffered-payload";
+    try buffered_request.setHeader("Cookie", "session=test");
+    try buffered_request.setHeader("Host", "registry.example");
     try buffered_request.setHeader("Authorization", "Bearer registry-token");
     var response = try buffered_sequence.asTransport().send(&buffered_request);
     defer response.deinit();
@@ -1851,6 +1914,8 @@ test "transport follows safe redirects and strips cross-origin authorization" {
     try std.testing.expectEqualStrings("buffered-ok", response.body);
     try std.testing.expectEqual(@as(usize, 2), buffered_sequence.call_count);
     try std.testing.expect(buffered_sequence.captured_authorization[1]);
+    try std.testing.expect(buffered_sequence.captured_cookie[1]);
+    try std.testing.expect(!buffered_sequence.captured_host[1]);
     try std.testing.expectEqual(Method.PUT, buffered_sequence.captured_methods[1].?);
     try std.testing.expectEqualStrings("buffered-payload", buffered_sequence.capturedBody(1));
     try std.testing.expectEqualStrings(

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const url_mod = @import("../url.zig");
 
 /// HTTP method verbs.
 pub const Method = enum {
@@ -84,7 +85,7 @@ pub const Request = struct {
         try self.headers.put(owned_key, owned_value);
     }
 
-    pub fn getHeader(self: *Request, key: []const u8) ?[]const u8 {
+    pub fn getHeader(self: *const Request, key: []const u8) ?[]const u8 {
         var iterator = self.headers.iterator();
         while (iterator.next()) |entry| {
             if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, key)) {
@@ -245,19 +246,84 @@ pub const CancellationToken = struct {
     }
 };
 
-/// A borrowed request-body reader. A known length uses `Content-Length`;
-/// otherwise the transport uses chunked transfer encoding.
+/// A borrowed request-body reader. `knownLength` uses `Content-Length`;
+/// `chunked` uses chunked transfer encoding.
 ///
 /// The reader must remain valid until `HttpTransport.open` returns.
+/// Redirects and retries are allowed only when both rewind fields are set.
 pub const StreamingRequestBody = struct {
     reader: *std.Io.Reader,
     content_length: ?u64 = null,
+    rewind_context: ?*anyopaque = null,
+    rewindFn: ?*const fn (context: *anyopaque) anyerror!*std.Io.Reader = null,
+
+    pub fn knownLength(reader: *std.Io.Reader, content_length: u64) StreamingRequestBody {
+        return .{ .reader = reader, .content_length = content_length };
+    }
+
+    pub fn chunked(reader: *std.Io.Reader) StreamingRequestBody {
+        return .{ .reader = reader };
+    }
+
+    pub fn withRewind(
+        self: StreamingRequestBody,
+        context: *anyopaque,
+        rewindFn: *const fn (context: *anyopaque) anyerror!*std.Io.Reader,
+    ) StreamingRequestBody {
+        var replayable = self;
+        replayable.rewind_context = context;
+        replayable.rewindFn = rewindFn;
+        return replayable;
+    }
+
+    pub fn isReplayable(self: StreamingRequestBody) bool {
+        return self.rewind_context != null and self.rewindFn != null;
+    }
+
+    pub fn rewind(self: *StreamingRequestBody) !void {
+        const context = self.rewind_context orelse return error.RequestBodyNotReplayable;
+        const rewindFn = self.rewindFn orelse return error.RequestBodyNotReplayable;
+        self.reader = try rewindFn(context);
+    }
+};
+
+/// A borrowed, bounded-memory byte body that can be replayed without copying.
+///
+/// Keep this value and its bytes alive until `HttpPipeline.open` returns.
+pub const ReplayableBytes = struct {
+    bytes: []const u8,
+    reader_impl: std.Io.Reader,
+
+    pub fn init(bytes: []const u8) ReplayableBytes {
+        return .{
+            .bytes = bytes,
+            .reader_impl = std.Io.Reader.fixed(bytes),
+        };
+    }
+
+    pub fn body(self: *ReplayableBytes) StreamingRequestBody {
+        return StreamingRequestBody.knownLength(
+            &self.reader_impl,
+            self.bytes.len,
+        ).withRewind(self, &rewindImpl);
+    }
+
+    fn rewindImpl(context: *anyopaque) !*std.Io.Reader {
+        const self: *ReplayableBytes = @ptrCast(@alignCast(context));
+        self.reader_impl = std.Io.Reader.fixed(self.bytes);
+        return &self.reader_impl;
+    }
 };
 
 pub const OpenOptions = struct {
     /// When null, `Request.body` is used as a known-length body.
     body: ?StreamingRequestBody = null,
     cancellation: ?*const CancellationToken = null,
+
+    pub fn isReplayable(self: OpenOptions) bool {
+        // Buffered Request.body bytes and body-less requests are replayable.
+        return if (self.body) |body| body.isReplayable() else true;
+    }
 };
 
 const BodyFraming = union(enum) {
@@ -374,7 +440,7 @@ pub const HttpTransport = struct {
 
     pub fn send(self: *HttpTransport, request: *Request) !Response {
         request.transport_started = true;
-        return self.sendFn(self, request);
+        return sendFollowingRedirects(self, request);
     }
 
     pub fn open(
@@ -382,15 +448,162 @@ pub const HttpTransport = struct {
         request: *Request,
         options: OpenOptions,
     ) !*HttpOperation {
-        if (self.openFn) |openFn| {
-            request.transport_started = true;
-            return openFn(self, request, options);
+        request.transport_started = true;
+        return openFollowingRedirects(self, request, options);
+    }
+};
+
+const max_redirects = 10;
+
+fn sendFollowingRedirects(transport: *HttpTransport, request: *Request) !Response {
+    var current = request;
+    var owned: ?*OwnedRedirectRequest = null;
+    defer if (owned) |value| value.destroy();
+
+    var redirect_count: usize = 0;
+    while (true) {
+        var response = try transport.sendFn(transport, current);
+        const location = redirectLocation(response.status_code, response.getHeader("Location")) orelse
+            return response;
+        if (current.redirect_policy == .not_allowed) return response;
+        if (redirect_count >= max_redirects) {
+            response.deinit();
+            return error.TooManyRedirects;
         }
-        if (options.body != null) return error.StreamingRequestUnsupported;
-        if (options.cancellation) |token| {
-            if (token.isCancelled()) return error.OperationCancelled;
+
+        const target = resolveRedirect(current, location) catch |err| {
+            response.deinit();
+            return err;
+        };
+        response.deinit();
+        const next = OwnedRedirectRequest.create(current, target.url, target.cross_origin) catch |err| {
+            target.allocator.free(target.url);
+            return err;
+        };
+        target.allocator.free(target.url);
+        if (owned) |previous| previous.destroy();
+        owned = next;
+        current = &next.request;
+        redirect_count += 1;
+    }
+}
+
+fn openFollowingRedirects(
+    transport: *HttpTransport,
+    request: *Request,
+    options: OpenOptions,
+) !*HttpOperation {
+    var current = request;
+    var current_options = options;
+    var owned: ?*OwnedRedirectRequest = null;
+    defer if (owned) |value| value.destroy();
+
+    var redirect_count: usize = 0;
+    while (true) {
+        var operation = try rawOpen(transport, current, current_options);
+        const location = redirectLocation(operation.status_code, operation.getHeader("Location")) orelse
+            return operation;
+        if (current.redirect_policy == .not_allowed or !current_options.isReplayable())
+            return operation;
+        if (redirect_count >= max_redirects) {
+            operation.abort();
+            operation.deinit();
+            return error.TooManyRedirects;
         }
-        return BufferedOperation.open(self, request);
+
+        const target = resolveRedirect(current, location) catch |err| {
+            operation.abort();
+            operation.deinit();
+            return err;
+        };
+        operation.abort();
+        operation.deinit();
+        if (current_options.body) |*body| body.rewind() catch |err| {
+            target.allocator.free(target.url);
+            return err;
+        };
+        const next = OwnedRedirectRequest.create(current, target.url, target.cross_origin) catch |err| {
+            target.allocator.free(target.url);
+            return err;
+        };
+        target.allocator.free(target.url);
+        if (owned) |previous| previous.destroy();
+        owned = next;
+        current = &next.request;
+        redirect_count += 1;
+    }
+}
+
+fn rawOpen(
+    transport: *HttpTransport,
+    request: *Request,
+    options: OpenOptions,
+) !*HttpOperation {
+    if (transport.openFn) |openFn| return openFn(transport, request, options);
+    if (options.body != null) return error.StreamingRequestUnsupported;
+    try checkCancelled(options.cancellation);
+    return BufferedOperation.openRaw(transport, request);
+}
+
+fn redirectLocation(status_code: u16, location: ?[]const u8) ?[]const u8 {
+    if (status_code != 307 and status_code != 308) return null;
+    return location;
+}
+
+const ResolvedRedirect = struct {
+    allocator: std.mem.Allocator,
+    url: []u8,
+    cross_origin: bool,
+};
+
+fn resolveRedirect(request: *const Request, location: []const u8) !ResolvedRedirect {
+    const resolved = try url_mod.resolveAndValidateUrl(request.allocator, request.url, location, &.{});
+    errdefer request.allocator.free(resolved);
+    return .{
+        .allocator = request.allocator,
+        .url = resolved,
+        .cross_origin = !(try url_mod.sameOrigin(request.url, resolved)),
+    };
+}
+
+const OwnedRedirectRequest = struct {
+    allocator: std.mem.Allocator,
+    request: Request,
+    url: []u8,
+
+    fn create(
+        source: *const Request,
+        target_url: []const u8,
+        cross_origin: bool,
+    ) !*OwnedRedirectRequest {
+        const self = try source.allocator.create(OwnedRedirectRequest);
+        errdefer source.allocator.destroy(self);
+        const owned_url = try source.allocator.dupe(u8, target_url);
+        errdefer source.allocator.free(owned_url);
+        self.* = .{
+            .allocator = source.allocator,
+            .request = Request.init(source.allocator, source.method, owned_url),
+            .url = owned_url,
+        };
+        errdefer self.request.deinit();
+        var headers = source.headers.iterator();
+        while (headers.next()) |header| {
+            if (cross_origin and std.ascii.eqlIgnoreCase(header.key_ptr.*, "Authorization"))
+                continue;
+            try self.request.setHeader(header.key_ptr.*, header.value_ptr.*);
+        }
+        self.request.body = source.body;
+        self.request.retryable = source.retryable;
+        self.request.transport_started = true;
+        self.request.redirect_policy = source.redirect_policy;
+        self.request.operation_timeout_ms = source.operation_timeout_ms;
+        return self;
+    }
+
+    fn destroy(self: *OwnedRedirectRequest) void {
+        self.request.deinit();
+        self.allocator.free(self.url);
+        self.allocator.destroy(self);
     }
 };
 
@@ -400,10 +613,13 @@ const BufferedOperation = struct {
     response: Response,
     reader_impl: std.Io.Reader,
 
-    fn open(transport: *HttpTransport, request: *Request) !*HttpOperation {
-        var response = try transport.send(request);
-        errdefer response.deinit();
+    fn openRaw(transport: *HttpTransport, request: *Request) !*HttpOperation {
+        return fromResponse(try transport.sendFn(transport, request));
+    }
 
+    fn fromResponse(response_value: Response) !*HttpOperation {
+        var response = response_value;
+        errdefer response.deinit();
         const self = try response.allocator.create(BufferedOperation);
         self.* = .{
             .operation = undefined,
@@ -450,12 +666,14 @@ const BufferedOperation = struct {
 /// synchronization.
 pub const StdHttpTransport = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     client: std.http.Client,
     transport: HttpTransport,
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io) StdHttpTransport {
         return .{
             .allocator = allocator,
+            .io = io,
             .client = .{ .allocator = allocator, .io = io },
             .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
@@ -473,7 +691,7 @@ pub const StdHttpTransport = struct {
         const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
         const allocator = self.allocator;
 
-        var operation = try openImpl(transport, request, .{});
+        var operation = try StdStreamingOperation.open(self, request, .{}, false);
         defer operation.deinit();
 
         const body = operation.body_reader.allocRemaining(
@@ -508,13 +726,16 @@ pub const StdHttpTransport = struct {
         options: OpenOptions,
     ) !*HttpOperation {
         const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
-        return StdStreamingOperation.open(self, request, options);
+        return StdStreamingOperation.open(self, request, options, true);
     }
 };
 
 const StdStreamingOperation = struct {
     operation: HttpOperation,
     allocator: std.mem.Allocator,
+    client: std.http.Client,
+    client_ptr: *std.http.Client,
+    owns_client: bool,
     request_headers: std.StringHashMap([]const u8),
     extra_headers: []std.http.Header,
     redirect_buffer: []u8,
@@ -532,6 +753,7 @@ const StdStreamingOperation = struct {
         transport: *StdHttpTransport,
         request: *Request,
         options: OpenOptions,
+        owns_client: bool,
     ) !*HttpOperation {
         if (options.body != null and request.body != null) {
             return error.MultipleRequestBodies;
@@ -545,6 +767,12 @@ const StdStreamingOperation = struct {
         self.* = .{
             .operation = undefined,
             .allocator = allocator,
+            .client = if (owns_client)
+                .{ .allocator = allocator, .io = transport.io }
+            else
+                undefined,
+            .client_ptr = undefined,
+            .owns_client = owns_client,
             .request_headers = std.StringHashMap([]const u8).init(allocator),
             .extra_headers = &.{},
             .redirect_buffer = &.{},
@@ -558,6 +786,7 @@ const StdStreamingOperation = struct {
             .upload_write_buffer = undefined,
             .decompress = undefined,
         };
+        self.client_ptr = if (owns_client) &self.client else &transport.client;
         errdefer {
             self.releaseRequest(true);
             self.cleanupStorage();
@@ -569,13 +798,9 @@ const StdStreamingOperation = struct {
         self.redirect_buffer = try allocator.alloc(u8, 8 * 1024);
 
         const uri = try std.Uri.parse(request.url);
-        const authenticated = request.getHeader("Authorization") != null;
-        self.request = try transport.client.request(request.method.toStd(), uri, .{
+        self.request = try self.client_ptr.request(request.method.toStd(), uri, .{
             .extra_headers = self.extra_headers,
-            .redirect_behavior = if (authenticated or request.redirect_policy == .not_allowed)
-                .unhandled
-            else
-                @enumFromInt(3),
+            .redirect_behavior = .unhandled,
         });
         self.request_active = true;
         self.request.accept_encoding[@intFromEnum(std.http.ContentEncoding.zstd)] = true;
@@ -749,6 +974,7 @@ const StdStreamingOperation = struct {
         if (self.redirect_buffer.len > 0) self.allocator.free(self.redirect_buffer);
         if (self.extra_headers.len > 0) self.allocator.free(self.extra_headers);
         deinitOwnedHeaders(self.allocator, &self.request_headers);
+        if (self.owns_client) self.client.deinit();
     }
 };
 
@@ -1192,18 +1418,28 @@ fn deinitOwnedHeaders(
 
 /// A transport that returns a sequence of canned responses — for retry testing.
 pub const SequenceMockTransport = struct {
-    pub const CannedResponse = struct { status: u16, body: []const u8 };
+    pub const CannedResponse = struct {
+        status: u16,
+        body: []const u8,
+        headers: []const MockTransport.HeaderPair = &.{},
+    };
 
     responses: []const CannedResponse,
     call_count: usize = 0,
     allocator: std.mem.Allocator,
     transport: HttpTransport,
+    captured_methods: [16]?Method = .{null} ** 16,
+    captured_authorization: [16]bool = .{false} ** 16,
+    captured_url_lengths: [16]usize = .{0} ** 16,
+    captured_urls: [16][512]u8 = undefined,
+    captured_body_lengths: [16]usize = .{0} ** 16,
+    captured_bodies: [16][512]u8 = undefined,
 
     pub fn init(allocator: std.mem.Allocator, responses: []const CannedResponse) SequenceMockTransport {
         return .{
             .responses = responses,
             .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl },
+            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
 
@@ -1213,18 +1449,115 @@ pub const SequenceMockTransport = struct {
 
     fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
         const self: *SequenceMockTransport = @alignCast(@fieldParentPtr("transport", transport));
-        _ = request;
-        const idx = @min(self.call_count, self.responses.len - 1);
-        self.call_count += 1;
+        const idx = try self.capture(request, request.body);
+        return self.response(idx);
+    }
+
+    fn openImpl(
+        transport: *HttpTransport,
+        request: *Request,
+        options: OpenOptions,
+    ) !*HttpOperation {
+        const self: *SequenceMockTransport = @alignCast(@fieldParentPtr("transport", transport));
+        if (options.body != null and request.body != null) return error.MultipleRequestBodies;
+        try checkCancelled(options.cancellation);
+        const framing = requestBodyFraming(request, options);
+        var framing_headers = request.headers.iterator();
+        while (framing_headers.next()) |header| {
+            _ = try validateFramingHeader(header.key_ptr.*, header.value_ptr.*, framing);
+        }
+        var body_bytes: ?[]const u8 = request.body;
+        var captured: std.Io.Writer.Allocating = .init(self.allocator);
+        defer captured.deinit();
+        if (options.body) |body| {
+            var buffer: [7]u8 = undefined;
+            if (body.content_length) |length| {
+                var remaining = length;
+                while (remaining > 0) {
+                    try checkCancelled(options.cancellation);
+                    const limit: usize = @intCast(@min(remaining, buffer.len));
+                    const count = try body.reader.readSliceShort(buffer[0..limit]);
+                    if (count == 0) return error.RequestBodyTooShort;
+                    try captured.writer.writeAll(buffer[0..count]);
+                    remaining -= count;
+                }
+                var extra: [1]u8 = undefined;
+                if (try body.reader.readSliceShort(&extra) != 0) return error.RequestBodyTooLong;
+            } else {
+                while (true) {
+                    try checkCancelled(options.cancellation);
+                    const count = try body.reader.readSliceShort(&buffer);
+                    if (count == 0) break;
+                    try captured.writer.writeAll(buffer[0..count]);
+                }
+            }
+            body_bytes = captured.writer.buffered();
+        }
+
+        const idx = try self.capture(request, body_bytes);
+        return BufferedOperation.fromResponse(try self.response(idx));
+    }
+
+    fn response(self: *SequenceMockTransport, idx: usize) !Response {
         const r = self.responses[idx];
         const body_copy = try self.allocator.dupe(u8, r.body);
-        const headers = std.StringHashMap([]const u8).init(self.allocator);
+        errdefer self.allocator.free(body_copy);
+        var headers = std.StringHashMap([]const u8).init(self.allocator);
+        errdefer deinitOwnedHeaders(self.allocator, &headers);
+        var response_headers = ResponseHeaders.init(self.allocator);
+        errdefer response_headers.deinit();
+        for (r.headers) |header| {
+            try response_headers.append(header.name, header.value);
+            const name = try self.allocator.dupe(u8, header.name);
+            errdefer self.allocator.free(name);
+            const value = try self.allocator.dupe(u8, header.value);
+            errdefer self.allocator.free(value);
+            const entry = try headers.getOrPut(name);
+            if (entry.found_existing) {
+                self.allocator.free(name);
+                self.allocator.free(entry.value_ptr.*);
+            } else {
+                entry.key_ptr.* = name;
+            }
+            entry.value_ptr.* = value;
+        }
         return .{
             .status_code = r.status,
             .headers = headers,
             .body = body_copy,
             .allocator = self.allocator,
+            .response_headers = response_headers,
         };
+    }
+
+    fn capture(
+        self: *SequenceMockTransport,
+        request: *const Request,
+        body: ?[]const u8,
+    ) !usize {
+        if (self.responses.len == 0) return error.NoCannedResponses;
+        if (self.call_count >= self.captured_methods.len) return error.TooManyMockRequests;
+        if (request.url.len > self.captured_urls[0].len) return error.MockRequestUrlTooLong;
+        const body_value = body orelse "";
+        if (body_value.len > self.captured_bodies[0].len) return error.MockRequestBodyTooLong;
+
+        const call = self.call_count;
+        self.captured_methods[call] = request.method;
+        self.captured_authorization[call] = request.getHeader("Authorization") != null;
+        @memcpy(self.captured_urls[call][0..request.url.len], request.url);
+        self.captured_url_lengths[call] = request.url.len;
+        @memcpy(self.captured_bodies[call][0..body_value.len], body_value);
+        self.captured_body_lengths[call] = body_value.len;
+        self.call_count += 1;
+        return @min(call, self.responses.len - 1);
+    }
+
+    pub fn capturedUrl(self: *const SequenceMockTransport, index: usize) []const u8 {
+        return self.captured_urls[index][0..self.captured_url_lengths[index]];
+    }
+
+    pub fn capturedBody(self: *const SequenceMockTransport, index: usize) []const u8 {
+        return self.captured_bodies[index][0..self.captured_body_lengths[index]];
     }
 };
 
@@ -1352,6 +1685,118 @@ test "mock streaming transport accepts known and chunked uploads" {
     try std.testing.expectEqual(@as(usize, 1), mock.stream_finish_count);
     try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
     try std.testing.expectEqual(@as(usize, 2), mock.stream_deinit_count);
+}
+
+test "ReplayableBytes rewinds without copying" {
+    var replay = ReplayableBytes.init("replay-body");
+    var body = replay.body();
+    var buffer: [32]u8 = undefined;
+    const first = try body.reader.readSliceShort(&buffer);
+    try std.testing.expectEqualStrings("replay-body", buffer[0..first]);
+    try body.rewind();
+    const second = try body.reader.readSliceShort(&buffer);
+    try std.testing.expectEqualStrings("replay-body", buffer[0..second]);
+}
+
+test "transport follows safe redirects and strips cross-origin authorization" {
+    const allocator = std.testing.allocator;
+    var sequence = SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "https://storage.example/blob" }},
+        },
+        .{ .status = 200, .body = "ok" },
+    });
+    var request = Request.init(allocator, .POST, "https://registry.example/v2/upload");
+    defer request.deinit();
+    try request.setHeader("Authorization", "Bearer registry-token");
+    var replay = ReplayableBytes.init("payload");
+    var operation = try sequence.asTransport().open(&request, .{ .body = replay.body() });
+    defer operation.deinit();
+    try std.testing.expectEqual(@as(u16, 200), operation.status_code);
+    try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
+    try std.testing.expect(sequence.captured_authorization[0]);
+    try std.testing.expect(!sequence.captured_authorization[1]);
+    try std.testing.expectEqual(Method.POST, sequence.captured_methods[1].?);
+    try std.testing.expectEqualStrings("payload", sequence.capturedBody(0));
+    try std.testing.expectEqualStrings("payload", sequence.capturedBody(1));
+    try std.testing.expectEqualStrings("https://storage.example/blob", sequence.capturedUrl(1));
+    try operation.finish();
+
+    var buffered_sequence = SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 308,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "/v2/continued" }},
+        },
+        .{ .status = 200, .body = "buffered-ok" },
+    });
+    var buffered_request = Request.init(allocator, .PUT, "https://registry.example/v2/upload");
+    defer buffered_request.deinit();
+    buffered_request.body = "buffered-payload";
+    try buffered_request.setHeader("Authorization", "Bearer registry-token");
+    var response = try buffered_sequence.asTransport().send(&buffered_request);
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expectEqualStrings("buffered-ok", response.body);
+    try std.testing.expectEqual(@as(usize, 2), buffered_sequence.call_count);
+    try std.testing.expect(buffered_sequence.captured_authorization[1]);
+    try std.testing.expectEqual(Method.PUT, buffered_sequence.captured_methods[1].?);
+    try std.testing.expectEqualStrings("buffered-payload", buffered_sequence.capturedBody(1));
+    try std.testing.expectEqualStrings(
+        "https://registry.example/v2/continued",
+        buffered_sequence.capturedUrl(1),
+    );
+}
+
+test "transport does not replay one-shot bodies and rejects insecure redirects" {
+    const allocator = std.testing.allocator;
+    const redirect_headers = &.{MockTransport.HeaderPair{
+        .name = "Location",
+        .value = "https://storage.example/blob",
+    }};
+    var one_shot_sequence = SequenceMockTransport.init(allocator, &.{
+        .{ .status = 308, .body = "", .headers = redirect_headers },
+        .{ .status = 200, .body = "unexpected" },
+    });
+    var request = Request.init(allocator, .PUT, "https://registry.example/v2/upload");
+    defer request.deinit();
+    var source = std.Io.Reader.fixed("one-shot");
+    var operation = try one_shot_sequence.asTransport().open(&request, .{
+        .body = StreamingRequestBody.knownLength(&source, 8),
+    });
+    defer operation.deinit();
+    try std.testing.expectEqual(@as(u16, 308), operation.status_code);
+    try std.testing.expectEqual(@as(usize, 1), one_shot_sequence.call_count);
+    operation.abort();
+
+    var insecure_sequence = SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "http://storage.example/blob" }},
+        },
+    });
+    var insecure_request = Request.init(allocator, .GET, "https://registry.example/v2/blob");
+    defer insecure_request.deinit();
+    try std.testing.expectError(
+        error.HttpsRequired,
+        insecure_sequence.asTransport().send(&insecure_request),
+    );
+    try std.testing.expectEqual(@as(usize, 1), insecure_sequence.call_count);
+
+    var disabled_sequence = SequenceMockTransport.init(allocator, &.{
+        .{ .status = 307, .body = "", .headers = redirect_headers },
+        .{ .status = 200, .body = "unexpected" },
+    });
+    var disabled_request = Request.init(allocator, .GET, "https://registry.example/v2/blob");
+    defer disabled_request.deinit();
+    disabled_request.redirect_policy = .not_allowed;
+    var disabled_response = try disabled_sequence.asTransport().send(&disabled_request);
+    defer disabled_response.deinit();
+    try std.testing.expectEqual(@as(u16, 307), disabled_response.status_code);
+    try std.testing.expectEqual(@as(usize, 1), disabled_sequence.call_count);
 }
 
 test "mock streaming transport validates upload lengths and failures" {
@@ -1524,17 +1969,18 @@ fn runStdStreamingCase(
     defer allocator.free(url);
 
     var transport = StdHttpTransport.init(allocator, io);
-    defer transport.deinit();
     var request = Request.init(allocator, .POST, url);
     defer request.deinit();
     var source = std.Io.Reader.fixed("streaming upload body");
     var operation = transport.asTransport().open(&request, .{
         .body = .{ .reader = &source, .content_length = content_length },
     }) catch |err| {
+        transport.deinit();
         thread.join();
         if (context.failure) |failure| return failure;
         return err;
     };
+    transport.deinit();
     defer operation.deinit();
     try std.testing.expectEqualStrings("first", operation.getHeader("x-test").?);
     const test_headers = try operation.getHeaderValues(allocator, "X-Test");
@@ -1706,6 +2152,34 @@ test "mock streaming operation releases every allocation failure path" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         mockStreamingAllocationFixture,
+        .{},
+    );
+}
+
+fn redirectAllocationFixture(allocator: std.mem.Allocator) !void {
+    var sequence = SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "https://storage.example/blob" }},
+        },
+        .{ .status = 200, .body = "ok" },
+    });
+    var request = Request.init(allocator, .PUT, "https://registry.example/v2/upload");
+    defer request.deinit();
+    request.body = "body";
+    try request.setHeader("Authorization", "Bearer token");
+    var response = sequence.asTransport().send(&request) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
+        else => |other| return other,
+    };
+    defer response.deinit();
+}
+
+test "redirect handling releases every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        redirectAllocationFixture,
         .{},
     );
 }

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -666,15 +666,26 @@ const BufferedOperation = struct {
 /// synchronization.
 pub const StdHttpTransport = struct {
     allocator: std.mem.Allocator,
-    io: std.Io,
+    /// Configure this client before the first request. On first use its exact
+    /// state is transferred to heap-owned shared storage so operations may
+    /// safely outlive the transport.
     client: std.http.Client,
+    shared_client: ?*SharedHttpClient = null,
     transport: HttpTransport,
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io) StdHttpTransport {
+        return initWithClient(allocator, .{ .allocator = allocator, .io = io });
+    }
+
+    /// Takes ownership of a configured client. The caller must not use or
+    /// deinitialize the supplied client after this call.
+    pub fn initWithClient(
+        allocator: std.mem.Allocator,
+        client: std.http.Client,
+    ) StdHttpTransport {
         return .{
             .allocator = allocator,
-            .io = io,
-            .client = .{ .allocator = allocator, .io = io },
+            .client = client,
             .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
@@ -684,14 +695,34 @@ pub const StdHttpTransport = struct {
     }
 
     pub fn deinit(self: *StdHttpTransport) void {
-        self.client.deinit();
+        if (self.shared_client) |shared| {
+            shared.release();
+            self.shared_client = null;
+        } else {
+            self.client.deinit();
+        }
+    }
+
+    fn sharedClient(self: *StdHttpTransport) !*SharedHttpClient {
+        if (self.shared_client) |shared| return shared;
+        const shared = try self.allocator.create(SharedHttpClient);
+        shared.* = .{
+            .allocator = self.allocator,
+            .client = self.client,
+        };
+        self.shared_client = shared;
+        return shared;
     }
 
     fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
         const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
         const allocator = self.allocator;
 
-        var operation = try StdStreamingOperation.open(self, request, .{}, false);
+        var operation = try StdStreamingOperation.open(
+            try self.sharedClient(),
+            request,
+            .{},
+        );
         defer operation.deinit();
 
         const body = operation.body_reader.allocRemaining(
@@ -726,16 +757,30 @@ pub const StdHttpTransport = struct {
         options: OpenOptions,
     ) !*HttpOperation {
         const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
-        return StdStreamingOperation.open(self, request, options, true);
+        return StdStreamingOperation.open(try self.sharedClient(), request, options);
+    }
+};
+
+const SharedHttpClient = struct {
+    allocator: std.mem.Allocator,
+    client: std.http.Client,
+    references: std.atomic.Value(usize) = std.atomic.Value(usize).init(1),
+
+    fn acquire(self: *SharedHttpClient) void {
+        _ = self.references.fetchAdd(1, .monotonic);
+    }
+
+    fn release(self: *SharedHttpClient) void {
+        if (self.references.fetchSub(1, .acq_rel) != 1) return;
+        self.client.deinit();
+        self.allocator.destroy(self);
     }
 };
 
 const StdStreamingOperation = struct {
     operation: HttpOperation,
     allocator: std.mem.Allocator,
-    client: std.http.Client,
-    client_ptr: *std.http.Client,
-    owns_client: bool,
+    shared_client: *SharedHttpClient,
     request_headers: std.StringHashMap([]const u8),
     extra_headers: []std.http.Header,
     redirect_buffer: []u8,
@@ -750,10 +795,9 @@ const StdStreamingOperation = struct {
     decompress: std.http.Decompress,
 
     fn open(
-        transport: *StdHttpTransport,
+        shared_client: *SharedHttpClient,
         request: *Request,
         options: OpenOptions,
-        owns_client: bool,
     ) !*HttpOperation {
         if (options.body != null and request.body != null) {
             return error.MultipleRequestBodies;
@@ -762,17 +806,13 @@ const StdStreamingOperation = struct {
             if (token.isCancelled()) return error.OperationCancelled;
         }
 
-        const allocator = transport.allocator;
+        const allocator = shared_client.allocator;
         const self = try allocator.create(StdStreamingOperation);
+        shared_client.acquire();
         self.* = .{
             .operation = undefined,
             .allocator = allocator,
-            .client = if (owns_client)
-                .{ .allocator = allocator, .io = transport.io }
-            else
-                undefined,
-            .client_ptr = undefined,
-            .owns_client = owns_client,
+            .shared_client = shared_client,
             .request_headers = std.StringHashMap([]const u8).init(allocator),
             .extra_headers = &.{},
             .redirect_buffer = &.{},
@@ -786,7 +826,6 @@ const StdStreamingOperation = struct {
             .upload_write_buffer = undefined,
             .decompress = undefined,
         };
-        self.client_ptr = if (owns_client) &self.client else &transport.client;
         errdefer {
             self.releaseRequest(true);
             self.cleanupStorage();
@@ -798,7 +837,7 @@ const StdStreamingOperation = struct {
         self.redirect_buffer = try allocator.alloc(u8, 8 * 1024);
 
         const uri = try std.Uri.parse(request.url);
-        self.request = try self.client_ptr.request(request.method.toStd(), uri, .{
+        self.request = try self.shared_client.client.request(request.method.toStd(), uri, .{
             .extra_headers = self.extra_headers,
             .redirect_behavior = .unhandled,
         });
@@ -974,7 +1013,7 @@ const StdStreamingOperation = struct {
         if (self.redirect_buffer.len > 0) self.allocator.free(self.redirect_buffer);
         if (self.extra_headers.len > 0) self.allocator.free(self.extra_headers);
         deinitOwnedHeaders(self.allocator, &self.request_headers);
-        if (self.owns_client) self.client.deinit();
+        self.shared_client.release();
     }
 };
 
@@ -1904,7 +1943,7 @@ test "buffered transport adapts to response streaming" {
     try operation.finish();
 }
 
-test "standard transport streams known and chunked uploads with decompression" {
+test "standard transport preserves configured client for streaming uploads and decompression" {
     const cases = [_]struct {
         content_length: ?u64,
         encoding: []const u8,
@@ -1968,7 +2007,10 @@ fn runStdStreamingCase(
     );
     defer allocator.free(url);
 
-    var transport = StdHttpTransport.init(allocator, io);
+    const configured_read_buffer_size = 12 * 1024;
+    var configured_client = std.http.Client{ .allocator = allocator, .io = io };
+    configured_client.read_buffer_size = configured_read_buffer_size;
+    var transport = StdHttpTransport.initWithClient(allocator, configured_client);
     var request = Request.init(allocator, .POST, url);
     defer request.deinit();
     var source = std.Io.Reader.fixed("streaming upload body");
@@ -1980,6 +2022,13 @@ fn runStdStreamingCase(
         if (context.failure) |failure| return failure;
         return err;
     };
+    const operation_state: *StdStreamingOperation =
+        @alignCast(@fieldParentPtr("operation", operation));
+    try std.testing.expect(operation_state.shared_client == transport.shared_client.?);
+    try std.testing.expectEqual(
+        @as(usize, configured_read_buffer_size),
+        operation_state.shared_client.client.read_buffer_size,
+    );
     transport.deinit();
     defer operation.deinit();
     try std.testing.expectEqualStrings("first", operation.getHeader("x-test").?);

--- a/sdk/core/url.zig
+++ b/sdk/core/url.zig
@@ -126,6 +126,34 @@ pub fn resolveAndValidateUrl(
     return resolved;
 }
 
+/// Compare URL origins using case-insensitive schemes and hosts plus effective
+/// ports. Both URLs must be absolute and must not contain user information.
+pub fn sameOrigin(left_raw: []const u8, right_raw: []const u8) !bool {
+    const left = std.Uri.parse(left_raw) catch return error.InvalidUrl;
+    const right = std.Uri.parse(right_raw) catch return error.InvalidUrl;
+    if (left.host == null or right.host == null or
+        left.user != null or left.password != null or
+        right.user != null or right.password != null)
+    {
+        return error.InvalidUrl;
+    }
+
+    var left_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    var right_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const left_host = left.getHost(&left_buffer) catch return error.InvalidUrl;
+    const right_host = right.getHost(&right_buffer) catch return error.InvalidUrl;
+    return std.ascii.eqlIgnoreCase(left.scheme, right.scheme) and
+        std.ascii.eqlIgnoreCase(left_host.bytes, right_host.bytes) and
+        effectivePort(left) == effectivePort(right);
+}
+
+fn effectivePort(uri: std.Uri) ?u16 {
+    if (uri.port) |port| return port;
+    if (std.ascii.eqlIgnoreCase(uri.scheme, "https")) return 443;
+    if (std.ascii.eqlIgnoreCase(uri.scheme, "http")) return 80;
+    return null;
+}
+
 const EncodeMode = enum {
     segment,
     repository,
@@ -344,6 +372,21 @@ test "validate HTTPS URL expected hosts" {
         error.InvalidUrl,
         validateHttpsUrl("https://user@registry.example/v2/", &expected),
     );
+}
+
+test "sameOrigin compares effective ports and host case" {
+    try std.testing.expect(try sameOrigin(
+        "https://REGISTRY.example/v2/",
+        "https://registry.example:443/blobs/data",
+    ));
+    try std.testing.expect(!(try sameOrigin(
+        "https://registry.example/v2/",
+        "https://storage.example/blobs/data",
+    )));
+    try std.testing.expect(!(try sameOrigin(
+        "https://registry.example/v2/",
+        "https://registry.example:444/blobs/data",
+    )));
 }
 
 test "percentDecode round-trip" {


### PR DESCRIPTION
Implements bounded-memory streaming request/response operations, replay-aware retries, cancellation-safe redirects, configured-client preservation, and redirect credential protections.

Closes #81