### PR TITLE
sdk/container_registry: implement challenge authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 
 | Package | Clients |
 |---------|---------|
+| `azure_sdk_container_registry` | `ContainerRegistryClient` with ACR challenge authentication; generated APIs under `protocol` |
 | `azure_storage_blobs` | `BlobClient`, `BlobContainerClient`, `SasBlobClient` |
 | `azure_storage_queues` | `QueueClient`, `QueueServiceClient`, `SasQueueClient` |
 | `azure_storage_files_shares` | `ShareClient`, `ShareDirectoryClient`, `ShareFileClient` |

--- a/build.zig
+++ b/build.zig
@@ -28,12 +28,24 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    _ = b.addModule("azure_rest_container_registry", .{
+    const container_registry_protocol_mod = b.addModule("azure_rest_container_registry", .{
         .root_source_file = b.path("rest/container_registry/src/root.zig"),
         .target = target,
         .imports = &.{
             .{ .name = "azure_core", .module = core_mod },
             .{ .name = "serde", .module = serde_mod },
+        },
+    });
+
+    _ = b.addModule("azure_sdk_container_registry", .{
+        .root_source_file = b.path("sdk/container_registry/src/root.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "azure_core", .module = core_mod },
+            .{
+                .name = "azure_rest_container_registry",
+                .module = container_registry_protocol_mod,
+            },
         },
     });
 
@@ -322,6 +334,22 @@ pub fn build(b: *std.Build) void {
         }),
     });
     test_step.dependOn(&b.addRunArtifact(container_registry_tests).step);
+
+    const container_registry_sdk_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("sdk/container_registry/src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = core_mod },
+                .{
+                    .name = "azure_rest_container_registry",
+                    .module = container_registry_protocol_mod,
+                },
+            },
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(container_registry_sdk_tests).step);
 
     // Service SDK tests — core + identity deps
     const service_test_sources_ci = [_][]const u8{

--- a/doc/package-branch-model.md
+++ b/doc/package-branch-model.md
@@ -178,6 +178,18 @@ When the canonical API changes, refresh
 `codegen/fixtures/container_registry.json` first using the command documented
 in `codegen/README.md`, then run the package generation command above.
 
+The hand-written package is validated independently with local path
+dependencies during development:
+
+```bash
+(cd sdk/container_registry && zig build test --summary all)
+```
+
+Before publishing `sdk/container_registry`, replace both local paths in its
+`build.zig.zon` with immutable `azure_sdk` and
+`azure_rest_container_registry` commit/hash pins, then rerun the same package
+test command from the orphan branch.
+
 For a release commit, generate complete immutable dependency metadata before
 splitting the package to its orphan branch:
 

--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -1,0 +1,29 @@
+# Azure Container Registry for Zig
+
+`azure_sdk_container_registry` adds secure ACR challenge authentication and
+token caching to the generated `azure_rest_container_registry` protocol
+package.
+
+```zig
+const acr = @import("azure_sdk_container_registry");
+
+var client = try acr.ContainerRegistryClient.init(allocator, registry_endpoint, .{
+    .transport = transport,
+    .authentication = .{ .credential = credential },
+});
+defer client.deinit();
+
+var service = client.protocolClient().containerRegistry();
+try service.checkDockerV2Support(allocator);
+```
+
+Use `.authentication = .anonymous` only for intentional anonymous access.
+The generated dependency is available as `acr.protocol`.
+By default only the endpoint host is trusted. Add explicit
+`authentication_options.expected_hosts` entries for known ACR data endpoints;
+requests and challenge realms on every other host are rejected before tokens
+are sent.
+
+Local development uses relative package dependencies. Release branches replace
+them with immutable `azure_sdk` and `azure_rest_container_registry` Git
+commit/hash pins as described in `doc/package-branch-model.md`.

--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -19,10 +19,15 @@ try service.checkDockerV2Support(allocator);
 
 Use `.authentication = .anonymous` only for intentional anonymous access.
 The generated dependency is available as `acr.protocol`.
-By default only the endpoint host is trusted. Add explicit
-`authentication_options.expected_hosts` entries for known ACR data endpoints;
-requests and challenge realms on every other host are rejected before tokens
+By default only the endpoint HTTPS origin is trusted. Hostname-only
+`authentication_options.expected_hosts` entries imply port 443; use an
+explicit origin such as `https://registry.example:8443` to trust another port.
+Requests and challenge realms on every other origin are rejected before tokens
 are sent.
+
+Long-lived clients use bounded LRU caches: 128 routes, 128 scoped access
+tokens, and 32 refresh tokens. Tokens that reach the configured expiry skew
+are pruned before lookup or insertion.
 
 Local development uses relative package dependencies. Release branches replace
 them with immutable `azure_sdk` and `azure_rest_container_registry` Git

--- a/sdk/container_registry/build.zig
+++ b/sdk/container_registry/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const azure_sdk_dep = b.dependency("azure_sdk", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const azure_core_mod = azure_sdk_dep.module("azure_core");
+
+    const rest_dep = b.dependency("azure_rest_container_registry", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const rest_mod = rest_dep.module("azure_rest_container_registry");
+
+    _ = b.addModule("azure_sdk_container_registry", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "azure_core", .module = azure_core_mod },
+            .{ .name = "azure_rest_container_registry", .module = rest_mod },
+        },
+    });
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = azure_core_mod },
+                .{ .name = "azure_rest_container_registry", .module = rest_mod },
+            },
+        }),
+    });
+    const test_step = b.step("test", "Run Container Registry SDK tests");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}

--- a/sdk/container_registry/build.zig.zon
+++ b/sdk/container_registry/build.zig.zon
@@ -1,0 +1,20 @@
+.{
+    .name = .azure_sdk_container_registry,
+    .version = "0.1.0",
+    .fingerprint = 0x29fb8cf06d809db5,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .azure_sdk = .{
+            .path = "../..",
+        },
+        .azure_rest_container_registry = .{
+            .path = "../../rest/container_registry",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+    },
+}

--- a/sdk/container_registry/src/auth_policy.zig
+++ b/sdk/container_registry/src/auth_policy.zig
@@ -131,6 +131,7 @@ const TokenFlight = struct {
     participants: usize = 1,
     token: ?[]u8 = null,
     failure: ?anyerror = null,
+    worker: ?std.Thread = null,
 
     fn init(
         allocator: std.mem.Allocator,
@@ -164,6 +165,16 @@ const TokenFlight = struct {
         allocator.free(self.scope);
         if (self.token) |token| allocator.free(token);
         self.* = undefined;
+    }
+
+    fn challenge(self: *TokenFlight, allocator: std.mem.Allocator) BearerChallenge {
+        return .{
+            .allocator = allocator,
+            .realm = self.realm,
+            .service = self.service,
+            .scope = self.scope,
+            .tenant = if (self.tenant.len == 0) null else self.tenant,
+        };
     }
 };
 
@@ -242,8 +253,20 @@ pub const ChallengeAuthenticationPolicy = struct {
     /// Requires that no callers are using or waiting on this policy.
     pub fn deinit(self: *ChallengeAuthenticationPolicy) void {
         self.mutex.lockUncancelable(self.io);
+        while (self.findUnjoinedFlightWorkerLocked()) |flight| {
+            const worker = flight.worker.?;
+            flight.worker = null;
+            self.mutex.unlock(self.io);
+            worker.join();
+            self.mutex.lockUncancelable(self.io);
+        }
         std.debug.assert(self.waiting_callers == 0);
-        std.debug.assert(self.token_flights.items.len == 0);
+        for (self.token_flights.items) |flight| {
+            std.debug.assert(flight.state != .running);
+            std.debug.assert(flight.participants == 0);
+            flight.deinit(self.allocator);
+            self.allocator.destroy(flight);
+        }
         for (self.refresh_tokens.items) |*entry| entry.deinit(self.allocator);
         self.refresh_tokens.deinit(self.allocator);
         for (self.access_tokens.items) |*entry| entry.deinit(self.allocator);
@@ -277,6 +300,8 @@ pub const ChallengeAuthenticationPolicy = struct {
 
         var known_challenge: ?BearerChallenge = null;
         defer if (known_challenge) |*challenge| challenge.deinit();
+        var authorization = RequestAuthorizationState.init(request);
+        defer authorization.restore(request);
         var sdk_authorized = false;
 
         if (request.getHeader("Authorization") == null) {
@@ -288,7 +313,7 @@ pub const ChallengeAuthenticationPolicy = struct {
                     final_transport,
                 );
                 defer self.allocator.free(token);
-                try setBearerHeader(request, token);
+                try authorization.setBearer(request, token);
                 sdk_authorized = true;
             }
         }
@@ -323,7 +348,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             return err;
         };
         defer self.allocator.free(token);
-        setBearerHeader(request, token) catch |err| {
+        authorization.setBearer(request, token) catch |err| {
             response.deinit();
             return err;
         };
@@ -354,6 +379,8 @@ pub const ChallengeAuthenticationPolicy = struct {
 
         var known_challenge: ?BearerChallenge = null;
         defer if (known_challenge) |*challenge| challenge.deinit();
+        var authorization = RequestAuthorizationState.init(request);
+        defer authorization.restore(request);
         var sdk_authorized = false;
 
         if (request.getHeader("Authorization") == null) {
@@ -365,72 +392,61 @@ pub const ChallengeAuthenticationPolicy = struct {
                     final_transport,
                 );
                 defer self.allocator.free(token);
-                try setBearerHeader(request, token);
+                try authorization.setBearer(request, token);
                 sdk_authorized = true;
             }
         }
 
-        var operation = try callNextOpen(
+        var owned_operation: ?*HttpOperation = try callNextOpen(
             request,
             options,
             next,
             final_transport,
         );
-        if (operation.status_code != 401) return operation;
-
-        if (!sdk_authorized and request.getHeader("Authorization") != null)
+        defer if (owned_operation) |operation| operation.deinit();
+        var operation = owned_operation.?;
+        if (operation.status_code != 401) {
+            owned_operation = null;
             return operation;
+        }
+
+        if (!sdk_authorized and request.getHeader("Authorization") != null) {
+            owned_operation = null;
+            return operation;
+        }
         if (sdk_authorized) self.invalidateAccessToken(&known_challenge.?);
 
-        var challenge = parseChallengeFromResponse(self.allocator, operation) catch |err| {
-            operation.deinit();
-            return err;
-        };
+        var challenge = try parseChallengeFromResponse(self.allocator, operation);
         defer challenge.deinit();
-        self.validateChallenge(&challenge) catch |err| {
-            operation.deinit();
-            return err;
-        };
-        if (!options.isReplayable()) {
-            operation.deinit();
-            return error.RequestBodyNotReplayable;
-        }
+        try self.validateChallenge(&challenge);
+        if (!options.isReplayable()) return error.RequestBodyNotReplayable;
         try checkCancelled(options.cancellation);
-        self.storeRoute(request, &challenge) catch |err| {
-            operation.deinit();
-            return err;
-        };
+        try self.storeRoute(request, &challenge);
 
-        const token = self.acquireAccessToken(
+        const token = try self.acquireAccessToken(
             &challenge,
             options.cancellation,
             final_transport,
-        ) catch |err| {
-            operation.deinit();
-            return err;
-        };
+        );
         defer self.allocator.free(token);
-        setBearerHeader(request, token) catch |err| {
-            operation.deinit();
-            return err;
-        };
+        try authorization.setBearer(request, token);
 
         var replay_options = options;
         if (replay_options.body) |*body| {
-            body.rewind() catch |err| {
-                operation.deinit();
-                return err;
-            };
+            try body.rewind();
         }
         try checkCancelled(options.cancellation);
         operation.deinit();
+        owned_operation = null;
         operation = try callNextOpen(
             request,
             replay_options,
             next,
             final_transport,
         );
+        owned_operation = operation;
         if (operation.status_code == 401) self.invalidateAccessToken(&challenge);
+        owned_operation = null;
         return operation;
     }
 
@@ -443,6 +459,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         try checkCancelled(cancellation);
         const current_time = self.now();
         self.mutex.lockUncancelable(self.io);
+        self.reapCompletedFlightsLocked();
         self.pruneAccessTokensLocked(current_time);
         if (self.findValidAccessTokenLocked(challenge, current_time)) |token| {
             const copy = self.allocator.dupe(u8, token) catch |err| {
@@ -461,43 +478,25 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.mutex.unlock(self.io);
             return err;
         };
-        self.mutex.unlock(self.io);
-
-        const token = self.requestAccessToken(
-            challenge,
-            cancellation,
-            transport,
-        ) catch |err| return self.failFlight(flight, err);
-        const expires_on = jwtExpiry(self.allocator, token) catch |err| {
-            self.allocator.free(token);
-            return self.failFlight(flight, err);
+        self.startFlightWorkerLocked(flight, transport) catch |err| {
+            self.removeFlightLocked(flight);
+            self.mutex.unlock(self.io);
+            return err;
         };
-        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds)) {
-            self.allocator.free(token);
-            return self.failFlight(flight, error.AcrTokenExpired);
-        }
-
-        self.mutex.lockUncancelable(self.io);
-        self.pruneAccessTokensLocked(self.now());
-        self.storeAccessTokenLocked(challenge, token, expires_on) catch |err| {
-            self.allocator.free(token);
-            self.completeFlightFailureLocked(flight, err);
-            return self.consumeFlightResultLocked(flight, false);
-        };
-        self.completeFlightSuccessLocked(flight, token);
-        return self.consumeFlightResultLocked(flight, false);
+        self.waiting_callers += 1;
+        return self.waitForFlightLocked(flight, cancellation);
     }
 
     fn acquireRefreshToken(
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
-        credential: *core.credentials.TokenCredential,
         cancellation: ?*const CancellationToken,
         transport: *HttpTransport,
     ) ![]u8 {
         try checkCancelled(cancellation);
         const current_time = self.now();
         self.mutex.lockUncancelable(self.io);
+        self.reapCompletedFlightsLocked();
         self.pruneRefreshTokensLocked(current_time);
         if (self.findValidRefreshTokenLocked(challenge, current_time)) |token| {
             const copy = self.allocator.dupe(u8, token) catch |err| {
@@ -516,40 +515,13 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.mutex.unlock(self.io);
             return err;
         };
-        self.mutex.unlock(self.io);
-
-        const scopes = [_][]const u8{self.aad_scope};
-        var aad_token = credential.getToken(
-            .{ .scopes = &scopes },
-            core.context.Context.none,
-        ) catch |err| return self.failFlight(flight, err);
-        defer aad_token.deinit();
-        checkCancelled(cancellation) catch |err| return self.failFlight(flight, err);
-
-        const refresh_token = self.exchangeRefreshToken(
-            challenge,
-            aad_token.token,
-            cancellation,
-            transport,
-        ) catch |err| return self.failFlight(flight, err);
-        const expires_on = jwtExpiry(self.allocator, refresh_token) catch |err| {
-            self.allocator.free(refresh_token);
-            return self.failFlight(flight, err);
+        self.startFlightWorkerLocked(flight, transport) catch |err| {
+            self.removeFlightLocked(flight);
+            self.mutex.unlock(self.io);
+            return err;
         };
-        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds)) {
-            self.allocator.free(refresh_token);
-            return self.failFlight(flight, error.AcrRefreshTokenExpired);
-        }
-
-        self.mutex.lockUncancelable(self.io);
-        self.pruneRefreshTokensLocked(self.now());
-        self.storeRefreshTokenLocked(challenge, refresh_token, expires_on) catch |err| {
-            self.allocator.free(refresh_token);
-            self.completeFlightFailureLocked(flight, err);
-            return self.consumeFlightResultLocked(flight, false);
-        };
-        self.completeFlightSuccessLocked(flight, refresh_token);
-        return self.consumeFlightResultLocked(flight, false);
+        self.waiting_callers += 1;
+        return self.waitForFlightLocked(flight, cancellation);
     }
 
     fn requestAccessToken(
@@ -566,12 +538,11 @@ pub const ChallengeAuthenticationPolicy = struct {
                 cancellation,
                 transport,
             ),
-            .credential => |credential| blk: {
+            .credential => blk: {
                 var retried = false;
                 while (true) {
                     const refresh_token = try self.acquireRefreshToken(
                         challenge,
-                        credential,
                         cancellation,
                         transport,
                     );
@@ -1043,6 +1014,130 @@ pub const ChallengeAuthenticationPolicy = struct {
         return flight;
     }
 
+    fn startFlightWorkerLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        transport: *HttpTransport,
+    ) !void {
+        std.debug.assert(flight.worker == null);
+        flight.worker = try std.Thread.spawn(
+            .{},
+            runFlightWorker,
+            .{ self, flight, transport },
+        );
+    }
+
+    fn runFlightWorker(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        transport: *HttpTransport,
+    ) void {
+        switch (flight.kind) {
+            .refresh => self.runRefreshFlight(flight, transport),
+            .access => self.runAccessFlight(flight, transport),
+        }
+    }
+
+    fn runAccessFlight(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        transport: *HttpTransport,
+    ) void {
+        const challenge = flight.challenge(self.allocator);
+        const token = self.requestAccessToken(
+            &challenge,
+            null,
+            transport,
+        ) catch |err| {
+            self.publishFlightFailure(flight, err);
+            return;
+        };
+        const expires_on = jwtExpiry(self.allocator, token) catch |err| {
+            self.allocator.free(token);
+            self.publishFlightFailure(flight, err);
+            return;
+        };
+        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds)) {
+            self.allocator.free(token);
+            self.publishFlightFailure(flight, error.AcrTokenExpired);
+            return;
+        }
+
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.pruneAccessTokensLocked(self.now());
+        self.storeAccessTokenLocked(&challenge, token, expires_on) catch |err| {
+            self.allocator.free(token);
+            self.completeFlightFailureLocked(flight, err);
+            return;
+        };
+        self.completeFlightSuccessLocked(flight, token);
+    }
+
+    fn runRefreshFlight(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        transport: *HttpTransport,
+    ) void {
+        const credential = switch (self.authentication) {
+            .credential => |value| value,
+            .anonymous => {
+                self.publishFlightFailure(flight, error.CredentialRequired);
+                return;
+            },
+        };
+        const scopes = [_][]const u8{self.aad_scope};
+        var aad_token = credential.getToken(
+            .{ .scopes = &scopes },
+            core.context.Context.none,
+        ) catch |err| {
+            self.publishFlightFailure(flight, err);
+            return;
+        };
+        defer aad_token.deinit();
+
+        const challenge = flight.challenge(self.allocator);
+        const token = self.exchangeRefreshToken(
+            &challenge,
+            aad_token.token,
+            null,
+            transport,
+        ) catch |err| {
+            self.publishFlightFailure(flight, err);
+            return;
+        };
+        const expires_on = jwtExpiry(self.allocator, token) catch |err| {
+            self.allocator.free(token);
+            self.publishFlightFailure(flight, err);
+            return;
+        };
+        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds)) {
+            self.allocator.free(token);
+            self.publishFlightFailure(flight, error.AcrRefreshTokenExpired);
+            return;
+        }
+
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.pruneRefreshTokensLocked(self.now());
+        self.storeRefreshTokenLocked(&challenge, token, expires_on) catch |err| {
+            self.allocator.free(token);
+            self.completeFlightFailureLocked(flight, err);
+            return;
+        };
+        self.completeFlightSuccessLocked(flight, token);
+    }
+
+    fn publishFlightFailure(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        failure: anyerror,
+    ) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.completeFlightFailureLocked(flight, failure);
+    }
+
     fn waitForFlightLocked(
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
@@ -1077,16 +1172,6 @@ pub const ChallengeAuthenticationPolicy = struct {
         self.releaseFlightLocked(flight);
         self.mutex.unlock(self.io);
         return failure;
-    }
-
-    fn failFlight(
-        self: *ChallengeAuthenticationPolicy,
-        flight: *TokenFlight,
-        failure: anyerror,
-    ) anyerror![]u8 {
-        self.mutex.lockUncancelable(self.io);
-        self.completeFlightFailureLocked(flight, failure);
-        return self.consumeFlightResultLocked(flight, false);
     }
 
     fn completeFlightSuccessLocked(
@@ -1129,7 +1214,8 @@ pub const ChallengeAuthenticationPolicy = struct {
             },
             .failed => failure = flight.failure.?,
         }
-        if (waiter) self.waiting_callers -= 1;
+        std.debug.assert(waiter);
+        self.waiting_callers -= 1;
         self.releaseFlightLocked(flight);
         self.mutex.unlock(self.io);
         if (failure) |err| return err;
@@ -1143,15 +1229,57 @@ pub const ChallengeAuthenticationPolicy = struct {
         std.debug.assert(flight.participants > 0);
         flight.participants -= 1;
         if (flight.participants != 0) return;
-        std.debug.assert(flight.state != .running);
+        if (flight.state == .running) return;
+        self.removeFlightLocked(flight);
+    }
+
+    fn reapCompletedFlightsLocked(
+        self: *ChallengeAuthenticationPolicy,
+    ) void {
+        var index: usize = 0;
+        while (index < self.token_flights.items.len) {
+            const flight = self.token_flights.items[index];
+            if (flight.state == .running or flight.participants != 0) {
+                index += 1;
+                continue;
+            }
+            _ = self.token_flights.swapRemove(index);
+            self.joinAndDeinitFlightLocked(flight);
+        }
+    }
+
+    fn removeFlightLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+    ) void {
         for (self.token_flights.items, 0..) |candidate, index| {
             if (candidate != flight) continue;
             _ = self.token_flights.swapRemove(index);
-            flight.deinit(self.allocator);
-            self.allocator.destroy(flight);
+            self.joinAndDeinitFlightLocked(flight);
             return;
         }
         unreachable;
+    }
+
+    fn joinAndDeinitFlightLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+    ) void {
+        if (flight.worker) |worker| {
+            flight.worker = null;
+            worker.join();
+        }
+        flight.deinit(self.allocator);
+        self.allocator.destroy(flight);
+    }
+
+    fn findUnjoinedFlightWorkerLocked(
+        self: *ChallengeAuthenticationPolicy,
+    ) ?*TokenFlight {
+        for (self.token_flights.items) |flight| {
+            if (flight.worker != null) return flight;
+        }
+        return null;
     }
 
     fn effectiveTenant(
@@ -1433,6 +1561,46 @@ fn setBearerHeader(request: *Request, token: []const u8) !void {
     const value = try std.fmt.allocPrint(request.allocator, "Bearer {s}", .{token});
     defer request.allocator.free(value);
     try request.setHeader("Authorization", value);
+}
+
+const RequestAuthorizationState = struct {
+    original_authorization: ?[]const u8,
+    modified: bool = false,
+
+    fn init(request: *const Request) RequestAuthorizationState {
+        return .{ .original_authorization = request.getHeader("Authorization") };
+    }
+
+    fn setBearer(
+        self: *RequestAuthorizationState,
+        request: *Request,
+        token: []const u8,
+    ) !void {
+        std.debug.assert(self.original_authorization == null);
+        try setBearerHeader(request, token);
+        self.modified = true;
+    }
+
+    fn restore(self: *RequestAuthorizationState, request: *Request) void {
+        if (!self.modified) return;
+        std.debug.assert(self.original_authorization == null);
+        removeRequestHeader(request, "Authorization");
+    }
+};
+
+fn removeRequestHeader(request: *Request, name: []const u8) void {
+    var owned_name: ?[]const u8 = null;
+    var iterator = request.headers.iterator();
+    while (iterator.next()) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, name)) {
+            owned_name = entry.key_ptr.*;
+            break;
+        }
+    }
+    const key = owned_name orelse return;
+    const removed = request.headers.fetchRemove(key).?;
+    request.allocator.free(removed.key);
+    request.allocator.free(removed.value);
 }
 
 fn appendFormField(
@@ -1729,6 +1897,82 @@ const ParallelAccessTransport = struct {
         if (std.mem.indexOf(u8, body, "repository%3Atwo%3Apull") != null)
             return testResponse(self.allocator, 200, self.access_two_body);
         return error.UnexpectedMockScope;
+    }
+};
+
+const CancelAfterOpenPolicy = struct {
+    cancellation: *CancellationToken,
+    policy: HttpPolicy,
+
+    fn init(cancellation: *CancellationToken) CancelAfterOpenPolicy {
+        return .{
+            .cancellation = cancellation,
+            .policy = .{
+                .processFn = &processImpl,
+                .prepareFn = &prepareImpl,
+                .openFn = &openImpl,
+            },
+        };
+    }
+
+    fn processImpl(
+        _: *HttpPolicy,
+        request: *Request,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !Response {
+        return callNext(request, next, final_transport);
+    }
+
+    fn prepareImpl(_: *HttpPolicy, _: *Request) !void {}
+
+    fn openImpl(
+        policy: *HttpPolicy,
+        request: *Request,
+        options: OpenOptions,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !*HttpOperation {
+        const self: *CancelAfterOpenPolicy =
+            @alignCast(@fieldParentPtr("policy", policy));
+        const operation = try callNextOpen(request, options, next, final_transport);
+        self.cancellation.cancel();
+        return operation;
+    }
+};
+
+const BlockingTokenTransport = struct {
+    allocator: std.mem.Allocator,
+    response_body: []const u8,
+    entered: std.Io.Semaphore = .{},
+    release: std.Io.Semaphore = .{},
+    calls: std.atomic.Value(usize) = .init(0),
+    transport: HttpTransport,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        response_body: []const u8,
+    ) BlockingTokenTransport {
+        return .{
+            .allocator = allocator,
+            .response_body = response_body,
+            .transport = .{ .sendFn = &sendImpl },
+        };
+    }
+
+    fn asTransport(self: *BlockingTokenTransport) *HttpTransport {
+        return &self.transport;
+    }
+
+    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
+        const self: *BlockingTokenTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        if (std.mem.indexOf(u8, request.url, "/oauth2/token") == null)
+            return error.UnexpectedMockRequest;
+        _ = self.calls.fetchAdd(1, .monotonic);
+        self.entered.post(std.Io.Threaded.global_single_threaded.io());
+        self.release.waitUncancelable(std.Io.Threaded.global_single_threaded.io());
+        return testResponse(self.allocator, 200, self.response_body);
     }
 };
 
@@ -2076,6 +2320,104 @@ test "401 invalidates one scoped access token and replays exactly once" {
     );
     try std.testing.expectEqual(
         @as(usize, 2),
+        countCapturedUrl(&transport, "/oauth2/token"),
+    );
+}
+
+test "buffered request reuse restores SDK authorization across invalidation and expiry" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const refresh_token = try makeJwt(allocator, 5_000, "refresh");
+    defer allocator.free(refresh_token);
+    const access_one = try makeJwt(allocator, 1_100, "access-one");
+    defer allocator.free(access_one);
+    const access_two = try makeJwt(allocator, 1_200, "access-two");
+    defer allocator.free(access_two);
+    const access_three = try makeJwt(allocator, 3_000, "access-three");
+    defer allocator.free(access_three);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const access_one_body = try makeTokenResponse(allocator, "access_token", access_one);
+    defer allocator.free(access_one_body);
+    const access_two_body = try makeTokenResponse(allocator, "access_token", access_two);
+    defer allocator.free(access_two_body);
+    const access_three_body = try makeTokenResponse(allocator, "access_token", access_three);
+    defer allocator.free(access_three_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_one_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = access_two_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 200, .body = access_three_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var policies = [_]*HttpPolicy{policy.asPolicy()};
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport.asTransport(),
+    };
+    var request = Request.init(
+        allocator,
+        .GET,
+        "https://registry.example/v2/one/manifests/latest",
+    );
+    defer request.deinit();
+
+    var first = try pipeline.send(&request);
+    first.deinit();
+    try std.testing.expect(request.getHeader("Authorization") == null);
+
+    var second = try pipeline.send(&request);
+    second.deinit();
+    try std.testing.expect(request.getHeader("Authorization") == null);
+
+    clock.value = 1_300;
+    var third = try pipeline.send(&request);
+    third.deinit();
+    try std.testing.expect(request.getHeader("Authorization") == null);
+
+    try request.setHeader("Authorization", "Custom caller-token");
+    var caller_authorized = try pipeline.send(&request);
+    caller_authorized.deinit();
+    try std.testing.expectEqualStrings(
+        "Custom caller-token",
+        request.getHeader("Authorization").?,
+    );
+
+    try std.testing.expectEqual(@as(usize, 10), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countCapturedUrl(&transport, "/oauth2/exchange"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 3),
         countCapturedUrl(&transport, "/oauth2/token"),
     );
 }
@@ -2617,6 +2959,136 @@ test "streaming cancellation is preserved before transport" {
         pipeline.open(&request, .{ .cancellation = &cancellation }),
     );
     try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
+
+test "streaming challenge cancellation aborts and deinitializes the active operation" {
+    const allocator = std.testing.allocator;
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "registry:catalog:*",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    var transport = core.http.MockTransport.init(allocator, 401, "");
+    defer transport.deinit();
+    transport.response_headers_list = &headers;
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{},
+    );
+    defer policy.deinit();
+    var cancellation = CancellationToken{};
+    var cancel_policy = CancelAfterOpenPolicy.init(&cancellation);
+    var policies = [_]*HttpPolicy{ policy.asPolicy(), &cancel_policy.policy };
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport.asTransport(),
+    };
+    var request = Request.init(allocator, .GET, "https://registry.example/v2/_catalog");
+    defer request.deinit();
+
+    try std.testing.expectError(
+        error.OperationCancelled,
+        pipeline.open(&request, .{ .cancellation = &cancellation }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_abort_count);
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_deinit_count);
+    try std.testing.expectEqual(@as(usize, 0), transport.stream_finish_count);
+    try std.testing.expect(request.getHeader("Authorization") == null);
+}
+
+test "streaming request reuse restores SDK authorization across invalidation and expiry" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    const access_one = try makeJwt(allocator, 1_100, "access-one");
+    defer allocator.free(access_one);
+    const access_two = try makeJwt(allocator, 1_200, "access-two");
+    defer allocator.free(access_two);
+    const access_three = try makeJwt(allocator, 3_000, "access-three");
+    defer allocator.free(access_three);
+    const access_one_body = try makeTokenResponse(allocator, "access_token", access_one);
+    defer allocator.free(access_one_body);
+    const access_two_body = try makeTokenResponse(allocator, "access_token", access_two);
+    defer allocator.free(access_two_body);
+    const access_three_body = try makeTokenResponse(allocator, "access_token", access_three);
+    defer allocator.free(access_three_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "registry:catalog:*",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = access_one_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = access_two_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 200, .body = access_three_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var policies = [_]*HttpPolicy{policy.asPolicy()};
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport.asTransport(),
+    };
+    var request = Request.init(allocator, .GET, "https://registry.example/v2/_catalog");
+    defer request.deinit();
+
+    var first = try pipeline.open(&request, .{});
+    try first.finish();
+    first.deinit();
+    try std.testing.expect(request.getHeader("Authorization") == null);
+
+    var second = try pipeline.open(&request, .{});
+    try second.finish();
+    second.deinit();
+    try std.testing.expect(request.getHeader("Authorization") == null);
+
+    clock.value = 1_300;
+    var third = try pipeline.open(&request, .{});
+    try third.finish();
+    third.deinit();
+    try std.testing.expect(request.getHeader("Authorization") == null);
+
+    try request.setHeader("Authorization", "Custom caller-token");
+    var caller_authorized = try pipeline.open(&request, .{});
+    try caller_authorized.finish();
+    caller_authorized.deinit();
+    try std.testing.expectEqualStrings(
+        "Custom caller-token",
+        request.getHeader("Authorization").?,
+    );
+
+    try std.testing.expectEqual(@as(usize, 9), transport.call_count);
+    try std.testing.expectEqual(
+        @as(usize, 3),
+        countCapturedUrl(&transport, "/oauth2/token"),
+    );
 }
 
 test "trusted origins compare HTTPS host and effective port" {
@@ -3456,6 +3928,298 @@ test "same-key flight wakes waiters with the leader failure" {
     try std.testing.expectEqual(error.MockCredentialFailure, second.err.?);
     try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
     try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
+
+test "cancelled refresh flight leader does not fail a non-cancelled follower" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var entered: std.Io.Semaphore = .{};
+    var release: std.Io.Semaphore = .{};
+    var credential = TestCredential.init();
+    credential.entered = &entered;
+    credential.release = &release;
+    const refresh_token = try makeJwt(allocator, 5_000, "refresh");
+    defer allocator.free(refresh_token);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = refresh_body },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var leader_challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    var leader_challenge_owned = true;
+    defer if (leader_challenge_owned) leader_challenge.deinit();
+    var follower_challenge = try leader_challenge.clone(allocator);
+    defer follower_challenge.deinit();
+    var cancellation = CancellationToken{};
+
+    const AcquireContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+        token: ?[]u8 = null,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.token = self.policy.acquireRefreshToken(
+                self.challenge,
+                self.cancellation,
+                self.transport,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    };
+    var leader = AcquireContext{
+        .policy = &policy,
+        .challenge = &leader_challenge,
+        .cancellation = &cancellation,
+        .transport = transport.asTransport(),
+    };
+    var follower = AcquireContext{
+        .policy = &policy,
+        .challenge = &follower_challenge,
+        .cancellation = null,
+        .transport = transport.asTransport(),
+    };
+    const leader_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&leader});
+    entered.waitUncancelable(policy.io);
+    const follower_thread = std.Thread.spawn(.{}, AcquireContext.run, .{&follower}) catch |err| {
+        release.post(policy.io);
+        leader_thread.join();
+        return err;
+    };
+    while (true) {
+        policy.mutex.lockUncancelable(policy.io);
+        const waiting = policy.waiting_callers;
+        policy.mutex.unlock(policy.io);
+        if (waiting >= 2) break;
+        try policy.io.sleep(.fromMilliseconds(1), .awake);
+    }
+
+    cancellation.cancel();
+    leader_thread.join();
+    try std.testing.expectEqual(error.OperationCancelled, leader.err.?);
+    leader_challenge.deinit();
+    leader_challenge_owned = false;
+
+    release.post(policy.io);
+    follower_thread.join();
+    defer if (leader.token) |token| allocator.free(token);
+    defer if (follower.token) |token| allocator.free(token);
+
+    try std.testing.expect(follower.err == null);
+    try std.testing.expectEqualStrings(refresh_token, follower.token.?);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+}
+
+test "cancelled access flight leader does not fail a non-cancelled follower" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    const access_token = try makeJwt(allocator, 4_000, "access");
+    defer allocator.free(access_token);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    var transport = BlockingTokenTransport.init(allocator, access_body);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var leader_challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    var leader_challenge_owned = true;
+    defer if (leader_challenge_owned) leader_challenge.deinit();
+    var follower_challenge = try leader_challenge.clone(allocator);
+    defer follower_challenge.deinit();
+    var cancellation = CancellationToken{};
+
+    const AcquireContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+        token: ?[]u8 = null,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.token = self.policy.acquireAccessToken(
+                self.challenge,
+                self.cancellation,
+                self.transport,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    };
+    var leader = AcquireContext{
+        .policy = &policy,
+        .challenge = &leader_challenge,
+        .cancellation = &cancellation,
+        .transport = transport.asTransport(),
+    };
+    var follower = AcquireContext{
+        .policy = &policy,
+        .challenge = &follower_challenge,
+        .cancellation = null,
+        .transport = transport.asTransport(),
+    };
+    const leader_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&leader});
+    transport.entered.waitUncancelable(policy.io);
+    const follower_thread = std.Thread.spawn(.{}, AcquireContext.run, .{&follower}) catch |err| {
+        transport.release.post(policy.io);
+        leader_thread.join();
+        return err;
+    };
+    while (true) {
+        policy.mutex.lockUncancelable(policy.io);
+        const waiting = policy.waiting_callers;
+        policy.mutex.unlock(policy.io);
+        if (waiting >= 2) break;
+        try policy.io.sleep(.fromMilliseconds(1), .awake);
+    }
+
+    cancellation.cancel();
+    leader_thread.join();
+    try std.testing.expectEqual(error.OperationCancelled, leader.err.?);
+    leader_challenge.deinit();
+    leader_challenge_owned = false;
+
+    transport.release.post(policy.io);
+    follower_thread.join();
+    defer if (leader.token) |token| allocator.free(token);
+    defer if (follower.token) |token| allocator.free(token);
+
+    try std.testing.expect(follower.err == null);
+    try std.testing.expectEqualStrings(access_token, follower.token.?);
+    try std.testing.expectEqual(@as(usize, 1), transport.calls.load(.monotonic));
+}
+
+test "policy deinit joins orphaned shared work after participant cancellation" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    const access_token = try makeJwt(allocator, 4_000, "access");
+    defer allocator.free(access_token);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    var transport = BlockingTokenTransport.init(allocator, access_body);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    var policy_owned = true;
+    defer if (policy_owned) policy.deinit();
+    var challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    var challenge_owned = true;
+    defer if (challenge_owned) challenge.deinit();
+    var cancellation = CancellationToken{};
+
+    const AcquireContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        cancellation: *const CancellationToken,
+        transport: *HttpTransport,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            const token = self.policy.acquireAccessToken(
+                self.challenge,
+                self.cancellation,
+                self.transport,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+            self.policy.allocator.free(token);
+        }
+    };
+    var acquire = AcquireContext{
+        .policy = &policy,
+        .challenge = &challenge,
+        .cancellation = &cancellation,
+        .transport = transport.asTransport(),
+    };
+    const acquire_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&acquire});
+    transport.entered.waitUncancelable(policy.io);
+    cancellation.cancel();
+    acquire_thread.join();
+    try std.testing.expectEqual(error.OperationCancelled, acquire.err.?);
+    challenge.deinit();
+    challenge_owned = false;
+
+    const DeinitContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        completed: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            self.policy.deinit();
+            self.completed.store(true, .release);
+        }
+    };
+    var deinit_context = DeinitContext{ .policy = &policy };
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const deinit_thread = std.Thread.spawn(.{}, DeinitContext.run, .{&deinit_context}) catch |err| {
+        transport.release.post(io);
+        return err;
+    };
+    io.sleep(
+        .fromMilliseconds(10),
+        .awake,
+    ) catch |err| {
+        transport.release.post(io);
+        deinit_thread.join();
+        policy_owned = false;
+        return err;
+    };
+    const completed_while_worker_blocked = deinit_context.completed.load(.acquire);
+    transport.release.post(io);
+    deinit_thread.join();
+    policy_owned = false;
+
+    try std.testing.expect(!completed_while_worker_blocked);
+    try std.testing.expect(deinit_context.completed.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 1), transport.calls.load(.monotonic));
 }
 
 test "cancelling a same-key waiter leaves the leader race safe" {

--- a/sdk/container_registry/src/auth_policy.zig
+++ b/sdk/container_registry/src/auth_policy.zig
@@ -14,6 +14,10 @@ const CancellationToken = core.http.CancellationToken;
 const default_aad_scope = "https://containerregistry.azure.net/.default";
 const default_api_version = "2021-07-01";
 const default_expiry_skew_seconds: i64 = 300;
+// Small fixed LRU bounds keep cache scans predictable for long-lived clients.
+const max_refresh_token_entries: usize = 32;
+const max_access_token_entries: usize = 128;
+const max_route_entries: usize = 128;
 
 pub const Authentication = union(enum) {
     credential: *core.credentials.TokenCredential,
@@ -36,7 +40,9 @@ pub const Options = struct {
     aad_scope: []const u8 = default_aad_scope,
     /// ACR authentication API version.
     api_version: []const u8 = default_api_version,
-    /// Additional exact HTTPS hosts trusted for registry requests and realms.
+    /// Additional trusted HTTPS origins. A hostname implies port 443; use an
+    /// absolute origin such as `https://registry.example:8443` for another
+    /// port.
     expected_hosts: []const []const u8 = &.{},
     /// Tokens at or within this many seconds of expiry are refreshed.
     expiry_skew_seconds: i64 = default_expiry_skew_seconds,
@@ -50,6 +56,7 @@ const RefreshTokenEntry = struct {
     tenant: []u8,
     token: []u8,
     expires_on: i64,
+    last_used: u64,
 
     fn deinit(self: *RefreshTokenEntry, allocator: std.mem.Allocator) void {
         allocator.free(self.realm);
@@ -67,6 +74,7 @@ const AccessTokenEntry = struct {
     scope: []u8,
     token: []u8,
     expires_on: i64,
+    last_used: u64,
 
     fn deinit(self: *AccessTokenEntry, allocator: std.mem.Allocator) void {
         allocator.free(self.realm);
@@ -82,6 +90,7 @@ const RouteEntry = struct {
     method: core.http.Method,
     url: []u8,
     challenge: BearerChallenge,
+    last_used: u64,
 
     fn deinit(self: *RouteEntry, allocator: std.mem.Allocator) void {
         allocator.free(self.url);
@@ -90,14 +99,82 @@ const RouteEntry = struct {
     }
 };
 
+const TrustedOrigin = struct {
+    host: []u8,
+    port: u16,
+
+    fn deinit(self: *TrustedOrigin, allocator: std.mem.Allocator) void {
+        allocator.free(self.host);
+        self.* = undefined;
+    }
+};
+
+const FlightKind = enum {
+    refresh,
+    access,
+};
+
+const FlightState = enum {
+    running,
+    succeeded,
+    failed,
+};
+
+const TokenFlight = struct {
+    kind: FlightKind,
+    realm: []u8,
+    service: []u8,
+    tenant: []u8,
+    scope: []u8,
+    condition: std.Io.Condition = .init,
+    state: FlightState = .running,
+    participants: usize = 1,
+    token: ?[]u8 = null,
+    failure: ?anyerror = null,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        kind: FlightKind,
+        realm_value: []const u8,
+        service_value: []const u8,
+        tenant_value: []const u8,
+        scope_value: []const u8,
+    ) !TokenFlight {
+        const realm = try allocator.dupe(u8, realm_value);
+        errdefer allocator.free(realm);
+        const service = try allocator.dupe(u8, service_value);
+        errdefer allocator.free(service);
+        const tenant = try allocator.dupe(u8, tenant_value);
+        errdefer allocator.free(tenant);
+        const scope = try allocator.dupe(u8, scope_value);
+        errdefer allocator.free(scope);
+        return .{
+            .kind = kind,
+            .realm = realm,
+            .service = service,
+            .tenant = tenant,
+            .scope = scope,
+        };
+    }
+
+    fn deinit(self: *TokenFlight, allocator: std.mem.Allocator) void {
+        allocator.free(self.realm);
+        allocator.free(self.service);
+        allocator.free(self.tenant);
+        allocator.free(self.scope);
+        if (self.token) |token| allocator.free(token);
+        self.* = undefined;
+    }
+};
+
 /// ACR Bearer challenge policy. The policy validates every destination before
 /// sending, performs token bootstrap calls without redirects, and replays a
-/// challenged request at most once.
+/// challenged request at most once. Concurrent use requires thread-safe
+/// allocator, credential, and clock dependencies.
 pub const ChallengeAuthenticationPolicy = struct {
     allocator: std.mem.Allocator,
     endpoint: []u8,
-    endpoint_host: []u8,
-    expected_hosts: [][]u8,
+    trusted_origins: []TrustedOrigin,
     authentication: Authentication,
     tenant_id: ?[]u8,
     aad_scope: []u8,
@@ -106,12 +183,12 @@ pub const ChallengeAuthenticationPolicy = struct {
     time_source: ?TimeSource,
     io: std.Io,
     mutex: std.Io.Mutex = .init,
-    refresh_finished: std.Io.Condition = .init,
-    refreshing: bool = false,
     waiting_callers: usize = 0,
+    cache_clock: u64 = 0,
     refresh_tokens: std.ArrayList(RefreshTokenEntry) = .empty,
     access_tokens: std.ArrayList(AccessTokenEntry) = .empty,
     routes: std.ArrayList(RouteEntry) = .empty,
+    token_flights: std.ArrayList(*TokenFlight) = .empty,
     policy: HttpPolicy,
 
     pub fn init(
@@ -126,14 +203,12 @@ pub const ChallengeAuthenticationPolicy = struct {
 
         const normalized_endpoint = try normalizeEndpoint(allocator, endpoint);
         errdefer allocator.free(normalized_endpoint);
-        const endpoint_host = try extractHost(allocator, normalized_endpoint);
-        errdefer allocator.free(endpoint_host);
-        const expected_hosts = try copyExpectedHosts(
+        const trusted_origins = try copyTrustedOrigins(
             allocator,
-            endpoint_host,
+            normalized_endpoint,
             options.expected_hosts,
         );
-        errdefer deinitStringSlice(allocator, expected_hosts);
+        errdefer deinitTrustedOrigins(allocator, trusted_origins);
 
         const tenant_id = if (options.tenant_id) |tenant|
             try allocator.dupe(u8, tenant)
@@ -148,8 +223,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         return .{
             .allocator = allocator,
             .endpoint = normalized_endpoint,
-            .endpoint_host = endpoint_host,
-            .expected_hosts = expected_hosts,
+            .trusted_origins = trusted_origins,
             .authentication = authentication,
             .tenant_id = tenant_id,
             .aad_scope = aad_scope,
@@ -168,19 +242,19 @@ pub const ChallengeAuthenticationPolicy = struct {
     /// Requires that no callers are using or waiting on this policy.
     pub fn deinit(self: *ChallengeAuthenticationPolicy) void {
         self.mutex.lockUncancelable(self.io);
-        std.debug.assert(!self.refreshing);
         std.debug.assert(self.waiting_callers == 0);
+        std.debug.assert(self.token_flights.items.len == 0);
         for (self.refresh_tokens.items) |*entry| entry.deinit(self.allocator);
         self.refresh_tokens.deinit(self.allocator);
         for (self.access_tokens.items) |*entry| entry.deinit(self.allocator);
         self.access_tokens.deinit(self.allocator);
         for (self.routes.items) |*entry| entry.deinit(self.allocator);
         self.routes.deinit(self.allocator);
+        self.token_flights.deinit(self.allocator);
         self.mutex.unlock(self.io);
 
         self.allocator.free(self.endpoint);
-        self.allocator.free(self.endpoint_host);
-        deinitStringSlice(self.allocator, self.expected_hosts);
+        deinitTrustedOrigins(self.allocator, self.trusted_origins);
         if (self.tenant_id) |tenant| self.allocator.free(tenant);
         self.allocator.free(self.aad_scope);
         self.allocator.free(self.api_version);
@@ -366,84 +440,52 @@ pub const ChallengeAuthenticationPolicy = struct {
         cancellation: ?*const CancellationToken,
         transport: *HttpTransport,
     ) ![]u8 {
-        while (true) {
-            try checkCancelled(cancellation);
-            const current_time = self.now();
-            self.mutex.lockUncancelable(self.io);
-            if (self.findValidAccessTokenLocked(challenge, current_time)) |token| {
-                const copy = self.allocator.dupe(u8, token) catch |err| {
-                    self.mutex.unlock(self.io);
-                    return err;
-                };
-                self.mutex.unlock(self.io);
-                return copy;
-            }
-            if (self.refreshing) {
-                if (cancellation == null) {
-                    self.waiting_callers += 1;
-                    self.refresh_finished.waitUncancelable(self.io, &self.mutex);
-                    self.waiting_callers -= 1;
-                    self.mutex.unlock(self.io);
-                } else {
-                    self.mutex.unlock(self.io);
-                    while (true) {
-                        try checkCancelled(cancellation);
-                        self.io.sleep(.fromMilliseconds(1), .awake) catch {};
-                        self.mutex.lockUncancelable(self.io);
-                        if (!self.refreshing) {
-                            self.mutex.unlock(self.io);
-                            break;
-                        }
-                        self.mutex.unlock(self.io);
-                    }
-                }
-                continue;
-            }
-            self.refreshing = true;
-            self.mutex.unlock(self.io);
-            break;
-        }
-
-        errdefer self.finishRefresh();
-        const token = switch (self.authentication) {
-            .anonymous => try self.exchangeAccessToken(
-                challenge,
-                "",
-                .password,
-                cancellation,
-                transport,
-            ),
-            .credential => |credential| blk: {
-                const refresh_token = try self.acquireRefreshToken(
-                    challenge,
-                    credential,
-                    cancellation,
-                    transport,
-                );
-                defer self.allocator.free(refresh_token);
-                break :blk try self.exchangeAccessToken(
-                    challenge,
-                    refresh_token,
-                    .refresh_token,
-                    cancellation,
-                    transport,
-                );
-            },
-        };
-        errdefer self.allocator.free(token);
-        const expires_on = try jwtExpiry(self.allocator, token);
-        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds))
-            return error.AcrTokenExpired;
-
+        try checkCancelled(cancellation);
+        const current_time = self.now();
         self.mutex.lockUncancelable(self.io);
-        self.storeAccessTokenLocked(challenge, token, expires_on) catch |err| {
+        self.pruneAccessTokensLocked(current_time);
+        if (self.findValidAccessTokenLocked(challenge, current_time)) |token| {
+            const copy = self.allocator.dupe(u8, token) catch |err| {
+                self.mutex.unlock(self.io);
+                return err;
+            };
+            self.mutex.unlock(self.io);
+            return copy;
+        }
+        if (self.findRunningFlightLocked(.access, challenge)) |flight| {
+            flight.participants += 1;
+            self.waiting_callers += 1;
+            return self.waitForFlightLocked(flight, cancellation);
+        }
+        const flight = self.createFlightLocked(.access, challenge) catch |err| {
             self.mutex.unlock(self.io);
             return err;
         };
-        self.refreshing = false;
-        self.refresh_finished.broadcast(self.io);
         self.mutex.unlock(self.io);
-        return token;
+
+        const token = self.requestAccessToken(
+            challenge,
+            cancellation,
+            transport,
+        ) catch |err| return self.failFlight(flight, err);
+        const expires_on = jwtExpiry(self.allocator, token) catch |err| {
+            self.allocator.free(token);
+            return self.failFlight(flight, err);
+        };
+        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds)) {
+            self.allocator.free(token);
+            return self.failFlight(flight, error.AcrTokenExpired);
+        }
+
+        self.mutex.lockUncancelable(self.io);
+        self.pruneAccessTokensLocked(self.now());
+        self.storeAccessTokenLocked(challenge, token, expires_on) catch |err| {
+            self.allocator.free(token);
+            self.completeFlightFailureLocked(flight, err);
+            return self.consumeFlightResultLocked(flight, false);
+        };
+        self.completeFlightSuccessLocked(flight, token);
+        return self.consumeFlightResultLocked(flight, false);
     }
 
     fn acquireRefreshToken(
@@ -453,8 +495,10 @@ pub const ChallengeAuthenticationPolicy = struct {
         cancellation: ?*const CancellationToken,
         transport: *HttpTransport,
     ) ![]u8 {
+        try checkCancelled(cancellation);
         const current_time = self.now();
         self.mutex.lockUncancelable(self.io);
+        self.pruneRefreshTokensLocked(current_time);
         if (self.findValidRefreshTokenLocked(challenge, current_time)) |token| {
             const copy = self.allocator.dupe(u8, token) catch |err| {
                 self.mutex.unlock(self.io);
@@ -463,35 +507,92 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.mutex.unlock(self.io);
             return copy;
         }
-        self.mutex.unlock(self.io);
-
-        try checkCancelled(cancellation);
-        const scopes = [_][]const u8{self.aad_scope};
-        var aad_token = try credential.getToken(
-            .{ .scopes = &scopes },
-            core.context.Context.none,
-        );
-        defer aad_token.deinit();
-        try checkCancelled(cancellation);
-
-        const refresh_token = try self.exchangeRefreshToken(
-            challenge,
-            aad_token.token,
-            cancellation,
-            transport,
-        );
-        errdefer self.allocator.free(refresh_token);
-        const expires_on = try jwtExpiry(self.allocator, refresh_token);
-        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds))
-            return error.AcrRefreshTokenExpired;
-
-        self.mutex.lockUncancelable(self.io);
-        self.storeRefreshTokenLocked(challenge, refresh_token, expires_on) catch |err| {
+        if (self.findRunningFlightLocked(.refresh, challenge)) |flight| {
+            flight.participants += 1;
+            self.waiting_callers += 1;
+            return self.waitForFlightLocked(flight, cancellation);
+        }
+        const flight = self.createFlightLocked(.refresh, challenge) catch |err| {
             self.mutex.unlock(self.io);
             return err;
         };
         self.mutex.unlock(self.io);
-        return refresh_token;
+
+        const scopes = [_][]const u8{self.aad_scope};
+        var aad_token = credential.getToken(
+            .{ .scopes = &scopes },
+            core.context.Context.none,
+        ) catch |err| return self.failFlight(flight, err);
+        defer aad_token.deinit();
+        checkCancelled(cancellation) catch |err| return self.failFlight(flight, err);
+
+        const refresh_token = self.exchangeRefreshToken(
+            challenge,
+            aad_token.token,
+            cancellation,
+            transport,
+        ) catch |err| return self.failFlight(flight, err);
+        const expires_on = jwtExpiry(self.allocator, refresh_token) catch |err| {
+            self.allocator.free(refresh_token);
+            return self.failFlight(flight, err);
+        };
+        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds)) {
+            self.allocator.free(refresh_token);
+            return self.failFlight(flight, error.AcrRefreshTokenExpired);
+        }
+
+        self.mutex.lockUncancelable(self.io);
+        self.pruneRefreshTokensLocked(self.now());
+        self.storeRefreshTokenLocked(challenge, refresh_token, expires_on) catch |err| {
+            self.allocator.free(refresh_token);
+            self.completeFlightFailureLocked(flight, err);
+            return self.consumeFlightResultLocked(flight, false);
+        };
+        self.completeFlightSuccessLocked(flight, refresh_token);
+        return self.consumeFlightResultLocked(flight, false);
+    }
+
+    fn requestAccessToken(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+    ) ![]u8 {
+        return switch (self.authentication) {
+            .anonymous => self.exchangeAccessToken(
+                challenge,
+                "",
+                .password,
+                cancellation,
+                transport,
+            ),
+            .credential => |credential| blk: {
+                var retried = false;
+                while (true) {
+                    const refresh_token = try self.acquireRefreshToken(
+                        challenge,
+                        credential,
+                        cancellation,
+                        transport,
+                    );
+                    defer self.allocator.free(refresh_token);
+                    const access_token = self.exchangeAccessToken(
+                        challenge,
+                        refresh_token,
+                        .refresh_token,
+                        cancellation,
+                        transport,
+                    ) catch |err| {
+                        if (!isRefreshTokenRejection(err)) return err;
+                        self.invalidateRefreshToken(challenge, refresh_token);
+                        if (retried) return err;
+                        retried = true;
+                        continue;
+                    };
+                    break :blk access_token;
+                }
+            },
+        };
     }
 
     fn exchangeRefreshToken(
@@ -513,7 +614,14 @@ pub const ChallengeAuthenticationPolicy = struct {
             try appendFormField(self.allocator, &body, &first, "tenant", tenant);
         }
         try appendFormField(self.allocator, &body, &first, "access_token", aad_token);
-        return self.sendTokenRequest(url, body.items, "refresh_token", cancellation, transport);
+        return self.sendTokenRequest(
+            url,
+            body.items,
+            "refresh_token",
+            false,
+            cancellation,
+            transport,
+        );
     }
 
     const AccessGrant = enum {
@@ -539,7 +647,14 @@ pub const ChallengeAuthenticationPolicy = struct {
         try appendFormField(self.allocator, &body, &first, "service", challenge.service);
         try appendFormField(self.allocator, &body, &first, "scope", challenge.scope);
         try appendFormField(self.allocator, &body, &first, "refresh_token", refresh_token);
-        return self.sendTokenRequest(url, body.items, "access_token", cancellation, transport);
+        return self.sendTokenRequest(
+            url,
+            body.items,
+            "access_token",
+            grant == .refresh_token,
+            cancellation,
+            transport,
+        );
     }
 
     fn sendTokenRequest(
@@ -547,6 +662,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         url: []const u8,
         body: []const u8,
         response_field: []const u8,
+        classify_refresh_rejection: bool,
         cancellation: ?*const CancellationToken,
         transport: *HttpTransport,
     ) ![]u8 {
@@ -561,21 +677,36 @@ pub const ChallengeAuthenticationPolicy = struct {
         var response = try transport.send(&request);
         defer response.deinit();
         try checkCancelled(cancellation);
-        if (response.status_code != 200) return error.AcrTokenExchangeFailed;
-        return parseTokenResponse(self.allocator, response.body, response_field);
+        if (response.status_code == 401) return error.AcrTokenEndpointUnauthorized;
+        if (response.status_code == 403) return error.AcrTokenEndpointForbidden;
+        if (response.status_code != 200) {
+            if (classify_refresh_rejection and
+                try isProtocolRefreshTokenRejection(self.allocator, response.body))
+            {
+                return error.AcrRefreshTokenRejected;
+            }
+            return error.AcrTokenExchangeFailed;
+        }
+        return parseTokenResponse(self.allocator, response.body, response_field) catch |err| {
+            if (err == error.InvalidAcrTokenResponse and
+                classify_refresh_rejection and
+                try isProtocolRefreshTokenRejection(self.allocator, response.body))
+            {
+                return error.AcrRefreshTokenRejected;
+            }
+            return err;
+        };
     }
 
     fn validateRequestUrl(self: *ChallengeAuthenticationPolicy, url: []const u8) !void {
-        const hosts: []const []const u8 = @ptrCast(self.expected_hosts);
-        try core.url.validateHttpsUrl(url, hosts);
+        try validateTrustedHttpsUrl(url, self.trusted_origins);
     }
 
     fn validateChallenge(
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
     ) !void {
-        const hosts: []const []const u8 = @ptrCast(self.expected_hosts);
-        try core.url.validateHttpsUrl(challenge.realm, hosts);
+        try validateTrustedHttpsUrl(challenge.realm, self.trusted_origins);
         const realm_uri = std.Uri.parse(challenge.realm) catch return error.InvalidChallengeRealm;
         if (realm_uri.query != null or realm_uri.fragment != null)
             return error.InvalidChallengeRealm;
@@ -585,12 +716,16 @@ pub const ChallengeAuthenticationPolicy = struct {
         };
         if (!std.mem.eql(u8, path, "/oauth2/token")) return error.InvalidChallengeRealm;
 
-        const realm_host = try extractHost(self.allocator, challenge.realm);
-        defer self.allocator.free(realm_host);
-        if (!std.ascii.eqlIgnoreCase(realm_host, challenge.service))
+        var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+        const realm_host = realm_uri.getHost(&host_buffer) catch
+            return error.InvalidChallengeRealm;
+        if (!serviceMatchesOrigin(
+            challenge.service,
+            realm_host.bytes,
+            effectiveHttpsPort(realm_uri),
+        )) {
             return error.UntrustedChallengeService;
-        if (!hostExpected(hosts, challenge.service))
-            return error.UntrustedChallengeService;
+        }
         if (challenge.tenant) |challenge_tenant| {
             if (challenge_tenant.len == 0) return error.InvalidChallengeTenant;
             if (self.tenant_id) |configured| {
@@ -607,9 +742,11 @@ pub const ChallengeAuthenticationPolicy = struct {
         const route_url = requestRoute(request.url);
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
-        for (self.routes.items) |entry| {
-            if (entry.method == request.method and std.mem.eql(u8, entry.url, route_url))
+        for (self.routes.items) |*entry| {
+            if (entry.method == request.method and std.mem.eql(u8, entry.url, route_url)) {
+                entry.last_used = self.nextUseLocked();
                 return try entry.challenge.clone(self.allocator);
+            }
         }
         return null;
     }
@@ -628,6 +765,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             const replacement = try challenge.clone(self.allocator);
             entry.challenge.deinit();
             entry.challenge = replacement;
+            entry.last_used = self.nextUseLocked();
             return;
         }
 
@@ -635,10 +773,13 @@ pub const ChallengeAuthenticationPolicy = struct {
         errdefer self.allocator.free(url_copy);
         var challenge_copy = try challenge.clone(self.allocator);
         errdefer challenge_copy.deinit();
+        if (self.routes.items.len >= max_route_entries)
+            self.evictLeastRecentlyUsedRouteLocked();
         try self.routes.append(self.allocator, .{
             .method = request.method,
             .url = url_copy,
             .challenge = challenge_copy,
+            .last_used = self.nextUseLocked(),
         });
     }
 
@@ -659,15 +800,35 @@ pub const ChallengeAuthenticationPolicy = struct {
         }
     }
 
+    fn invalidateRefreshToken(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        rejected_token: []const u8,
+    ) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        for (self.refresh_tokens.items, 0..) |*entry, index| {
+            if (!refreshKeyMatches(entry, challenge, self.effectiveTenant(challenge)) or
+                !std.mem.eql(u8, entry.token, rejected_token))
+            {
+                continue;
+            }
+            var removed = self.refresh_tokens.swapRemove(index);
+            removed.deinit(self.allocator);
+            return;
+        }
+    }
+
     fn findValidRefreshTokenLocked(
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         current_time: i64,
     ) ?[]const u8 {
-        for (self.refresh_tokens.items) |entry| {
-            if (refreshKeyMatches(&entry, challenge, self.effectiveTenant(challenge)) and
+        for (self.refresh_tokens.items) |*entry| {
+            if (refreshKeyMatches(entry, challenge, self.effectiveTenant(challenge)) and
                 isTokenValid(entry.expires_on, current_time, self.expiry_skew_seconds))
             {
+                entry.last_used = self.nextUseLocked();
                 return entry.token;
             }
         }
@@ -679,10 +840,11 @@ pub const ChallengeAuthenticationPolicy = struct {
         challenge: *const BearerChallenge,
         current_time: i64,
     ) ?[]const u8 {
-        for (self.access_tokens.items) |entry| {
-            if (accessKeyMatches(&entry, challenge, self.effectiveTenant(challenge)) and
+        for (self.access_tokens.items) |*entry| {
+            if (accessKeyMatches(entry, challenge, self.effectiveTenant(challenge)) and
                 isTokenValid(entry.expires_on, current_time, self.expiry_skew_seconds))
             {
+                entry.last_used = self.nextUseLocked();
                 return entry.token;
             }
         }
@@ -702,6 +864,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.allocator.free(entry.token);
             entry.token = replacement;
             entry.expires_on = expires_on;
+            entry.last_used = self.nextUseLocked();
             return;
         }
 
@@ -713,12 +876,15 @@ pub const ChallengeAuthenticationPolicy = struct {
         errdefer self.allocator.free(tenant_copy);
         const token_copy = try self.allocator.dupe(u8, token);
         errdefer self.allocator.free(token_copy);
+        if (self.refresh_tokens.items.len >= max_refresh_token_entries)
+            self.evictLeastRecentlyUsedRefreshTokenLocked();
         try self.refresh_tokens.append(self.allocator, .{
             .realm = realm,
             .service = service,
             .tenant = tenant_copy,
             .token = token_copy,
             .expires_on = expires_on,
+            .last_used = self.nextUseLocked(),
         });
     }
 
@@ -735,6 +901,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.allocator.free(entry.token);
             entry.token = replacement;
             entry.expires_on = expires_on;
+            entry.last_used = self.nextUseLocked();
             return;
         }
 
@@ -748,6 +915,8 @@ pub const ChallengeAuthenticationPolicy = struct {
         errdefer self.allocator.free(scope);
         const token_copy = try self.allocator.dupe(u8, token);
         errdefer self.allocator.free(token_copy);
+        if (self.access_tokens.items.len >= max_access_token_entries)
+            self.evictLeastRecentlyUsedAccessTokenLocked();
         try self.access_tokens.append(self.allocator, .{
             .realm = realm,
             .service = service,
@@ -755,14 +924,234 @@ pub const ChallengeAuthenticationPolicy = struct {
             .scope = scope,
             .token = token_copy,
             .expires_on = expires_on,
+            .last_used = self.nextUseLocked(),
         });
     }
 
-    fn finishRefresh(self: *ChallengeAuthenticationPolicy) void {
-        self.mutex.lockUncancelable(self.io);
-        self.refreshing = false;
-        self.refresh_finished.broadcast(self.io);
+    fn pruneRefreshTokensLocked(
+        self: *ChallengeAuthenticationPolicy,
+        current_time: i64,
+    ) void {
+        var index: usize = 0;
+        while (index < self.refresh_tokens.items.len) {
+            if (isTokenValid(
+                self.refresh_tokens.items[index].expires_on,
+                current_time,
+                self.expiry_skew_seconds,
+            )) {
+                index += 1;
+                continue;
+            }
+            var removed = self.refresh_tokens.swapRemove(index);
+            removed.deinit(self.allocator);
+        }
+    }
+
+    fn pruneAccessTokensLocked(
+        self: *ChallengeAuthenticationPolicy,
+        current_time: i64,
+    ) void {
+        var index: usize = 0;
+        while (index < self.access_tokens.items.len) {
+            if (isTokenValid(
+                self.access_tokens.items[index].expires_on,
+                current_time,
+                self.expiry_skew_seconds,
+            )) {
+                index += 1;
+                continue;
+            }
+            var removed = self.access_tokens.swapRemove(index);
+            removed.deinit(self.allocator);
+        }
+    }
+
+    fn evictLeastRecentlyUsedRefreshTokenLocked(
+        self: *ChallengeAuthenticationPolicy,
+    ) void {
+        var oldest_index: usize = 0;
+        for (self.refresh_tokens.items[1..], 1..) |entry, index| {
+            if (entry.last_used < self.refresh_tokens.items[oldest_index].last_used)
+                oldest_index = index;
+        }
+        var removed = self.refresh_tokens.swapRemove(oldest_index);
+        removed.deinit(self.allocator);
+    }
+
+    fn evictLeastRecentlyUsedAccessTokenLocked(
+        self: *ChallengeAuthenticationPolicy,
+    ) void {
+        var oldest_index: usize = 0;
+        for (self.access_tokens.items[1..], 1..) |entry, index| {
+            if (entry.last_used < self.access_tokens.items[oldest_index].last_used)
+                oldest_index = index;
+        }
+        var removed = self.access_tokens.swapRemove(oldest_index);
+        removed.deinit(self.allocator);
+    }
+
+    fn evictLeastRecentlyUsedRouteLocked(
+        self: *ChallengeAuthenticationPolicy,
+    ) void {
+        var oldest_index: usize = 0;
+        for (self.routes.items[1..], 1..) |entry, index| {
+            if (entry.last_used < self.routes.items[oldest_index].last_used)
+                oldest_index = index;
+        }
+        var removed = self.routes.swapRemove(oldest_index);
+        removed.deinit(self.allocator);
+    }
+
+    fn nextUseLocked(self: *ChallengeAuthenticationPolicy) u64 {
+        self.cache_clock +%= 1;
+        if (self.cache_clock == 0) self.cache_clock = 1;
+        return self.cache_clock;
+    }
+
+    fn findRunningFlightLocked(
+        self: *ChallengeAuthenticationPolicy,
+        kind: FlightKind,
+        challenge: *const BearerChallenge,
+    ) ?*TokenFlight {
+        for (self.token_flights.items) |flight| {
+            if (flight.state == .running and
+                flightKeyMatches(flight, kind, challenge, self.effectiveTenant(challenge)))
+            {
+                return flight;
+            }
+        }
+        return null;
+    }
+
+    fn createFlightLocked(
+        self: *ChallengeAuthenticationPolicy,
+        kind: FlightKind,
+        challenge: *const BearerChallenge,
+    ) !*TokenFlight {
+        const flight = try self.allocator.create(TokenFlight);
+        errdefer self.allocator.destroy(flight);
+        flight.* = try TokenFlight.init(
+            self.allocator,
+            kind,
+            challenge.realm,
+            challenge.service,
+            self.effectiveTenant(challenge) orelse "",
+            if (kind == .access) challenge.scope else "",
+        );
+        errdefer flight.deinit(self.allocator);
+        try self.token_flights.append(self.allocator, flight);
+        return flight;
+    }
+
+    fn waitForFlightLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        cancellation: ?*const CancellationToken,
+    ) ![]u8 {
+        if (cancellation == null) {
+            while (flight.state == .running)
+                flight.condition.waitUncancelable(self.io, &self.mutex);
+            return self.consumeFlightResultLocked(flight, true);
+        }
+
         self.mutex.unlock(self.io);
+        while (true) {
+            checkCancelled(cancellation) catch |err|
+                return self.leaveFlightWait(flight, err);
+            self.io.sleep(.fromMilliseconds(1), .awake) catch |err|
+                return self.leaveFlightWait(flight, err);
+            self.mutex.lockUncancelable(self.io);
+            if (flight.state != .running)
+                return self.consumeFlightResultLocked(flight, true);
+            self.mutex.unlock(self.io);
+        }
+    }
+
+    fn leaveFlightWait(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        failure: anyerror,
+    ) anyerror![]u8 {
+        self.mutex.lockUncancelable(self.io);
+        self.waiting_callers -= 1;
+        self.releaseFlightLocked(flight);
+        self.mutex.unlock(self.io);
+        return failure;
+    }
+
+    fn failFlight(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        failure: anyerror,
+    ) anyerror![]u8 {
+        self.mutex.lockUncancelable(self.io);
+        self.completeFlightFailureLocked(flight, failure);
+        return self.consumeFlightResultLocked(flight, false);
+    }
+
+    fn completeFlightSuccessLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        token: []u8,
+    ) void {
+        std.debug.assert(flight.state == .running);
+        flight.token = token;
+        flight.state = .succeeded;
+        flight.condition.broadcast(self.io);
+    }
+
+    fn completeFlightFailureLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        failure: anyerror,
+    ) void {
+        std.debug.assert(flight.state == .running);
+        flight.failure = failure;
+        flight.state = .failed;
+        flight.condition.broadcast(self.io);
+    }
+
+    fn consumeFlightResultLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+        waiter: bool,
+    ) ![]u8 {
+        std.debug.assert(flight.state != .running);
+        var token: ?[]u8 = null;
+        var failure: ?anyerror = null;
+        switch (flight.state) {
+            .running => unreachable,
+            .succeeded => {
+                token = self.allocator.dupe(u8, flight.token.?) catch |err| blk: {
+                    failure = err;
+                    break :blk null;
+                };
+            },
+            .failed => failure = flight.failure.?,
+        }
+        if (waiter) self.waiting_callers -= 1;
+        self.releaseFlightLocked(flight);
+        self.mutex.unlock(self.io);
+        if (failure) |err| return err;
+        return token.?;
+    }
+
+    fn releaseFlightLocked(
+        self: *ChallengeAuthenticationPolicy,
+        flight: *TokenFlight,
+    ) void {
+        std.debug.assert(flight.participants > 0);
+        flight.participants -= 1;
+        if (flight.participants != 0) return;
+        std.debug.assert(flight.state != .running);
+        for (self.token_flights.items, 0..) |candidate, index| {
+            if (candidate != flight) continue;
+            _ = self.token_flights.swapRemove(index);
+            flight.deinit(self.allocator);
+            self.allocator.destroy(flight);
+            return;
+        }
+        unreachable;
     }
 
     fn effectiveTenant(
@@ -841,34 +1230,59 @@ fn normalizeEndpoint(allocator: std.mem.Allocator, endpoint: []const u8) ![]u8 {
         endpoint);
 }
 
-fn extractHost(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
-    const uri = std.Uri.parse(raw) catch return error.InvalidUrl;
-    if (uri.host == null) return error.InvalidUrl;
-    var buffer: [std.Io.net.HostName.max_len]u8 = undefined;
-    const host = uri.getHost(&buffer) catch return error.InvalidUrl;
-    return allocator.dupe(u8, host.bytes);
-}
-
-fn copyExpectedHosts(
+fn copyTrustedOrigins(
     allocator: std.mem.Allocator,
-    endpoint_host: []const u8,
+    endpoint: []const u8,
     additional: []const []const u8,
-) ![][]u8 {
-    const hosts = try allocator.alloc([]u8, additional.len + 1);
-    errdefer allocator.free(hosts);
+) ![]TrustedOrigin {
+    const origins = try allocator.alloc(TrustedOrigin, additional.len + 1);
+    errdefer allocator.free(origins);
     var initialized: usize = 0;
     errdefer {
-        for (hosts[0..initialized]) |host| allocator.free(host);
+        for (origins[0..initialized]) |*origin| origin.deinit(allocator);
     }
 
-    hosts[0] = try allocator.dupe(u8, endpoint_host);
+    origins[0] = try trustedOriginFromUrl(allocator, endpoint);
     initialized += 1;
-    for (additional, 0..) |host, index| {
-        try validateExpectedHost(host);
-        hosts[index + 1] = try allocator.dupe(u8, host);
+    for (additional, 0..) |value, index| {
+        origins[index + 1] = if (std.mem.indexOf(u8, value, "://") != null)
+            try trustedOriginFromUrl(allocator, value)
+        else blk: {
+            try validateExpectedHost(value);
+            break :blk .{
+                .host = try allocator.dupe(u8, value),
+                .port = 443,
+            };
+        };
         initialized += 1;
     }
-    return hosts;
+    return origins;
+}
+
+fn trustedOriginFromUrl(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+) !TrustedOrigin {
+    const uri = std.Uri.parse(raw) catch return error.InvalidExpectedOrigin;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https"))
+        return error.InvalidExpectedOrigin;
+    if (uri.host == null or uri.user != null or uri.password != null or
+        uri.query != null or uri.fragment != null)
+    {
+        return error.InvalidExpectedOrigin;
+    }
+    const path = if (uri.path.isEmpty()) "" else switch (uri.path) {
+        .raw => |value| value,
+        .percent_encoded => |value| value,
+    };
+    if (path.len != 0 and !std.mem.eql(u8, path, "/"))
+        return error.InvalidExpectedOrigin;
+    var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const host = uri.getHost(&host_buffer) catch return error.InvalidExpectedOrigin;
+    return .{
+        .host = try allocator.dupe(u8, host.bytes),
+        .port = effectiveHttpsPort(uri),
+    };
 }
 
 fn validateExpectedHost(host: []const u8) !void {
@@ -879,16 +1293,56 @@ fn validateExpectedHost(host: []const u8) !void {
     }
 }
 
-fn deinitStringSlice(allocator: std.mem.Allocator, values: [][]u8) void {
-    for (values) |value| allocator.free(value);
-    allocator.free(values);
+fn deinitTrustedOrigins(
+    allocator: std.mem.Allocator,
+    origins: []TrustedOrigin,
+) void {
+    for (origins) |*origin| origin.deinit(allocator);
+    allocator.free(origins);
 }
 
-fn hostExpected(hosts: []const []const u8, value: []const u8) bool {
-    for (hosts) |host| {
-        if (std.ascii.eqlIgnoreCase(host, value)) return true;
+fn validateTrustedHttpsUrl(
+    raw: []const u8,
+    trusted_origins: []const TrustedOrigin,
+) !void {
+    const uri = std.Uri.parse(raw) catch return error.InvalidUrl;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) return error.HttpsRequired;
+    if (uri.host == null or uri.user != null or uri.password != null or
+        uri.fragment != null)
+    {
+        return error.InvalidUrl;
     }
-    return false;
+    var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const host = uri.getHost(&host_buffer) catch return error.InvalidUrl;
+    const port = effectiveHttpsPort(uri);
+    for (trusted_origins) |origin| {
+        if (origin.port == port and
+            std.ascii.eqlIgnoreCase(origin.host, host.bytes))
+        {
+            return;
+        }
+    }
+    return error.UnexpectedHost;
+}
+
+fn effectiveHttpsPort(uri: std.Uri) u16 {
+    return uri.port orelse 443;
+}
+
+fn serviceMatchesOrigin(
+    service: []const u8,
+    host: []const u8,
+    port: u16,
+) bool {
+    if (std.ascii.eqlIgnoreCase(service, host)) return true;
+    var authority_buffer: [std.Io.net.HostName.max_len + 8]u8 = undefined;
+    const authority = if (std.mem.indexOfScalar(u8, host, ':') != null)
+        std.fmt.bufPrint(&authority_buffer, "[{s}]:{d}", .{ host, port }) catch
+            unreachable
+    else
+        std.fmt.bufPrint(&authority_buffer, "{s}:{d}", .{ host, port }) catch
+            unreachable;
+    return std.ascii.eqlIgnoreCase(service, authority);
 }
 
 fn requestRoute(url: []const u8) []const u8 {
@@ -917,8 +1371,62 @@ fn accessKeyMatches(
         std.mem.eql(u8, entry.scope, challenge.scope);
 }
 
+fn flightKeyMatches(
+    flight: *const TokenFlight,
+    kind: FlightKind,
+    challenge: *const BearerChallenge,
+    tenant: ?[]const u8,
+) bool {
+    return flight.kind == kind and
+        std.mem.eql(u8, flight.realm, challenge.realm) and
+        std.mem.eql(u8, flight.service, challenge.service) and
+        std.mem.eql(u8, flight.tenant, tenant orelse "") and
+        (kind == .refresh or std.mem.eql(u8, flight.scope, challenge.scope));
+}
+
 fn isTokenValid(expires_on: i64, now: i64, skew: i64) bool {
     return expires_on > now and now < expires_on -| skew;
+}
+
+fn isRefreshTokenRejection(err: anyerror) bool {
+    return err == error.AcrTokenEndpointUnauthorized or
+        err == error.AcrTokenEndpointForbidden or
+        err == error.AcrRefreshTokenRejected;
+}
+
+fn isProtocolRefreshTokenRejection(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !bool {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch |err|
+        switch (err) {
+            error.OutOfMemory => return err,
+            else => return false,
+        };
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    if (parsed.value.object.get("error")) |oauth_error| {
+        if (oauth_error == .string and
+            (std.ascii.eqlIgnoreCase(oauth_error.string, "invalid_grant") or
+                std.ascii.eqlIgnoreCase(oauth_error.string, "invalid_token") or
+                std.ascii.eqlIgnoreCase(oauth_error.string, "unauthorized")))
+        {
+            return true;
+        }
+    }
+    const errors = parsed.value.object.get("errors") orelse return false;
+    if (errors != .array) return false;
+    for (errors.array.items) |acr_error| {
+        if (acr_error != .object) continue;
+        const code = acr_error.object.get("code") orelse continue;
+        if (code == .string and
+            (std.ascii.eqlIgnoreCase(code.string, "UNAUTHORIZED") or
+                std.ascii.eqlIgnoreCase(code.string, "INVALID_TOKEN")))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 fn setBearerHeader(request: *Request, token: []const u8) !void {
@@ -967,8 +1475,11 @@ fn parseTokenResponse(
     body: []const u8,
     field: []const u8,
 ) ![]u8 {
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch
-        return error.InvalidAcrTokenResponse;
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch |err|
+        switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.InvalidAcrTokenResponse,
+        };
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidAcrTokenResponse;
     const token = parsed.value.object.get(field) orelse
@@ -989,11 +1500,17 @@ fn jwtExpiry(allocator: std.mem.Allocator, token: []const u8) !i64 {
         payload = payload[0 .. payload.len - 1];
     if (payload.len == 0) return error.InvalidAcrToken;
 
-    const decoded = core.base64.urlDecode(allocator, payload) catch
-        return error.InvalidAcrToken;
+    const decoded = core.base64.urlDecode(allocator, payload) catch |err|
+        switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.InvalidAcrToken,
+        };
     defer allocator.free(decoded);
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, decoded, .{}) catch
-        return error.InvalidAcrToken;
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, decoded, .{}) catch |err|
+        switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.InvalidAcrToken,
+        };
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidAcrToken;
     const expires = parsed.value.object.get("exp") orelse return error.InvalidAcrToken;
@@ -1085,6 +1602,29 @@ fn makeChallenge(
     );
 }
 
+fn parseTestChallenge(
+    allocator: std.mem.Allocator,
+    realm: []const u8,
+    service: []const u8,
+    scope: []const u8,
+    tenant: ?[]const u8,
+) !BearerChallenge {
+    const base = try makeChallenge(allocator, realm, service, scope);
+    defer allocator.free(base);
+    if (tenant) |value| {
+        const header = try std.fmt.allocPrint(
+            allocator,
+            "{s},tenant=\"{s}\"",
+            .{ base, value },
+        );
+        defer allocator.free(header);
+        const values = [_][]const u8{header};
+        return challenge_mod.parseBearerChallenge(allocator, &values);
+    }
+    const values = [_][]const u8{base};
+    return challenge_mod.parseBearerChallenge(allocator, &values);
+}
+
 fn capturedUrl(
     transport: *const core.http.SequenceMockTransport,
     index: usize,
@@ -1127,6 +1667,70 @@ fn sendBuffered(
     defer request.deinit();
     return pipeline.send(&request);
 }
+
+fn testResponse(
+    allocator: std.mem.Allocator,
+    status_code: u16,
+    body: []const u8,
+) !Response {
+    return .{
+        .status_code = status_code,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(u8, body),
+        .allocator = allocator,
+        .response_headers = core.http.ResponseHeaders.init(allocator),
+    };
+}
+
+const ParallelAccessTransport = struct {
+    allocator: std.mem.Allocator,
+    refresh_body: []const u8,
+    access_one_body: []const u8,
+    access_two_body: []const u8,
+    exchange_calls: std.atomic.Value(usize) = .init(0),
+    access_calls: std.atomic.Value(usize) = .init(0),
+    access_release: std.Io.Semaphore = .{},
+    transport: HttpTransport,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        refresh_body: []const u8,
+        access_one_body: []const u8,
+        access_two_body: []const u8,
+    ) ParallelAccessTransport {
+        return .{
+            .allocator = allocator,
+            .refresh_body = refresh_body,
+            .access_one_body = access_one_body,
+            .access_two_body = access_two_body,
+            .transport = .{ .sendFn = &sendImpl },
+        };
+    }
+
+    fn asTransport(self: *ParallelAccessTransport) *HttpTransport {
+        return &self.transport;
+    }
+
+    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
+        const self: *ParallelAccessTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        if (std.mem.indexOf(u8, request.url, "/oauth2/exchange") != null) {
+            _ = self.exchange_calls.fetchAdd(1, .monotonic);
+            return testResponse(self.allocator, 200, self.refresh_body);
+        }
+        if (std.mem.indexOf(u8, request.url, "/oauth2/token") == null)
+            return error.UnexpectedMockRequest;
+        _ = self.access_calls.fetchAdd(1, .monotonic);
+        const io = std.Io.Threaded.global_single_threaded.io();
+        self.access_release.waitUncancelable(io);
+        const body = request.body orelse return error.MissingMockRequestBody;
+        if (std.mem.indexOf(u8, body, "repository%3Aone%3Apull") != null)
+            return testResponse(self.allocator, 200, self.access_one_body);
+        if (std.mem.indexOf(u8, body, "repository%3Atwo%3Apull") != null)
+            return testResponse(self.allocator, 200, self.access_two_body);
+        return error.UnexpectedMockScope;
+    }
+};
 
 test "authenticated challenge flow uses form encoding and caches both tokens" {
     const allocator = std.testing.allocator;
@@ -1646,7 +2250,7 @@ test "concurrent token acquisition is single flight" {
         const waiting = policy.waiting_callers;
         policy.mutex.unlock(policy.io);
         if (waiting > 0) break;
-        io.sleep(.fromMilliseconds(1), .awake) catch {};
+        try io.sleep(.fromMilliseconds(1), .awake);
     }
     release.post(io);
     first_thread.join();
@@ -2013,4 +2617,943 @@ test "streaming cancellation is preserved before transport" {
         pipeline.open(&request, .{ .cancellation = &cancellation }),
     );
     try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
+
+test "trusted origins compare HTTPS host and effective port" {
+    const allocator = std.testing.allocator;
+    const unused = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = "{}" },
+    };
+    var unused_transport = core.http.SequenceMockTransport.init(allocator, &unused);
+    var default_policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{},
+    );
+    defer default_policy.deinit();
+
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        sendBuffered(
+            allocator,
+            &default_policy,
+            unused_transport.asTransport(),
+            .GET,
+            "https://registry.example:8443/v2/_catalog",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 0), unused_transport.call_count);
+
+    const untrusted_challenge = try makeChallenge(
+        allocator,
+        "https://registry.example:8443/oauth2/token",
+        "registry.example:8443",
+        "registry:catalog:*",
+    );
+    defer allocator.free(untrusted_challenge);
+    const untrusted_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = untrusted_challenge },
+    };
+    const untrusted_responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &untrusted_headers },
+    };
+    var untrusted_transport = core.http.SequenceMockTransport.init(
+        allocator,
+        &untrusted_responses,
+    );
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        sendBuffered(
+            allocator,
+            &default_policy,
+            untrusted_transport.asTransport(),
+            .GET,
+            "https://registry.example/v2/_catalog",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), untrusted_transport.call_count);
+
+    var hostname_policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{ .expected_hosts = &.{"auth.example"} },
+    );
+    defer hostname_policy.deinit();
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        sendBuffered(
+            allocator,
+            &hostname_policy,
+            unused_transport.asTransport(),
+            .GET,
+            "https://auth.example:8443/v2/_catalog",
+        ),
+    );
+
+    const access_token = try makeJwt(allocator, 4_102_444_800, "port-8443");
+    defer allocator.free(access_token);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example:8443/oauth2/token",
+        "REGISTRY.EXAMPLE:8443",
+        "registry:catalog:*",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = access_body },
+        .{ .status = 200, .body = "{}" },
+    };
+    var explicit_transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var explicit_policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{ .expected_hosts = &.{"https://registry.example:8443"} },
+    );
+    defer explicit_policy.deinit();
+
+    var response = try sendBuffered(
+        allocator,
+        &explicit_policy,
+        explicit_transport.asTransport(),
+        .GET,
+        "https://REGISTRY.example:8443/v2/_catalog",
+    );
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expectEqual(@as(usize, 3), explicit_transport.call_count);
+    try std.testing.expectEqualStrings(
+        "https://registry.example:8443/oauth2/token?api-version=2021-07-01",
+        capturedUrl(&explicit_transport, 1),
+    );
+    try std.testing.expect(explicit_transport.captured_authorization[2]);
+}
+
+test "cached refresh rejection invalidates exact token and recovers once" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const stale_refresh = try makeJwt(allocator, 5_000, "stale-refresh");
+    defer allocator.free(stale_refresh);
+    const fresh_refresh = try makeJwt(allocator, 6_000, "fresh-refresh");
+    defer allocator.free(fresh_refresh);
+    const other_refresh = try makeJwt(allocator, 6_000, "other-refresh");
+    defer allocator.free(other_refresh);
+    const access_token = try makeJwt(allocator, 4_000, "recovered-access");
+    defer allocator.free(access_token);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", fresh_refresh);
+    defer allocator.free(refresh_body);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "{\"errors\":[{\"code\":\"UNAUTHORIZED\"}]}" },
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_body },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    defer challenge.deinit();
+    var other_challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        "other-tenant",
+    );
+    defer other_challenge.deinit();
+    {
+        policy.mutex.lockUncancelable(policy.io);
+        defer policy.mutex.unlock(policy.io);
+        try policy.storeRefreshTokenLocked(&challenge, stale_refresh, 5_000);
+        try policy.storeRefreshTokenLocked(&other_challenge, other_refresh, 6_000);
+    }
+
+    const token = try policy.acquireAccessToken(
+        &challenge,
+        null,
+        transport.asTransport(),
+    );
+    defer allocator.free(token);
+    try std.testing.expectEqualStrings(access_token, token);
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countCapturedUrl(&transport, "/oauth2/exchange"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        countCapturedUrl(&transport, "/oauth2/token"),
+    );
+    try std.testing.expect(std.mem.indexOf(u8, capturedBody(&transport, 0), stale_refresh) != null);
+    try std.testing.expect(std.mem.indexOf(u8, capturedBody(&transport, 2), fresh_refresh) != null);
+    {
+        policy.mutex.lockUncancelable(policy.io);
+        defer policy.mutex.unlock(policy.io);
+        const cached = policy.findValidRefreshTokenLocked(&challenge, clock.value).?;
+        try std.testing.expectEqualStrings(fresh_refresh, cached);
+        const other_cached = policy.findValidRefreshTokenLocked(
+            &other_challenge,
+            clock.value,
+        ).?;
+        try std.testing.expectEqualStrings(other_refresh, other_cached);
+        try std.testing.expectEqual(@as(usize, 2), policy.refresh_tokens.items.len);
+    }
+}
+
+test "refresh rejection retry is bounded and unrelated failures are not retried" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const stale_refresh = try makeJwt(allocator, 5_000, "stale");
+    defer allocator.free(stale_refresh);
+    const rejected_refresh = try makeJwt(allocator, 6_000, "rejected");
+    defer allocator.free(rejected_refresh);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", rejected_refresh);
+    defer allocator.free(refresh_body);
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 403, .body = "{}" },
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = "{\"error\":\"invalid_grant\"}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    defer challenge.deinit();
+    {
+        policy.mutex.lockUncancelable(policy.io);
+        defer policy.mutex.unlock(policy.io);
+        try policy.storeRefreshTokenLocked(&challenge, stale_refresh, 5_000);
+    }
+
+    try std.testing.expectError(
+        error.AcrRefreshTokenRejected,
+        policy.acquireAccessToken(&challenge, null, transport.asTransport()),
+    );
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    {
+        policy.mutex.lockUncancelable(policy.io);
+        defer policy.mutex.unlock(policy.io);
+        try std.testing.expectEqual(@as(usize, 0), policy.refresh_tokens.items.len);
+    }
+
+    var unrelated_credential = TestCredential.init();
+    const unrelated_responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 500, .body = "{\"errors\":[{\"code\":\"UNAVAILABLE\"}]}" },
+    };
+    var unrelated_transport = core.http.SequenceMockTransport.init(
+        allocator,
+        &unrelated_responses,
+    );
+    var unrelated_policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &unrelated_credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer unrelated_policy.deinit();
+    {
+        unrelated_policy.mutex.lockUncancelable(unrelated_policy.io);
+        defer unrelated_policy.mutex.unlock(unrelated_policy.io);
+        try unrelated_policy.storeRefreshTokenLocked(&challenge, stale_refresh, 5_000);
+    }
+    try std.testing.expectError(
+        error.AcrTokenExchangeFailed,
+        unrelated_policy.acquireAccessToken(
+            &challenge,
+            null,
+            unrelated_transport.asTransport(),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), unrelated_transport.call_count);
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        unrelated_credential.calls.load(.monotonic),
+    );
+    {
+        unrelated_policy.mutex.lockUncancelable(unrelated_policy.io);
+        defer unrelated_policy.mutex.unlock(unrelated_policy.io);
+        const cached = unrelated_policy.findValidRefreshTokenLocked(
+            &challenge,
+            clock.value,
+        ).?;
+        try std.testing.expectEqualStrings(stale_refresh, cached);
+    }
+}
+
+test "token endpoint preserves authentication rejection classification" {
+    const allocator = std.testing.allocator;
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{},
+    );
+    defer policy.deinit();
+    const url = "https://registry.example/oauth2/token";
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "{}" },
+        .{ .status = 403, .body = "{}" },
+        .{ .status = 200, .body = "{\"errors\":[{\"code\":\"UNAUTHORIZED\"}]}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    try std.testing.expectError(
+        error.AcrTokenEndpointUnauthorized,
+        policy.sendTokenRequest(
+            url,
+            "",
+            "access_token",
+            true,
+            null,
+            transport.asTransport(),
+        ),
+    );
+    try std.testing.expectError(
+        error.AcrTokenEndpointForbidden,
+        policy.sendTokenRequest(
+            url,
+            "",
+            "access_token",
+            true,
+            null,
+            transport.asTransport(),
+        ),
+    );
+    try std.testing.expectError(
+        error.AcrRefreshTokenRejected,
+        policy.sendTokenRequest(
+            url,
+            "",
+            "access_token",
+            true,
+            null,
+            transport.asTransport(),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+}
+
+test "token caches prune expired entries and preserve valid keys" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var expired_access = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:expired:pull",
+        null,
+    );
+    defer expired_access.deinit();
+    var valid_access = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:valid:pull",
+        null,
+    );
+    defer valid_access.deinit();
+    var expired_refresh = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        "expired-tenant",
+    );
+    defer expired_refresh.deinit();
+    var valid_refresh = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        "valid-tenant",
+    );
+    defer valid_refresh.deinit();
+
+    {
+        policy.mutex.lockUncancelable(policy.io);
+        defer policy.mutex.unlock(policy.io);
+        try policy.storeAccessTokenLocked(&expired_access, "expired-access", 1_005);
+        try policy.storeAccessTokenLocked(&valid_access, "valid-access", 5_000);
+        try policy.storeRefreshTokenLocked(&expired_refresh, "expired-refresh", 1_005);
+        try policy.storeRefreshTokenLocked(&valid_refresh, "valid-refresh", 5_000);
+        policy.pruneAccessTokensLocked(clock.value);
+        policy.pruneRefreshTokensLocked(clock.value);
+        try std.testing.expectEqual(@as(usize, 1), policy.access_tokens.items.len);
+        try std.testing.expectEqual(@as(usize, 1), policy.refresh_tokens.items.len);
+        try std.testing.expect(
+            policy.findValidAccessTokenLocked(&expired_access, clock.value) == null,
+        );
+        try std.testing.expect(
+            policy.findValidRefreshTokenLocked(&expired_refresh, clock.value) == null,
+        );
+        try std.testing.expectEqualStrings(
+            "valid-access",
+            policy.findValidAccessTokenLocked(&valid_access, clock.value).?,
+        );
+        try std.testing.expectEqualStrings(
+            "valid-refresh",
+            policy.findValidRefreshTokenLocked(&valid_refresh, clock.value).?,
+        );
+    }
+}
+
+test "bounded caches evict least recently used keys without mixups" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+
+    for (0..max_access_token_entries) |index| {
+        const scope = try std.fmt.allocPrint(
+            allocator,
+            "repository:access-{d}:pull",
+            .{index},
+        );
+        defer allocator.free(scope);
+        const token = try std.fmt.allocPrint(allocator, "access-token-{d}", .{index});
+        defer allocator.free(token);
+        var challenge = try parseTestChallenge(
+            allocator,
+            "https://registry.example/oauth2/token",
+            "registry.example",
+            scope,
+            null,
+        );
+        defer challenge.deinit();
+        policy.mutex.lockUncancelable(policy.io);
+        {
+            defer policy.mutex.unlock(policy.io);
+            try policy.storeAccessTokenLocked(&challenge, token, 5_000);
+        }
+    }
+    var access_zero = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:access-0:pull",
+        null,
+    );
+    defer access_zero.deinit();
+    var access_one = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:access-1:pull",
+        null,
+    );
+    defer access_one.deinit();
+    const overflow_scope = try std.fmt.allocPrint(
+        allocator,
+        "repository:access-{d}:pull",
+        .{max_access_token_entries},
+    );
+    defer allocator.free(overflow_scope);
+    var access_overflow = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        overflow_scope,
+        null,
+    );
+    defer access_overflow.deinit();
+    {
+        policy.mutex.lockUncancelable(policy.io);
+        defer policy.mutex.unlock(policy.io);
+        try std.testing.expectEqualStrings(
+            "access-token-0",
+            policy.findValidAccessTokenLocked(&access_zero, clock.value).?,
+        );
+        try policy.storeAccessTokenLocked(
+            &access_overflow,
+            "access-token-overflow",
+            5_000,
+        );
+        try std.testing.expectEqual(max_access_token_entries, policy.access_tokens.items.len);
+        try std.testing.expect(
+            policy.findValidAccessTokenLocked(&access_one, clock.value) == null,
+        );
+        try std.testing.expectEqualStrings(
+            "access-token-0",
+            policy.findValidAccessTokenLocked(&access_zero, clock.value).?,
+        );
+        try std.testing.expectEqualStrings(
+            "access-token-overflow",
+            policy.findValidAccessTokenLocked(&access_overflow, clock.value).?,
+        );
+    }
+
+    for (0..max_refresh_token_entries) |index| {
+        const tenant = try std.fmt.allocPrint(allocator, "tenant-{d}", .{index});
+        defer allocator.free(tenant);
+        const token = try std.fmt.allocPrint(allocator, "refresh-token-{d}", .{index});
+        defer allocator.free(token);
+        var challenge = try parseTestChallenge(
+            allocator,
+            "https://registry.example/oauth2/token",
+            "registry.example",
+            "repository:refresh:pull",
+            tenant,
+        );
+        defer challenge.deinit();
+        policy.mutex.lockUncancelable(policy.io);
+        {
+            defer policy.mutex.unlock(policy.io);
+            try policy.storeRefreshTokenLocked(&challenge, token, 5_000);
+        }
+    }
+    var refresh_zero = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:refresh:pull",
+        "tenant-0",
+    );
+    defer refresh_zero.deinit();
+    var refresh_one = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:refresh:pull",
+        "tenant-1",
+    );
+    defer refresh_one.deinit();
+    const overflow_tenant = try std.fmt.allocPrint(
+        allocator,
+        "tenant-{d}",
+        .{max_refresh_token_entries},
+    );
+    defer allocator.free(overflow_tenant);
+    var refresh_overflow = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:refresh:pull",
+        overflow_tenant,
+    );
+    defer refresh_overflow.deinit();
+    {
+        policy.mutex.lockUncancelable(policy.io);
+        defer policy.mutex.unlock(policy.io);
+        try std.testing.expectEqualStrings(
+            "refresh-token-0",
+            policy.findValidRefreshTokenLocked(&refresh_zero, clock.value).?,
+        );
+        try policy.storeRefreshTokenLocked(
+            &refresh_overflow,
+            "refresh-token-overflow",
+            5_000,
+        );
+        try std.testing.expectEqual(max_refresh_token_entries, policy.refresh_tokens.items.len);
+        try std.testing.expect(
+            policy.findValidRefreshTokenLocked(&refresh_one, clock.value) == null,
+        );
+        try std.testing.expectEqualStrings(
+            "refresh-token-0",
+            policy.findValidRefreshTokenLocked(&refresh_zero, clock.value).?,
+        );
+        try std.testing.expectEqualStrings(
+            "refresh-token-overflow",
+            policy.findValidRefreshTokenLocked(&refresh_overflow, clock.value).?,
+        );
+    }
+
+    var route_challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:route:pull",
+        null,
+    );
+    defer route_challenge.deinit();
+    for (0..max_route_entries) |index| {
+        const url = try std.fmt.allocPrint(
+            allocator,
+            "https://registry.example/v2/route-{d}/tags/list",
+            .{index},
+        );
+        defer allocator.free(url);
+        var request = Request.init(allocator, .GET, url);
+        defer request.deinit();
+        try policy.storeRoute(&request, &route_challenge);
+    }
+    var route_zero_request = Request.init(
+        allocator,
+        .GET,
+        "https://registry.example/v2/route-0/tags/list",
+    );
+    defer route_zero_request.deinit();
+    var route_one_request = Request.init(
+        allocator,
+        .GET,
+        "https://registry.example/v2/route-1/tags/list",
+    );
+    defer route_one_request.deinit();
+    const overflow_url = try std.fmt.allocPrint(
+        allocator,
+        "https://registry.example/v2/route-{d}/tags/list",
+        .{max_route_entries},
+    );
+    defer allocator.free(overflow_url);
+    var overflow_request = Request.init(allocator, .GET, overflow_url);
+    defer overflow_request.deinit();
+    var touched_route = (try policy.findRoute(&route_zero_request)).?;
+    touched_route.deinit();
+    try policy.storeRoute(&overflow_request, &route_challenge);
+    try std.testing.expectEqual(max_route_entries, policy.routes.items.len);
+    try std.testing.expect((try policy.findRoute(&route_one_request)) == null);
+    var retained_route = (try policy.findRoute(&route_zero_request)).?;
+    defer retained_route.deinit();
+    var newest_route = (try policy.findRoute(&overflow_request)).?;
+    defer newest_route.deinit();
+    try std.testing.expectEqualStrings(route_challenge.scope, retained_route.scope);
+    try std.testing.expectEqualStrings(route_challenge.scope, newest_route.scope);
+}
+
+test "different access keys refresh concurrently while sharing refresh flight" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const refresh_token = try makeJwt(allocator, 5_000, "shared-refresh");
+    defer allocator.free(refresh_token);
+    const access_one = try makeJwt(allocator, 4_000, "parallel-one");
+    defer allocator.free(access_one);
+    const access_two = try makeJwt(allocator, 4_000, "parallel-two");
+    defer allocator.free(access_two);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const access_one_body = try makeTokenResponse(allocator, "access_token", access_one);
+    defer allocator.free(access_one_body);
+    const access_two_body = try makeTokenResponse(allocator, "access_token", access_two);
+    defer allocator.free(access_two_body);
+    var transport = ParallelAccessTransport.init(
+        allocator,
+        refresh_body,
+        access_one_body,
+        access_two_body,
+    );
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var challenge_one = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    defer challenge_one.deinit();
+    var challenge_two = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:two:pull",
+        null,
+    );
+    defer challenge_two.deinit();
+
+    const AcquireContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        transport: *HttpTransport,
+        token: ?[]u8 = null,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.token = self.policy.acquireAccessToken(
+                self.challenge,
+                null,
+                self.transport,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    };
+    var first = AcquireContext{
+        .policy = &policy,
+        .challenge = &challenge_one,
+        .transport = transport.asTransport(),
+    };
+    var second = AcquireContext{
+        .policy = &policy,
+        .challenge = &challenge_two,
+        .transport = transport.asTransport(),
+    };
+    const first_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&first});
+    const second_thread = std.Thread.spawn(.{}, AcquireContext.run, .{&second}) catch |err| {
+        transport.access_release.post(policy.io);
+        first_thread.join();
+        return err;
+    };
+    var parallel = false;
+    for (0..1_000) |_| {
+        if (transport.access_calls.load(.monotonic) == 2) {
+            parallel = true;
+            break;
+        }
+        try policy.io.sleep(.fromMilliseconds(1), .awake);
+    }
+    transport.access_release.post(policy.io);
+    transport.access_release.post(policy.io);
+    first_thread.join();
+    second_thread.join();
+    defer if (first.token) |token| allocator.free(token);
+    defer if (second.token) |token| allocator.free(token);
+
+    try std.testing.expect(parallel);
+    try std.testing.expect(first.err == null);
+    try std.testing.expect(second.err == null);
+    try std.testing.expectEqualStrings(access_one, first.token.?);
+    try std.testing.expectEqualStrings(access_two, second.token.?);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 1), transport.exchange_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 2), transport.access_calls.load(.monotonic));
+}
+
+test "same-key flight wakes waiters with the leader failure" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var entered: std.Io.Semaphore = .{};
+    var release: std.Io.Semaphore = .{};
+    var credential = TestCredential.init();
+    credential.fail = true;
+    credential.entered = &entered;
+    credential.release = &release;
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    defer challenge.deinit();
+
+    const AcquireContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        transport: *HttpTransport,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            const token = self.policy.acquireAccessToken(
+                self.challenge,
+                null,
+                self.transport,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+            self.policy.allocator.free(token);
+        }
+    };
+    var first = AcquireContext{
+        .policy = &policy,
+        .challenge = &challenge,
+        .transport = transport.asTransport(),
+    };
+    var second = first;
+    const first_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&first});
+    entered.waitUncancelable(policy.io);
+    const second_thread = std.Thread.spawn(.{}, AcquireContext.run, .{&second}) catch |err| {
+        release.post(policy.io);
+        first_thread.join();
+        return err;
+    };
+    while (true) {
+        policy.mutex.lockUncancelable(policy.io);
+        const waiting = policy.waiting_callers;
+        policy.mutex.unlock(policy.io);
+        if (waiting > 0) break;
+        try policy.io.sleep(.fromMilliseconds(1), .awake);
+    }
+    release.post(policy.io);
+    first_thread.join();
+    second_thread.join();
+
+    try std.testing.expectEqual(error.MockCredentialFailure, first.err.?);
+    try std.testing.expectEqual(error.MockCredentialFailure, second.err.?);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
+
+test "cancelling a same-key waiter leaves the leader race safe" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var entered: std.Io.Semaphore = .{};
+    var release: std.Io.Semaphore = .{};
+    var credential = TestCredential.init();
+    credential.entered = &entered;
+    credential.release = &release;
+    const refresh_token = try makeJwt(allocator, 5_000, "refresh");
+    defer allocator.free(refresh_token);
+    const access_token = try makeJwt(allocator, 4_000, "access");
+    defer allocator.free(access_token);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_body },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    var challenge = try parseTestChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+        null,
+    );
+    defer challenge.deinit();
+    var cancellation = CancellationToken{};
+
+    const AcquireContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+        token: ?[]u8 = null,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.token = self.policy.acquireAccessToken(
+                self.challenge,
+                self.cancellation,
+                self.transport,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    };
+    var leader = AcquireContext{
+        .policy = &policy,
+        .challenge = &challenge,
+        .cancellation = null,
+        .transport = transport.asTransport(),
+    };
+    var waiter = AcquireContext{
+        .policy = &policy,
+        .challenge = &challenge,
+        .cancellation = &cancellation,
+        .transport = transport.asTransport(),
+    };
+    const leader_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&leader});
+    entered.waitUncancelable(policy.io);
+    const waiter_thread = std.Thread.spawn(.{}, AcquireContext.run, .{&waiter}) catch |err| {
+        release.post(policy.io);
+        leader_thread.join();
+        return err;
+    };
+    while (true) {
+        policy.mutex.lockUncancelable(policy.io);
+        const waiting = policy.waiting_callers;
+        policy.mutex.unlock(policy.io);
+        if (waiting > 0) break;
+        try policy.io.sleep(.fromMilliseconds(1), .awake);
+    }
+    cancellation.cancel();
+    waiter_thread.join();
+    release.post(policy.io);
+    leader_thread.join();
+    defer if (leader.token) |token| allocator.free(token);
+    defer if (waiter.token) |token| allocator.free(token);
+
+    try std.testing.expectEqual(error.OperationCancelled, waiter.err.?);
+    try std.testing.expect(leader.err == null);
+    try std.testing.expectEqualStrings(access_token, leader.token.?);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
 }

--- a/sdk/container_registry/src/auth_policy.zig
+++ b/sdk/container_registry/src/auth_policy.zig
@@ -73,6 +73,7 @@ const AccessTokenEntry = struct {
     tenant: []u8,
     scope: []u8,
     token: []u8,
+    version: u64,
     expires_on: i64,
     last_used: u64,
 
@@ -130,6 +131,7 @@ const TokenFlight = struct {
     state: FlightState = .running,
     participants: usize = 1,
     token: ?[]u8 = null,
+    token_version: u64 = 0,
     failure: ?anyerror = null,
     worker: ?std.Thread = null,
 
@@ -176,6 +178,20 @@ const TokenFlight = struct {
             .tenant = if (self.tenant.len == 0) null else self.tenant,
         };
     }
+};
+
+const AcquiredAccessToken = struct {
+    value: []u8,
+    version: u64,
+
+    fn deinit(self: AcquiredAccessToken, allocator: std.mem.Allocator) void {
+        allocator.free(self.value);
+    }
+};
+
+const AcquiredFlightToken = struct {
+    value: []u8,
+    version: u64,
 };
 
 /// ACR Bearer challenge policy. The policy validates every destination before
@@ -303,17 +319,18 @@ pub const ChallengeAuthenticationPolicy = struct {
         var authorization = RequestAuthorizationState.init(request);
         defer authorization.restore(request);
         var sdk_authorized = false;
+        var first_attempt_token: ?AcquiredAccessToken = null;
+        defer if (first_attempt_token) |token| token.deinit(self.allocator);
 
         if (request.getHeader("Authorization") == null) {
             known_challenge = try self.findRoute(request);
             if (known_challenge) |*challenge| {
-                const token = try self.acquireAccessToken(
+                first_attempt_token = try self.acquireAccessTokenVersioned(
                     challenge,
                     null,
                     final_transport,
                 );
-                defer self.allocator.free(token);
-                try authorization.setBearer(request, token);
+                try authorization.setBearer(request, first_attempt_token.?.value);
                 sdk_authorized = true;
             }
         }
@@ -323,7 +340,8 @@ pub const ChallengeAuthenticationPolicy = struct {
 
         if (!sdk_authorized and request.getHeader("Authorization") != null)
             return response;
-        if (sdk_authorized) self.invalidateAccessToken(&known_challenge.?);
+        if (sdk_authorized)
+            self.invalidateAccessToken(&known_challenge.?, first_attempt_token.?);
 
         var challenge = parseChallengeFromResponse(self.allocator, &response) catch |err| {
             response.deinit();
@@ -339,7 +357,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             return err;
         };
 
-        const token = self.acquireAccessToken(
+        const token = self.acquireAccessTokenVersioned(
             &challenge,
             null,
             final_transport,
@@ -347,15 +365,16 @@ pub const ChallengeAuthenticationPolicy = struct {
             response.deinit();
             return err;
         };
-        defer self.allocator.free(token);
-        authorization.setBearer(request, token) catch |err| {
+        defer token.deinit(self.allocator);
+        authorization.setBearer(request, token.value) catch |err| {
             response.deinit();
             return err;
         };
 
         response.deinit();
         const replay = try callNext(request, next, final_transport);
-        if (replay.status_code == 401) self.invalidateAccessToken(&challenge);
+        if (replay.status_code == 401)
+            self.invalidateAccessToken(&challenge, token);
         return replay;
     }
 
@@ -382,17 +401,18 @@ pub const ChallengeAuthenticationPolicy = struct {
         var authorization = RequestAuthorizationState.init(request);
         defer authorization.restore(request);
         var sdk_authorized = false;
+        var first_attempt_token: ?AcquiredAccessToken = null;
+        defer if (first_attempt_token) |token| token.deinit(self.allocator);
 
         if (request.getHeader("Authorization") == null) {
             known_challenge = try self.findRoute(request);
             if (known_challenge) |*challenge| {
-                const token = try self.acquireAccessToken(
+                first_attempt_token = try self.acquireAccessTokenVersioned(
                     challenge,
                     options.cancellation,
                     final_transport,
                 );
-                defer self.allocator.free(token);
-                try authorization.setBearer(request, token);
+                try authorization.setBearer(request, first_attempt_token.?.value);
                 sdk_authorized = true;
             }
         }
@@ -414,7 +434,8 @@ pub const ChallengeAuthenticationPolicy = struct {
             owned_operation = null;
             return operation;
         }
-        if (sdk_authorized) self.invalidateAccessToken(&known_challenge.?);
+        if (sdk_authorized)
+            self.invalidateAccessToken(&known_challenge.?, first_attempt_token.?);
 
         var challenge = try parseChallengeFromResponse(self.allocator, operation);
         defer challenge.deinit();
@@ -423,13 +444,13 @@ pub const ChallengeAuthenticationPolicy = struct {
         try checkCancelled(options.cancellation);
         try self.storeRoute(request, &challenge);
 
-        const token = try self.acquireAccessToken(
+        const token = try self.acquireAccessTokenVersioned(
             &challenge,
             options.cancellation,
             final_transport,
         );
-        defer self.allocator.free(token);
-        try authorization.setBearer(request, token);
+        defer token.deinit(self.allocator);
+        try authorization.setBearer(request, token.value);
 
         var replay_options = options;
         if (replay_options.body) |*body| {
@@ -445,7 +466,8 @@ pub const ChallengeAuthenticationPolicy = struct {
             final_transport,
         );
         owned_operation = operation;
-        if (operation.status_code == 401) self.invalidateAccessToken(&challenge);
+        if (operation.status_code == 401)
+            self.invalidateAccessToken(&challenge, token);
         owned_operation = null;
         return operation;
     }
@@ -456,23 +478,42 @@ pub const ChallengeAuthenticationPolicy = struct {
         cancellation: ?*const CancellationToken,
         transport: *HttpTransport,
     ) ![]u8 {
+        return (try self.acquireAccessTokenVersioned(
+            challenge,
+            cancellation,
+            transport,
+        )).value;
+    }
+
+    fn acquireAccessTokenVersioned(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+    ) !AcquiredAccessToken {
         try checkCancelled(cancellation);
         const current_time = self.now();
         self.mutex.lockUncancelable(self.io);
         self.reapCompletedFlightsLocked();
         self.pruneAccessTokensLocked(current_time);
-        if (self.findValidAccessTokenLocked(challenge, current_time)) |token| {
-            const copy = self.allocator.dupe(u8, token) catch |err| {
+        if (self.findValidAccessTokenLocked(challenge, current_time)) |entry| {
+            const copy = self.allocator.dupe(u8, entry.token) catch |err| {
                 self.mutex.unlock(self.io);
                 return err;
             };
+            const result = AcquiredAccessToken{
+                .value = copy,
+                .version = entry.version,
+            };
             self.mutex.unlock(self.io);
-            return copy;
+            return result;
         }
         if (self.findRunningFlightLocked(.access, challenge)) |flight| {
             flight.participants += 1;
+            flight.condition.broadcast(self.io);
             self.waiting_callers += 1;
-            return self.waitForFlightLocked(flight, cancellation);
+            const result = try self.waitForFlightLocked(flight, cancellation);
+            return .{ .value = result.value, .version = result.version };
         }
         const flight = self.createFlightLocked(.access, challenge) catch |err| {
             self.mutex.unlock(self.io);
@@ -484,7 +525,8 @@ pub const ChallengeAuthenticationPolicy = struct {
             return err;
         };
         self.waiting_callers += 1;
-        return self.waitForFlightLocked(flight, cancellation);
+        const result = try self.waitForFlightLocked(flight, cancellation);
+        return .{ .value = result.value, .version = result.version };
     }
 
     fn acquireRefreshToken(
@@ -508,8 +550,9 @@ pub const ChallengeAuthenticationPolicy = struct {
         }
         if (self.findRunningFlightLocked(.refresh, challenge)) |flight| {
             flight.participants += 1;
+            flight.condition.broadcast(self.io);
             self.waiting_callers += 1;
-            return self.waitForFlightLocked(flight, cancellation);
+            return (try self.waitForFlightLocked(flight, cancellation)).value;
         }
         const flight = self.createFlightLocked(.refresh, challenge) catch |err| {
             self.mutex.unlock(self.io);
@@ -521,7 +564,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             return err;
         };
         self.waiting_callers += 1;
-        return self.waitForFlightLocked(flight, cancellation);
+        return (try self.waitForFlightLocked(flight, cancellation)).value;
     }
 
     fn requestAccessToken(
@@ -757,17 +800,20 @@ pub const ChallengeAuthenticationPolicy = struct {
     fn invalidateAccessToken(
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
+        rejected_token: AcquiredAccessToken,
     ) void {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
-        var index: usize = 0;
-        while (index < self.access_tokens.items.len) {
-            if (accessKeyMatches(&self.access_tokens.items[index], challenge, self.effectiveTenant(challenge))) {
-                var removed = self.access_tokens.swapRemove(index);
-                removed.deinit(self.allocator);
-            } else {
-                index += 1;
+        for (self.access_tokens.items, 0..) |*entry, index| {
+            if (!accessKeyMatches(entry, challenge, self.effectiveTenant(challenge)) or
+                entry.version != rejected_token.version or
+                !std.mem.eql(u8, entry.token, rejected_token.value))
+            {
+                continue;
             }
+            var removed = self.access_tokens.swapRemove(index);
+            removed.deinit(self.allocator);
+            return;
         }
     }
 
@@ -810,13 +856,13 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         current_time: i64,
-    ) ?[]const u8 {
+    ) ?*AccessTokenEntry {
         for (self.access_tokens.items) |*entry| {
             if (accessKeyMatches(entry, challenge, self.effectiveTenant(challenge)) and
                 isTokenValid(entry.expires_on, current_time, self.expiry_skew_seconds))
             {
                 entry.last_used = self.nextUseLocked();
-                return entry.token;
+                return entry;
             }
         }
         return null;
@@ -864,16 +910,18 @@ pub const ChallengeAuthenticationPolicy = struct {
         challenge: *const BearerChallenge,
         token: []const u8,
         expires_on: i64,
-    ) !void {
+    ) !u64 {
         const tenant = self.effectiveTenant(challenge) orelse "";
         for (self.access_tokens.items) |*entry| {
             if (!accessKeyMatches(entry, challenge, tenant)) continue;
             const replacement = try self.allocator.dupe(u8, token);
+            const version = self.nextUseLocked();
             self.allocator.free(entry.token);
             entry.token = replacement;
+            entry.version = version;
             entry.expires_on = expires_on;
-            entry.last_used = self.nextUseLocked();
-            return;
+            entry.last_used = version;
+            return version;
         }
 
         const realm = try self.allocator.dupe(u8, challenge.realm);
@@ -888,15 +936,18 @@ pub const ChallengeAuthenticationPolicy = struct {
         errdefer self.allocator.free(token_copy);
         if (self.access_tokens.items.len >= max_access_token_entries)
             self.evictLeastRecentlyUsedAccessTokenLocked();
+        const version = self.nextUseLocked();
         try self.access_tokens.append(self.allocator, .{
             .realm = realm,
             .service = service,
             .tenant = tenant_copy,
             .scope = scope,
             .token = token_copy,
+            .version = version,
             .expires_on = expires_on,
-            .last_used = self.nextUseLocked(),
+            .last_used = version,
         });
+        return version;
     }
 
     fn pruneRefreshTokensLocked(
@@ -1066,12 +1117,16 @@ pub const ChallengeAuthenticationPolicy = struct {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
         self.pruneAccessTokensLocked(self.now());
-        self.storeAccessTokenLocked(&challenge, token, expires_on) catch |err| {
+        const token_version = self.storeAccessTokenLocked(
+            &challenge,
+            token,
+            expires_on,
+        ) catch |err| {
             self.allocator.free(token);
             self.completeFlightFailureLocked(flight, err);
             return;
         };
-        self.completeFlightSuccessLocked(flight, token);
+        self.completeFlightSuccessLocked(flight, token, token_version);
     }
 
     fn runRefreshFlight(
@@ -1125,7 +1180,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.completeFlightFailureLocked(flight, err);
             return;
         };
-        self.completeFlightSuccessLocked(flight, token);
+        self.completeFlightSuccessLocked(flight, token, 0);
     }
 
     fn publishFlightFailure(
@@ -1142,7 +1197,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
         cancellation: ?*const CancellationToken,
-    ) ![]u8 {
+    ) !AcquiredFlightToken {
         if (cancellation == null) {
             while (flight.state == .running)
                 flight.condition.waitUncancelable(self.io, &self.mutex);
@@ -1166,7 +1221,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
         failure: anyerror,
-    ) anyerror![]u8 {
+    ) anyerror!AcquiredFlightToken {
         self.mutex.lockUncancelable(self.io);
         self.waiting_callers -= 1;
         self.releaseFlightLocked(flight);
@@ -1178,9 +1233,11 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
         token: []u8,
+        token_version: u64,
     ) void {
         std.debug.assert(flight.state == .running);
         flight.token = token;
+        flight.token_version = token_version;
         flight.state = .succeeded;
         flight.condition.broadcast(self.io);
     }
@@ -1200,7 +1257,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
         waiter: bool,
-    ) ![]u8 {
+    ) !AcquiredFlightToken {
         std.debug.assert(flight.state != .running);
         var token: ?[]u8 = null;
         var failure: ?anyerror = null;
@@ -1214,12 +1271,16 @@ pub const ChallengeAuthenticationPolicy = struct {
             },
             .failed => failure = flight.failure.?,
         }
+        const token_version = flight.token_version;
         std.debug.assert(waiter);
         self.waiting_callers -= 1;
         self.releaseFlightLocked(flight);
         self.mutex.unlock(self.io);
         if (failure) |err| return err;
-        return token.?;
+        return .{
+            .value = token.?,
+            .version = token_version,
+        };
     }
 
     fn releaseFlightLocked(
@@ -1850,6 +1911,19 @@ fn testResponse(
     };
 }
 
+fn waitForFlightParticipants(
+    policy: *ChallengeAuthenticationPolicy,
+    kind: FlightKind,
+    challenge: *const BearerChallenge,
+    expected: usize,
+) void {
+    policy.mutex.lockUncancelable(policy.io);
+    defer policy.mutex.unlock(policy.io);
+    const flight = policy.findRunningFlightLocked(kind, challenge) orelse unreachable;
+    while (flight.participants < expected)
+        flight.condition.waitUncancelable(policy.io, &policy.mutex);
+}
+
 const ParallelAccessTransport = struct {
     allocator: std.mem.Allocator,
     refresh_body: []const u8,
@@ -1973,6 +2047,136 @@ const BlockingTokenTransport = struct {
         self.entered.post(std.Io.Threaded.global_single_threaded.io());
         self.release.waitUncancelable(std.Io.Threaded.global_single_threaded.io());
         return testResponse(self.allocator, 200, self.response_body);
+    }
+};
+
+const RequestPath = enum {
+    buffered,
+    streaming,
+};
+
+const DelayedUnauthorizedTransport = struct {
+    allocator: std.mem.Allocator,
+    challenge: []const u8,
+    token_one: []const u8,
+    token_two: []const u8,
+    token_two_body: []const u8,
+    delayed_entered: std.Io.Semaphore = .{},
+    delayed_release: std.Io.Semaphore = .{},
+    token_one_requests: std.atomic.Value(usize) = .init(0),
+    token_two_requests: std.atomic.Value(usize) = .init(0),
+    token_requests: std.atomic.Value(usize) = .init(0),
+    transport: HttpTransport,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        challenge: []const u8,
+        token_one: []const u8,
+        token_two: []const u8,
+        token_two_body: []const u8,
+    ) DelayedUnauthorizedTransport {
+        return .{
+            .allocator = allocator,
+            .challenge = challenge,
+            .token_one = token_one,
+            .token_two = token_two,
+            .token_two_body = token_two_body,
+            .transport = .{ .sendFn = &sendImpl },
+        };
+    }
+
+    fn asTransport(self: *DelayedUnauthorizedTransport) *HttpTransport {
+        return &self.transport;
+    }
+
+    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
+        const self: *DelayedUnauthorizedTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        if (std.mem.indexOf(u8, request.url, "/oauth2/token") != null) {
+            _ = self.token_requests.fetchAdd(1, .monotonic);
+            return testResponse(self.allocator, 200, self.token_two_body);
+        }
+
+        const authorization = request.getHeader("Authorization") orelse
+            return error.MissingMockAuthorization;
+        if (bearerTokenMatches(authorization, self.token_one)) {
+            const request_index = self.token_one_requests.fetchAdd(1, .monotonic);
+            if (request_index == 0) {
+                const io = std.Io.Threaded.global_single_threaded.io();
+                self.delayed_entered.post(io);
+                self.delayed_release.waitUncancelable(io);
+            }
+            var response = try testResponse(self.allocator, 401, "");
+            errdefer response.deinit();
+            try response.response_headers.append("WWW-Authenticate", self.challenge);
+            return response;
+        }
+        if (bearerTokenMatches(authorization, self.token_two)) {
+            _ = self.token_two_requests.fetchAdd(1, .monotonic);
+            return testResponse(self.allocator, 200, "{}");
+        }
+        return error.UnexpectedMockAuthorization;
+    }
+};
+
+fn bearerTokenMatches(authorization: []const u8, token: []const u8) bool {
+    const prefix = "Bearer ";
+    return authorization.len == prefix.len + token.len and
+        std.mem.eql(u8, authorization[0..prefix.len], prefix) and
+        std.mem.eql(u8, authorization[prefix.len..], token);
+}
+
+const AuthRaceRequest = struct {
+    allocator: std.mem.Allocator,
+    policy: *ChallengeAuthenticationPolicy,
+    transport: *HttpTransport,
+    path: RequestPath,
+    status_code: ?u16 = null,
+    authorization_restored: bool = false,
+    err: ?anyerror = null,
+
+    fn run(self: *@This()) void {
+        var policies = [_]*HttpPolicy{self.policy.asPolicy()};
+        var pipeline = core.pipeline.HttpPipeline{
+            .policies = &policies,
+            .transport_impl = self.transport,
+        };
+        var request = Request.init(
+            self.allocator,
+            .GET,
+            "https://registry.example/v2/_catalog",
+        );
+        defer request.deinit();
+
+        switch (self.path) {
+            .buffered => {
+                var response = pipeline.send(&request) catch |err| {
+                    self.err = err;
+                    self.authorization_restored =
+                        request.getHeader("Authorization") == null;
+                    return;
+                };
+                defer response.deinit();
+                self.status_code = response.status_code;
+            },
+            .streaming => {
+                var operation = pipeline.open(&request, .{}) catch |err| {
+                    self.err = err;
+                    self.authorization_restored =
+                        request.getHeader("Authorization") == null;
+                    return;
+                };
+                defer operation.deinit();
+                operation.finish() catch |err| {
+                    self.err = err;
+                    self.authorization_restored =
+                        request.getHeader("Authorization") == null;
+                    return;
+                };
+                self.status_code = operation.status_code;
+            },
+        }
+        self.authorization_restored = request.getHeader("Authorization") == null;
     }
 };
 
@@ -2587,13 +2791,7 @@ test "concurrent token acquisition is single flight" {
         first_thread.join();
         return err;
     };
-    while (true) {
-        policy.mutex.lockUncancelable(policy.io);
-        const waiting = policy.waiting_callers;
-        policy.mutex.unlock(policy.io);
-        if (waiting > 0) break;
-        try io.sleep(.fromMilliseconds(1), .awake);
-    }
+    waitForFlightParticipants(&policy, .access, &challenge, 2);
     release.post(io);
     first_thread.join();
     second_thread.join();
@@ -3091,6 +3289,149 @@ test "streaming request reuse restores SDK authorization across invalidation and
     );
 }
 
+test "delayed unauthorized response preserves a newer same-key access token" {
+    const allocator = std.testing.allocator;
+    for ([_]RequestPath{ .buffered, .streaming }) |path| {
+        var clock = TestClock{ .value = 1_000 };
+        const token_one = try makeJwt(allocator, 4_000, "token-one");
+        defer allocator.free(token_one);
+        const token_two = try makeJwt(allocator, 5_000, "token-two");
+        defer allocator.free(token_two);
+        const token_two_body = try makeTokenResponse(
+            allocator,
+            "access_token",
+            token_two,
+        );
+        defer allocator.free(token_two_body);
+        const challenge_header = try makeChallenge(
+            allocator,
+            "https://registry.example/oauth2/token",
+            "registry.example",
+            "registry:catalog:*",
+        );
+        defer allocator.free(challenge_header);
+        var challenge = try parseTestChallenge(
+            allocator,
+            "https://registry.example/oauth2/token",
+            "registry.example",
+            "registry:catalog:*",
+            null,
+        );
+        defer challenge.deinit();
+        var transport = DelayedUnauthorizedTransport.init(
+            allocator,
+            challenge_header,
+            token_one,
+            token_two,
+            token_two_body,
+        );
+        var policy = try ChallengeAuthenticationPolicy.init(
+            allocator,
+            "https://registry.example",
+            .anonymous,
+            .{
+                .expiry_skew_seconds = 10,
+                .time_source = clock.source(),
+            },
+        );
+        defer policy.deinit();
+        var route_request = Request.init(
+            allocator,
+            .GET,
+            "https://registry.example/v2/_catalog",
+        );
+        defer route_request.deinit();
+        try policy.storeRoute(&route_request, &challenge);
+        {
+            policy.mutex.lockUncancelable(policy.io);
+            defer policy.mutex.unlock(policy.io);
+            _ = try policy.storeAccessTokenLocked(
+                &challenge,
+                token_one,
+                4_000,
+            );
+        }
+
+        var delayed = AuthRaceRequest{
+            .allocator = allocator,
+            .policy = &policy,
+            .transport = transport.asTransport(),
+            .path = path,
+        };
+        var refresher = AuthRaceRequest{
+            .allocator = allocator,
+            .policy = &policy,
+            .transport = transport.asTransport(),
+            .path = path,
+        };
+        const delayed_thread = try std.Thread.spawn(
+            .{},
+            AuthRaceRequest.run,
+            .{&delayed},
+        );
+        var delayed_joined = false;
+        defer if (!delayed_joined) delayed_thread.join();
+        transport.delayed_entered.waitUncancelable(policy.io);
+        var delayed_released = false;
+        defer if (!delayed_released) transport.delayed_release.post(policy.io);
+
+        const refresher_thread = try std.Thread.spawn(
+            .{},
+            AuthRaceRequest.run,
+            .{&refresher},
+        );
+        var refresher_joined = false;
+        defer if (!refresher_joined) refresher_thread.join();
+        refresher_thread.join();
+        refresher_joined = true;
+
+        try std.testing.expect(refresher.err == null);
+        try std.testing.expectEqual(@as(?u16, 200), refresher.status_code);
+        try std.testing.expect(refresher.authorization_restored);
+        const token_two_version = blk: {
+            policy.mutex.lockUncancelable(policy.io);
+            defer policy.mutex.unlock(policy.io);
+            const entry = policy.findValidAccessTokenLocked(
+                &challenge,
+                clock.value,
+            ) orelse return error.TestExpectedCachedAccessToken;
+            try std.testing.expectEqualStrings(token_two, entry.token);
+            break :blk entry.version;
+        };
+
+        transport.delayed_release.post(policy.io);
+        delayed_released = true;
+        delayed_thread.join();
+        delayed_joined = true;
+
+        try std.testing.expect(delayed.err == null);
+        try std.testing.expectEqual(@as(?u16, 200), delayed.status_code);
+        try std.testing.expect(delayed.authorization_restored);
+        {
+            policy.mutex.lockUncancelable(policy.io);
+            defer policy.mutex.unlock(policy.io);
+            const entry = policy.findValidAccessTokenLocked(
+                &challenge,
+                clock.value,
+            ) orelse return error.TestExpectedCachedAccessToken;
+            try std.testing.expectEqualStrings(token_two, entry.token);
+            try std.testing.expectEqual(token_two_version, entry.version);
+        }
+        try std.testing.expectEqual(
+            @as(usize, 2),
+            transport.token_one_requests.load(.monotonic),
+        );
+        try std.testing.expectEqual(
+            @as(usize, 2),
+            transport.token_two_requests.load(.monotonic),
+        );
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            transport.token_requests.load(.monotonic),
+        );
+    }
+}
+
 test "trusted origins compare HTTPS host and effective port" {
     const allocator = std.testing.allocator;
     const unused = [_]core.http.SequenceMockTransport.CannedResponse{
@@ -3497,8 +3838,8 @@ test "token caches prune expired entries and preserve valid keys" {
     {
         policy.mutex.lockUncancelable(policy.io);
         defer policy.mutex.unlock(policy.io);
-        try policy.storeAccessTokenLocked(&expired_access, "expired-access", 1_005);
-        try policy.storeAccessTokenLocked(&valid_access, "valid-access", 5_000);
+        _ = try policy.storeAccessTokenLocked(&expired_access, "expired-access", 1_005);
+        _ = try policy.storeAccessTokenLocked(&valid_access, "valid-access", 5_000);
         try policy.storeRefreshTokenLocked(&expired_refresh, "expired-refresh", 1_005);
         try policy.storeRefreshTokenLocked(&valid_refresh, "valid-refresh", 5_000);
         policy.pruneAccessTokensLocked(clock.value);
@@ -3513,7 +3854,7 @@ test "token caches prune expired entries and preserve valid keys" {
         );
         try std.testing.expectEqualStrings(
             "valid-access",
-            policy.findValidAccessTokenLocked(&valid_access, clock.value).?,
+            policy.findValidAccessTokenLocked(&valid_access, clock.value).?.token,
         );
         try std.testing.expectEqualStrings(
             "valid-refresh",
@@ -3556,7 +3897,7 @@ test "bounded caches evict least recently used keys without mixups" {
         policy.mutex.lockUncancelable(policy.io);
         {
             defer policy.mutex.unlock(policy.io);
-            try policy.storeAccessTokenLocked(&challenge, token, 5_000);
+            _ = try policy.storeAccessTokenLocked(&challenge, token, 5_000);
         }
     }
     var access_zero = try parseTestChallenge(
@@ -3594,9 +3935,9 @@ test "bounded caches evict least recently used keys without mixups" {
         defer policy.mutex.unlock(policy.io);
         try std.testing.expectEqualStrings(
             "access-token-0",
-            policy.findValidAccessTokenLocked(&access_zero, clock.value).?,
+            policy.findValidAccessTokenLocked(&access_zero, clock.value).?.token,
         );
-        try policy.storeAccessTokenLocked(
+        _ = try policy.storeAccessTokenLocked(
             &access_overflow,
             "access-token-overflow",
             5_000,
@@ -3607,11 +3948,11 @@ test "bounded caches evict least recently used keys without mixups" {
         );
         try std.testing.expectEqualStrings(
             "access-token-0",
-            policy.findValidAccessTokenLocked(&access_zero, clock.value).?,
+            policy.findValidAccessTokenLocked(&access_zero, clock.value).?.token,
         );
         try std.testing.expectEqualStrings(
             "access-token-overflow",
-            policy.findValidAccessTokenLocked(&access_overflow, clock.value).?,
+            policy.findValidAccessTokenLocked(&access_overflow, clock.value).?.token,
         );
     }
 
@@ -3913,13 +4254,7 @@ test "same-key flight wakes waiters with the leader failure" {
         first_thread.join();
         return err;
     };
-    while (true) {
-        policy.mutex.lockUncancelable(policy.io);
-        const waiting = policy.waiting_callers;
-        policy.mutex.unlock(policy.io);
-        if (waiting > 0) break;
-        try policy.io.sleep(.fromMilliseconds(1), .awake);
-    }
+    waitForFlightParticipants(&policy, .access, &challenge, 2);
     release.post(policy.io);
     first_thread.join();
     second_thread.join();
@@ -4007,13 +4342,7 @@ test "cancelled refresh flight leader does not fail a non-cancelled follower" {
         leader_thread.join();
         return err;
     };
-    while (true) {
-        policy.mutex.lockUncancelable(policy.io);
-        const waiting = policy.waiting_callers;
-        policy.mutex.unlock(policy.io);
-        if (waiting >= 2) break;
-        try policy.io.sleep(.fromMilliseconds(1), .awake);
-    }
+    waitForFlightParticipants(&policy, .refresh, &leader_challenge, 2);
 
     cancellation.cancel();
     leader_thread.join();
@@ -4101,13 +4430,7 @@ test "cancelled access flight leader does not fail a non-cancelled follower" {
         leader_thread.join();
         return err;
     };
-    while (true) {
-        policy.mutex.lockUncancelable(policy.io);
-        const waiting = policy.waiting_callers;
-        policy.mutex.unlock(policy.io);
-        if (waiting >= 2) break;
-        try policy.io.sleep(.fromMilliseconds(1), .awake);
-    }
+    waitForFlightParticipants(&policy, .access, &leader_challenge, 2);
 
     cancellation.cancel();
     leader_thread.join();
@@ -4301,13 +4624,7 @@ test "cancelling a same-key waiter leaves the leader race safe" {
         leader_thread.join();
         return err;
     };
-    while (true) {
-        policy.mutex.lockUncancelable(policy.io);
-        const waiting = policy.waiting_callers;
-        policy.mutex.unlock(policy.io);
-        if (waiting > 0) break;
-        try policy.io.sleep(.fromMilliseconds(1), .awake);
-    }
+    waitForFlightParticipants(&policy, .access, &challenge, 2);
     cancellation.cancel();
     waiter_thread.join();
     release.post(policy.io);

--- a/sdk/container_registry/src/auth_policy.zig
+++ b/sdk/container_registry/src/auth_policy.zig
@@ -1,0 +1,2016 @@
+const std = @import("std");
+const core = @import("azure_core");
+const challenge_mod = @import("challenge.zig");
+
+const BearerChallenge = challenge_mod.BearerChallenge;
+const Request = core.http.Request;
+const Response = core.http.Response;
+const HttpOperation = core.http.HttpOperation;
+const HttpPolicy = core.pipeline.HttpPolicy;
+const HttpTransport = core.http.HttpTransport;
+const OpenOptions = core.http.OpenOptions;
+const CancellationToken = core.http.CancellationToken;
+
+const default_aad_scope = "https://containerregistry.azure.net/.default";
+const default_api_version = "2021-07-01";
+const default_expiry_skew_seconds: i64 = 300;
+
+pub const Authentication = union(enum) {
+    credential: *core.credentials.TokenCredential,
+    anonymous,
+};
+
+pub const TimeSource = struct {
+    context: *anyopaque,
+    nowFn: *const fn (context: *anyopaque) i64,
+
+    pub fn now(self: TimeSource) i64 {
+        return self.nowFn(self.context);
+    }
+};
+
+pub const Options = struct {
+    /// Optional tenant sent during AAD-to-ACR token exchange.
+    tenant_id: ?[]const u8 = null,
+    /// AAD scope requested from the supplied TokenCredential.
+    aad_scope: []const u8 = default_aad_scope,
+    /// ACR authentication API version.
+    api_version: []const u8 = default_api_version,
+    /// Additional exact HTTPS hosts trusted for registry requests and realms.
+    expected_hosts: []const []const u8 = &.{},
+    /// Tokens at or within this many seconds of expiry are refreshed.
+    expiry_skew_seconds: i64 = default_expiry_skew_seconds,
+    /// Deterministic clock override, primarily for tests.
+    time_source: ?TimeSource = null,
+};
+
+const RefreshTokenEntry = struct {
+    realm: []u8,
+    service: []u8,
+    tenant: []u8,
+    token: []u8,
+    expires_on: i64,
+
+    fn deinit(self: *RefreshTokenEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.realm);
+        allocator.free(self.service);
+        allocator.free(self.tenant);
+        allocator.free(self.token);
+        self.* = undefined;
+    }
+};
+
+const AccessTokenEntry = struct {
+    realm: []u8,
+    service: []u8,
+    tenant: []u8,
+    scope: []u8,
+    token: []u8,
+    expires_on: i64,
+
+    fn deinit(self: *AccessTokenEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.realm);
+        allocator.free(self.service);
+        allocator.free(self.tenant);
+        allocator.free(self.scope);
+        allocator.free(self.token);
+        self.* = undefined;
+    }
+};
+
+const RouteEntry = struct {
+    method: core.http.Method,
+    url: []u8,
+    challenge: BearerChallenge,
+
+    fn deinit(self: *RouteEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.url);
+        self.challenge.deinit();
+        self.* = undefined;
+    }
+};
+
+/// ACR Bearer challenge policy. The policy validates every destination before
+/// sending, performs token bootstrap calls without redirects, and replays a
+/// challenged request at most once.
+pub const ChallengeAuthenticationPolicy = struct {
+    allocator: std.mem.Allocator,
+    endpoint: []u8,
+    endpoint_host: []u8,
+    expected_hosts: [][]u8,
+    authentication: Authentication,
+    tenant_id: ?[]u8,
+    aad_scope: []u8,
+    api_version: []u8,
+    expiry_skew_seconds: i64,
+    time_source: ?TimeSource,
+    io: std.Io,
+    mutex: std.Io.Mutex = .init,
+    refresh_finished: std.Io.Condition = .init,
+    refreshing: bool = false,
+    waiting_callers: usize = 0,
+    refresh_tokens: std.ArrayList(RefreshTokenEntry) = .empty,
+    access_tokens: std.ArrayList(AccessTokenEntry) = .empty,
+    routes: std.ArrayList(RouteEntry) = .empty,
+    policy: HttpPolicy,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        endpoint: []const u8,
+        authentication: Authentication,
+        options: Options,
+    ) !ChallengeAuthenticationPolicy {
+        if (options.aad_scope.len == 0) return error.AadScopeRequired;
+        if (options.api_version.len == 0) return error.ApiVersionRequired;
+        if (options.expiry_skew_seconds < 0) return error.InvalidExpirySkew;
+
+        const normalized_endpoint = try normalizeEndpoint(allocator, endpoint);
+        errdefer allocator.free(normalized_endpoint);
+        const endpoint_host = try extractHost(allocator, normalized_endpoint);
+        errdefer allocator.free(endpoint_host);
+        const expected_hosts = try copyExpectedHosts(
+            allocator,
+            endpoint_host,
+            options.expected_hosts,
+        );
+        errdefer deinitStringSlice(allocator, expected_hosts);
+
+        const tenant_id = if (options.tenant_id) |tenant|
+            try allocator.dupe(u8, tenant)
+        else
+            null;
+        errdefer if (tenant_id) |tenant| allocator.free(tenant);
+        const aad_scope = try allocator.dupe(u8, options.aad_scope);
+        errdefer allocator.free(aad_scope);
+        const api_version = try allocator.dupe(u8, options.api_version);
+        errdefer allocator.free(api_version);
+
+        return .{
+            .allocator = allocator,
+            .endpoint = normalized_endpoint,
+            .endpoint_host = endpoint_host,
+            .expected_hosts = expected_hosts,
+            .authentication = authentication,
+            .tenant_id = tenant_id,
+            .aad_scope = aad_scope,
+            .api_version = api_version,
+            .expiry_skew_seconds = options.expiry_skew_seconds,
+            .time_source = options.time_source,
+            .io = std.Io.Threaded.global_single_threaded.io(),
+            .policy = .{
+                .processFn = &processImpl,
+                .prepareFn = &prepareImpl,
+                .openFn = &openImpl,
+            },
+        };
+    }
+
+    /// Requires that no callers are using or waiting on this policy.
+    pub fn deinit(self: *ChallengeAuthenticationPolicy) void {
+        self.mutex.lockUncancelable(self.io);
+        std.debug.assert(!self.refreshing);
+        std.debug.assert(self.waiting_callers == 0);
+        for (self.refresh_tokens.items) |*entry| entry.deinit(self.allocator);
+        self.refresh_tokens.deinit(self.allocator);
+        for (self.access_tokens.items) |*entry| entry.deinit(self.allocator);
+        self.access_tokens.deinit(self.allocator);
+        for (self.routes.items) |*entry| entry.deinit(self.allocator);
+        self.routes.deinit(self.allocator);
+        self.mutex.unlock(self.io);
+
+        self.allocator.free(self.endpoint);
+        self.allocator.free(self.endpoint_host);
+        deinitStringSlice(self.allocator, self.expected_hosts);
+        if (self.tenant_id) |tenant| self.allocator.free(tenant);
+        self.allocator.free(self.aad_scope);
+        self.allocator.free(self.api_version);
+        self.* = undefined;
+    }
+
+    pub fn asPolicy(self: *ChallengeAuthenticationPolicy) *HttpPolicy {
+        return &self.policy;
+    }
+
+    fn processImpl(
+        policy: *HttpPolicy,
+        request: *Request,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !Response {
+        const self: *ChallengeAuthenticationPolicy =
+            @alignCast(@fieldParentPtr("policy", policy));
+        try self.validateRequestUrl(request.url);
+
+        var known_challenge: ?BearerChallenge = null;
+        defer if (known_challenge) |*challenge| challenge.deinit();
+        var sdk_authorized = false;
+
+        if (request.getHeader("Authorization") == null) {
+            known_challenge = try self.findRoute(request);
+            if (known_challenge) |*challenge| {
+                const token = try self.acquireAccessToken(
+                    challenge,
+                    null,
+                    final_transport,
+                );
+                defer self.allocator.free(token);
+                try setBearerHeader(request, token);
+                sdk_authorized = true;
+            }
+        }
+
+        var response = try callNext(request, next, final_transport);
+        if (response.status_code != 401) return response;
+
+        if (!sdk_authorized and request.getHeader("Authorization") != null)
+            return response;
+        if (sdk_authorized) self.invalidateAccessToken(&known_challenge.?);
+
+        var challenge = parseChallengeFromResponse(self.allocator, &response) catch |err| {
+            response.deinit();
+            return err;
+        };
+        defer challenge.deinit();
+        self.validateChallenge(&challenge) catch |err| {
+            response.deinit();
+            return err;
+        };
+        self.storeRoute(request, &challenge) catch |err| {
+            response.deinit();
+            return err;
+        };
+
+        const token = self.acquireAccessToken(
+            &challenge,
+            null,
+            final_transport,
+        ) catch |err| {
+            response.deinit();
+            return err;
+        };
+        defer self.allocator.free(token);
+        setBearerHeader(request, token) catch |err| {
+            response.deinit();
+            return err;
+        };
+
+        response.deinit();
+        const replay = try callNext(request, next, final_transport);
+        if (replay.status_code == 401) self.invalidateAccessToken(&challenge);
+        return replay;
+    }
+
+    fn prepareImpl(policy: *HttpPolicy, request: *Request) !void {
+        const self: *ChallengeAuthenticationPolicy =
+            @alignCast(@fieldParentPtr("policy", policy));
+        try self.validateRequestUrl(request.url);
+    }
+
+    fn openImpl(
+        policy: *HttpPolicy,
+        request: *Request,
+        options: OpenOptions,
+        next: []*HttpPolicy,
+        final_transport: *HttpTransport,
+    ) !*HttpOperation {
+        const self: *ChallengeAuthenticationPolicy =
+            @alignCast(@fieldParentPtr("policy", policy));
+        try self.validateRequestUrl(request.url);
+        try checkCancelled(options.cancellation);
+
+        var known_challenge: ?BearerChallenge = null;
+        defer if (known_challenge) |*challenge| challenge.deinit();
+        var sdk_authorized = false;
+
+        if (request.getHeader("Authorization") == null) {
+            known_challenge = try self.findRoute(request);
+            if (known_challenge) |*challenge| {
+                const token = try self.acquireAccessToken(
+                    challenge,
+                    options.cancellation,
+                    final_transport,
+                );
+                defer self.allocator.free(token);
+                try setBearerHeader(request, token);
+                sdk_authorized = true;
+            }
+        }
+
+        var operation = try callNextOpen(
+            request,
+            options,
+            next,
+            final_transport,
+        );
+        if (operation.status_code != 401) return operation;
+
+        if (!sdk_authorized and request.getHeader("Authorization") != null)
+            return operation;
+        if (sdk_authorized) self.invalidateAccessToken(&known_challenge.?);
+
+        var challenge = parseChallengeFromResponse(self.allocator, operation) catch |err| {
+            operation.deinit();
+            return err;
+        };
+        defer challenge.deinit();
+        self.validateChallenge(&challenge) catch |err| {
+            operation.deinit();
+            return err;
+        };
+        if (!options.isReplayable()) {
+            operation.deinit();
+            return error.RequestBodyNotReplayable;
+        }
+        try checkCancelled(options.cancellation);
+        self.storeRoute(request, &challenge) catch |err| {
+            operation.deinit();
+            return err;
+        };
+
+        const token = self.acquireAccessToken(
+            &challenge,
+            options.cancellation,
+            final_transport,
+        ) catch |err| {
+            operation.deinit();
+            return err;
+        };
+        defer self.allocator.free(token);
+        setBearerHeader(request, token) catch |err| {
+            operation.deinit();
+            return err;
+        };
+
+        var replay_options = options;
+        if (replay_options.body) |*body| {
+            body.rewind() catch |err| {
+                operation.deinit();
+                return err;
+            };
+        }
+        try checkCancelled(options.cancellation);
+        operation.deinit();
+        operation = try callNextOpen(
+            request,
+            replay_options,
+            next,
+            final_transport,
+        );
+        if (operation.status_code == 401) self.invalidateAccessToken(&challenge);
+        return operation;
+    }
+
+    fn acquireAccessToken(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+    ) ![]u8 {
+        while (true) {
+            try checkCancelled(cancellation);
+            const current_time = self.now();
+            self.mutex.lockUncancelable(self.io);
+            if (self.findValidAccessTokenLocked(challenge, current_time)) |token| {
+                const copy = self.allocator.dupe(u8, token) catch |err| {
+                    self.mutex.unlock(self.io);
+                    return err;
+                };
+                self.mutex.unlock(self.io);
+                return copy;
+            }
+            if (self.refreshing) {
+                if (cancellation == null) {
+                    self.waiting_callers += 1;
+                    self.refresh_finished.waitUncancelable(self.io, &self.mutex);
+                    self.waiting_callers -= 1;
+                    self.mutex.unlock(self.io);
+                } else {
+                    self.mutex.unlock(self.io);
+                    while (true) {
+                        try checkCancelled(cancellation);
+                        self.io.sleep(.fromMilliseconds(1), .awake) catch {};
+                        self.mutex.lockUncancelable(self.io);
+                        if (!self.refreshing) {
+                            self.mutex.unlock(self.io);
+                            break;
+                        }
+                        self.mutex.unlock(self.io);
+                    }
+                }
+                continue;
+            }
+            self.refreshing = true;
+            self.mutex.unlock(self.io);
+            break;
+        }
+
+        errdefer self.finishRefresh();
+        const token = switch (self.authentication) {
+            .anonymous => try self.exchangeAccessToken(
+                challenge,
+                "",
+                .password,
+                cancellation,
+                transport,
+            ),
+            .credential => |credential| blk: {
+                const refresh_token = try self.acquireRefreshToken(
+                    challenge,
+                    credential,
+                    cancellation,
+                    transport,
+                );
+                defer self.allocator.free(refresh_token);
+                break :blk try self.exchangeAccessToken(
+                    challenge,
+                    refresh_token,
+                    .refresh_token,
+                    cancellation,
+                    transport,
+                );
+            },
+        };
+        errdefer self.allocator.free(token);
+        const expires_on = try jwtExpiry(self.allocator, token);
+        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds))
+            return error.AcrTokenExpired;
+
+        self.mutex.lockUncancelable(self.io);
+        self.storeAccessTokenLocked(challenge, token, expires_on) catch |err| {
+            self.mutex.unlock(self.io);
+            return err;
+        };
+        self.refreshing = false;
+        self.refresh_finished.broadcast(self.io);
+        self.mutex.unlock(self.io);
+        return token;
+    }
+
+    fn acquireRefreshToken(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        credential: *core.credentials.TokenCredential,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+    ) ![]u8 {
+        const current_time = self.now();
+        self.mutex.lockUncancelable(self.io);
+        if (self.findValidRefreshTokenLocked(challenge, current_time)) |token| {
+            const copy = self.allocator.dupe(u8, token) catch |err| {
+                self.mutex.unlock(self.io);
+                return err;
+            };
+            self.mutex.unlock(self.io);
+            return copy;
+        }
+        self.mutex.unlock(self.io);
+
+        try checkCancelled(cancellation);
+        const scopes = [_][]const u8{self.aad_scope};
+        var aad_token = try credential.getToken(
+            .{ .scopes = &scopes },
+            core.context.Context.none,
+        );
+        defer aad_token.deinit();
+        try checkCancelled(cancellation);
+
+        const refresh_token = try self.exchangeRefreshToken(
+            challenge,
+            aad_token.token,
+            cancellation,
+            transport,
+        );
+        errdefer self.allocator.free(refresh_token);
+        const expires_on = try jwtExpiry(self.allocator, refresh_token);
+        if (!isTokenValid(expires_on, self.now(), self.expiry_skew_seconds))
+            return error.AcrRefreshTokenExpired;
+
+        self.mutex.lockUncancelable(self.io);
+        self.storeRefreshTokenLocked(challenge, refresh_token, expires_on) catch |err| {
+            self.mutex.unlock(self.io);
+            return err;
+        };
+        self.mutex.unlock(self.io);
+        return refresh_token;
+    }
+
+    fn exchangeRefreshToken(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        aad_token: []const u8,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+    ) ![]u8 {
+        const url = try self.tokenUrl(challenge.realm, "/oauth2/exchange");
+        defer self.allocator.free(url);
+
+        var body: std.ArrayList(u8) = .empty;
+        defer body.deinit(self.allocator);
+        var first = true;
+        try appendFormField(self.allocator, &body, &first, "grant_type", "access_token");
+        try appendFormField(self.allocator, &body, &first, "service", challenge.service);
+        if (self.effectiveTenant(challenge)) |tenant| {
+            try appendFormField(self.allocator, &body, &first, "tenant", tenant);
+        }
+        try appendFormField(self.allocator, &body, &first, "access_token", aad_token);
+        return self.sendTokenRequest(url, body.items, "refresh_token", cancellation, transport);
+    }
+
+    const AccessGrant = enum {
+        refresh_token,
+        password,
+    };
+
+    fn exchangeAccessToken(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        refresh_token: []const u8,
+        grant: AccessGrant,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+    ) ![]u8 {
+        const url = try self.tokenUrl(challenge.realm, "/oauth2/token");
+        defer self.allocator.free(url);
+
+        var body: std.ArrayList(u8) = .empty;
+        defer body.deinit(self.allocator);
+        var first = true;
+        try appendFormField(self.allocator, &body, &first, "grant_type", @tagName(grant));
+        try appendFormField(self.allocator, &body, &first, "service", challenge.service);
+        try appendFormField(self.allocator, &body, &first, "scope", challenge.scope);
+        try appendFormField(self.allocator, &body, &first, "refresh_token", refresh_token);
+        return self.sendTokenRequest(url, body.items, "access_token", cancellation, transport);
+    }
+
+    fn sendTokenRequest(
+        self: *ChallengeAuthenticationPolicy,
+        url: []const u8,
+        body: []const u8,
+        response_field: []const u8,
+        cancellation: ?*const CancellationToken,
+        transport: *HttpTransport,
+    ) ![]u8 {
+        try checkCancelled(cancellation);
+        var request = Request.init(self.allocator, .POST, url);
+        defer request.deinit();
+        request.body = body;
+        request.redirect_policy = .not_allowed;
+        try request.setHeader("Accept", "application/json");
+        try request.setHeader("Content-Type", "application/x-www-form-urlencoded");
+
+        var response = try transport.send(&request);
+        defer response.deinit();
+        try checkCancelled(cancellation);
+        if (response.status_code != 200) return error.AcrTokenExchangeFailed;
+        return parseTokenResponse(self.allocator, response.body, response_field);
+    }
+
+    fn validateRequestUrl(self: *ChallengeAuthenticationPolicy, url: []const u8) !void {
+        const hosts: []const []const u8 = @ptrCast(self.expected_hosts);
+        try core.url.validateHttpsUrl(url, hosts);
+    }
+
+    fn validateChallenge(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+    ) !void {
+        const hosts: []const []const u8 = @ptrCast(self.expected_hosts);
+        try core.url.validateHttpsUrl(challenge.realm, hosts);
+        const realm_uri = std.Uri.parse(challenge.realm) catch return error.InvalidChallengeRealm;
+        if (realm_uri.query != null or realm_uri.fragment != null)
+            return error.InvalidChallengeRealm;
+        const path = if (realm_uri.path.isEmpty()) "/" else switch (realm_uri.path) {
+            .raw => |value| value,
+            .percent_encoded => |value| value,
+        };
+        if (!std.mem.eql(u8, path, "/oauth2/token")) return error.InvalidChallengeRealm;
+
+        const realm_host = try extractHost(self.allocator, challenge.realm);
+        defer self.allocator.free(realm_host);
+        if (!std.ascii.eqlIgnoreCase(realm_host, challenge.service))
+            return error.UntrustedChallengeService;
+        if (!hostExpected(hosts, challenge.service))
+            return error.UntrustedChallengeService;
+        if (challenge.tenant) |challenge_tenant| {
+            if (challenge_tenant.len == 0) return error.InvalidChallengeTenant;
+            if (self.tenant_id) |configured| {
+                if (!std.mem.eql(u8, configured, challenge_tenant))
+                    return error.UntrustedChallengeTenant;
+            }
+        }
+    }
+
+    fn findRoute(
+        self: *ChallengeAuthenticationPolicy,
+        request: *const Request,
+    ) !?BearerChallenge {
+        const route_url = requestRoute(request.url);
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        for (self.routes.items) |entry| {
+            if (entry.method == request.method and std.mem.eql(u8, entry.url, route_url))
+                return try entry.challenge.clone(self.allocator);
+        }
+        return null;
+    }
+
+    fn storeRoute(
+        self: *ChallengeAuthenticationPolicy,
+        request: *const Request,
+        challenge: *const BearerChallenge,
+    ) !void {
+        const route_url = requestRoute(request.url);
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        for (self.routes.items) |*entry| {
+            if (entry.method != request.method or !std.mem.eql(u8, entry.url, route_url))
+                continue;
+            const replacement = try challenge.clone(self.allocator);
+            entry.challenge.deinit();
+            entry.challenge = replacement;
+            return;
+        }
+
+        const url_copy = try self.allocator.dupe(u8, route_url);
+        errdefer self.allocator.free(url_copy);
+        var challenge_copy = try challenge.clone(self.allocator);
+        errdefer challenge_copy.deinit();
+        try self.routes.append(self.allocator, .{
+            .method = request.method,
+            .url = url_copy,
+            .challenge = challenge_copy,
+        });
+    }
+
+    fn invalidateAccessToken(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+    ) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        var index: usize = 0;
+        while (index < self.access_tokens.items.len) {
+            if (accessKeyMatches(&self.access_tokens.items[index], challenge, self.effectiveTenant(challenge))) {
+                var removed = self.access_tokens.swapRemove(index);
+                removed.deinit(self.allocator);
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    fn findValidRefreshTokenLocked(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        current_time: i64,
+    ) ?[]const u8 {
+        for (self.refresh_tokens.items) |entry| {
+            if (refreshKeyMatches(&entry, challenge, self.effectiveTenant(challenge)) and
+                isTokenValid(entry.expires_on, current_time, self.expiry_skew_seconds))
+            {
+                return entry.token;
+            }
+        }
+        return null;
+    }
+
+    fn findValidAccessTokenLocked(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        current_time: i64,
+    ) ?[]const u8 {
+        for (self.access_tokens.items) |entry| {
+            if (accessKeyMatches(&entry, challenge, self.effectiveTenant(challenge)) and
+                isTokenValid(entry.expires_on, current_time, self.expiry_skew_seconds))
+            {
+                return entry.token;
+            }
+        }
+        return null;
+    }
+
+    fn storeRefreshTokenLocked(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        token: []const u8,
+        expires_on: i64,
+    ) !void {
+        const tenant = self.effectiveTenant(challenge) orelse "";
+        for (self.refresh_tokens.items) |*entry| {
+            if (!refreshKeyMatches(entry, challenge, tenant)) continue;
+            const replacement = try self.allocator.dupe(u8, token);
+            self.allocator.free(entry.token);
+            entry.token = replacement;
+            entry.expires_on = expires_on;
+            return;
+        }
+
+        const realm = try self.allocator.dupe(u8, challenge.realm);
+        errdefer self.allocator.free(realm);
+        const service = try self.allocator.dupe(u8, challenge.service);
+        errdefer self.allocator.free(service);
+        const tenant_copy = try self.allocator.dupe(u8, tenant);
+        errdefer self.allocator.free(tenant_copy);
+        const token_copy = try self.allocator.dupe(u8, token);
+        errdefer self.allocator.free(token_copy);
+        try self.refresh_tokens.append(self.allocator, .{
+            .realm = realm,
+            .service = service,
+            .tenant = tenant_copy,
+            .token = token_copy,
+            .expires_on = expires_on,
+        });
+    }
+
+    fn storeAccessTokenLocked(
+        self: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        token: []const u8,
+        expires_on: i64,
+    ) !void {
+        const tenant = self.effectiveTenant(challenge) orelse "";
+        for (self.access_tokens.items) |*entry| {
+            if (!accessKeyMatches(entry, challenge, tenant)) continue;
+            const replacement = try self.allocator.dupe(u8, token);
+            self.allocator.free(entry.token);
+            entry.token = replacement;
+            entry.expires_on = expires_on;
+            return;
+        }
+
+        const realm = try self.allocator.dupe(u8, challenge.realm);
+        errdefer self.allocator.free(realm);
+        const service = try self.allocator.dupe(u8, challenge.service);
+        errdefer self.allocator.free(service);
+        const tenant_copy = try self.allocator.dupe(u8, tenant);
+        errdefer self.allocator.free(tenant_copy);
+        const scope = try self.allocator.dupe(u8, challenge.scope);
+        errdefer self.allocator.free(scope);
+        const token_copy = try self.allocator.dupe(u8, token);
+        errdefer self.allocator.free(token_copy);
+        try self.access_tokens.append(self.allocator, .{
+            .realm = realm,
+            .service = service,
+            .tenant = tenant_copy,
+            .scope = scope,
+            .token = token_copy,
+            .expires_on = expires_on,
+        });
+    }
+
+    fn finishRefresh(self: *ChallengeAuthenticationPolicy) void {
+        self.mutex.lockUncancelable(self.io);
+        self.refreshing = false;
+        self.refresh_finished.broadcast(self.io);
+        self.mutex.unlock(self.io);
+    }
+
+    fn effectiveTenant(
+        self: *const ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+    ) ?[]const u8 {
+        return challenge.tenant orelse self.tenant_id;
+    }
+
+    fn tokenUrl(
+        self: *ChallengeAuthenticationPolicy,
+        realm: []const u8,
+        path: []const u8,
+    ) ![]u8 {
+        const parsed = try core.url.Url.parse(realm);
+        var output: std.ArrayList(u8) = .empty;
+        defer output.deinit(self.allocator);
+        try output.print(self.allocator, "{s}://{s}", .{ parsed.scheme, parsed.host });
+        if (parsed.port) |port| try output.print(self.allocator, ":{d}", .{port});
+        try output.appendSlice(self.allocator, path);
+        try output.appendSlice(self.allocator, "?api-version=");
+        const encoded = try core.url.percentEncode(self.allocator, self.api_version);
+        defer self.allocator.free(encoded);
+        try output.appendSlice(self.allocator, encoded);
+        return output.toOwnedSlice(self.allocator);
+    }
+
+    fn now(self: *const ChallengeAuthenticationPolicy) i64 {
+        if (self.time_source) |source| return source.now();
+        var threaded: std.Io.Threaded = .init_single_threaded;
+        return std.Io.Timestamp.now(threaded.io(), .real).toSeconds();
+    }
+};
+
+fn callNext(
+    request: *Request,
+    next: []*HttpPolicy,
+    final_transport: *HttpTransport,
+) !Response {
+    if (next.len == 0) return final_transport.send(request);
+    return next[0].process(request, next[1..], final_transport);
+}
+
+fn callNextOpen(
+    request: *Request,
+    options: OpenOptions,
+    next: []*HttpPolicy,
+    final_transport: *HttpTransport,
+) !*HttpOperation {
+    if (next.len == 0) return final_transport.open(request, options);
+    return next[0].open(request, options, next[1..], final_transport);
+}
+
+fn parseChallengeFromResponse(
+    allocator: std.mem.Allocator,
+    response: anytype,
+) !BearerChallenge {
+    const values = try response.getHeaderValues(allocator, "WWW-Authenticate");
+    defer allocator.free(values);
+    return challenge_mod.parseBearerChallenge(allocator, values);
+}
+
+fn normalizeEndpoint(allocator: std.mem.Allocator, endpoint: []const u8) ![]u8 {
+    try core.url.validateHttpsUrl(endpoint, &.{});
+    const uri = std.Uri.parse(endpoint) catch return error.InvalidRegistryEndpoint;
+    if (uri.query != null or uri.fragment != null) return error.InvalidRegistryEndpoint;
+    const path = if (uri.path.isEmpty()) "" else switch (uri.path) {
+        .raw => |value| value,
+        .percent_encoded => |value| value,
+    };
+    if (path.len != 0 and !std.mem.eql(u8, path, "/"))
+        return error.InvalidRegistryEndpoint;
+    return allocator.dupe(u8, if (std.mem.endsWith(u8, endpoint, "/"))
+        endpoint[0 .. endpoint.len - 1]
+    else
+        endpoint);
+}
+
+fn extractHost(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
+    const uri = std.Uri.parse(raw) catch return error.InvalidUrl;
+    if (uri.host == null) return error.InvalidUrl;
+    var buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const host = uri.getHost(&buffer) catch return error.InvalidUrl;
+    return allocator.dupe(u8, host.bytes);
+}
+
+fn copyExpectedHosts(
+    allocator: std.mem.Allocator,
+    endpoint_host: []const u8,
+    additional: []const []const u8,
+) ![][]u8 {
+    const hosts = try allocator.alloc([]u8, additional.len + 1);
+    errdefer allocator.free(hosts);
+    var initialized: usize = 0;
+    errdefer {
+        for (hosts[0..initialized]) |host| allocator.free(host);
+    }
+
+    hosts[0] = try allocator.dupe(u8, endpoint_host);
+    initialized += 1;
+    for (additional, 0..) |host, index| {
+        try validateExpectedHost(host);
+        hosts[index + 1] = try allocator.dupe(u8, host);
+        initialized += 1;
+    }
+    return hosts;
+}
+
+fn validateExpectedHost(host: []const u8) !void {
+    if (host.len == 0) return error.InvalidExpectedHost;
+    for (host) |byte| {
+        if (std.ascii.isAlphanumeric(byte) or byte == '.' or byte == '-') continue;
+        return error.InvalidExpectedHost;
+    }
+}
+
+fn deinitStringSlice(allocator: std.mem.Allocator, values: [][]u8) void {
+    for (values) |value| allocator.free(value);
+    allocator.free(values);
+}
+
+fn hostExpected(hosts: []const []const u8, value: []const u8) bool {
+    for (hosts) |host| {
+        if (std.ascii.eqlIgnoreCase(host, value)) return true;
+    }
+    return false;
+}
+
+fn requestRoute(url: []const u8) []const u8 {
+    const query = std.mem.indexOfScalar(u8, url, '?') orelse url.len;
+    return url[0..query];
+}
+
+fn refreshKeyMatches(
+    entry: *const RefreshTokenEntry,
+    challenge: *const BearerChallenge,
+    tenant: ?[]const u8,
+) bool {
+    return std.mem.eql(u8, entry.realm, challenge.realm) and
+        std.mem.eql(u8, entry.service, challenge.service) and
+        std.mem.eql(u8, entry.tenant, tenant orelse "");
+}
+
+fn accessKeyMatches(
+    entry: *const AccessTokenEntry,
+    challenge: *const BearerChallenge,
+    tenant: ?[]const u8,
+) bool {
+    return std.mem.eql(u8, entry.realm, challenge.realm) and
+        std.mem.eql(u8, entry.service, challenge.service) and
+        std.mem.eql(u8, entry.tenant, tenant orelse "") and
+        std.mem.eql(u8, entry.scope, challenge.scope);
+}
+
+fn isTokenValid(expires_on: i64, now: i64, skew: i64) bool {
+    return expires_on > now and now < expires_on -| skew;
+}
+
+fn setBearerHeader(request: *Request, token: []const u8) !void {
+    const value = try std.fmt.allocPrint(request.allocator, "Bearer {s}", .{token});
+    defer request.allocator.free(value);
+    try request.setHeader("Authorization", value);
+}
+
+fn appendFormField(
+    allocator: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    first: *bool,
+    key: []const u8,
+    value: []const u8,
+) !void {
+    if (!first.*) try output.append(allocator, '&');
+    first.* = false;
+    try formEncodeAppend(allocator, output, key);
+    try output.append(allocator, '=');
+    try formEncodeAppend(allocator, output, value);
+}
+
+fn formEncodeAppend(
+    allocator: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    value: []const u8,
+) !void {
+    const hex = "0123456789ABCDEF";
+    for (value) |byte| {
+        if (std.ascii.isAlphanumeric(byte) or
+            byte == '-' or byte == '.' or byte == '_' or byte == '*')
+        {
+            try output.append(allocator, byte);
+        } else if (byte == ' ') {
+            try output.append(allocator, '+');
+        } else {
+            try output.append(allocator, '%');
+            try output.append(allocator, hex[byte >> 4]);
+            try output.append(allocator, hex[byte & 0x0f]);
+        }
+    }
+}
+
+fn parseTokenResponse(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    field: []const u8,
+) ![]u8 {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch
+        return error.InvalidAcrTokenResponse;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidAcrTokenResponse;
+    const token = parsed.value.object.get(field) orelse
+        return error.InvalidAcrTokenResponse;
+    if (token != .string or token.string.len == 0)
+        return error.InvalidAcrTokenResponse;
+    return allocator.dupe(u8, token.string);
+}
+
+fn jwtExpiry(allocator: std.mem.Allocator, token: []const u8) !i64 {
+    const first_dot = std.mem.indexOfScalar(u8, token, '.') orelse
+        return error.InvalidAcrToken;
+    const rest = token[first_dot + 1 ..];
+    const second_dot = std.mem.indexOfScalar(u8, rest, '.') orelse
+        return error.InvalidAcrToken;
+    var payload = rest[0..second_dot];
+    while (payload.len > 0 and payload[payload.len - 1] == '=')
+        payload = payload[0 .. payload.len - 1];
+    if (payload.len == 0) return error.InvalidAcrToken;
+
+    const decoded = core.base64.urlDecode(allocator, payload) catch
+        return error.InvalidAcrToken;
+    defer allocator.free(decoded);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, decoded, .{}) catch
+        return error.InvalidAcrToken;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidAcrToken;
+    const expires = parsed.value.object.get("exp") orelse return error.InvalidAcrToken;
+    if (expires != .integer or expires.integer <= 0) return error.InvalidAcrToken;
+    return expires.integer;
+}
+
+fn checkCancelled(cancellation: ?*const CancellationToken) !void {
+    if (cancellation) |token| {
+        if (token.isCancelled()) return error.OperationCancelled;
+    }
+}
+
+const TestClock = struct {
+    value: i64,
+
+    fn source(self: *TestClock) TimeSource {
+        return .{ .context = self, .nowFn = &now };
+    }
+
+    fn now(context: *anyopaque) i64 {
+        const self: *TestClock = @ptrCast(@alignCast(context));
+        return self.value;
+    }
+};
+
+const TestCredential = struct {
+    credential: core.credentials.TokenCredential,
+    calls: std.atomic.Value(usize) = .init(0),
+    token: []const u8 = "aad-token",
+    fail: bool = false,
+    entered: ?*std.Io.Semaphore = null,
+    release: ?*std.Io.Semaphore = null,
+
+    fn init() TestCredential {
+        return .{ .credential = .{ .getTokenFn = &getToken } };
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        _: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+    ) anyerror!core.credentials.AccessToken {
+        const self: *TestCredential =
+            @alignCast(@fieldParentPtr("credential", credential));
+        _ = self.calls.fetchAdd(1, .monotonic);
+        const io = std.Io.Threaded.global_single_threaded.io();
+        if (self.entered) |entered| entered.post(io);
+        if (self.release) |release| release.waitUncancelable(io);
+        if (self.fail) return error.MockCredentialFailure;
+        return .{ .token = self.token, .expires_on = 10_000 };
+    }
+};
+
+fn makeJwt(
+    allocator: std.mem.Allocator,
+    expires_on: i64,
+    marker: []const u8,
+) ![]u8 {
+    const payload = try std.fmt.allocPrint(
+        allocator,
+        "{{\"exp\":{d},\"jti\":\"{s}\"}}",
+        .{ expires_on, marker },
+    );
+    defer allocator.free(payload);
+    const encoded = try core.base64.urlEncode(allocator, payload);
+    defer allocator.free(encoded);
+    return std.fmt.allocPrint(allocator, "e30.{s}.signature", .{encoded});
+}
+
+fn makeTokenResponse(
+    allocator: std.mem.Allocator,
+    field: []const u8,
+    token: []const u8,
+) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{{\"{s}\":\"{s}\"}}", .{ field, token });
+}
+
+fn makeChallenge(
+    allocator: std.mem.Allocator,
+    realm: []const u8,
+    service: []const u8,
+    scope: []const u8,
+) ![]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "Bearer realm=\"{s}\",service=\"{s}\",scope=\"{s}\"",
+        .{ realm, service, scope },
+    );
+}
+
+fn capturedUrl(
+    transport: *const core.http.SequenceMockTransport,
+    index: usize,
+) []const u8 {
+    return transport.captured_urls[index][0..transport.captured_url_lengths[index]];
+}
+
+fn capturedBody(
+    transport: *const core.http.SequenceMockTransport,
+    index: usize,
+) []const u8 {
+    return transport.captured_bodies[index][0..transport.captured_body_lengths[index]];
+}
+
+fn countCapturedUrl(
+    transport: *const core.http.SequenceMockTransport,
+    needle: []const u8,
+) usize {
+    var count: usize = 0;
+    for (0..transport.call_count) |index| {
+        if (std.mem.indexOf(u8, capturedUrl(transport, index), needle) != null)
+            count += 1;
+    }
+    return count;
+}
+
+fn sendBuffered(
+    allocator: std.mem.Allocator,
+    policy: *ChallengeAuthenticationPolicy,
+    transport: *HttpTransport,
+    method: core.http.Method,
+    url: []const u8,
+) !Response {
+    var policies = [_]*HttpPolicy{policy.asPolicy()};
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport,
+    };
+    var request = Request.init(allocator, method, url);
+    defer request.deinit();
+    return pipeline.send(&request);
+}
+
+test "authenticated challenge flow uses form encoding and caches both tokens" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    credential.token = "aad token+secret";
+
+    const refresh_token = try makeJwt(allocator, 4_000, "refresh");
+    defer allocator.free(refresh_token);
+    const access_token = try makeJwt(allocator, 2_000, "access");
+    defer allocator.free(access_token);
+    const refresh_body = try makeTokenResponse(
+        allocator,
+        "refresh_token",
+        refresh_token,
+    );
+    defer allocator.free(refresh_body);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:team/image:pull",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .tenant_id = "tenant one",
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+
+    var first = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/team/image/manifests/latest",
+    );
+    defer first.deinit();
+    try std.testing.expectEqual(@as(u16, 200), first.status_code);
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expect(!transport.captured_authorization[0]);
+    try std.testing.expect(transport.captured_authorization[3]);
+    try std.testing.expect(transport.captured_content_type[1]);
+    try std.testing.expect(transport.captured_content_type[2]);
+    try std.testing.expectEqualStrings(
+        "grant_type=access_token&service=registry.example&tenant=tenant+one&access_token=aad+token%2Bsecret",
+        capturedBody(&transport, 1),
+    );
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        capturedBody(&transport, 2),
+        "grant_type=refresh_token&service=registry.example&scope=repository%3Ateam%2Fimage%3Apull&refresh_token=",
+    ));
+
+    var second = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/team/image/manifests/latest?reference=other",
+    );
+    defer second.deinit();
+    try std.testing.expectEqual(@as(u16, 200), second.status_code);
+    try std.testing.expectEqual(@as(usize, 5), transport.call_count);
+    try std.testing.expect(transport.captured_authorization[4]);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countCapturedUrl(&transport, "/oauth2/exchange"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countCapturedUrl(&transport, "/oauth2/token"),
+    );
+}
+
+test "explicit anonymous mode obtains an anonymous scoped token" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    const access_token = try makeJwt(allocator, 2_000, "anonymous");
+    defer allocator.free(access_token);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "registry:catalog:*",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = access_body },
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+
+    var response = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/_catalog",
+    );
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        countCapturedUrl(&transport, "/oauth2/exchange"),
+    );
+    try std.testing.expectEqualStrings(
+        "grant_type=password&service=registry.example&scope=registry%3Acatalog%3A*&refresh_token=",
+        capturedBody(&transport, 1),
+    );
+}
+
+test "authenticated credential failures never downgrade to anonymous" {
+    const allocator = std.testing.allocator;
+    var credential = TestCredential.init();
+    credential.fail = true;
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "registry:catalog:*",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{ .expiry_skew_seconds = 10 },
+    );
+    defer policy.deinit();
+
+    try std.testing.expectError(
+        error.MockCredentialFailure,
+        sendBuffered(
+            allocator,
+            &policy,
+            transport.asTransport(),
+            .GET,
+            "https://registry.example/v2/_catalog",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+}
+
+test "expired refresh and access tokens are refreshed before sending" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const refresh_one = try makeJwt(allocator, 2_000, "refresh-one");
+    defer allocator.free(refresh_one);
+    const access_one = try makeJwt(allocator, 1_500, "access-one");
+    defer allocator.free(access_one);
+    const refresh_two = try makeJwt(allocator, 5_000, "refresh-two");
+    defer allocator.free(refresh_two);
+    const access_two = try makeJwt(allocator, 4_000, "access-two");
+    defer allocator.free(access_two);
+    const refresh_one_body = try makeTokenResponse(allocator, "refresh_token", refresh_one);
+    defer allocator.free(refresh_one_body);
+    const access_one_body = try makeTokenResponse(allocator, "access_token", access_one);
+    defer allocator.free(access_one_body);
+    const refresh_two_body = try makeTokenResponse(allocator, "refresh_token", refresh_two);
+    defer allocator.free(refresh_two_body);
+    const access_two_body = try makeTokenResponse(allocator, "access_token", access_two);
+    defer allocator.free(access_two_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = refresh_one_body },
+        .{ .status = 200, .body = access_one_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 200, .body = refresh_two_body },
+        .{ .status = 200, .body = access_two_body },
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+
+    var first = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/one/manifests/latest",
+    );
+    first.deinit();
+    clock.value = 2_500;
+    var second = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/one/manifests/latest",
+    );
+    defer second.deinit();
+
+    try std.testing.expectEqual(@as(usize, 7), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 2), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        countCapturedUrl(&transport, "/oauth2/exchange"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        countCapturedUrl(&transport, "/oauth2/token"),
+    );
+    try std.testing.expect(transport.captured_authorization[6]);
+}
+
+test "401 invalidates one scoped access token and replays exactly once" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const refresh_token = try makeJwt(allocator, 5_000, "refresh");
+    defer allocator.free(refresh_token);
+    const access_one = try makeJwt(allocator, 3_000, "access-one");
+    defer allocator.free(access_one);
+    const access_two = try makeJwt(allocator, 3_000, "access-two");
+    defer allocator.free(access_two);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const access_one_body = try makeTokenResponse(allocator, "access_token", access_one);
+    defer allocator.free(access_one_body);
+    const access_two_body = try makeTokenResponse(allocator, "access_token", access_two);
+    defer allocator.free(access_two_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_one_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = access_two_body },
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+
+    var first = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/one/manifests/latest",
+    );
+    first.deinit();
+    var second = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/one/manifests/latest",
+    );
+    defer second.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), second.status_code);
+    try std.testing.expectEqual(@as(usize, 7), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countCapturedUrl(&transport, "/oauth2/exchange"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        countCapturedUrl(&transport, "/oauth2/token"),
+    );
+}
+
+test "repository scopes use isolated access token cache entries" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const refresh_token = try makeJwt(allocator, 5_000, "refresh");
+    defer allocator.free(refresh_token);
+    const access_one = try makeJwt(allocator, 3_000, "access-one");
+    defer allocator.free(access_one);
+    const access_two = try makeJwt(allocator, 3_000, "access-two");
+    defer allocator.free(access_two);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const access_one_body = try makeTokenResponse(allocator, "access_token", access_one);
+    defer allocator.free(access_one_body);
+    const access_two_body = try makeTokenResponse(allocator, "access_token", access_two);
+    defer allocator.free(access_two_body);
+    const challenge_one = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:pull",
+    );
+    defer allocator.free(challenge_one);
+    const challenge_two = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:two:pull",
+    );
+    defer allocator.free(challenge_two);
+    const headers_one = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge_one },
+    };
+    const headers_two = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge_two },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers_one },
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_one_body },
+        .{ .status = 200, .body = "{}" },
+        .{ .status = 401, .body = "", .headers = &headers_two },
+        .{ .status = 200, .body = access_two_body },
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+
+    var one = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/one/manifests/latest",
+    );
+    one.deinit();
+    var two = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/two/manifests/latest",
+    );
+    defer two.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countCapturedUrl(&transport, "/oauth2/exchange"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        countCapturedUrl(&transport, "/oauth2/token"),
+    );
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedBody(&transport, 2),
+        "scope=repository%3Aone%3Apull",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedBody(&transport, 5),
+        "scope=repository%3Atwo%3Apull",
+    ) != null);
+}
+
+test "concurrent token acquisition is single flight" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var entered: std.Io.Semaphore = .{};
+    var release: std.Io.Semaphore = .{};
+    var credential = TestCredential.init();
+    credential.entered = &entered;
+    credential.release = &release;
+    const refresh_token = try makeJwt(allocator, 5_000, "refresh");
+    defer allocator.free(refresh_token);
+    const access_token = try makeJwt(allocator, 3_000, "access");
+    defer allocator.free(access_token);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_body },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    const values = [_][]const u8{
+        "Bearer realm=\"https://registry.example/oauth2/token\",service=\"registry.example\",scope=\"repository:one:pull\"",
+    };
+    var challenge = try challenge_mod.parseBearerChallenge(allocator, &values);
+    defer challenge.deinit();
+
+    const AcquireContext = struct {
+        policy: *ChallengeAuthenticationPolicy,
+        challenge: *const BearerChallenge,
+        transport: *HttpTransport,
+        token: ?[]u8 = null,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.token = self.policy.acquireAccessToken(
+                self.challenge,
+                null,
+                self.transport,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    };
+
+    var first = AcquireContext{
+        .policy = &policy,
+        .challenge = &challenge,
+        .transport = transport.asTransport(),
+    };
+    var second = first;
+    const first_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&first});
+    const io = std.Io.Threaded.global_single_threaded.io();
+    entered.waitUncancelable(io);
+    const second_thread = std.Thread.spawn(.{}, AcquireContext.run, .{&second}) catch |err| {
+        release.post(io);
+        first_thread.join();
+        return err;
+    };
+    while (true) {
+        policy.mutex.lockUncancelable(policy.io);
+        const waiting = policy.waiting_callers;
+        policy.mutex.unlock(policy.io);
+        if (waiting > 0) break;
+        io.sleep(.fromMilliseconds(1), .awake) catch {};
+    }
+    release.post(io);
+    first_thread.join();
+    second_thread.join();
+    if (first.token) |token| allocator.free(token);
+    if (second.token) |token| allocator.free(token);
+    try std.testing.expect(first.err == null);
+    try std.testing.expect(second.err == null);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+}
+
+test "untrusted request and challenge hosts never receive tokens" {
+    const allocator = std.testing.allocator;
+    var credential = TestCredential.init();
+    const unused = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = "{}" },
+    };
+    var untrusted_transport = core.http.SequenceMockTransport.init(allocator, &unused);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{},
+    );
+    defer policy.deinit();
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        sendBuffered(
+            allocator,
+            &policy,
+            untrusted_transport.asTransport(),
+            .GET,
+            "https://evil.example/v2/_catalog",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 0), untrusted_transport.call_count);
+
+    const malicious = try makeChallenge(
+        allocator,
+        "https://evil.example/oauth2/token",
+        "evil.example",
+        "registry:catalog:*",
+    );
+    defer allocator.free(malicious);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = malicious },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+    };
+    var malicious_transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    try std.testing.expectError(
+        error.UnexpectedHost,
+        sendBuffered(
+            allocator,
+            &policy,
+            malicious_transport.asTransport(),
+            .GET,
+            "https://registry.example/v2/_catalog",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), malicious_transport.call_count);
+    try std.testing.expectEqual(@as(usize, 0), credential.calls.load(.monotonic));
+}
+
+test "token bootstrap redirects cannot forward AAD credentials" {
+    const allocator = std.testing.allocator;
+    var credential = TestCredential.init();
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "registry:catalog:*",
+    );
+    defer allocator.free(challenge);
+    const challenge_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const redirect_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Location", .value = "https://evil.example/steal" },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &challenge_headers },
+        .{ .status = 302, .body = "", .headers = &redirect_headers },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{},
+    );
+    defer policy.deinit();
+
+    try std.testing.expectError(
+        error.AcrTokenExchangeFailed,
+        sendBuffered(
+            allocator,
+            &policy,
+            transport.asTransport(),
+            .GET,
+            "https://registry.example/v2/_catalog",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/oauth2/exchange?api-version=2021-07-01",
+        capturedUrl(&transport, 1),
+    );
+}
+
+test "refresh token cache keys include the challenge tenant" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const refresh_one = try makeJwt(allocator, 5_000, "refresh-one");
+    defer allocator.free(refresh_one);
+    const access_one = try makeJwt(allocator, 3_000, "access-one");
+    defer allocator.free(access_one);
+    const refresh_two = try makeJwt(allocator, 5_000, "refresh-two");
+    defer allocator.free(refresh_two);
+    const access_two = try makeJwt(allocator, 3_000, "access-two");
+    defer allocator.free(access_two);
+    const refresh_one_body = try makeTokenResponse(allocator, "refresh_token", refresh_one);
+    defer allocator.free(refresh_one_body);
+    const access_one_body = try makeTokenResponse(allocator, "access_token", access_one);
+    defer allocator.free(access_one_body);
+    const refresh_two_body = try makeTokenResponse(allocator, "refresh_token", refresh_two);
+    defer allocator.free(refresh_two_body);
+    const access_two_body = try makeTokenResponse(allocator, "access_token", access_two);
+    defer allocator.free(access_two_body);
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = refresh_one_body },
+        .{ .status = 200, .body = access_one_body },
+        .{ .status = 200, .body = refresh_two_body },
+        .{ .status = 200, .body = access_two_body },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+    const first_values = [_][]const u8{
+        "Bearer realm=\"https://registry.example/oauth2/token\",service=\"registry.example\",scope=\"repository:one:pull\",tenant=\"tenant-one\"",
+    };
+    const second_values = [_][]const u8{
+        "Bearer realm=\"https://registry.example/oauth2/token\",service=\"registry.example\",scope=\"repository:one:pull\",tenant=\"tenant-two\"",
+    };
+    var first = try challenge_mod.parseBearerChallenge(allocator, &first_values);
+    defer first.deinit();
+    var second = try challenge_mod.parseBearerChallenge(allocator, &second_values);
+    defer second.deinit();
+    try policy.validateChallenge(&first);
+    try policy.validateChallenge(&second);
+
+    const first_token = try policy.acquireAccessToken(
+        &first,
+        null,
+        transport.asTransport(),
+    );
+    defer allocator.free(first_token);
+    const second_token = try policy.acquireAccessToken(
+        &second,
+        null,
+        transport.asTransport(),
+    );
+    defer allocator.free(second_token);
+
+    try std.testing.expectEqual(@as(usize, 2), credential.calls.load(.monotonic));
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedBody(&transport, 0),
+        "tenant=tenant-one",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedBody(&transport, 2),
+        "tenant=tenant-two",
+    ) != null);
+}
+
+test "a replayed 401 is returned without a second replay" {
+    const allocator = std.testing.allocator;
+    var clock = TestClock{ .value = 1_000 };
+    var credential = TestCredential.init();
+    const refresh_token = try makeJwt(allocator, 5_000, "refresh");
+    defer allocator.free(refresh_token);
+    const access_token = try makeJwt(allocator, 3_000, "access");
+    defer allocator.free(access_token);
+    const refresh_body = try makeTokenResponse(allocator, "refresh_token", refresh_token);
+    defer allocator.free(refresh_body);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "registry:catalog:*",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = refresh_body },
+        .{ .status = 200, .body = access_body },
+        .{ .status = 401, .body = "", .headers = &headers },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{
+            .expiry_skew_seconds = 10,
+            .time_source = clock.source(),
+        },
+    );
+    defer policy.deinit();
+
+    var response = try sendBuffered(
+        allocator,
+        &policy,
+        transport.asTransport(),
+        .GET,
+        "https://registry.example/v2/_catalog",
+    );
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 401), response.status_code);
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+}
+
+test "non-rewindable streaming bodies are not replayed" {
+    const allocator = std.testing.allocator;
+    var credential = TestCredential.init();
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:push",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .{ .credential = &credential.credential },
+        .{},
+    );
+    defer policy.deinit();
+    var policies = [_]*HttpPolicy{policy.asPolicy()};
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport.asTransport(),
+    };
+    var request = Request.init(
+        allocator,
+        .PATCH,
+        "https://registry.example/v2/one/blobs/uploads/id",
+    );
+    defer request.deinit();
+    var reader = std.Io.Reader.fixed("data");
+    try std.testing.expectError(
+        error.RequestBodyNotReplayable,
+        pipeline.open(
+            &request,
+            .{ .body = core.http.StreamingRequestBody.knownLength(&reader, 4) },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 0), credential.calls.load(.monotonic));
+}
+
+test "rewindable streaming bodies are replayed once after authentication" {
+    const allocator = std.testing.allocator;
+    const access_token = try makeJwt(allocator, 4_102_444_800, "anonymous");
+    defer allocator.free(access_token);
+    const access_body = try makeTokenResponse(allocator, "access_token", access_token);
+    defer allocator.free(access_body);
+    const challenge = try makeChallenge(
+        allocator,
+        "https://registry.example/oauth2/token",
+        "registry.example",
+        "repository:one:push",
+    );
+    defer allocator.free(challenge);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{ .status = 200, .body = access_body },
+        .{ .status = 200, .body = "ok" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{},
+    );
+    defer policy.deinit();
+    var policies = [_]*HttpPolicy{policy.asPolicy()};
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport.asTransport(),
+    };
+    var request = Request.init(
+        allocator,
+        .PATCH,
+        "https://registry.example/v2/one/blobs/uploads/id",
+    );
+    defer request.deinit();
+    var replayable = core.http.ReplayableBytes.init("data");
+    var operation = try pipeline.open(&request, .{ .body = replayable.body() });
+    defer operation.deinit();
+    try std.testing.expectEqual(@as(u16, 200), operation.status_code);
+    try operation.finish();
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expectEqualStrings("data", capturedBody(&transport, 0));
+    try std.testing.expectEqualStrings("data", capturedBody(&transport, 2));
+    try std.testing.expect(transport.captured_authorization[2]);
+}
+
+test "streaming cancellation is preserved before transport" {
+    const allocator = std.testing.allocator;
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = "{}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var policy = try ChallengeAuthenticationPolicy.init(
+        allocator,
+        "https://registry.example",
+        .anonymous,
+        .{},
+    );
+    defer policy.deinit();
+    var policies = [_]*HttpPolicy{policy.asPolicy()};
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport.asTransport(),
+    };
+    var request = Request.init(allocator, .GET, "https://registry.example/v2/_catalog");
+    defer request.deinit();
+    var cancellation = CancellationToken{};
+    cancellation.cancel();
+    try std.testing.expectError(
+        error.OperationCancelled,
+        pipeline.open(&request, .{ .cancellation = &cancellation }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}

--- a/sdk/container_registry/src/challenge.zig
+++ b/sdk/container_registry/src/challenge.zig
@@ -1,0 +1,327 @@
+const std = @import("std");
+
+pub const BearerChallenge = struct {
+    allocator: std.mem.Allocator,
+    realm: []u8,
+    service: []u8,
+    scope: []u8,
+    tenant: ?[]u8 = null,
+
+    pub fn clone(self: BearerChallenge, allocator: std.mem.Allocator) !BearerChallenge {
+        const realm = try allocator.dupe(u8, self.realm);
+        errdefer allocator.free(realm);
+        const service = try allocator.dupe(u8, self.service);
+        errdefer allocator.free(service);
+        const scope = try allocator.dupe(u8, self.scope);
+        errdefer allocator.free(scope);
+        const tenant = if (self.tenant) |value|
+            try allocator.dupe(u8, value)
+        else
+            null;
+        return .{
+            .allocator = allocator,
+            .realm = realm,
+            .service = service,
+            .scope = scope,
+            .tenant = tenant,
+        };
+    }
+
+    pub fn deinit(self: *BearerChallenge) void {
+        self.allocator.free(self.realm);
+        self.allocator.free(self.service);
+        self.allocator.free(self.scope);
+        if (self.tenant) |tenant| self.allocator.free(tenant);
+        self.* = undefined;
+    }
+};
+
+const ParsedValue = struct {
+    bytes: []const u8,
+    next: usize,
+};
+
+const TemporaryChallenge = struct {
+    realm: ?[]const u8 = null,
+    service: ?[]const u8 = null,
+    scope: ?[]const u8 = null,
+    tenant: ?[]const u8 = null,
+};
+
+/// Parses exactly one Bearer challenge from one or more WWW-Authenticate
+/// header values. Returned fields are allocator-owned.
+pub fn parseBearerChallenge(
+    allocator: std.mem.Allocator,
+    header_values: []const []const u8,
+) !BearerChallenge {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var found: ?TemporaryChallenge = null;
+    for (header_values) |header| {
+        try parseHeaderValue(arena.allocator(), header, &found);
+    }
+
+    const parsed = found orelse return error.BearerChallengeMissing;
+    const realm_value = parsed.realm orelse return error.BearerChallengeRealmMissing;
+    const service_value = parsed.service orelse return error.BearerChallengeServiceMissing;
+    const scope_value = parsed.scope orelse return error.BearerChallengeScopeMissing;
+    if (realm_value.len == 0) return error.BearerChallengeRealmMissing;
+    if (service_value.len == 0) return error.BearerChallengeServiceMissing;
+    if (scope_value.len == 0) return error.BearerChallengeScopeMissing;
+
+    const realm = try allocator.dupe(u8, realm_value);
+    errdefer allocator.free(realm);
+    const service = try allocator.dupe(u8, service_value);
+    errdefer allocator.free(service);
+    const scope = try allocator.dupe(u8, scope_value);
+    errdefer allocator.free(scope);
+    const tenant = if (parsed.tenant) |value|
+        try allocator.dupe(u8, value)
+    else
+        null;
+
+    return .{
+        .allocator = allocator,
+        .realm = realm,
+        .service = service,
+        .scope = scope,
+        .tenant = tenant,
+    };
+}
+
+fn parseHeaderValue(
+    allocator: std.mem.Allocator,
+    header: []const u8,
+    found: *?TemporaryChallenge,
+) !void {
+    var index: usize = 0;
+    while (true) {
+        skipSeparators(header, &index);
+        if (index == header.len) return;
+
+        const scheme_start = index;
+        try parseToken(header, &index);
+        const scheme = header[scheme_start..index];
+        if (index == header.len) {
+            if (std.ascii.eqlIgnoreCase(scheme, "Bearer"))
+                return error.MalformedBearerChallenge;
+            return;
+        }
+        if (!isWhitespace(header[index])) return error.MalformedAuthenticationChallenge;
+        skipWhitespace(header, &index);
+
+        var bearer = TemporaryChallenge{};
+        const is_bearer = std.ascii.eqlIgnoreCase(scheme, "Bearer");
+        var saw_parameter = false;
+
+        while (index < header.len) {
+            const key_start = index;
+            try parseToken(header, &index);
+            const key = header[key_start..index];
+            var after_key = index;
+            skipWhitespace(header, &after_key);
+
+            if (after_key >= header.len or header[after_key] != '=') {
+                if (saw_parameter) {
+                    index = key_start;
+                    break;
+                }
+                while (index < header.len and header[index] != ',') {
+                    if (isWhitespace(header[index])) return error.MalformedAuthenticationChallenge;
+                    index += 1;
+                }
+                if (is_bearer) return error.UnsupportedBearerChallenge;
+                break;
+            }
+
+            index = after_key + 1;
+            skipWhitespace(header, &index);
+            const value = try parseParameterValue(allocator, header, index);
+            index = value.next;
+            saw_parameter = true;
+
+            if (is_bearer) try assignBearerParameter(&bearer, key, value.bytes);
+
+            skipWhitespace(header, &index);
+            if (index == header.len) break;
+            if (header[index] != ',') return error.MalformedAuthenticationChallenge;
+            index += 1;
+            skipWhitespace(header, &index);
+            if (index == header.len) return error.MalformedAuthenticationChallenge;
+
+            var lookahead = index;
+            try parseToken(header, &lookahead);
+            skipWhitespace(header, &lookahead);
+            if (lookahead >= header.len or header[lookahead] != '=') break;
+        }
+
+        if (is_bearer) {
+            if (!saw_parameter) return error.MalformedBearerChallenge;
+            if (found.* != null) return error.AmbiguousBearerChallenge;
+            found.* = bearer;
+        }
+    }
+}
+
+fn assignBearerParameter(
+    challenge: *TemporaryChallenge,
+    key: []const u8,
+    value: []const u8,
+) !void {
+    if (std.ascii.eqlIgnoreCase(key, "realm")) {
+        if (challenge.realm != null) return error.AmbiguousBearerChallenge;
+        challenge.realm = value;
+    } else if (std.ascii.eqlIgnoreCase(key, "service")) {
+        if (challenge.service != null) return error.AmbiguousBearerChallenge;
+        challenge.service = value;
+    } else if (std.ascii.eqlIgnoreCase(key, "scope")) {
+        if (challenge.scope != null) return error.AmbiguousBearerChallenge;
+        challenge.scope = value;
+    } else if (std.ascii.eqlIgnoreCase(key, "tenant")) {
+        if (challenge.tenant != null) return error.AmbiguousBearerChallenge;
+        challenge.tenant = value;
+    }
+}
+
+fn parseParameterValue(
+    allocator: std.mem.Allocator,
+    input: []const u8,
+    start: usize,
+) !ParsedValue {
+    if (start >= input.len) return error.MalformedAuthenticationChallenge;
+    if (input[start] != '"') {
+        var index = start;
+        try parseToken(input, &index);
+        return .{ .bytes = input[start..index], .next = index };
+    }
+
+    var output: std.ArrayList(u8) = .empty;
+    var index = start + 1;
+    while (index < input.len) {
+        const byte = input[index];
+        switch (byte) {
+            '"' => return .{
+                .bytes = try output.toOwnedSlice(allocator),
+                .next = index + 1,
+            },
+            '\\' => {
+                index += 1;
+                if (index == input.len) return error.MalformedAuthenticationChallenge;
+                const escaped = input[index];
+                if (escaped < 0x20 or escaped == 0x7f)
+                    return error.MalformedAuthenticationChallenge;
+                try output.append(allocator, escaped);
+            },
+            '\t' => try output.append(allocator, byte),
+            else => {
+                if (byte < 0x20 or byte == 0x7f)
+                    return error.MalformedAuthenticationChallenge;
+                try output.append(allocator, byte);
+            },
+        }
+        index += 1;
+    }
+    return error.MalformedAuthenticationChallenge;
+}
+
+fn parseToken(input: []const u8, index: *usize) !void {
+    const start = index.*;
+    while (index.* < input.len and isTokenByte(input[index.*])) index.* += 1;
+    if (index.* == start) return error.MalformedAuthenticationChallenge;
+}
+
+fn skipSeparators(input: []const u8, index: *usize) void {
+    while (index.* < input.len) {
+        if (input[index.*] == ',' or isWhitespace(input[index.*])) {
+            index.* += 1;
+        } else {
+            break;
+        }
+    }
+}
+
+fn skipWhitespace(input: []const u8, index: *usize) void {
+    while (index.* < input.len and isWhitespace(input[index.*])) index.* += 1;
+}
+
+fn isWhitespace(byte: u8) bool {
+    return byte == ' ' or byte == '\t';
+}
+
+fn isTokenByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or switch (byte) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        else => false,
+    };
+}
+
+test "Bearer challenge parses quoted commas and escapes" {
+    const allocator = std.testing.allocator;
+    const values = [_][]const u8{
+        "Basic realm=\"legacy\", Bearer realm=\"https://registry.example/oauth2/token\", service=\"registry.example\", scope=\"repository:team\\/image,one:pull\", error_description=\"expired, retry\"",
+    };
+    var challenge = try parseBearerChallenge(allocator, &values);
+    defer challenge.deinit();
+
+    try std.testing.expectEqualStrings(
+        "https://registry.example/oauth2/token",
+        challenge.realm,
+    );
+    try std.testing.expectEqualStrings("registry.example", challenge.service);
+    try std.testing.expectEqualStrings(
+        "repository:team/image,one:pull",
+        challenge.scope,
+    );
+}
+
+test "Bearer challenge accepts case-insensitive parameters across header values" {
+    const allocator = std.testing.allocator;
+    const values = [_][]const u8{
+        "Basic realm=\"legacy\"",
+        "bEaReR REALM=\"https://registry.example/oauth2/token\", SERVICE=\"registry.example\", SCOPE=\"registry:catalog:*\", TENANT=\"tenant-a\"",
+    };
+    var challenge = try parseBearerChallenge(allocator, &values);
+    defer challenge.deinit();
+
+    try std.testing.expectEqualStrings("tenant-a", challenge.tenant.?);
+}
+
+test "Bearer challenge rejects malformed quoted values" {
+    const values = [_][]const u8{
+        "Bearer realm=\"https://registry.example/oauth2/token, service=\"registry.example\", scope=\"registry:catalog:*\"",
+    };
+    try std.testing.expectError(
+        error.MalformedAuthenticationChallenge,
+        parseBearerChallenge(std.testing.allocator, &values),
+    );
+}
+
+test "Bearer challenge rejects duplicate and multiple Bearer challenges" {
+    const duplicate = [_][]const u8{
+        "Bearer realm=\"https://registry.example/oauth2/token\", service=\"registry.example\", scope=\"one\", scope=\"two\"",
+    };
+    try std.testing.expectError(
+        error.AmbiguousBearerChallenge,
+        parseBearerChallenge(std.testing.allocator, &duplicate),
+    );
+
+    const multiple = [_][]const u8{
+        "Bearer realm=\"https://registry.example/oauth2/token\", service=\"registry.example\", scope=\"one\"",
+        "Bearer realm=\"https://registry.example/oauth2/token\", service=\"registry.example\", scope=\"two\"",
+    };
+    try std.testing.expectError(
+        error.AmbiguousBearerChallenge,
+        parseBearerChallenge(std.testing.allocator, &multiple),
+    );
+}
+
+test "Bearer challenge requires realm service and scope" {
+    const values = [_][]const u8{
+        "Bearer realm=\"https://registry.example/oauth2/token\", service=\"registry.example\"",
+    };
+    try std.testing.expectError(
+        error.BearerChallengeScopeMissing,
+        parseBearerChallenge(std.testing.allocator, &values),
+    );
+}

--- a/sdk/container_registry/src/client.zig
+++ b/sdk/container_registry/src/client.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+const core = @import("azure_core");
+const protocol = @import("azure_rest_container_registry");
+const auth = @import("auth_policy.zig");
+
+pub const ContainerRegistryClientOptions = struct {
+    transport: *core.http.HttpTransport,
+    authentication: auth.Authentication,
+    api_version: []const u8 = "2021-07-01",
+    authentication_options: auth.Options = .{},
+};
+
+/// Authenticated wrapper over the generated Container Registry protocol client.
+pub const ContainerRegistryClient = struct {
+    allocator: std.mem.Allocator,
+    auth_policy: *auth.ChallengeAuthenticationPolicy,
+    policy_ptrs: []*core.pipeline.HttpPolicy,
+    protocol_client: protocol.ContainerRegistryClient,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        endpoint: []const u8,
+        options: ContainerRegistryClientOptions,
+    ) !ContainerRegistryClient {
+        var authentication_options = options.authentication_options;
+        authentication_options.api_version = options.api_version;
+        const auth_policy = try allocator.create(auth.ChallengeAuthenticationPolicy);
+        errdefer allocator.destroy(auth_policy);
+        auth_policy.* = try auth.ChallengeAuthenticationPolicy.init(
+            allocator,
+            endpoint,
+            options.authentication,
+            authentication_options,
+        );
+        errdefer auth_policy.deinit();
+
+        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
+        errdefer allocator.free(policy_ptrs);
+        policy_ptrs[0] = auth_policy.asPolicy();
+
+        const pipeline = core.pipeline.HttpPipeline{
+            .policies = policy_ptrs,
+            .transport_impl = options.transport,
+        };
+        return .{
+            .allocator = allocator,
+            .auth_policy = auth_policy,
+            .policy_ptrs = policy_ptrs,
+            .protocol_client = protocol.ContainerRegistryClient.initWithPipeline(
+                allocator,
+                pipeline,
+                .{
+                    .endpoint = auth_policy.endpoint,
+                    .api_version = options.api_version,
+                },
+            ),
+        };
+    }
+
+    pub fn deinit(self: *ContainerRegistryClient) void {
+        self.protocol_client.deinit();
+        self.allocator.free(self.policy_ptrs);
+        self.auth_policy.deinit();
+        self.allocator.destroy(self.auth_policy);
+        self.* = undefined;
+    }
+
+    /// Access the generated protocol client using the prepared challenge-auth
+    /// pipeline. The returned pointer borrows from this client.
+    pub fn protocolClient(self: *ContainerRegistryClient) *protocol.ContainerRegistryClient {
+        return &self.protocol_client;
+    }
+};
+
+test "ContainerRegistryClient drives generated protocol APIs through challenge auth" {
+    const allocator = std.testing.allocator;
+    const challenge =
+        "Bearer realm=\"https://registry.example/oauth2/token\",service=\"registry.example\",scope=\"registry:catalog:*\"";
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &headers },
+        .{
+            .status = 200,
+            .body = "{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.signature\"}",
+        },
+        .{ .status = 200, .body = "" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+
+    var service = client.protocolClient().containerRegistry();
+    try service.checkDockerV2Support(allocator);
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expect(transport.captured_authorization[2]);
+}

--- a/sdk/container_registry/src/root.zig
+++ b/sdk/container_registry/src/root.zig
@@ -1,0 +1,20 @@
+//! Azure Container Registry client with secure challenge authentication.
+
+pub const protocol = @import("azure_rest_container_registry");
+
+const challenge = @import("challenge.zig");
+const auth = @import("auth_policy.zig");
+const client = @import("client.zig");
+
+pub const BearerChallenge = challenge.BearerChallenge;
+pub const parseBearerChallenge = challenge.parseBearerChallenge;
+pub const Authentication = auth.Authentication;
+pub const ChallengeAuthenticationPolicy = auth.ChallengeAuthenticationPolicy;
+pub const ChallengeAuthenticationPolicyOptions = auth.Options;
+pub const TimeSource = auth.TimeSource;
+pub const ContainerRegistryClient = client.ContainerRegistryClient;
+pub const ContainerRegistryClientOptions = client.ContainerRegistryClientOptions;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}


### PR DESCRIPTION
Adds the handwritten ACR SDK package with secure Bearer challenge parsing, AAD-to-ACR token exchange, scoped bounded caches, per-key single-flight, trusted-origin enforcement, anonymous mode, and exactly-one safe replay.

Closes #84