### PR TITLE
rest/container_registry: generate complete protocol package

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,6 +28,15 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    _ = b.addModule("azure_rest_container_registry", .{
+        .root_source_file = b.path("rest/container_registry/src/root.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "azure_core", .module = core_mod },
+            .{ .name = "serde", .module = serde_mod },
+        },
+    });
+
     const storage_common_mod = b.addModule("azure_storage_common", .{
         .root_source_file = b.path("sdk/storage/common/root.zig"),
         .target = target,
@@ -300,6 +309,19 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_storage_common_tests.step);
     test_step.dependOn(&run_kv_secrets_tests.step);
     test_step.dependOn(&run_tables_tests.step);
+
+    const container_registry_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("rest/container_registry/src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = core_mod },
+                .{ .name = "serde", .module = serde_mod },
+            },
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(container_registry_tests).step);
 
     // Service SDK tests — core + identity deps
     const service_test_sources_ci = [_][]const u8{

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -39,7 +39,7 @@ component into a single wasm executable.
  └──────────────────────────────────────────┘
       │
       ▼
- git push origin rest/<package_name>        ← orphan branch
+ git push origin rest/<service>             ← orphan branch
 ```
 
 ## Layout
@@ -52,7 +52,7 @@ component into a single wasm executable.
 | `cli/`                            | Zig WASI emitter — `codegen-cli.wasm`, composed with `tcgc.wasm` and driven by `cli/scripts/run.sh`. |
 | `tspconfigs/`                     | Zig tool that manages `tspconfigs.yaml` (`zig build tspconfigs-update` / `-resolve`). |
 | `scripts/sync.sh`                 | Resyncs `rest/<pkg>/` from the canonical spec; overwrites only `src/models.zig` by default. |
-| `fixtures/`                       | Small JSON code-model fixtures used by emitter tests.  |
+| `fixtures/`                       | Checked-in code models and deterministic package generators used by emitter tests. |
 
 `fixtures/container_registry.json` is the checked-in wire contract for
 Container Registry API `2021-07-01`. Regenerate it from the canonical
@@ -64,18 +64,31 @@ AZURE_REST_API_SPECS=/path/to/azure-rest-api-specs \
   npm run fixture:container-registry
 ```
 
+Regenerate the tracked, entirely generator-owned ACR protocol package
+from that fixture with:
+
+```bash
+cd codegen/cli
+zig build generate-container-registry-package
+```
+
+The step replaces `rest/container_registry` and emits the package/module
+name `azure_rest_container_registry`, including its generated contract
+tests. Run it a second time and require an empty `git diff` when checking
+generator determinism.
+
 ## Branch model
 
-Each generated package lives on its own **orphan branch** named
-`rest/<package_name>`:
+Each generated package can be published from its own **orphan branch** named
+`rest/<service>`:
 
 ```
-rest/<package_name>
+rest/<service>
 ```
 
-- `<package_name>` is the snake_case Zig module name, e.g.
-  `rest/keyvault_secrets`, `rest/arm_avs` (see the `zig:` field in
-  `tspconfigs.yaml`).
+- New generated packages use the module name `azure_rest_<service>`.
+  Existing packages such as `keyvault_secrets` and `arm_avs` retain
+  their pre-convention names until migrated separately.
 - The orphan branch references `azure_core` (and friends) from `main`
   through a pinned git URL+hash in `build.zig.zon`.
 
@@ -123,7 +136,8 @@ cd ../../..
 codegen/cli/scripts/run.sh \
     ../azure-rest-api-specs/specification/keyvault/data-plane/Secrets \
     .tsp-generated/client/keyvault_secrets \
-    --package-name keyvault_secrets --display-name keyvault-secrets
+    --package-name keyvault_secrets --display-name keyvault-secrets \
+    --azure-sdk-path ../../..
 ```
 
 ## How to resync a tracked package
@@ -150,6 +164,12 @@ when onboarding a brand-new package.
 > `keyvault-secrets`) still work, but larger ARM specs OOM during
 > TypeSpec compilation. Override the engine location with
 > `STARLINGMONKEY_ENGINE=/path/to/wasm npm run build`.
+
+`rest/container_registry` is intentionally different: every package and
+source file is owned by
+`fixtures/generate_container_registry_package.zig`. Use the dedicated
+`generate-container-registry-package` step above rather than `sync.sh`;
+do not patch its generated files manually.
 
 ## References
 

--- a/codegen/cli/build.zig
+++ b/codegen/cli/build.zig
@@ -87,6 +87,55 @@ pub fn build(b: *std.Build) void {
     const generated_fixture_dir =
         generate_fixture.addOutputDirectoryArg("container-registry-package");
 
+    const generate_container_registry = b.addRunArtifact(fixture_generator);
+    generate_container_registry.setCwd(b.path("."));
+    generate_container_registry.has_side_effects = true;
+    generate_container_registry.addArg(
+        b.option(
+            []const u8,
+            "container-registry-output",
+            "Container Registry package output directory",
+        ) orelse "../../rest/container_registry",
+    );
+    const azure_core_commit = b.option(
+        []const u8,
+        "azure-core-commit",
+        "azure-sdk-for-zig commit for an independently consumable package",
+    );
+    const azure_core_hash = b.option(
+        []const u8,
+        "azure-core-hash",
+        "Zig package hash for -Dazure-core-commit",
+    );
+    if ((azure_core_commit == null) != (azure_core_hash == null)) {
+        std.debug.panic(
+            "-Dazure-core-commit and -Dazure-core-hash must be supplied together",
+            .{},
+        );
+    }
+    if (azure_core_commit) |commit| {
+        generate_container_registry.addArgs(&.{
+            "--azure-core-commit",
+            commit,
+            "--azure-core-hash",
+            azure_core_hash.?,
+        });
+    } else {
+        generate_container_registry.addArgs(&.{
+            "--azure-sdk-path",
+            b.option(
+                []const u8,
+                "azure-sdk-path",
+                "Local azure_sdk dependency path in generated build.zig.zon",
+            ) orelse "../..",
+        });
+    }
+    const generate_container_registry_step = b.step(
+        "generate-container-registry-package",
+        "Regenerate rest/container_registry from the checked-in TypeSpec fixture",
+    );
+    generate_container_registry_step.dependOn(&generate_container_registry.step);
+
     const azure_sdk_dep = b.dependency("azure_sdk", .{
         .target = host_target,
         .optimize = optimize,

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -43,6 +43,13 @@ pub const EmitOptions = struct {
     /// build.zig.zon references `azure_core` by a local `path =` entry
     /// pointing relative to the worktree root.
     azure_core_commit: ?[]const u8 = null,
+    /// Zig package hash for `azure_core_commit`. Required whenever a
+    /// commit is supplied so release output is complete and reproducible.
+    azure_core_hash: ?[]const u8 = null,
+    /// Local path used for the `azure_sdk` dependency when
+    /// `azure_core_commit` is null. Defaults to the sibling-worktree
+    /// layout used by orphan package development.
+    azure_sdk_path: []const u8 = "../azure-sdk-for-zig",
     /// Run the in-process formatter (`std.zig.Ast.parse` +
     /// `renderAlloc`) on every `.zig` and `.zon` file before writing
     /// it out. Set to `false` to skip — useful when debugging emitter
@@ -90,7 +97,14 @@ pub fn emit(
         try writeFile(allocator, io, out_dir, "build.zig", s, opts.run_zig_fmt);
     }
     {
-        const s = try renderBuildZigZon(allocator, pkg_name, model.package_version, opts.azure_core_commit);
+        const s = try renderBuildZigZon(
+            allocator,
+            pkg_name,
+            model.package_version,
+            opts.azure_core_commit,
+            opts.azure_core_hash,
+            opts.azure_sdk_path,
+        );
         defer allocator.free(s);
         try writeFile(allocator, io, out_dir, "build.zig.zon", s, opts.run_zig_fmt);
     }
@@ -1944,25 +1958,24 @@ fn renderBuildZigZon(
     pkg_name: []const u8,
     pkg_version: []const u8,
     azure_core_commit: ?[]const u8,
+    azure_core_hash: ?[]const u8,
+    azure_sdk_path: []const u8,
 ) ![]u8 {
-    const azure_sdk_entry = if (azure_core_commit) |sha|
-        try std.fmt.allocPrint(allocator,
+    const azure_sdk_entry = if (azure_core_commit) |sha| blk: {
+        const hash = azure_core_hash orelse return error.MissingAzureCoreHash;
+        break :blk try std.fmt.allocPrint(allocator,
             \\        .azure_sdk = .{{
             \\            .url = "git+https://github.com/cataggar/azure-sdk-for-zig#{s}",
-            \\            // Hash is filled in by `zig fetch`; for now the orphan
-            \\            // branch publishes without a pinned hash and the caller
-            \\            // resolves it before commit.
+            \\            .hash = "{s}",
             \\        }},
             \\
-        , .{sha})
-    else
-        try allocator.dupe(u8,
-            \\        .azure_sdk = .{
-            \\            // During local development, point at the main worktree.
-            \\            .path = "../azure-sdk-for-zig",
-            \\        },
-            \\
-        );
+        , .{ sha, hash });
+    } else try std.fmt.allocPrint(allocator,
+        \\        .azure_sdk = .{{
+        \\            .path = "{s}",
+        \\        }},
+        \\
+    , .{azure_sdk_path});
     defer allocator.free(azure_sdk_entry);
 
     const serde_entry =
@@ -2022,7 +2035,7 @@ fn renderReadme(allocator: std.mem.Allocator, display_name: []const u8, model: c
         \\
         \\This package is produced by `codegen` from the TypeSpec
         \\specification in [`Azure/azure-rest-api-specs`](https://github.com/Azure/azure-rest-api-specs).
-        \\Do not edit the contents of `src/` by hand — they will be
+        \\Do not edit generated package files by hand — they will be
         \\overwritten on the next regeneration.
         \\
         \\## Clients
@@ -2031,7 +2044,6 @@ fn renderReadme(allocator: std.mem.Allocator, display_name: []const u8, model: c
     for (model.clients) |c| {
         try w.print("- `{s}`\n", .{c.name});
     }
-    try w.writeAll("\n");
     return try aw.toOwnedSlice();
 }
 
@@ -2095,10 +2107,78 @@ test "display_name surfaces in root.zig + README, not build.zig" {
     try testing.expect(std.mem.indexOf(u8, build_zig, "\"arm_avs\"") != null);
     try testing.expect(std.mem.indexOf(u8, build_zig, "arm-avs") == null);
 
-    const zon = try renderBuildZigZon(alloc, "arm_avs", "0.1.0", null);
+    const zon = try renderBuildZigZon(
+        alloc,
+        "arm_avs",
+        "0.1.0",
+        null,
+        null,
+        "../azure-sdk-for-zig",
+    );
     defer alloc.free(zon);
     try testing.expect(std.mem.indexOf(u8, zon, ".name = .arm_avs") != null);
     try testing.expect(std.mem.indexOf(u8, zon, "arm-avs") == null);
+}
+
+test "REST package metadata supports local and pinned azure_sdk dependencies" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const build_zig = try renderBuildZig(alloc, "azure_rest_container_registry");
+    defer alloc.free(build_zig);
+    try testing.expect(std.mem.indexOf(
+        u8,
+        build_zig,
+        "b.addModule(\"azure_rest_container_registry\"",
+    ) != null);
+
+    const local_zon = try renderBuildZigZon(
+        alloc,
+        "azure_rest_container_registry",
+        "0.1.0",
+        null,
+        null,
+        "../..",
+    );
+    defer alloc.free(local_zon);
+    try testing.expect(std.mem.indexOf(
+        u8,
+        local_zon,
+        ".name = .azure_rest_container_registry",
+    ) != null);
+    try testing.expect(std.mem.indexOf(u8, local_zon, ".path = \"../..\"") != null);
+
+    const pinned_zon = try renderBuildZigZon(
+        alloc,
+        "azure_rest_container_registry",
+        "0.1.0",
+        "0123456789abcdef",
+        "azure_sdk-0.1.0-example",
+        "../..",
+    );
+    defer alloc.free(pinned_zon);
+    try testing.expect(std.mem.indexOf(
+        u8,
+        pinned_zon,
+        "#0123456789abcdef",
+    ) != null);
+    try testing.expect(std.mem.indexOf(
+        u8,
+        pinned_zon,
+        ".hash = \"azure_sdk-0.1.0-example\"",
+    ) != null);
+
+    try testing.expectError(
+        error.MissingAzureCoreHash,
+        renderBuildZigZon(
+            alloc,
+            "azure_rest_container_registry",
+            "0.1.0",
+            "0123456789abcdef",
+            null,
+            "../..",
+        ),
+    );
 }
 
 test "bodyless success status alternatives preserve the void API" {

--- a/codegen/cli/src/main.zig
+++ b/codegen/cli/src/main.zig
@@ -16,7 +16,8 @@
 //! Architecture summary:
 //!   * `main` parses argv (positional: spec-dir, out-dir; flag:
 //!     --package-name, --package-version, --display-name,
-//!     --azure-core-commit, --no-fmt).
+//!     --azure-core-commit, --azure-core-hash, --azure-sdk-path,
+//!     --no-fmt).
 //!   * Calls `tcgc.compile(/spec, emitter-options-json)` via the
 //!     hand-rolled canonical-ABI binding in `tcgc_import.zig`.
 //!   * Parses the JSON code model via `codemodel.zig` (std.json).
@@ -45,7 +46,8 @@ const usage =
     \\  codegen-cli <spec-dir> <out-dir>
     \\              [--package-name <name>] [--package-version <ver>]
     \\              [--display-name <label>]
-    \\              [--azure-core-commit <sha>] [--no-fmt]
+    \\              [--azure-core-commit <sha> --azure-core-hash <hash>]
+    \\              [--azure-sdk-path <path>] [--no-fmt]
     \\
 ;
 
@@ -63,6 +65,8 @@ pub fn main(init: std.process.Init) !u8 {
     var package_version: ?[]const u8 = null;
     var display_name: ?[]const u8 = null;
     var azure_core_commit: ?[]const u8 = null;
+    var azure_core_hash: ?[]const u8 = null;
+    var azure_sdk_path: ?[]const u8 = null;
     var run_fmt = true;
 
     while (it.next()) |a| {
@@ -74,6 +78,10 @@ pub fn main(init: std.process.Init) !u8 {
             display_name = it.next() orelse return die("--display-name requires a value");
         } else if (std.mem.eql(u8, a, "--azure-core-commit")) {
             azure_core_commit = it.next() orelse return die("--azure-core-commit requires a value");
+        } else if (std.mem.eql(u8, a, "--azure-core-hash")) {
+            azure_core_hash = it.next() orelse return die("--azure-core-hash requires a value");
+        } else if (std.mem.eql(u8, a, "--azure-sdk-path")) {
+            azure_sdk_path = it.next() orelse return die("--azure-sdk-path requires a value");
         } else if (std.mem.eql(u8, a, "--no-fmt")) {
             run_fmt = false;
         } else if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
@@ -94,6 +102,12 @@ pub fn main(init: std.process.Init) !u8 {
 
     const sd = spec_dir orelse return die("missing positional: <spec-dir>");
     const od = out_dir orelse return die("missing positional: <out-dir>");
+    if ((azure_core_commit == null) != (azure_core_hash == null)) {
+        return die("--azure-core-commit and --azure-core-hash must be supplied together");
+    }
+    if (azure_core_commit != null and azure_sdk_path != null) {
+        return die("--azure-sdk-path cannot be combined with --azure-core-commit");
+    }
 
     const sd_owned = try allocator.dupe(u8, sd);
     defer allocator.free(sd_owned);
@@ -133,6 +147,14 @@ pub fn main(init: std.process.Init) !u8 {
     var commit_buf: ?[]u8 = null;
     defer if (commit_buf) |b| allocator.free(b);
     if (azure_core_commit) |c| commit_buf = try allocator.dupe(u8, c);
+
+    var hash_buf: ?[]u8 = null;
+    defer if (hash_buf) |b| allocator.free(b);
+    if (azure_core_hash) |h| hash_buf = try allocator.dupe(u8, h);
+
+    var sdk_path_buf: ?[]u8 = null;
+    defer if (sdk_path_buf) |b| allocator.free(b);
+    if (azure_sdk_path) |p| sdk_path_buf = try allocator.dupe(u8, p);
 
     // ── Build emitter-options JSON ────────────────────────────────────
     //
@@ -217,6 +239,8 @@ pub fn main(init: std.process.Init) !u8 {
         .package_name = pkg_buf,
         .display_name = display_buf,
         .azure_core_commit = commit_buf,
+        .azure_core_hash = hash_buf,
+        .azure_sdk_path = sdk_path_buf orelse "../azure-sdk-for-zig",
         .run_zig_fmt = run_fmt,
     });
 

--- a/codegen/fixtures/container_registry_test.zig
+++ b/codegen/fixtures/container_registry_test.zig
@@ -53,6 +53,172 @@ fn expectMethodSet(
     }
 }
 
+fn renderWireContract(
+    allocator: std.mem.Allocator,
+    model: cm.CodeModel,
+) ![]u8 {
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const writer = &output.writer;
+
+    for (model.clients) |client| {
+        for (client.methods) |method| {
+            try writer.print(
+                "{s}|{s}|{s}|{s}|P[",
+                .{
+                    method.name,
+                    method.http_method,
+                    method.path,
+                    method.uri_template orelse "-",
+                },
+            );
+            try writeWireParameters(writer, method.path_parameters, true);
+            try writer.writeAll("]|Q[");
+            try writeWireParameters(writer, method.query_parameters, false);
+            try writer.writeAll("]|H[");
+            try writeWireParameters(writer, method.header_parameters, false);
+            try writer.writeAll("]|B[");
+            if (method.body_parameter) |body| {
+                try writer.print(
+                    "{s}:{s}:",
+                    .{ body.serialization_kind, body.content_type },
+                );
+                try writeTypeRef(writer, body.body_type);
+            } else {
+                try writer.writeByte('-');
+            }
+            try writer.writeAll("]|R[");
+            for (method.responses, 0..) |response, response_index| {
+                if (response_index != 0) try writer.writeByte(';');
+                for (response.status_codes, 0..) |status, status_index| {
+                    if (status_index != 0) try writer.writeByte(',');
+                    switch (status) {
+                        .integer => |value| try writer.print("{d}", .{value}),
+                        .string => |value| try writer.writeAll(value),
+                        else => try writer.writeByte('?'),
+                    }
+                }
+                try writer.print(":{s}:", .{response.body_kind});
+                try writeTypeRef(writer, response.response_type);
+                try writer.writeByte(':');
+                if (response.headers.len == 0) {
+                    try writer.writeByte('-');
+                } else {
+                    for (response.headers, 0..) |header, header_index| {
+                        if (header_index != 0) try writer.writeByte(',');
+                        try writer.print(
+                            "{s}:{s}:",
+                            .{
+                                header.wire_name,
+                                if (header.optional) "optional" else "required",
+                            },
+                        );
+                        try writeTypeRef(writer, header.header_type);
+                    }
+                }
+            }
+            try writer.writeAll("]\n");
+        }
+    }
+
+    return try output.toOwnedSlice();
+}
+
+fn writeWireParameters(
+    writer: *std.Io.Writer,
+    parameters: []const cm.WireParameter,
+    include_path_metadata: bool,
+) !void {
+    if (parameters.len == 0) {
+        try writer.writeByte('-');
+        return;
+    }
+    for (parameters, 0..) |parameter, index| {
+        if (index != 0) try writer.writeByte(',');
+        const source_value = parameter.source.name orelse
+            parameter.source.value orelse "-";
+        try writer.print(
+            "{s}={s}:{s}:{s}",
+            .{
+                parameter.wire_name,
+                parameter.source.kind,
+                source_value,
+                if (parameter.optional) "optional" else "required",
+            },
+        );
+        if (include_path_metadata) {
+            try writer.print(
+                ":{s}:{s}",
+                .{
+                    parameter.path_encoding orelse "-",
+                    if (parameter.allow_reserved orelse false)
+                        "reserved"
+                    else
+                        "encoded",
+                },
+            );
+        }
+    }
+}
+
+fn writeTypeRef(writer: *std.Io.Writer, type_ref: ?cm.TypeRef) !void {
+    const value = type_ref orelse {
+        try writer.writeByte('-');
+        return;
+    };
+    try writer.writeAll(value.kind);
+    switch (value.value) {
+        .string => |name| try writer.print(":{s}", .{name}),
+        else => {},
+    }
+}
+
+test "Container Registry fixture pins every operation wire signature" {
+    const testing = std.testing;
+    var parsed = try std.json.parseFromSlice(
+        cm.CodeModel,
+        testing.allocator,
+        @embedFile("container_registry.json"),
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
+
+    const actual = try renderWireContract(testing.allocator, parsed.value);
+    defer testing.allocator.free(actual);
+    const expected =
+        \\check_docker_v2_support|get|/v2/|/v2/{?api%2Dversion}|P[-]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[200:none:-:-]
+        \\get_manifest|get|/v2/{name}/manifests/{reference}|/v2/{name}/manifests/{reference}{?api%2Dversion}|P[name=user:name:required:repository:encoded,reference=user:reference:required:segment:encoded]|Q[api-version=client:api_version:required]|H[accept=user:accept:optional]|B[-]|R[200:json:Model:ManifestWrapper:-]
+        \\create_manifest|put|/v2/{name}/manifests/{reference}|/v2/{name}/manifests/{reference}{?api%2Dversion}|P[name=user:name:required:repository:encoded,reference=user:reference:required:segment:encoded]|Q[api-version=client:api_version:required]|H[Content-Type=constant:application/vnd.docker.distribution.manifest.v2+json:required]|B[json:application/vnd.docker.distribution.manifest.v2+json:Model:Manifest]|R[201:none:-:Location:required:Scalar:string,Content-Length:required:Scalar:int64,Docker-Content-Digest:required:Scalar:string]
+        \\delete_manifest|delete|/v2/{name}/manifests/{reference}|/v2/{name}/manifests/{reference}{?api%2Dversion}|P[name=user:name:required:repository:encoded,reference=user:reference:required:segment:encoded]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[202:none:-:-;404:none:-:-]
+        \\get_repositories|get|/acr/v1/_catalog|/acr/v1/_catalog{?api%2Dversion,last,n}|P[-]|Q[api-version=client:api_version:required,last=user:last:optional,n=user:n:optional]|H[Accept=constant:application/json:required]|B[-]|R[200:json:Model:Repositories:Link:optional:Scalar:string]
+        \\get_properties|get|/acr/v1/{name}|/acr/v1/{name}{?api%2Dversion}|P[name=user:name:required:repository:encoded]|Q[api-version=client:api_version:required]|H[Accept=constant:application/json:required]|B[-]|R[200:json:Model:ContainerRepositoryProperties:-]
+        \\delete_repository|delete|/acr/v1/{name}|/acr/v1/{name}{?api%2Dversion}|P[name=user:name:required:repository:encoded]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[202:none:-:-;404:none:-:-]
+        \\update_properties|patch|/acr/v1/{name}|/acr/v1/{name}{?api%2Dversion}|P[name=user:name:required:repository:encoded]|Q[api-version=client:api_version:required]|H[Content-Type=constant:application/json:optional,Accept=constant:application/json:required]|B[json:application/json:Model:RepositoryChangeableAttributes]|R[200:json:Model:ContainerRepositoryProperties:-]
+        \\get_tags|get|/acr/v1/{name}/_tags|/acr/v1/{name}/_tags{?api%2Dversion,last,n,orderby,digest}|P[name=user:name:required:repository:encoded]|Q[api-version=client:api_version:required,last=user:last:optional,n=user:n:optional,orderby=user:orderby:optional,digest=user:digest:optional]|H[Accept=constant:application/json:required]|B[-]|R[200:json:Model:TagList:Link:optional:Scalar:string]
+        \\get_tag_properties|get|/acr/v1/{name}/_tags/{reference}|/acr/v1/{name}/_tags/{reference}{?api%2Dversion}|P[name=user:name:required:repository:encoded,reference=user:reference:required:segment:encoded]|Q[api-version=client:api_version:required]|H[Accept=constant:application/json:required]|B[-]|R[200:json:Model:ArtifactTagProperties:-]
+        \\update_tag_attributes|patch|/acr/v1/{name}/_tags/{reference}|/acr/v1/{name}/_tags/{reference}{?api%2Dversion}|P[name=user:name:required:repository:encoded,reference=user:reference:required:segment:encoded]|Q[api-version=client:api_version:required]|H[Content-Type=constant:application/json:optional,Accept=constant:application/json:required]|B[json:application/json:Model:TagChangeableAttributes]|R[200:json:Model:ArtifactTagProperties:-]
+        \\delete_tag|delete|/acr/v1/{name}/_tags/{reference}|/acr/v1/{name}/_tags/{reference}{?api%2Dversion}|P[name=user:name:required:repository:encoded,reference=user:reference:required:segment:encoded]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[202:none:-:-;404:none:-:-]
+        \\get_manifests|get|/acr/v1/{name}/_manifests|/acr/v1/{name}/_manifests{?api%2Dversion,last,n,orderby}|P[name=user:name:required:repository:encoded]|Q[api-version=client:api_version:required,last=user:last:optional,n=user:n:optional,orderby=user:orderby:optional]|H[Accept=constant:application/json:required]|B[-]|R[200:json:Model:AcrManifests:Link:optional:Scalar:string]
+        \\get_manifest_properties|get|/acr/v1/{name}/_manifests/{digest}|/acr/v1/{name}/_manifests/{digest}{?api%2Dversion}|P[name=user:name:required:repository:encoded,digest=user:digest:required:segment:encoded]|Q[api-version=client:api_version:required]|H[Accept=constant:application/json:required]|B[-]|R[200:json:Model:ArtifactManifestProperties:-]
+        \\update_manifest_properties|patch|/acr/v1/{name}/_manifests/{digest}|/acr/v1/{name}/_manifests/{digest}{?api%2Dversion}|P[name=user:name:required:repository:encoded,digest=user:digest:required:segment:encoded]|Q[api-version=client:api_version:required]|H[Content-Type=constant:application/json:optional,Accept=constant:application/json:required]|B[json:application/json:Model:ManifestChangeableAttributes]|R[200:json:Model:ArtifactManifestProperties:-]
+        \\get_blob|get|/v2/{name}/blobs/{digest}|/v2/{name}/blobs/{digest}{?api%2Dversion}|P[name=user:name:required:repository:encoded,digest=user:digest:required:segment:encoded]|Q[api-version=client:api_version:required]|H[Accept=constant:application/octet-stream:required]|B[-]|R[200:raw:Scalar:bytes:Content-Length:required:Scalar:int64,Docker-Content-Digest:required:Scalar:string;307:none:-:Location:required:Scalar:string]
+        \\check_blob_exists|head|/v2/{name}/blobs/{digest}|/v2/{name}/blobs/{digest}{?api%2Dversion}|P[name=user:name:required:repository:encoded,digest=user:digest:required:segment:encoded]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[200:none:-:Content-Length:required:Scalar:int64,Docker-Content-Digest:required:Scalar:string;307:none:-:Location:required:Scalar:string]
+        \\delete_blob|delete|/v2/{name}/blobs/{digest}|/v2/{name}/blobs/{digest}{?api%2Dversion}|P[name=user:name:required:repository:encoded,digest=user:digest:required:segment:encoded]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[202:none:-:Docker-Content-Digest:required:Scalar:string]
+        \\mount_blob|post|/v2/{name}/blobs/uploads/|/v2/{name}/blobs/uploads/{?api%2Dversion,from,mount}|P[name=user:name:required:repository:encoded]|Q[api-version=client:api_version:required,from=user:from:required,mount=user:mount:required]|H[-]|B[-]|R[201:none:-:Location:required:Scalar:string,Docker-Upload-UUID:required:Scalar:string,Docker-Content-Digest:required:Scalar:string]
+        \\get_upload_status|get|/{nextBlobUuidLink}|/{+nextBlobUuidLink}{?api%2Dversion}|P[nextBlobUuidLink=user:next_blob_uuid_link:required:greedy:reserved]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[204:none:-:Range:required:Scalar:string,Docker-Upload-UUID:required:Scalar:string]
+        \\upload_chunk|patch|/{nextBlobUuidLink}|/{+nextBlobUuidLink}{?api%2Dversion}|P[nextBlobUuidLink=user:next_blob_uuid_link:required:greedy:reserved]|Q[api-version=client:api_version:required]|H[Content-Type=constant:application/octet-stream:required]|B[raw:application/octet-stream:Scalar:bytes]|R[202:none:-:Location:required:Scalar:string,Range:required:Scalar:string,Docker-Upload-UUID:required:Scalar:string]
+        \\complete_upload|put|/{nextBlobUuidLink}|/{+nextBlobUuidLink}{?api%2Dversion,digest}|P[nextBlobUuidLink=user:next_blob_uuid_link:required:greedy:reserved]|Q[api-version=client:api_version:required,digest=user:digest:required]|H[Content-Type=constant:application/octet-stream:optional]|B[raw:application/octet-stream:Scalar:bytes]|R[201:none:-:Location:required:Scalar:string,Range:required:Scalar:string,Docker-Content-Digest:required:Scalar:string]
+        \\cancel_upload|delete|/{nextBlobUuidLink}|/{+nextBlobUuidLink}{?api%2Dversion}|P[nextBlobUuidLink=user:next_blob_uuid_link:required:greedy:reserved]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[204:none:-:-]
+        \\start_upload|post|/v2/{name}/blobs/uploads/|/v2/{name}/blobs/uploads/{?api%2Dversion}|P[name=user:name:required:repository:encoded]|Q[api-version=client:api_version:required]|H[-]|B[-]|R[202:none:-:Location:required:Scalar:string,Range:required:Scalar:string,Docker-Upload-UUID:required:Scalar:string]
+        \\get_chunk|get|/v2/{name}/blobs/{digest}|/v2/{name}/blobs/{digest}{?api%2Dversion}|P[name=user:name:required:repository:encoded,digest=user:digest:required:segment:encoded]|Q[api-version=client:api_version:required]|H[range=user:range:required,Accept=constant:application/octet-stream:required]|B[-]|R[206:raw:Scalar:bytes:Content-Length:required:Scalar:int64,Content-Range:required:Scalar:string]
+        \\check_chunk_exists|head|/v2/{name}/blobs/{digest}|/v2/{name}/blobs/{digest}{?api%2Dversion}|P[name=user:name:required:repository:encoded,digest=user:digest:required:segment:encoded]|Q[api-version=client:api_version:required]|H[range=user:range:required]|B[-]|R[200:none:-:Content-Length:required:Scalar:int64,Content-Range:required:Scalar:string]
+        \\exchange_aad_access_token_for_acr_refresh_token|post|/oauth2/exchange|/oauth2/exchange|P[-]|Q[-]|H[content-type=constant:multipart/form-data:required,Accept=constant:application/json:required]|B[multipart:multipart/form-data:Model:MultipartBodyParameter]|R[200:json:Model:AcrRefreshToken:-]
+        \\exchange_acr_refresh_token_for_acr_access_token|post|/oauth2/token|/oauth2/token|P[-]|Q[-]|H[content-type=constant:multipart/form-data:required,Accept=constant:application/json:required]|B[multipart:multipart/form-data:Model:MultipartBodyParameter]|R[200:json:Model:AcrAccessToken:-]
+        \\get_acr_access_token_from_login|get|/oauth2/token|/oauth2/token{?api%2Dversion,service,scope}|P[-]|Q[api-version=client:api_version:required,service=user:service:required,scope=user:scope:required]|H[Accept=constant:application/json:required]|B[-]|R[200:json:Model:AcrAccessToken:-]
+    ++ "\n";
+    try testing.expectEqualStrings(expected, actual);
+}
+
 test "Container Registry fixture preserves the complete wire contract" {
     const testing = std.testing;
     var parsed = try std.json.parseFromSlice(

--- a/codegen/fixtures/generate_container_registry_package.zig
+++ b/codegen/fixtures/generate_container_registry_package.zig
@@ -8,6 +8,26 @@ pub fn main(init: std.process.Init) !void {
     var args = init.minimal.args.iterate();
     _ = args.skip();
     const output_path = args.next() orelse return error.MissingOutputPath;
+    var azure_core_commit: ?[]const u8 = null;
+    var azure_core_hash: ?[]const u8 = null;
+    var azure_sdk_path: ?[]const u8 = null;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--azure-core-commit")) {
+            azure_core_commit = args.next() orelse return error.MissingAzureCoreCommit;
+        } else if (std.mem.eql(u8, arg, "--azure-core-hash")) {
+            azure_core_hash = args.next() orelse return error.MissingAzureCoreHash;
+        } else if (std.mem.eql(u8, arg, "--azure-sdk-path")) {
+            azure_sdk_path = args.next() orelse return error.MissingAzureSdkPath;
+        } else {
+            return error.UnexpectedArgument;
+        }
+    }
+    if ((azure_core_commit == null) != (azure_core_hash == null)) {
+        return error.IncompleteAzureCorePin;
+    }
+    if (azure_core_commit != null and azure_sdk_path != null) {
+        return error.ConflictingAzureSdkDependency;
+    }
 
     var parsed = try std.json.parseFromSlice(
         emitter.CodeModel,
@@ -24,10 +44,22 @@ pub fn main(init: std.process.Init) !void {
     else
         try std.Io.Dir.cwd().openDir(io, parent_path, .{});
     defer parent.close(io);
+    if (std.mem.eql(u8, directory_name, ".") or
+        std.mem.eql(u8, directory_name, ".."))
+    {
+        return error.InvalidOutputPath;
+    }
+    try parent.deleteTree(io, directory_name);
     var output = try parent.createDirPathOpen(io, directory_name, .{});
     defer output.close(io);
 
-    try emitter.emit(allocator, io, output, parsed.value, .{});
+    try emitter.emit(allocator, io, output, parsed.value, .{
+        .package_name = "azure_rest_container_registry",
+        .display_name = "container-registry",
+        .azure_core_commit = azure_core_commit,
+        .azure_core_hash = azure_core_hash,
+        .azure_sdk_path = azure_sdk_path orelse "../..",
+    });
     try output.writeFile(io, .{
         .sub_path = "src/clients_test.zig",
         .data = generated_tests,
@@ -40,6 +72,55 @@ const generated_tests =
     \\const serde = @import("serde");
     \\const clients = @import("clients.zig");
     \\const models = @import("models.zig");
+    \\
+    \\test "all 29 stable operations are directly accessible" {
+    \\    try expectPublicMethods(clients.ContainerRegistryClient, &.{
+    \\        "containerRegistry",
+    \\        "containerRegistryBlob",
+    \\        "authentication",
+    \\    });
+    \\    try expectPublicMethods(clients.ContainerRegistry, &.{
+    \\        "checkDockerV2Support",
+    \\        "getManifest",
+    \\        "createManifest",
+    \\        "deleteManifest",
+    \\        "getRepositories",
+    \\        "getProperties",
+    \\        "deleteRepository",
+    \\        "updateProperties",
+    \\        "getTags",
+    \\        "getTagProperties",
+    \\        "updateTagAttributes",
+    \\        "deleteTag",
+    \\        "getManifests",
+    \\        "getManifestProperties",
+    \\        "updateManifestProperties",
+    \\    });
+    \\    try expectPublicMethods(clients.ContainerRegistryBlob, &.{
+    \\        "getBlob",
+    \\        "checkBlobExists",
+    \\        "deleteBlob",
+    \\        "mountBlob",
+    \\        "getUploadStatus",
+    \\        "uploadChunk",
+    \\        "completeUpload",
+    \\        "cancelUpload",
+    \\        "startUpload",
+    \\        "getChunk",
+    \\        "checkChunkExists",
+    \\    });
+    \\    try expectPublicMethods(clients.Authentication, &.{
+    \\        "exchangeAadAccessTokenForAcrRefreshToken",
+    \\        "exchangeAcrRefreshTokenForAcrAccessToken",
+    \\        "getAcrAccessTokenFromLogin",
+    \\    });
+    \\}
+    \\
+    \\fn expectPublicMethods(comptime Client: type, comptime methods: []const []const u8) !void {
+    \\    inline for (methods) |method| {
+    \\        try std.testing.expect(@hasDecl(Client, method));
+    \\    }
+    \\}
     \\
     \\const Mock = struct {
     \\    allocator: std.mem.Allocator,

--- a/doc/package-branch-model.md
+++ b/doc/package-branch-model.md
@@ -164,6 +164,39 @@ A REST release does not require an SDK release unless its API or behavior
 changes what the SDK consumes. An SDK release always pins the exact REST
 revision used during testing.
 
+### Container Registry Commands
+
+`rest/container_registry` is regenerated from the checked-in TypeSpec code
+model and includes generator-owned contract tests:
+
+```bash
+(cd codegen/cli && zig build generate-container-registry-package)
+(cd rest/container_registry && zig build test --summary all)
+```
+
+When the canonical API changes, refresh
+`codegen/fixtures/container_registry.json` first using the command documented
+in `codegen/README.md`, then run the package generation command above.
+
+For a release commit, generate complete immutable dependency metadata before
+splitting the package to its orphan branch:
+
+```bash
+SDK_COMMIT="$(git rev-parse origin/main)"
+SDK_HASH="$(zig fetch "git+https://github.com/cataggar/azure-sdk-for-zig#$SDK_COMMIT")"
+(cd codegen/cli && zig build generate-container-registry-package \
+  -Dazure-core-commit="$SDK_COMMIT" \
+  -Dazure-core-hash="$SDK_HASH")
+(cd rest/container_registry && zig build test --summary all)
+git add rest/container_registry
+git commit -m "rest/container_registry: release generated package"
+REST_COMMIT="$(git subtree split --prefix=rest/container_registry HEAD)"
+git push origin "$REST_COMMIT:refs/heads/rest/container_registry"
+```
+
+The release generation is still deterministic: the commit and Zig package
+hash are explicit inputs, and no generated package file is edited afterward.
+
 ## Versioning
 
 - REST package versions describe the generated protocol surface.

--- a/rest/container_registry/.gitignore
+++ b/rest/container_registry/.gitignore
@@ -1,0 +1,4 @@
+zig-cache/
+zig-out/
+zig-pkg/
+.zig-cache/

--- a/rest/container_registry/README.md
+++ b/rest/container_registry/README.md
@@ -1,0 +1,14 @@
+# container-registry
+
+Generated Azure SDK client for Zig.
+
+This package is produced by `codegen` from the TypeSpec
+specification in [`Azure/azure-rest-api-specs`](https://github.com/Azure/azure-rest-api-specs).
+Do not edit generated package files by hand — they will be
+overwritten on the next regeneration.
+
+## Clients
+- `ContainerRegistryClient`
+- `ContainerRegistry`
+- `ContainerRegistryBlob`
+- `Authentication`

--- a/rest/container_registry/build.zig
+++ b/rest/container_registry/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const azure_sdk_dep = b.dependency("azure_sdk", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const azure_core_mod = azure_sdk_dep.module("azure_core");
+
+    const serde_dep = b.dependency("serde", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const serde_mod = serde_dep.module("serde");
+
+    _ = b.addModule("azure_rest_container_registry", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "azure_core", .module = azure_core_mod },
+            .{ .name = "serde", .module = serde_mod },
+        },
+    });
+
+    const t = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = azure_core_mod },
+                .{ .name = "serde", .module = serde_mod },
+            },
+        }),
+    });
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&b.addRunArtifact(t).step);
+}

--- a/rest/container_registry/build.zig.zon
+++ b/rest/container_registry/build.zig.zon
@@ -1,12 +1,11 @@
 .{
-    .name = .azure_sdk,
+    .name = .azure_rest_container_registry,
     .version = "0.1.0",
-    .fingerprint = 0x27c178e43525f3f8,
+    .fingerprint = 0x5dd0e10aa1e38a93,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
-        .uamqp = .{
-            .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",
-            .hash = "uamqp-0.1.0-lXMcafDqAQD3LSUZbUbyfrWhQfGG7OevKFUwhWxvGZDU",
+        .azure_sdk = .{
+            .path = "../..",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
@@ -16,10 +15,7 @@
     .paths = .{
         "build.zig",
         "build.zig.zon",
-        "sdk",
-        "rest",
-        "examples",
-        "LICENSE.txt",
+        "src",
         "README.md",
     },
 }

--- a/rest/container_registry/src/clients.zig
+++ b/rest/container_registry/src/clients.zig
@@ -1,0 +1,1782 @@
+//! Generated service clients.
+
+const std = @import("std");
+const serde = @import("serde");
+const core = @import("azure_core");
+const models = @import("models.zig");
+const enums = @import("enums.zig");
+
+// Keep raw-body ownership behind one helper so the generated shape can
+// adopt the core streaming response API without changing status/header logic.
+fn bufferRawResponseBody(allocator: std.mem.Allocator, body: []const u8) ![]u8 {
+    return allocator.dupe(u8, body);
+}
+
+fn responseStatusExpected(status: u16, expected: []const u16) bool {
+    if (expected.len == 0) return status >= 200 and status < 300;
+    for (expected) |value| {
+        if (status == value) return true;
+    }
+    return false;
+}
+const default_api_version = "2021-07-01";
+const auth_scopes: []const []const u8 = &.{"https://containerregistry.azure.net/.default"};
+
+/// Metadata API definition for the Azure Container Registry runtime
+pub const ContainerRegistryClient = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    allocator: std.mem.Allocator,
+    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
+    policy_ptrs: []*core.pipeline.HttpPolicy,
+
+    pub const InitOptions = struct {
+        credential: *core.credentials.TokenCredential,
+        transport: *core.http.HttpTransport,
+        endpoint: []const u8,
+        api_version: []const u8 = default_api_version,
+    };
+
+    pub const PipelineOptions = struct {
+        endpoint: []const u8,
+        api_version: []const u8 = default_api_version,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ContainerRegistryClient {
+        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
+        errdefer allocator.destroy(auth_policy);
+        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
+            allocator,
+            options.credential,
+            auth_scopes,
+        );
+
+        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
+        errdefer allocator.free(policy_ptrs);
+        policy_ptrs[0] = auth_policy.asPolicy();
+
+        return .{
+            .allocator = allocator,
+            .endpoint = options.endpoint,
+            .api_version = options.api_version,
+            .auth_policy = auth_policy,
+            .policy_ptrs = policy_ptrs,
+            .pipeline = .{
+                .policies = policy_ptrs,
+                .transport_impl = options.transport,
+            },
+        };
+    }
+    pub fn initWithPipeline(
+        allocator: std.mem.Allocator,
+        pipeline: core.pipeline.HttpPipeline,
+        options: PipelineOptions,
+    ) ContainerRegistryClient {
+        return .{
+            .allocator = allocator,
+            .endpoint = options.endpoint,
+            .api_version = options.api_version,
+            .auth_policy = null,
+            .policy_ptrs = &.{},
+            .pipeline = pipeline,
+        };
+    }
+
+    pub fn deinit(self: *@This()) void {
+        if (self.auth_policy) |auth_policy| {
+            auth_policy.deinit();
+            self.allocator.destroy(auth_policy);
+            self.allocator.free(self.policy_ptrs);
+        }
+    }
+
+    pub fn containerRegistry(self: *@This()) ContainerRegistry {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+        };
+    }
+
+    pub fn containerRegistryBlob(self: *@This()) ContainerRegistryBlob {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+        };
+    }
+
+    pub fn authentication(self: *@This()) Authentication {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+        };
+    }
+};
+
+pub const ContainerRegistry = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+
+    pub const CreateManifestResult = union(enum) {
+        status_201: struct {
+            status: u16 = 201,
+            headers: struct {
+                location: []const u8,
+                content_length: i64,
+                docker_content_digest: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const DeleteManifestResult = union(enum) {
+        status_202: struct {
+            status: u16 = 202,
+            headers: struct {},
+            body: void,
+        },
+        status_404: struct {
+            status: u16 = 404,
+            headers: struct {},
+            body: void,
+        },
+    };
+
+    pub const GetRepositoriesResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                link: ?[]const u8 = null,
+            },
+            body: models.Repositories,
+        },
+    };
+
+    pub const DeleteRepositoryResult = union(enum) {
+        status_202: struct {
+            status: u16 = 202,
+            headers: struct {},
+            body: void,
+        },
+        status_404: struct {
+            status: u16 = 404,
+            headers: struct {},
+            body: void,
+        },
+    };
+
+    pub const GetTagsResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                link: ?[]const u8 = null,
+            },
+            body: models.TagList,
+        },
+    };
+
+    pub const DeleteTagResult = union(enum) {
+        status_202: struct {
+            status: u16 = 202,
+            headers: struct {},
+            body: void,
+        },
+        status_404: struct {
+            status: u16 = 404,
+            headers: struct {},
+            body: void,
+        },
+    };
+
+    pub const GetManifestsResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                link: ?[]const u8 = null,
+            },
+            body: models.AcrManifests,
+        },
+    };
+    /// Tells whether this Docker Registry instance supports Docker Registry HTTP API v2
+    pub fn checkDockerV2Support(self: *@This(), alloc: std.mem.Allocator) !void {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.checkDockerV2Support", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return;
+    }
+    /// Get the manifest identified by `name` and `reference` where `reference` can be
+    /// a tag or digest.
+    pub fn getManifest(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8, accept: ?[]const u8) !models.ManifestWrapper {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/manifests/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        if (accept) |value| try req.setHeader("accept", value);
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.getManifest", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ManifestWrapper, alloc, resp.body);
+    }
+    /// Put the manifest identified by `name` and `reference` where `reference` can be
+    /// a tag or digest.
+    pub fn createManifest(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8, payload: models.Manifest) !CreateManifestResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/manifests/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/vnd.docker.distribution.manifest.v2+json");
+        const body_json = try serde.json.toSlice(alloc, payload);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            201 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Location") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try std.fmt.parseInt(
+                    i64,
+                    resp.getHeader("Content-Length") orelse return error.MissingResponseHeader,
+                    10,
+                );
+                const response_header_2 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Content-Digest") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_2);
+                return .{ .status_201 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .location = response_header_0,
+                        .content_length = response_header_1,
+                        .docker_content_digest = response_header_2,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistry.createManifest", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Delete the manifest identified by `name` and `reference`. Note that a manifest
+    /// can _only_ be deleted by `digest`.
+    pub fn deleteManifest(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8) !DeleteManifestResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/manifests/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            202 => {
+                return .{ .status_202 = .{
+                    .status = resp.status_code,
+                    .headers = .{},
+                    .body = {},
+                } };
+            },
+            404 => {
+                return .{ .status_404 = .{
+                    .status = resp.status_code,
+                    .headers = .{},
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistry.deleteManifest", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// List repositories
+    pub fn getRepositories(self: *@This(), alloc: std.mem.Allocator, last: ?[]const u8, n: ?i32) !GetRepositoriesResult {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/_catalog", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        if (last) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}last={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (n) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}n={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("Link")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice(models.Repositories, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .link = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistry.getRepositories", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Get repository attributes
+    pub fn getProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8) !models.ContainerRepositoryProperties {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.getProperties", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ContainerRepositoryProperties, alloc, resp.body);
+    }
+    /// Delete the repository identified by `name`
+    pub fn deleteRepository(self: *@This(), alloc: std.mem.Allocator, name: []const u8) !DeleteRepositoryResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            202 => {
+                return .{ .status_202 = .{
+                    .status = resp.status_code,
+                    .headers = .{},
+                    .body = {},
+                } };
+            },
+            404 => {
+                return .{ .status_404 = .{
+                    .status = resp.status_code,
+                    .headers = .{},
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistry.deleteRepository", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Update the attribute identified by `name` where `reference` is the name of the
+    /// repository.
+    pub fn updateProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, value: ?models.RepositoryChangeableAttributes) !models.ContainerRepositoryProperties {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        if (value != null) try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        var body_json: ?[]u8 = null;
+        defer if (body_json) |bytes| alloc.free(bytes);
+        if (value) |body| {
+            const bytes = try serde.json.toSlice(alloc, body);
+            body_json = bytes;
+            req.body = bytes;
+        }
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.updateProperties", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ContainerRepositoryProperties, alloc, resp.body);
+    }
+    /// List tags of a repository
+    pub fn getTags(self: *@This(), alloc: std.mem.Allocator, name: []const u8, last: ?[]const u8, n: ?i32, orderby: ?enums.ArtifactTagOrder, digest: ?[]const u8) !GetTagsResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_tags", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        if (last) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}last={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (n) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}n={d}", .{ sep, v });
+            has_query = true;
+        }
+        if (orderby) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v.toWire());
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}orderby={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (digest) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}digest={s}", .{ sep, enc });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("Link")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice(models.TagList, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .link = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistry.getTags", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Get tag attributes by tag
+    pub fn getTagProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8) !models.ArtifactTagProperties {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_tags/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.getTagProperties", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ArtifactTagProperties, alloc, resp.body);
+    }
+    /// Update tag attributes
+    pub fn updateTagAttributes(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8, value: ?models.TagChangeableAttributes) !models.ArtifactTagProperties {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_tags/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        if (value != null) try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        var body_json: ?[]u8 = null;
+        defer if (body_json) |bytes| alloc.free(bytes);
+        if (value) |body| {
+            const bytes = try serde.json.toSlice(alloc, body);
+            body_json = bytes;
+            req.body = bytes;
+        }
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.updateTagAttributes", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ArtifactTagProperties, alloc, resp.body);
+    }
+    /// Delete tag
+    pub fn deleteTag(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8) !DeleteTagResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_tags/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            202 => {
+                return .{ .status_202 = .{
+                    .status = resp.status_code,
+                    .headers = .{},
+                    .body = {},
+                } };
+            },
+            404 => {
+                return .{ .status_404 = .{
+                    .status = resp.status_code,
+                    .headers = .{},
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistry.deleteTag", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// List manifests of a repository
+    pub fn getManifests(self: *@This(), alloc: std.mem.Allocator, name: []const u8, last: ?[]const u8, n: ?i32, orderby: ?enums.ArtifactManifestOrder) !GetManifestsResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_manifests", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        if (last) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}last={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (n) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}n={d}", .{ sep, v });
+            has_query = true;
+        }
+        if (orderby) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v.toWire());
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}orderby={s}", .{ sep, enc });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("Link")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice(models.AcrManifests, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .link = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistry.getManifests", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Get manifest attributes
+    pub fn getManifestProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !models.ArtifactManifestProperties {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_manifests/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.getManifestProperties", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ArtifactManifestProperties, alloc, resp.body);
+    }
+    /// Update properties of a manifest
+    pub fn updateManifestProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8, value: ?models.ManifestChangeableAttributes) !models.ArtifactManifestProperties {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_manifests/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        if (value != null) try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        var body_json: ?[]u8 = null;
+        defer if (body_json) |bytes| alloc.free(bytes);
+        if (value) |body| {
+            const bytes = try serde.json.toSlice(alloc, body);
+            body_json = bytes;
+            req.body = bytes;
+        }
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("ContainerRegistry.updateManifestProperties", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.ArtifactManifestProperties, alloc, resp.body);
+    }
+};
+
+pub const ContainerRegistryBlob = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+
+    pub const GetBlobResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                content_length: i64,
+                docker_content_digest: []const u8,
+            },
+            body: []const u8,
+        },
+        status_307: struct {
+            status: u16 = 307,
+            headers: struct {
+                location: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const CheckBlobExistsResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                content_length: i64,
+                docker_content_digest: []const u8,
+            },
+            body: void,
+        },
+        status_307: struct {
+            status: u16 = 307,
+            headers: struct {
+                location: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const DeleteBlobResult = union(enum) {
+        status_202: struct {
+            status: u16 = 202,
+            headers: struct {
+                docker_content_digest: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const MountBlobResult = union(enum) {
+        status_201: struct {
+            status: u16 = 201,
+            headers: struct {
+                location: []const u8,
+                docker_upload_uuid: []const u8,
+                docker_content_digest: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const GetUploadStatusResult = union(enum) {
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                range: []const u8,
+                docker_upload_uuid: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const UploadChunkResult = union(enum) {
+        status_202: struct {
+            status: u16 = 202,
+            headers: struct {
+                location: []const u8,
+                range: []const u8,
+                docker_upload_uuid: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const CompleteUploadResult = union(enum) {
+        status_201: struct {
+            status: u16 = 201,
+            headers: struct {
+                location: []const u8,
+                range: []const u8,
+                docker_content_digest: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const StartUploadResult = union(enum) {
+        status_202: struct {
+            status: u16 = 202,
+            headers: struct {
+                location: []const u8,
+                range: []const u8,
+                docker_upload_uuid: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const GetChunkResult = union(enum) {
+        status_206: struct {
+            status: u16 = 206,
+            headers: struct {
+                content_length: i64,
+                content_range: []const u8,
+            },
+            body: []const u8,
+        },
+    };
+
+    pub const CheckChunkExistsResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                content_length: i64,
+                content_range: []const u8,
+            },
+            body: void,
+        },
+    };
+    /// Retrieve the blob from the registry identified by digest.
+    pub fn getBlob(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !GetBlobResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        req.redirect_policy = .not_allowed;
+        try req.setHeader("Accept", "application/octet-stream");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = try std.fmt.parseInt(
+                    i64,
+                    resp.getHeader("Content-Length") orelse return error.MissingResponseHeader,
+                    10,
+                );
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Content-Digest") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_body = try bufferRawResponseBody(alloc, resp.body);
+                errdefer alloc.free(response_body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .content_length = response_header_0,
+                        .docker_content_digest = response_header_1,
+                    },
+                    .body = response_body,
+                } };
+            },
+            307 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Location") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                return .{ .status_307 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .location = response_header_0,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.getBlob", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Same as GET, except only the headers are returned.
+    pub fn checkBlobExists(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !CheckBlobExistsResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .HEAD, url);
+        defer req.deinit();
+        req.redirect_policy = .not_allowed;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = try std.fmt.parseInt(
+                    i64,
+                    resp.getHeader("Content-Length") orelse return error.MissingResponseHeader,
+                    10,
+                );
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Content-Digest") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .content_length = response_header_0,
+                        .docker_content_digest = response_header_1,
+                    },
+                    .body = {},
+                } };
+            },
+            307 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Location") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                return .{ .status_307 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .location = response_header_0,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.checkBlobExists", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Removes an already uploaded blob.
+    pub fn deleteBlob(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !DeleteBlobResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            202 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Content-Digest") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                return .{ .status_202 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .docker_content_digest = response_header_0,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.deleteBlob", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Mount a blob identified by the `mount` parameter from another repository.
+    pub fn mountBlob(self: *@This(), alloc: std.mem.Allocator, name: []const u8, from: []const u8, mount: []const u8) !MountBlobResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/uploads/", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const encoded_query_1 = try core.url.percentEncode(alloc, from);
+        defer alloc.free(encoded_query_1);
+        try url_buf.print(alloc, "{s}from={s}", .{ if (has_query) "&" else "?", encoded_query_1 });
+        has_query = true;
+        const encoded_query_2 = try core.url.percentEncode(alloc, mount);
+        defer alloc.free(encoded_query_2);
+        try url_buf.print(alloc, "{s}mount={s}", .{ if (has_query) "&" else "?", encoded_query_2 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            201 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Location") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Upload-UUID") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Content-Digest") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_2);
+                return .{ .status_201 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .location = response_header_0,
+                        .docker_upload_uuid = response_header_1,
+                        .docker_content_digest = response_header_2,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.mountBlob", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Retrieve status of upload identified by uuid. The primary purpose of this
+    /// endpoint is to resolve the current status of a resumable upload.
+    pub fn getUploadStatus(self: *@This(), alloc: std.mem.Allocator, next_blob_uuid_link: []const u8) !GetUploadStatusResult {
+        const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
+        defer alloc.free(encoded_path_0);
+        const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
+        var endpoint_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+        const endpoint_host = endpoint_uri.getHost(&endpoint_host_buffer) catch return error.InvalidUrl;
+        const base_url = try core.url.resolveAndValidateUrl(
+            alloc,
+            self.endpoint,
+            encoded_path_0,
+            &.{endpoint_host.bytes},
+        );
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            204 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Range") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Upload-UUID") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .range = response_header_0,
+                        .docker_upload_uuid = response_header_1,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.getUploadStatus", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Upload a stream of data without completing the upload.
+    pub fn uploadChunk(self: *@This(), alloc: std.mem.Allocator, next_blob_uuid_link: []const u8, value: []const u8) !UploadChunkResult {
+        const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
+        defer alloc.free(encoded_path_0);
+        const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
+        var endpoint_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+        const endpoint_host = endpoint_uri.getHost(&endpoint_host_buffer) catch return error.InvalidUrl;
+        const base_url = try core.url.resolveAndValidateUrl(
+            alloc,
+            self.endpoint,
+            encoded_path_0,
+            &.{endpoint_host.bytes},
+        );
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/octet-stream");
+        req.body = value;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            202 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Location") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Range") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Upload-UUID") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_2);
+                return .{ .status_202 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .location = response_header_0,
+                        .range = response_header_1,
+                        .docker_upload_uuid = response_header_2,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.uploadChunk", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Complete the upload, providing all the data in the body, if necessary. A
+    /// request without a body will just complete the upload with previously uploaded
+    /// content.
+    pub fn completeUpload(self: *@This(), alloc: std.mem.Allocator, digest: []const u8, next_blob_uuid_link: []const u8, value: ?[]const u8) !CompleteUploadResult {
+        const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
+        defer alloc.free(encoded_path_0);
+        const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
+        var endpoint_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+        const endpoint_host = endpoint_uri.getHost(&endpoint_host_buffer) catch return error.InvalidUrl;
+        const base_url = try core.url.resolveAndValidateUrl(
+            alloc,
+            self.endpoint,
+            encoded_path_0,
+            &.{endpoint_host.bytes},
+        );
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const encoded_query_1 = try core.url.percentEncode(alloc, digest);
+        defer alloc.free(encoded_query_1);
+        try url_buf.print(alloc, "{s}digest={s}", .{ if (has_query) "&" else "?", encoded_query_1 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        if (value != null) try req.setHeader("Content-Type", "application/octet-stream");
+        if (value) |body| req.body = body;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            201 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Location") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Range") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Content-Digest") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_2);
+                return .{ .status_201 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .location = response_header_0,
+                        .range = response_header_1,
+                        .docker_content_digest = response_header_2,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.completeUpload", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Cancel outstanding upload processes, releasing associated resources. If this is
+    /// not called, the unfinished uploads will eventually timeout.
+    pub fn cancelUpload(self: *@This(), alloc: std.mem.Allocator, next_blob_uuid_link: []const u8) !void {
+        const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
+        defer alloc.free(encoded_path_0);
+        const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
+        var endpoint_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+        const endpoint_host = endpoint_uri.getHost(&endpoint_host_buffer) catch return error.InvalidUrl;
+        const base_url = try core.url.resolveAndValidateUrl(
+            alloc,
+            self.endpoint,
+            encoded_path_0,
+            &.{endpoint_host.bytes},
+        );
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{204})) {
+            core.pager.logHttpError("ContainerRegistryBlob.cancelUpload", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return;
+    }
+    /// Initiate a resumable blob upload with an empty request body.
+    pub fn startUpload(self: *@This(), alloc: std.mem.Allocator, name: []const u8) !StartUploadResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/uploads/", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            202 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Location") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Range") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Docker-Upload-UUID") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_2);
+                return .{ .status_202 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .location = response_header_0,
+                        .range = response_header_1,
+                        .docker_upload_uuid = response_header_2,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.startUpload", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Retrieve the blob from the registry identified by `digest`. This endpoint may
+    /// also support RFC7233 compliant range requests. Support can be detected by
+    /// issuing a HEAD request. If the header `Accept-Range: bytes` is returned, range
+    /// requests can be used to fetch partial content.
+    pub fn getChunk(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8, range: []const u8) !GetChunkResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("range", range);
+        try req.setHeader("Accept", "application/octet-stream");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            206 => {
+                const response_header_0 = try std.fmt.parseInt(
+                    i64,
+                    resp.getHeader("Content-Length") orelse return error.MissingResponseHeader,
+                    10,
+                );
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Range") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_body = try bufferRawResponseBody(alloc, resp.body);
+                errdefer alloc.free(response_body);
+                return .{ .status_206 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .content_length = response_header_0,
+                        .content_range = response_header_1,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.getChunk", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Same as GET, except only the headers are returned.
+    pub fn checkChunkExists(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8, range: []const u8) !CheckChunkExistsResult {
+        const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
+        defer alloc.free(encoded_path_1);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/{s}", .{ self.endpoint, encoded_path_0, encoded_path_1 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .HEAD, url);
+        defer req.deinit();
+        try req.setHeader("range", range);
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = try std.fmt.parseInt(
+                    i64,
+                    resp.getHeader("Content-Length") orelse return error.MissingResponseHeader,
+                    10,
+                );
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Range") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .content_length = response_header_0,
+                        .content_range = response_header_1,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("ContainerRegistryBlob.checkChunkExists", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+};
+
+pub const Authentication = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    /// Exchange AAD tokens for an ACR refresh Token
+    pub fn exchangeAadAccessTokenForAcrRefreshToken(self: *@This(), alloc: std.mem.Allocator, body: models.MultipartBodyParameter) !models.AcrRefreshToken {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/oauth2/exchange", .{self.endpoint});
+        defer alloc.free(base_url);
+        const url = base_url;
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+        const multipart_boundary = "azure-sdk-for-zig-acr-boundary";
+        var multipart_body: std.ArrayList(u8) = .empty;
+        defer multipart_body.deinit(alloc);
+        try multipart_body.print(
+            alloc,
+            "--{s}\r\nContent-Disposition: form-data; name=\"grantType\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+            .{ multipart_boundary, body.grant_type.toWire() },
+        );
+        try multipart_body.print(
+            alloc,
+            "--{s}\r\nContent-Disposition: form-data; name=\"service\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+            .{ multipart_boundary, body.service },
+        );
+        if (body.tenant) |value| {
+            try multipart_body.print(
+                alloc,
+                "--{s}\r\nContent-Disposition: form-data; name=\"tenant\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+                .{ multipart_boundary, value },
+            );
+        }
+        if (body.refresh_token) |value| {
+            try multipart_body.print(
+                alloc,
+                "--{s}\r\nContent-Disposition: form-data; name=\"refreshToken\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+                .{ multipart_boundary, value },
+            );
+        }
+        if (body.access_token) |value| {
+            try multipart_body.print(
+                alloc,
+                "--{s}\r\nContent-Disposition: form-data; name=\"accessToken\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+                .{ multipart_boundary, value },
+            );
+        }
+        try multipart_body.print(alloc, "--{s}--\r\n", .{multipart_boundary});
+        const multipart_bytes = try multipart_body.toOwnedSlice(alloc);
+        defer alloc.free(multipart_bytes);
+        req.body = multipart_bytes;
+        try req.setHeader("Content-Type", "multipart/form-data; boundary=azure-sdk-for-zig-acr-boundary");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("Authentication.exchangeAadAccessTokenForAcrRefreshToken", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.AcrRefreshToken, alloc, resp.body);
+    }
+    /// Exchange ACR Refresh token for an ACR Access Token
+    pub fn exchangeAcrRefreshTokenForAcrAccessToken(self: *@This(), alloc: std.mem.Allocator, body: models.MultipartBodyParameter) !models.AcrAccessToken {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/oauth2/token", .{self.endpoint});
+        defer alloc.free(base_url);
+        const url = base_url;
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+        const multipart_boundary = "azure-sdk-for-zig-acr-boundary";
+        var multipart_body: std.ArrayList(u8) = .empty;
+        defer multipart_body.deinit(alloc);
+        try multipart_body.print(
+            alloc,
+            "--{s}\r\nContent-Disposition: form-data; name=\"grantType\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+            .{ multipart_boundary, body.grant_type.toWire() },
+        );
+        try multipart_body.print(
+            alloc,
+            "--{s}\r\nContent-Disposition: form-data; name=\"service\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+            .{ multipart_boundary, body.service },
+        );
+        if (body.tenant) |value| {
+            try multipart_body.print(
+                alloc,
+                "--{s}\r\nContent-Disposition: form-data; name=\"tenant\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+                .{ multipart_boundary, value },
+            );
+        }
+        if (body.refresh_token) |value| {
+            try multipart_body.print(
+                alloc,
+                "--{s}\r\nContent-Disposition: form-data; name=\"refreshToken\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+                .{ multipart_boundary, value },
+            );
+        }
+        if (body.access_token) |value| {
+            try multipart_body.print(
+                alloc,
+                "--{s}\r\nContent-Disposition: form-data; name=\"accessToken\"\r\nContent-Type: text/plain\r\n\r\n{s}\r\n",
+                .{ multipart_boundary, value },
+            );
+        }
+        try multipart_body.print(alloc, "--{s}--\r\n", .{multipart_boundary});
+        const multipart_bytes = try multipart_body.toOwnedSlice(alloc);
+        defer alloc.free(multipart_bytes);
+        req.body = multipart_bytes;
+        try req.setHeader("Content-Type", "multipart/form-data; boundary=azure-sdk-for-zig-acr-boundary");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("Authentication.exchangeAcrRefreshTokenForAcrAccessToken", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.AcrAccessToken, alloc, resp.body);
+    }
+    /// Exchange Username, Password and Scope for an ACR Access Token
+    pub fn getAcrAccessTokenFromLogin(self: *@This(), alloc: std.mem.Allocator, service: []const u8, scope: []const u8) !models.AcrAccessToken {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/oauth2/token", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        const encoded_query_0 = try core.url.percentEncode(alloc, self.api_version);
+        defer alloc.free(encoded_query_0);
+        try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
+        has_query = true;
+        const encoded_query_1 = try core.url.percentEncode(alloc, service);
+        defer alloc.free(encoded_query_1);
+        try url_buf.print(alloc, "{s}service={s}", .{ if (has_query) "&" else "?", encoded_query_1 });
+        has_query = true;
+        const encoded_query_2 = try core.url.percentEncode(alloc, scope);
+        defer alloc.free(encoded_query_2);
+        try url_buf.print(alloc, "{s}scope={s}", .{ if (has_query) "&" else "?", encoded_query_2 });
+        has_query = true;
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!responseStatusExpected(resp.status_code, &.{200})) {
+            core.pager.logHttpError("Authentication.getAcrAccessTokenFromLogin", resp.status_code, resp.body);
+            return error.AzureRequestFailed;
+        }
+        return try serde.json.fromSlice(models.AcrAccessToken, alloc, resp.body);
+    }
+};

--- a/rest/container_registry/src/clients_test.zig
+++ b/rest/container_registry/src/clients_test.zig
@@ -1,0 +1,273 @@
+const std = @import("std");
+const core = @import("azure_core");
+const serde = @import("serde");
+const clients = @import("clients.zig");
+const models = @import("models.zig");
+
+test "all 29 stable operations are directly accessible" {
+    try expectPublicMethods(clients.ContainerRegistryClient, &.{
+        "containerRegistry",
+        "containerRegistryBlob",
+        "authentication",
+    });
+    try expectPublicMethods(clients.ContainerRegistry, &.{
+        "checkDockerV2Support",
+        "getManifest",
+        "createManifest",
+        "deleteManifest",
+        "getRepositories",
+        "getProperties",
+        "deleteRepository",
+        "updateProperties",
+        "getTags",
+        "getTagProperties",
+        "updateTagAttributes",
+        "deleteTag",
+        "getManifests",
+        "getManifestProperties",
+        "updateManifestProperties",
+    });
+    try expectPublicMethods(clients.ContainerRegistryBlob, &.{
+        "getBlob",
+        "checkBlobExists",
+        "deleteBlob",
+        "mountBlob",
+        "getUploadStatus",
+        "uploadChunk",
+        "completeUpload",
+        "cancelUpload",
+        "startUpload",
+        "getChunk",
+        "checkChunkExists",
+    });
+    try expectPublicMethods(clients.Authentication, &.{
+        "exchangeAadAccessTokenForAcrRefreshToken",
+        "exchangeAcrRefreshTokenForAcrAccessToken",
+        "getAcrAccessTokenFromLogin",
+    });
+}
+
+fn expectPublicMethods(comptime Client: type, comptime methods: []const []const u8) !void {
+    inline for (methods) |method| {
+        try std.testing.expect(@hasDecl(Client, method));
+    }
+}
+
+const Mock = struct {
+    allocator: std.mem.Allocator,
+    mode: enum { blob, redirect, multipart, cancel },
+    transport: core.http.HttpTransport = undefined,
+    calls: usize = 0,
+
+    fn init(allocator: std.mem.Allocator, mode: @FieldType(@This(), "mode")) @This() {
+        var result = @This(){ .allocator = allocator, .mode = mode };
+        result.transport = .{ .sendFn = send };
+        return result;
+    }
+
+    fn send(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
+        const self: *@This() = @alignCast(@fieldParentPtr("transport", transport));
+        self.calls += 1;
+        const headers = std.StringHashMap([]const u8).init(self.allocator);
+        var response_headers = core.http.ResponseHeaders.init(self.allocator);
+        const status: u16, const body: []u8 = switch (self.mode) {
+            .blob => .{
+                200,
+                try self.blobResponse(request, &response_headers),
+            },
+            .redirect => .{
+                307,
+                try self.redirectResponse(request, &response_headers),
+            },
+            .multipart => .{
+                200,
+                try self.multipartResponse(request),
+            },
+            .cancel => .{
+                204,
+                try self.allocator.alloc(u8, 0),
+            },
+        };
+        return .{
+            .status_code = status,
+            .headers = headers,
+            .body = body,
+            .allocator = self.allocator,
+            .response_headers = response_headers,
+        };
+    }
+
+    fn blobResponse(
+        self: *@This(),
+        request: *core.http.Request,
+        response_headers: *core.http.ResponseHeaders,
+    ) ![]u8 {
+        try std.testing.expectEqualStrings(
+            "application/octet-stream",
+            request.getHeader("Accept").?,
+        );
+        try std.testing.expect(
+            std.mem.indexOf(u8, request.url, "/v2/team/app/blobs/sha256%3Aabc") != null,
+        );
+        try response_headers.append("Content-Length", "4");
+        try response_headers.append("Docker-Content-Digest", "sha256:abc");
+        return self.allocator.dupe(u8, "blob");
+    }
+
+    fn redirectResponse(
+        self: *@This(),
+        request: *core.http.Request,
+        response_headers: *core.http.ResponseHeaders,
+    ) ![]u8 {
+        try std.testing.expectEqual(
+            core.http.RedirectPolicy.not_allowed,
+            request.redirect_policy,
+        );
+        try response_headers.append("Location", "https://storage.example/blob");
+        return self.allocator.alloc(u8, 0);
+    }
+
+    fn multipartResponse(self: *@This(), request: *core.http.Request) ![]u8 {
+        try std.testing.expect(std.mem.startsWith(
+            u8,
+            request.getHeader("Content-Type").?,
+            "multipart/form-data; boundary=",
+        ));
+        try std.testing.expect(
+            std.mem.indexOf(u8, request.body.?, "name=\"grantType\"") != null,
+        );
+        try std.testing.expect(
+            std.mem.indexOf(u8, request.body.?, "access_token") != null,
+        );
+        return self.allocator.dupe(u8, "{\"refresh_token\":\"token\"}");
+    }
+};
+
+test "generated ACR raw, multipart, statuses, and validated continuations" {
+    const allocator = std.testing.allocator;
+    var empty = [_]*core.pipeline.HttpPolicy{};
+
+    var blob_mock = Mock.init(allocator, .blob);
+    const blob_pipeline = core.pipeline.HttpPipeline{
+        .policies = &empty,
+        .transport_impl = &blob_mock.transport,
+    };
+    var root = clients.ContainerRegistryClient.initWithPipeline(
+        allocator,
+        blob_pipeline,
+        .{ .endpoint = "https://registry.example" },
+    );
+    var blob_client = root.containerRegistryBlob();
+    const blob_result = try blob_client.getBlob(allocator, "team/app", "sha256:abc");
+    switch (blob_result) {
+        .status_200 => |result| {
+            defer allocator.free(result.body);
+            defer allocator.free(result.headers.docker_content_digest);
+            try std.testing.expectEqualStrings("blob", result.body);
+        },
+        else => return error.UnexpectedStatus,
+    }
+
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        blob_client.getUploadStatus(
+            allocator,
+            "https://evil.example/v2/team/app/blobs/uploads/id",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), blob_mock.calls);
+
+    var redirect_mock = Mock.init(allocator, .redirect);
+    const redirect_pipeline = core.pipeline.HttpPipeline{
+        .policies = &empty,
+        .transport_impl = &redirect_mock.transport,
+    };
+    root = clients.ContainerRegistryClient.initWithPipeline(
+        allocator,
+        redirect_pipeline,
+        .{ .endpoint = "https://registry.example" },
+    );
+    blob_client = root.containerRegistryBlob();
+    const redirected_blob = try blob_client.getBlob(
+        allocator,
+        "team/app",
+        "sha256:abc",
+    );
+    switch (redirected_blob) {
+        .status_307 => |result| {
+            defer allocator.free(result.headers.location);
+            try std.testing.expectEqualStrings(
+                "https://storage.example/blob",
+                result.headers.location,
+            );
+        },
+        else => return error.UnexpectedStatus,
+    }
+    const redirected_exists = try blob_client.checkBlobExists(
+        allocator,
+        "team/app",
+        "sha256:abc",
+    );
+    switch (redirected_exists) {
+        .status_307 => |result| {
+            defer allocator.free(result.headers.location);
+            try std.testing.expectEqualStrings(
+                "https://storage.example/blob",
+                result.headers.location,
+            );
+        },
+        else => return error.UnexpectedStatus,
+    }
+    try std.testing.expectEqual(@as(usize, 2), redirect_mock.calls);
+
+    var multipart_mock = Mock.init(allocator, .multipart);
+    const multipart_pipeline = core.pipeline.HttpPipeline{
+        .policies = &empty,
+        .transport_impl = &multipart_mock.transport,
+    };
+    root = clients.ContainerRegistryClient.initWithPipeline(
+        allocator,
+        multipart_pipeline,
+        .{ .endpoint = "https://registry.example" },
+    );
+    var auth = root.authentication();
+    const token = try auth.exchangeAadAccessTokenForAcrRefreshToken(
+        allocator,
+        .{
+            .grant_type = .access_token,
+            .service = "registry.example",
+            .access_token = "aad-token",
+        },
+    );
+    defer allocator.free(token.refresh_token.?);
+    try std.testing.expectEqualStrings("token", token.refresh_token.?);
+
+    var cancel_mock = Mock.init(allocator, .cancel);
+    const cancel_pipeline = core.pipeline.HttpPipeline{
+        .policies = &empty,
+        .transport_impl = &cancel_mock.transport,
+    };
+    root = clients.ContainerRegistryClient.initWithPipeline(
+        allocator,
+        cancel_pipeline,
+        .{ .endpoint = "https://registry.example" },
+    );
+    blob_client = root.containerRegistryBlob();
+    try blob_client.cancelUpload(allocator, "/v2/team/app/blobs/uploads/id");
+}
+
+test "generated ACR open records round trip arbitrary JSON" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const value = try serde.json.fromSlice(
+        models.Annotations,
+        allocator,
+        "{\"org.opencontainers.image.created\":\"2026-01-01T00:00:00Z\",\"count\":3,\"nested\":{\"ok\":true}}",
+    );
+    try std.testing.expectEqualStrings("2026-01-01T00:00:00Z", value.created.?);
+    try std.testing.expect(value.additional_properties.get("count").? == .integer);
+    try std.testing.expect(value.additional_properties.get("nested").? == .object);
+    const encoded = try serde.json.toSlice(allocator, value);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"count\":3") != null);
+}

--- a/rest/container_registry/src/enums.zig
+++ b/rest/container_registry/src/enums.zig
@@ -1,0 +1,235 @@
+//! Generated enums.
+//!
+//! Azure data-plane enums are typically *extensible* — the wire
+//! contract may grow with new values that older clients still
+//! need to round-trip. Represented as a tagged union with a
+//! catch-all `unrecognized` variant.
+
+const std = @import("std");
+const core = @import("azure_core");
+
+/// Sort options for ordering tags in a collection.
+pub const ArtifactTagOrder = union(enum) {
+    none,
+    last_updated_on_descending,
+    last_updated_on_ascending,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .none = "none",
+        .last_updated_on_descending = "timedesc",
+        .last_updated_on_ascending = "timeasc",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+};
+
+/// Sort options for ordering manifests in a collection.
+pub const ArtifactManifestOrder = union(enum) {
+    none,
+    last_updated_on_descending,
+    last_updated_on_ascending,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .none = "none",
+        .last_updated_on_descending = "timedesc",
+        .last_updated_on_ascending = "timeasc",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+};
+
+/// The artifact platform's architecture.
+pub const ArtifactArchitecture = union(enum) {
+    i386,
+    amd64,
+    arm,
+    arm64,
+    mips,
+    mips_le,
+    mips64,
+    mips64le,
+    ppc64,
+    ppc64le,
+    risc_v64,
+    s390x,
+    wasm,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .i386 = "386",
+        .amd64 = "amd64",
+        .arm = "arm",
+        .arm64 = "arm64",
+        .mips = "mips",
+        .mips_le = "mipsle",
+        .mips64 = "mips64",
+        .mips64le = "mips64le",
+        .ppc64 = "ppc64",
+        .ppc64le = "ppc64le",
+        .risc_v64 = "riscv64",
+        .s390x = "s390x",
+        .wasm = "wasm",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+};
+
+/// The artifact platform's operating system.
+pub const ArtifactOperatingSystem = union(enum) {
+    aix,
+    android,
+    darwin,
+    dragonfly,
+    free_bsd,
+    illumos,
+    i_os,
+    js,
+    linux,
+    net_bsd,
+    open_bsd,
+    plan9,
+    solaris,
+    windows,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .aix = "aix",
+        .android = "android",
+        .darwin = "darwin",
+        .dragonfly = "dragonfly",
+        .free_bsd = "freebsd",
+        .illumos = "illumos",
+        .i_os = "ios",
+        .js = "js",
+        .linux = "linux",
+        .net_bsd = "netbsd",
+        .open_bsd = "openbsd",
+        .plan9 = "plan9",
+        .solaris = "solaris",
+        .windows = "windows",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+};
+
+/// Can take a value of access_token_refresh_token, or access_token, or
+/// refresh_token
+pub const PostContentSchemaGrantType = union(enum) {
+    access_token_refresh_token,
+    access_token,
+    refresh_token,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .access_token_refresh_token = "access_token_refresh_token",
+        .access_token = "access_token",
+        .refresh_token = "refresh_token",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+};
+
+/// The available API versions.
+pub const Versions = enum {
+    v2021_07_01,
+};
+
+/// Grant type is expected to be refresh_token
+pub const TokenGrantType = union(enum) {
+    refresh_token,
+    password,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .refresh_token = "refresh_token",
+        .password = "password",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+};

--- a/rest/container_registry/src/models.zig
+++ b/rest/container_registry/src/models.zig
@@ -1,0 +1,749 @@
+//! Generated data-transfer-object models.
+
+const std = @import("std");
+const enums = @import("enums.zig");
+
+pub const JsonValue = union(enum) {
+    null_value: void,
+    boolean: bool,
+    integer: i64,
+    float: f64,
+    string: []const u8,
+    array: []JsonValue,
+    object: std.StringArrayHashMapUnmanaged(JsonValue),
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        const saved = deserializer.*;
+        if (deserializer.deserializeVoid()) |_| {
+            return .{ .null_value = {} };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeBool()) |value| {
+            return .{ .boolean = value };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeInt(i64)) |value| {
+            return .{ .integer = value };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeFloat(f64)) |value| {
+            return .{ .float = value };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeString(allocator)) |value| {
+            return .{ .string = value };
+        } else |_| deserializer.* = saved;
+
+        if (deserializer.deserializeSeqAccess()) |sequence_value| {
+            var sequence = sequence_value;
+            var values: std.ArrayList(JsonValue) = .empty;
+            errdefer values.deinit(allocator);
+            while (try sequence.nextElement(JsonValue, allocator)) |value| {
+                values.append(allocator, value) catch
+                    return deserializer.raiseError(error.OutOfMemory);
+            }
+            return .{ .array = values.toOwnedSlice(allocator) catch
+                return deserializer.raiseError(error.OutOfMemory) };
+        } else |_| deserializer.* = saved;
+
+        var map = deserializer.deserializeStruct(T) catch
+            return deserializer.raiseError(error.UnexpectedToken);
+        var values: std.StringArrayHashMapUnmanaged(JsonValue) = .empty;
+        errdefer values.deinit(allocator);
+        while (try map.nextKey(allocator)) |key| {
+            const owned_key = allocator.dupe(u8, key) catch
+                return deserializer.raiseError(error.OutOfMemory);
+            const value = map.nextValue(JsonValue, allocator) catch |err| {
+                allocator.free(owned_key);
+                return err;
+            };
+            values.put(allocator, owned_key, value) catch {
+                allocator.free(owned_key);
+                return deserializer.raiseError(error.OutOfMemory);
+            };
+        }
+        return .{ .object = values };
+    }
+
+    pub fn zerdeSerialize(self: JsonValue, serializer: anytype) @TypeOf(serializer.*).Error!void {
+        switch (self) {
+            .null_value => return serializer.serializeNull(),
+            .boolean => |value| return serializer.serializeBool(value),
+            .integer => |value| return serializer.serializeInt(value),
+            .float => |value| return serializer.serializeFloat(value),
+            .string => |value| return serializer.serializeString(value),
+            .array => |values| {
+                var array = try serializer.beginArray();
+                for (values) |value| try value.zerdeSerialize(&array);
+                return array.end();
+            },
+            .object => |values| {
+                var object = try serializer.beginStruct();
+                var iterator = values.iterator();
+                while (iterator.next()) |entry| {
+                    try object.serializeEntry(entry.key_ptr.*, entry.value_ptr.*);
+                }
+                return object.end();
+            },
+        }
+    }
+};
+
+/// Acr error response describing why the operation failed
+pub const AcrErrors = struct {
+    /// Array of detailed error
+    errors: ?[]const AcrErrorInfo = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// Error information
+pub const AcrErrorInfo = struct {
+    /// Error code
+    code: ?[]const u8 = null,
+    /// Error message
+    message: ?[]const u8 = null,
+    /// Error details
+    detail: ?AcrErrorInfoDetail = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+pub const AcrErrorInfoDetail = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// Returns the requested manifest file
+pub const ManifestWrapper = struct {
+    /// Schema version
+    schema_version: ?i32 = null,
+    /// Media type for this Manifest
+    media_type: ?[]const u8 = null,
+    /// (ManifestList, OCIIndex) List of V2 image layer information
+    manifests: ?[]const ManifestListAttributes = null,
+    /// (V2, OCI) Image config descriptor
+    config: ?Descriptor = null,
+    /// (V2, OCI) List of V2 image layer information
+    layers: ?[]const Descriptor = null,
+    /// (OCI, OCIIndex) Additional metadata
+    annotations: ?Annotations = null,
+    /// (V1) CPU architecture
+    architecture: ?[]const u8 = null,
+    /// (V1) Image name
+    name: ?[]const u8 = null,
+    /// (V1) Image tag
+    tag: ?[]const u8 = null,
+    /// (V1) List of layer information
+    fs_layers: ?[]const FsLayer = null,
+    /// (V1) Image history
+    history: ?[]const History = null,
+    /// (V1) Image signature
+    signatures: ?[]const ImageSignature = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// Attributes of a manifest in a manifest list.
+pub const ManifestListAttributes = struct {
+    /// The MIME type of the referenced object. This will generally be
+    /// application/vnd.docker.image.manifest.v2+json, but it could also be
+    /// application/vnd.docker.image.manifest.v1+json
+    media_type: ?[]const u8 = null,
+    /// The size in bytes of the object
+    size: ?i64 = null,
+    /// The digest of the content, as defined by the Registry V2 HTTP API Specification
+    digest: ?[]const u8 = null,
+    /// The platform object describes the platform which the image in the manifest runs
+    /// on. A full list of valid operating system and architecture values are listed in
+    /// the Go language documentation for $GOOS and $GOARCH
+    platform: ?Platform = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// The platform object describes the platform which the image in the manifest runs
+/// on. A full list of valid operating system and architecture values are listed in
+/// the Go language documentation for $GOOS and $GOARCH
+pub const Platform = struct {
+    /// Specifies the CPU architecture, for example amd64 or ppc64le.
+    architecture: ?[]const u8 = null,
+    /// The os field specifies the operating system, for example linux or windows.
+    os: ?[]const u8 = null,
+    /// The optional os.version field specifies the operating system version, for
+    /// example 10.0.10586.
+    os_version: ?[]const u8 = null,
+    /// The optional os.features field specifies an array of strings, each listing a
+    /// required OS feature (for example on Windows win32k
+    os_features: ?[]const []const u8 = null,
+    /// The optional variant field specifies a variant of the CPU, for example armv6l
+    /// to specify a particular CPU variant of the ARM CPU.
+    variant: ?[]const u8 = null,
+    /// The optional features field specifies an array of strings, each listing a
+    /// required CPU feature (for example sse4 or aes
+    features: ?[]const []const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .os_version = "os.version",
+            .os_features = "os.features",
+        },
+    };
+};
+
+/// Docker V2 image layer descriptor including config and layers
+pub const Descriptor = struct {
+    /// Layer media type
+    media_type: ?[]const u8 = null,
+    /// Layer size
+    size: ?i64 = null,
+    /// Layer digest
+    digest: ?[]const u8 = null,
+    /// Specifies a list of URIs from which this object may be downloaded.
+    urls: ?[]const []const u8 = null,
+    /// Additional information provided through arbitrary metadata.
+    annotations: ?Annotations = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// Additional information provided through arbitrary metadata.
+pub const Annotations = struct {
+    /// Date and time on which the image was built (string, date-time as defined by
+    /// https://tools.ietf.org/html/rfc3339#section-5.6)
+    created: ?[]const u8 = null,
+    /// Contact details of the people or organization responsible for the image.
+    authors: ?[]const u8 = null,
+    /// URL to find more information on the image.
+    url: ?[]const u8 = null,
+    /// URL to get documentation on the image.
+    documentation: ?[]const u8 = null,
+    /// URL to get source code for building the image.
+    source: ?[]const u8 = null,
+    /// Version of the packaged software. The version MAY match a label or tag in the
+    /// source code repository, may also be Semantic versioning-compatible
+    version: ?[]const u8 = null,
+    /// Source control revision identifier for the packaged software.
+    revision: ?[]const u8 = null,
+    /// Name of the distributing entity, organization or individual.
+    vendor: ?[]const u8 = null,
+    /// License(s) under which contained software is distributed as an SPDX License
+    /// Expression.
+    licenses: ?[]const u8 = null,
+    /// Name of the reference for a target.
+    name: ?[]const u8 = null,
+    /// Human-readable title of the image
+    title: ?[]const u8 = null,
+    /// Human-readable description of the software packaged in the image
+    description: ?[]const u8 = null,
+    additional_properties: std.StringArrayHashMapUnmanaged(JsonValue) = .empty,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .created = "org.opencontainers.image.created",
+            .authors = "org.opencontainers.image.authors",
+            .url = "org.opencontainers.image.url",
+            .documentation = "org.opencontainers.image.documentation",
+            .source = "org.opencontainers.image.source",
+            .version = "org.opencontainers.image.version",
+            .revision = "org.opencontainers.image.revision",
+            .vendor = "org.opencontainers.image.vendor",
+            .licenses = "org.opencontainers.image.licenses",
+            .name = "org.opencontainers.image.ref.name",
+            .title = "org.opencontainers.image.title",
+            .description = "org.opencontainers.image.description",
+        },
+        .skip = .{ .additional_properties = .always },
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        var result: T = .{};
+        var map = try deserializer.deserializeStruct(T);
+        while (try map.nextKey(allocator)) |key| {
+            if (std.mem.eql(u8, key, "org.opencontainers.image.created")) {
+                result.created = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.authors")) {
+                result.authors = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.url")) {
+                result.url = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.documentation")) {
+                result.documentation = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.source")) {
+                result.source = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.version")) {
+                result.version = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.revision")) {
+                result.revision = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.vendor")) {
+                result.vendor = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.licenses")) {
+                result.licenses = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.ref.name")) {
+                result.name = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.title")) {
+                result.title = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            if (std.mem.eql(u8, key, "org.opencontainers.image.description")) {
+                result.description = try map.nextValue(?[]const u8, allocator);
+                continue;
+            }
+            const owned_key = allocator.dupe(u8, key) catch
+                return deserializer.raiseError(error.OutOfMemory);
+            const value = map.nextValue(JsonValue, allocator) catch |err| {
+                allocator.free(owned_key);
+                return err;
+            };
+            result.additional_properties.put(allocator, owned_key, value) catch {
+                allocator.free(owned_key);
+                return deserializer.raiseError(error.OutOfMemory);
+            };
+        }
+        return result;
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) @TypeOf(serializer.*).Error!void {
+        var object = try serializer.beginStruct();
+        if (self.created) |value| try object.serializeField("org.opencontainers.image.created", value);
+        if (self.authors) |value| try object.serializeField("org.opencontainers.image.authors", value);
+        if (self.url) |value| try object.serializeField("org.opencontainers.image.url", value);
+        if (self.documentation) |value| try object.serializeField("org.opencontainers.image.documentation", value);
+        if (self.source) |value| try object.serializeField("org.opencontainers.image.source", value);
+        if (self.version) |value| try object.serializeField("org.opencontainers.image.version", value);
+        if (self.revision) |value| try object.serializeField("org.opencontainers.image.revision", value);
+        if (self.vendor) |value| try object.serializeField("org.opencontainers.image.vendor", value);
+        if (self.licenses) |value| try object.serializeField("org.opencontainers.image.licenses", value);
+        if (self.name) |value| try object.serializeField("org.opencontainers.image.ref.name", value);
+        if (self.title) |value| try object.serializeField("org.opencontainers.image.title", value);
+        if (self.description) |value| try object.serializeField("org.opencontainers.image.description", value);
+        var iterator = self.additional_properties.iterator();
+        while (iterator.next()) |entry| {
+            try object.serializeEntry(entry.key_ptr.*, entry.value_ptr.*);
+        }
+        return object.end();
+    }
+};
+
+/// Image layer information
+pub const FsLayer = struct {
+    /// SHA of an image layer
+    blob_sum: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A list of unstructured historical data for v1 compatibility
+pub const History = struct {
+    /// The raw v1 compatibility information
+    v1_compatibility: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// Signature of a signed manifest
+pub const ImageSignature = struct {
+    /// A JSON web signature
+    header: ?JWK = null,
+    /// A signature for the image manifest, signed by a libtrust private key
+    signature: ?[]const u8 = null,
+    /// The signed protected header
+    protected: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A JSON web signature
+pub const JWK = struct {
+    /// JSON web key parameter
+    jwk: ?JWKHeader = null,
+    /// The algorithm used to sign or encrypt the JWT
+    alg: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// JSON web key parameter
+pub const JWKHeader = struct {
+    /// crv value
+    crv: ?[]const u8 = null,
+    /// kid value
+    kid: ?[]const u8 = null,
+    /// kty value
+    kty: ?[]const u8 = null,
+    /// x value
+    x: ?[]const u8 = null,
+    /// y value
+    y: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// Returns the requested manifest file
+pub const Manifest = struct {
+    /// Schema version
+    schema_version: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// List of repositories
+pub const Repositories = struct {
+    /// Repository names
+    repositories: ?[]const []const u8 = null,
+    /// Link to the next page of results
+    link: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// Properties of this repository.
+pub const ContainerRepositoryProperties = struct {
+    /// Registry login server name. This is likely to be similar to
+    /// {registry-name}.azurecr.io.
+    registry_login_server: []const u8,
+    /// Image name
+    name: []const u8,
+    /// Image created time
+    created_on: []const u8,
+    /// Image last update time
+    last_updated_on: []const u8,
+    /// Number of the manifests
+    manifest_count: i32,
+    /// Number of the tags
+    tag_count: i32,
+    /// Writeable properties of the resource
+    changeable_attributes: RepositoryChangeableAttributes,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .registry_login_server = "registry",
+            .name = "imageName",
+            .created_on = "createdTime",
+            .last_updated_on = "lastUpdateTime",
+        },
+    };
+};
+
+/// Changeable attributes for Repository
+pub const RepositoryChangeableAttributes = struct {
+    /// Delete enabled
+    can_delete: ?bool = null,
+    /// Write enabled
+    can_write: ?bool = null,
+    /// List enabled
+    can_list: ?bool = null,
+    /// Read enabled
+    can_read: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .can_delete = "deleteEnabled",
+            .can_write = "writeEnabled",
+            .can_list = "listEnabled",
+            .can_read = "readEnabled",
+        },
+    };
+};
+
+/// List of tag details
+pub const TagList = struct {
+    /// Registry login server name. This is likely to be similar to
+    /// {registry-name}.azurecr.io.
+    registry_login_server: []const u8,
+    /// Image name
+    repository: []const u8,
+    /// List of tag attribute details
+    tag_attribute_bases: []const TagAttributesBase,
+    /// Link to the next page of results
+    link: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .registry_login_server = "registry",
+            .repository = "imageName",
+            .tag_attribute_bases = "tags",
+        },
+    };
+};
+
+/// Tag attribute details
+pub const TagAttributesBase = struct {
+    /// Tag name
+    name: []const u8,
+    /// Tag digest
+    digest: []const u8,
+    /// Tag created time
+    created_on: []const u8,
+    /// Tag last update time
+    last_updated_on: []const u8,
+    /// Is signed
+    signed: ?bool = null,
+    /// Writeable properties of the resource
+    changeable_attributes: TagChangeableAttributes,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .created_on = "createdTime",
+            .last_updated_on = "lastUpdateTime",
+        },
+    };
+};
+
+/// Changeable attributes
+pub const TagChangeableAttributes = struct {
+    /// Delete enabled
+    can_delete: ?bool = null,
+    /// Write enabled
+    can_write: ?bool = null,
+    /// List enabled
+    can_list: ?bool = null,
+    /// Read enabled
+    can_read: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .can_delete = "deleteEnabled",
+            .can_write = "writeEnabled",
+            .can_list = "listEnabled",
+            .can_read = "readEnabled",
+        },
+    };
+};
+
+/// Tag attributes
+pub const ArtifactTagProperties = struct {
+    /// Registry login server name. This is likely to be similar to
+    /// {registry-name}.azurecr.io.
+    registry_login_server: []const u8,
+    /// Image name
+    repository_name: []const u8,
+    /// List of tag attribute details
+    tag: TagAttributesBase,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .registry_login_server = "registry",
+            .repository_name = "imageName",
+        },
+    };
+};
+
+/// Manifest attributes
+pub const AcrManifests = struct {
+    /// Registry login server name. This is likely to be similar to
+    /// {registry-name}.azurecr.io.
+    registry_login_server: ?[]const u8 = null,
+    /// Image name
+    repository: ?[]const u8 = null,
+    /// List of manifests
+    manifests: ?[]const ManifestAttributesBase = null,
+    /// Link to the next page of results
+    link: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .registry_login_server = "registry",
+            .repository = "imageName",
+        },
+    };
+};
+
+/// Manifest details
+pub const ManifestAttributesBase = struct {
+    /// Manifest
+    digest: []const u8,
+    /// Image size
+    size: ?i64 = null,
+    /// Created time
+    created_on: []const u8,
+    /// Last update time
+    last_updated_on: []const u8,
+    /// CPU architecture
+    architecture: ?enums.ArtifactArchitecture = null,
+    /// Operating system
+    operating_system: ?enums.ArtifactOperatingSystem = null,
+    /// List of artifacts that are referenced by this manifest list, with information
+    /// about the platform each supports.  This list will be empty if this is a leaf
+    /// manifest and not a manifest list.
+    related_artifacts: ?[]const ArtifactManifestPlatform = null,
+    /// Config blob media type
+    config_media_type: ?[]const u8 = null,
+    /// List of tags
+    tags: ?[]const []const u8 = null,
+    /// Writeable properties of the resource
+    changeable_attributes: ?ManifestChangeableAttributes = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .size = "imageSize",
+            .created_on = "createdTime",
+            .last_updated_on = "lastUpdateTime",
+            .operating_system = "os",
+            .related_artifacts = "references",
+        },
+    };
+};
+
+/// The artifact's platform, consisting of operating system and architecture.
+pub const ArtifactManifestPlatform = struct {
+    /// Manifest digest
+    digest: []const u8,
+    /// CPU architecture
+    architecture: ?enums.ArtifactArchitecture = null,
+    /// Operating system
+    operating_system: ?enums.ArtifactOperatingSystem = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .operating_system = "os",
+        },
+    };
+};
+
+/// Changeable attributes
+pub const ManifestChangeableAttributes = struct {
+    /// Delete enabled
+    can_delete: ?bool = null,
+    /// Write enabled
+    can_write: ?bool = null,
+    /// List enabled
+    can_list: ?bool = null,
+    /// Read enabled
+    can_read: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .can_delete = "deleteEnabled",
+            .can_write = "writeEnabled",
+            .can_list = "listEnabled",
+            .can_read = "readEnabled",
+        },
+    };
+};
+
+/// Manifest attributes details
+pub const ArtifactManifestProperties = struct {
+    /// Registry login server name. This is likely to be similar to
+    /// {registry-name}.azurecr.io.
+    registry_login_server: ?[]const u8 = null,
+    /// Repository name
+    repository_name: ?[]const u8 = null,
+    /// Manifest attributes
+    manifest: ManifestAttributesBase,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .registry_login_server = "registry",
+            .repository_name = "imageName",
+        },
+    };
+};
+
+/// The multipart body parameter for AAD token exchange.
+pub const MultipartBodyParameter = struct {
+    /// Can take a value of access_token_refresh_token, or access_token, or
+    /// refresh_token
+    grant_type: enums.PostContentSchemaGrantType,
+    /// Indicates the name of your Azure container registry.
+    service: []const u8,
+    /// AAD tenant associated to the AAD credentials.
+    tenant: ?[]const u8 = null,
+    /// AAD refresh token, mandatory when grant_type is access_token_refresh_token or
+    /// refresh_token
+    refresh_token: ?[]const u8 = null,
+    /// AAD access token, mandatory when grant_type is access_token_refresh_token or
+    /// access_token.
+    access_token: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// The ACR refresh token response containing the refresh token for authentication.
+pub const AcrRefreshToken = struct {
+    /// The refresh token to be used for generating access tokens
+    refresh_token: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .refresh_token = "refresh_token",
+        },
+    };
+};
+
+/// The ACR access token response containing the access token for authentication.
+pub const AcrAccessToken = struct {
+    /// The access token for performing authenticated requests
+    access_token: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .access_token = "access_token",
+        },
+    };
+};

--- a/rest/container_registry/src/root.zig
+++ b/rest/container_registry/src/root.zig
@@ -1,0 +1,12 @@
+//! container-registry — generated from TypeSpec.
+//!
+//! Do not edit by hand. Regenerate with `codegen`.
+
+const clients = @import("clients.zig");
+pub const models = @import("models.zig");
+pub const enums = @import("enums.zig");
+pub const ContainerRegistryClient = clients.ContainerRegistryClient;
+
+test {
+    _ = @import("clients_test.zig");
+}


### PR DESCRIPTION
Generates the stable ACR 2021-07-01 REST package with all 29 operations, injected-pipeline support, deterministic regeneration, independent package metadata, and root build integration.

Closes #83