### PR TITLE
sdk/container_registry: add metadata clients and Link paging

### DIFF
--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -1,8 +1,8 @@
 # Azure Container Registry for Zig
 
-`azure_sdk_container_registry` adds secure ACR challenge authentication and
-token caching to the generated `azure_rest_container_registry` protocol
-package.
+`azure_sdk_container_registry` adds secure ACR challenge authentication,
+metadata operations, Link-header paging, and structured service errors to the
+generated `azure_rest_container_registry` protocol package.
 
 ```zig
 const acr = @import("azure_sdk_container_registry");
@@ -16,6 +16,49 @@ defer client.deinit();
 var service = client.protocolClient().containerRegistry();
 try service.checkDockerV2Support(allocator);
 ```
+
+The high-level client lists repositories, manifests, and tags and supports
+get, update, and delete operations for their properties:
+
+```zig
+var pager = try client.listRepositories(allocator, .{ .max_results = 100 });
+defer pager.deinit();
+
+while (try pager.next()) |page_result| {
+    var result = page_result;
+    defer result.deinit();
+    switch (result) {
+        .ok => |page| {
+            for (page.names) |name| {
+                // use name
+            }
+        },
+        .err => |service_error| {
+            // status_code, code, message, detail, and all ACR errors are kept.
+            _ = service_error;
+        },
+    }
+}
+
+var update = try client.updateRepositoryProperties(
+    allocator,
+    "team/image",
+    .{ .can_write = false, .can_delete = true },
+);
+defer update.deinit();
+```
+
+Pages, property values, and service errors own their allocations. Keep the
+client alive until its pagers are deinitialized, and call `deinit()` on every
+pager result and unary result. Local failures such as transport, allocation,
+invalid response, or unsafe continuation errors remain in the outer Zig error
+union; HTTP service failures use the `.err` result variant.
+
+ACR `Link` continuations may be relative or absolute. The SDK resolves them
+against the current page, requires HTTPS, and only follows the original
+registry origin (case-insensitive scheme/host plus effective port). It rejects
+userinfo, fragments, malformed links, alternate ports, and untrusted hosts
+before the authentication policy can attach credentials.
 
 Use `.authentication = .anonymous` only for intentional anonymous access.
 The generated dependency is available as `acr.protocol`.

--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -46,6 +46,10 @@ var update = try client.updateRepositoryProperties(
     .{ .can_write = false, .can_delete = true },
 );
 defer update.deinit();
+
+var deletion = try client.deleteRepository(allocator, "team/image");
+defer deletion.deinit();
+// Both 202 Accepted and 404 Not Found are successful, idempotent outcomes.
 ```
 
 Pages, property values, and service errors own their allocations. Keep the

--- a/sdk/container_registry/src/client.zig
+++ b/sdk/container_registry/src/client.zig
@@ -2,6 +2,36 @@ const std = @import("std");
 const core = @import("azure_core");
 const protocol = @import("azure_rest_container_registry");
 const auth = @import("auth_policy.zig");
+const link_pager = @import("link_pager.zig");
+const models = @import("models.zig");
+const service_error = @import("service_error.zig");
+
+pub const RepositoryPager = link_pager.LinkPager(models.RepositoryPage);
+pub const ManifestPager = link_pager.LinkPager(models.ManifestPage);
+pub const TagPager = link_pager.LinkPager(models.TagPage);
+
+pub const RepositoryPropertiesResult =
+    service_error.Result(models.ContainerRepositoryProperties);
+pub const ManifestPropertiesResult =
+    service_error.Result(models.ArtifactManifestProperties);
+pub const TagPropertiesResult =
+    service_error.Result(models.ArtifactTagProperties);
+pub const DeleteResult = service_error.Result(void);
+
+pub const ListRepositoriesOptions = struct {
+    max_results: ?u32 = null,
+};
+
+pub const ListManifestPropertiesOptions = struct {
+    max_results: ?u32 = null,
+    order: ?protocol.enums.ArtifactManifestOrder = null,
+};
+
+pub const ListTagPropertiesOptions = struct {
+    max_results: ?u32 = null,
+    order: ?protocol.enums.ArtifactTagOrder = null,
+    digest: ?[]const u8 = null,
+};
 
 pub const ContainerRegistryClientOptions = struct {
     transport: *core.http.HttpTransport,
@@ -15,6 +45,9 @@ pub const ContainerRegistryClient = struct {
     allocator: std.mem.Allocator,
     auth_policy: *auth.ChallengeAuthenticationPolicy,
     policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.pipeline.HttpPipeline,
+    endpoint: []const u8,
+    api_version: []const u8,
     protocol_client: protocol.ContainerRegistryClient,
 
     pub fn init(
@@ -46,12 +79,15 @@ pub const ContainerRegistryClient = struct {
             .allocator = allocator,
             .auth_policy = auth_policy,
             .policy_ptrs = policy_ptrs,
+            .pipeline = pipeline,
+            .endpoint = auth_policy.endpoint,
+            .api_version = auth_policy.api_version,
             .protocol_client = protocol.ContainerRegistryClient.initWithPipeline(
                 allocator,
                 pipeline,
                 .{
                     .endpoint = auth_policy.endpoint,
-                    .api_version = options.api_version,
+                    .api_version = auth_policy.api_version,
                 },
             ),
         };
@@ -70,7 +106,450 @@ pub const ContainerRegistryClient = struct {
     pub fn protocolClient(self: *ContainerRegistryClient) *protocol.ContainerRegistryClient {
         return &self.protocol_client;
     }
+
+    /// List repository names. The returned pager and client must be kept alive
+    /// together because page requests use this client's authentication policy.
+    pub fn listRepositories(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        options: ListRepositoriesOptions,
+    ) !RepositoryPager {
+        const url = try self.buildListUrl(
+            allocator,
+            "/acr/v1/_catalog",
+            options.max_results,
+            null,
+            null,
+        );
+        defer allocator.free(url);
+        return RepositoryPager.init(
+            allocator,
+            self.pipeline,
+            self.endpoint,
+            url,
+            &models.parseRepositoryPage,
+        );
+    }
+
+    pub fn getRepositoryProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+    ) !RepositoryPropertiesResult {
+        const url = try self.buildRepositoryUrl(allocator, repository_name, "");
+        defer allocator.free(url);
+        return self.sendRepositoryProperties(allocator, .GET, url, null);
+    }
+
+    pub fn updateRepositoryProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        properties: models.ChangeableProperties,
+    ) !RepositoryPropertiesResult {
+        const url = try self.buildRepositoryUrl(allocator, repository_name, "");
+        defer allocator.free(url);
+        const body = try serializeChangeableProperties(allocator, properties);
+        defer allocator.free(body);
+        return self.sendRepositoryProperties(allocator, .PATCH, url, body);
+    }
+
+    pub fn deleteRepository(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+    ) !DeleteResult {
+        const url = try self.buildRepositoryUrl(allocator, repository_name, "");
+        defer allocator.free(url);
+        return self.sendDelete(allocator, url);
+    }
+
+    pub fn listManifestProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        options: ListManifestPropertiesOptions,
+    ) !ManifestPager {
+        const encoded_name = try core.url.encodeRepositoryName(allocator, repository_name);
+        defer allocator.free(encoded_name);
+        const path = try std.fmt.allocPrint(
+            allocator,
+            "/acr/v1/{s}/_manifests",
+            .{encoded_name},
+        );
+        defer allocator.free(path);
+        const order = if (options.order) |value| value.toWire() else null;
+        const url = try self.buildListUrl(
+            allocator,
+            path,
+            options.max_results,
+            order,
+            null,
+        );
+        defer allocator.free(url);
+        return ManifestPager.init(
+            allocator,
+            self.pipeline,
+            self.endpoint,
+            url,
+            &models.parseManifestPage,
+        );
+    }
+
+    pub fn getManifestProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        digest: []const u8,
+    ) !ManifestPropertiesResult {
+        const suffix = try encodedSuffix(allocator, "/_manifests/", digest);
+        defer allocator.free(suffix);
+        const url = try self.buildRepositoryUrl(allocator, repository_name, suffix);
+        defer allocator.free(url);
+        return self.sendManifestProperties(allocator, .GET, url, null);
+    }
+
+    pub fn updateManifestProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        digest: []const u8,
+        properties: models.ChangeableProperties,
+    ) !ManifestPropertiesResult {
+        const suffix = try encodedSuffix(allocator, "/_manifests/", digest);
+        defer allocator.free(suffix);
+        const url = try self.buildRepositoryUrl(allocator, repository_name, suffix);
+        defer allocator.free(url);
+        const body = try serializeChangeableProperties(allocator, properties);
+        defer allocator.free(body);
+        return self.sendManifestProperties(allocator, .PATCH, url, body);
+    }
+
+    pub fn deleteManifest(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        digest: []const u8,
+    ) !DeleteResult {
+        const encoded_name = try core.url.encodeRepositoryName(allocator, repository_name);
+        defer allocator.free(encoded_name);
+        const encoded_digest = try core.url.encodePathSegment(allocator, digest);
+        defer allocator.free(encoded_digest);
+        const path = try std.fmt.allocPrint(
+            allocator,
+            "/v2/{s}/manifests/{s}",
+            .{ encoded_name, encoded_digest },
+        );
+        defer allocator.free(path);
+        const url = try self.buildUrl(allocator, path);
+        defer allocator.free(url);
+        return self.sendDelete(allocator, url);
+    }
+
+    pub fn listTagProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        options: ListTagPropertiesOptions,
+    ) !TagPager {
+        const encoded_name = try core.url.encodeRepositoryName(allocator, repository_name);
+        defer allocator.free(encoded_name);
+        const path = try std.fmt.allocPrint(
+            allocator,
+            "/acr/v1/{s}/_tags",
+            .{encoded_name},
+        );
+        defer allocator.free(path);
+        const order = if (options.order) |value| value.toWire() else null;
+        const url = try self.buildListUrl(
+            allocator,
+            path,
+            options.max_results,
+            order,
+            options.digest,
+        );
+        defer allocator.free(url);
+        return TagPager.init(
+            allocator,
+            self.pipeline,
+            self.endpoint,
+            url,
+            &models.parseTagPage,
+        );
+    }
+
+    pub fn getTagProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        tag: []const u8,
+    ) !TagPropertiesResult {
+        const suffix = try encodedSuffix(allocator, "/_tags/", tag);
+        defer allocator.free(suffix);
+        const url = try self.buildRepositoryUrl(allocator, repository_name, suffix);
+        defer allocator.free(url);
+        return self.sendTagProperties(allocator, .GET, url, null);
+    }
+
+    pub fn updateTagProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        tag: []const u8,
+        properties: models.ChangeableProperties,
+    ) !TagPropertiesResult {
+        const suffix = try encodedSuffix(allocator, "/_tags/", tag);
+        defer allocator.free(suffix);
+        const url = try self.buildRepositoryUrl(allocator, repository_name, suffix);
+        defer allocator.free(url);
+        const body = try serializeChangeableProperties(allocator, properties);
+        defer allocator.free(body);
+        return self.sendTagProperties(allocator, .PATCH, url, body);
+    }
+
+    pub fn deleteTag(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        tag: []const u8,
+    ) !DeleteResult {
+        const suffix = try encodedSuffix(allocator, "/_tags/", tag);
+        defer allocator.free(suffix);
+        const url = try self.buildRepositoryUrl(allocator, repository_name, suffix);
+        defer allocator.free(url);
+        return self.sendDelete(allocator, url);
+    }
+
+    fn sendRepositoryProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        method: core.http.Method,
+        url: []const u8,
+        body: ?[]const u8,
+    ) !RepositoryPropertiesResult {
+        var response = try self.sendJson(allocator, method, url, body);
+        defer response.deinit();
+        if (response.status_code == 200) {
+            return .{ .ok = try models.parseRepositoryProperties(
+                allocator,
+                response.body,
+            ) };
+        }
+        return .{ .err = try service_error.ServiceError.fromResponse(
+            allocator,
+            &response,
+        ) };
+    }
+
+    fn sendManifestProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        method: core.http.Method,
+        url: []const u8,
+        body: ?[]const u8,
+    ) !ManifestPropertiesResult {
+        var response = try self.sendJson(allocator, method, url, body);
+        defer response.deinit();
+        if (response.status_code == 200) {
+            return .{ .ok = try models.parseManifestProperties(
+                allocator,
+                response.body,
+            ) };
+        }
+        return .{ .err = try service_error.ServiceError.fromResponse(
+            allocator,
+            &response,
+        ) };
+    }
+
+    fn sendTagProperties(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        method: core.http.Method,
+        url: []const u8,
+        body: ?[]const u8,
+    ) !TagPropertiesResult {
+        var response = try self.sendJson(allocator, method, url, body);
+        defer response.deinit();
+        if (response.status_code == 200) {
+            return .{ .ok = try models.parseTagProperties(
+                allocator,
+                response.body,
+            ) };
+        }
+        return .{ .err = try service_error.ServiceError.fromResponse(
+            allocator,
+            &response,
+        ) };
+    }
+
+    fn sendDelete(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        url: []const u8,
+    ) !DeleteResult {
+        var response = try self.sendJson(allocator, .DELETE, url, null);
+        defer response.deinit();
+        if (response.status_code == 202) return .{ .ok = {} };
+        return .{ .err = try service_error.ServiceError.fromResponse(
+            allocator,
+            &response,
+        ) };
+    }
+
+    fn sendJson(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        method: core.http.Method,
+        url: []const u8,
+        body: ?[]const u8,
+    ) !core.http.Response {
+        var request = core.http.Request.init(allocator, method, url);
+        defer request.deinit();
+        try request.setHeader("Accept", "application/json");
+        if (body) |value| {
+            try request.setHeader("Content-Type", "application/json");
+            request.body = value;
+        }
+        return self.pipeline.send(&request);
+    }
+
+    fn buildRepositoryUrl(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        repository_name: []const u8,
+        suffix: []const u8,
+    ) ![]u8 {
+        const encoded_name = try core.url.encodeRepositoryName(allocator, repository_name);
+        defer allocator.free(encoded_name);
+        const path = try std.fmt.allocPrint(
+            allocator,
+            "/acr/v1/{s}{s}",
+            .{ encoded_name, suffix },
+        );
+        defer allocator.free(path);
+        return self.buildUrl(allocator, path);
+    }
+
+    fn buildUrl(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        path: []const u8,
+    ) ![]u8 {
+        const encoded_version = try core.url.percentEncode(allocator, self.api_version);
+        defer allocator.free(encoded_version);
+        return std.fmt.allocPrint(
+            allocator,
+            "{s}{s}?api-version={s}",
+            .{ self.endpoint, path, encoded_version },
+        );
+    }
+
+    fn buildListUrl(
+        self: *ContainerRegistryClient,
+        allocator: std.mem.Allocator,
+        path: []const u8,
+        max_results: ?u32,
+        order: ?[]const u8,
+        digest: ?[]const u8,
+    ) ![]u8 {
+        if (max_results) |value| {
+            if (value == 0 or value > std.math.maxInt(i32))
+                return error.InvalidMaxResults;
+        }
+        const encoded_version = try core.url.percentEncode(allocator, self.api_version);
+        defer allocator.free(encoded_version);
+        var url: std.ArrayList(u8) = .empty;
+        errdefer url.deinit(allocator);
+        try url.print(
+            allocator,
+            "{s}{s}?api-version={s}",
+            .{ self.endpoint, path, encoded_version },
+        );
+        if (max_results) |value| try url.print(allocator, "&n={d}", .{value});
+        if (order) |value| {
+            const encoded_order = try core.url.percentEncode(allocator, value);
+            defer allocator.free(encoded_order);
+            try url.print(allocator, "&orderby={s}", .{encoded_order});
+        }
+        if (digest) |value| {
+            const encoded_digest = try core.url.percentEncode(allocator, value);
+            defer allocator.free(encoded_digest);
+            try url.print(allocator, "&digest={s}", .{encoded_digest});
+        }
+        return url.toOwnedSlice(allocator);
+    }
 };
+
+fn encodedSuffix(
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    value: []const u8,
+) ![]u8 {
+    const encoded = try core.url.encodePathSegment(allocator, value);
+    defer allocator.free(encoded);
+    return std.fmt.allocPrint(allocator, "{s}{s}", .{ prefix, encoded });
+}
+
+fn serializeChangeableProperties(
+    allocator: std.mem.Allocator,
+    properties: models.ChangeableProperties,
+) ![]u8 {
+    var body: std.ArrayList(u8) = .empty;
+    errdefer body.deinit(allocator);
+    try body.append(allocator, '{');
+    var first = true;
+    try appendBooleanField(
+        allocator,
+        &body,
+        &first,
+        "deleteEnabled",
+        properties.can_delete,
+    );
+    try appendBooleanField(
+        allocator,
+        &body,
+        &first,
+        "writeEnabled",
+        properties.can_write,
+    );
+    try appendBooleanField(
+        allocator,
+        &body,
+        &first,
+        "listEnabled",
+        properties.can_list,
+    );
+    try appendBooleanField(
+        allocator,
+        &body,
+        &first,
+        "readEnabled",
+        properties.can_read,
+    );
+    try body.append(allocator, '}');
+    return body.toOwnedSlice(allocator);
+}
+
+fn appendBooleanField(
+    allocator: std.mem.Allocator,
+    body: *std.ArrayList(u8),
+    first: *bool,
+    name: []const u8,
+    value: ?bool,
+) !void {
+    const boolean = value orelse return;
+    try body.print(
+        allocator,
+        "{s}\"{s}\":{s}",
+        .{
+            if (first.*) "" else ",",
+            name,
+            if (boolean) "true" else "false",
+        },
+    );
+    first.* = false;
+}
 
 test "ContainerRegistryClient drives generated protocol APIs through challenge auth" {
     const allocator = std.testing.allocator;

--- a/sdk/container_registry/src/client.zig
+++ b/sdk/container_registry/src/client.zig
@@ -16,7 +16,11 @@ pub const ManifestPropertiesResult =
     service_error.Result(models.ArtifactManifestProperties);
 pub const TagPropertiesResult =
     service_error.Result(models.ArtifactTagProperties);
-pub const DeleteResult = service_error.Result(void);
+pub const DeleteOutcome = enum {
+    accepted,
+    not_found,
+};
+pub const DeleteResult = service_error.Result(DeleteOutcome);
 
 pub const ListRepositoriesOptions = struct {
     max_results: ?u32 = null,
@@ -390,7 +394,8 @@ pub const ContainerRegistryClient = struct {
     ) !DeleteResult {
         var response = try self.sendJson(allocator, .DELETE, url, null);
         defer response.deinit();
-        if (response.status_code == 202) return .{ .ok = {} };
+        if (response.status_code == 202) return .{ .ok = .accepted };
+        if (response.status_code == 404) return .{ .ok = .not_found };
         return .{ .err = try service_error.ServiceError.fromResponse(
             allocator,
             &response,

--- a/sdk/container_registry/src/link_pager.zig
+++ b/sdk/container_registry/src/link_pager.zig
@@ -1,0 +1,228 @@
+const std = @import("std");
+const core = @import("azure_core");
+const service_error = @import("service_error.zig");
+
+pub fn LinkPager(comptime Page: type) type {
+    return struct {
+        allocator: std.mem.Allocator,
+        pipeline: core.pipeline.HttpPipeline,
+        trusted_origin: []u8,
+        next_url: ?[]u8,
+        parsePage: *const fn (std.mem.Allocator, []const u8) anyerror!Page,
+
+        const Self = @This();
+        pub const NextResult = service_error.Result(Page);
+
+        pub fn init(
+            allocator: std.mem.Allocator,
+            pipeline: core.pipeline.HttpPipeline,
+            trusted_origin: []const u8,
+            initial_url: []const u8,
+            parsePage: *const fn (std.mem.Allocator, []const u8) anyerror!Page,
+        ) !Self {
+            const owned_origin = try allocator.dupe(u8, trusted_origin);
+            errdefer allocator.free(owned_origin);
+            const owned_url = try allocator.dupe(u8, initial_url);
+            return .{
+                .allocator = allocator,
+                .pipeline = pipeline,
+                .trusted_origin = owned_origin,
+                .next_url = owned_url,
+                .parsePage = parsePage,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.allocator.free(self.trusted_origin);
+            if (self.next_url) |url| self.allocator.free(url);
+            self.* = undefined;
+        }
+
+        pub fn next(self: *Self) !?NextResult {
+            const current_url = self.next_url orelse return null;
+            self.next_url = null;
+            defer self.allocator.free(current_url);
+
+            var request = core.http.Request.init(self.allocator, .GET, current_url);
+            defer request.deinit();
+            try request.setHeader("Accept", "application/json");
+
+            var response = try self.pipeline.send(&request);
+            defer response.deinit();
+            if (response.status_code != 200) {
+                return .{ .err = try service_error.ServiceError.fromResponse(
+                    self.allocator,
+                    &response,
+                ) };
+            }
+
+            const next_url = try continuationFromResponse(
+                self.allocator,
+                current_url,
+                self.trusted_origin,
+                &response,
+            );
+            errdefer if (next_url) |url| self.allocator.free(url);
+            var page = try self.parsePage(self.allocator, response.body);
+            errdefer page.deinit();
+            self.next_url = next_url;
+            return .{ .ok = page };
+        }
+    };
+}
+
+pub fn continuationFromResponse(
+    allocator: std.mem.Allocator,
+    current_url: []const u8,
+    trusted_origin: []const u8,
+    response: *const core.http.Response,
+) !?[]u8 {
+    const header_values = try response.getHeaderValues(allocator, "Link");
+    defer allocator.free(header_values);
+
+    var continuation: ?[]u8 = null;
+    errdefer if (continuation) |url| allocator.free(url);
+    for (header_values) |header| {
+        if (std.mem.trim(u8, header, " \t").len == 0)
+            return error.MalformedLinkHeader;
+        var iterator = LinkIterator{ .value = header };
+        while (try iterator.next()) |link| {
+            if (!link.is_next) continue;
+            if (continuation != null) return error.AmbiguousContinuationLink;
+            continuation = try resolveTrustedContinuation(
+                allocator,
+                current_url,
+                trusted_origin,
+                link.target,
+            );
+        }
+    }
+    return continuation;
+}
+
+const ParsedLink = struct {
+    target: []const u8,
+    is_next: bool,
+};
+
+const LinkIterator = struct {
+    value: []const u8,
+    index: usize = 0,
+
+    fn next(self: *LinkIterator) !?ParsedLink {
+        skipOws(self.value, &self.index);
+        if (self.index == self.value.len) return null;
+        if (self.value[self.index] != '<') return error.MalformedLinkHeader;
+        self.index += 1;
+        const target_start = self.index;
+        while (self.index < self.value.len and self.value[self.index] != '>') {
+            if (self.value[self.index] == '\r' or self.value[self.index] == '\n')
+                return error.MalformedLinkHeader;
+            self.index += 1;
+        }
+        if (self.index == self.value.len or self.index == target_start)
+            return error.MalformedLinkHeader;
+        const target = self.value[target_start..self.index];
+        self.index += 1;
+
+        var is_next = false;
+        while (true) {
+            skipOws(self.value, &self.index);
+            if (self.index == self.value.len) break;
+            if (self.value[self.index] == ',') {
+                self.index += 1;
+                break;
+            }
+            if (self.value[self.index] != ';') return error.MalformedLinkHeader;
+            self.index += 1;
+            skipOws(self.value, &self.index);
+            const name_start = self.index;
+            while (self.index < self.value.len and isParameterNameByte(self.value[self.index]))
+                self.index += 1;
+            if (self.index == name_start) return error.MalformedLinkHeader;
+            const name = self.value[name_start..self.index];
+            skipOws(self.value, &self.index);
+            if (self.index == self.value.len or self.value[self.index] != '=')
+                return error.MalformedLinkHeader;
+            self.index += 1;
+            skipOws(self.value, &self.index);
+            const parameter = try parseParameterValue(self.value, &self.index);
+            if (std.ascii.eqlIgnoreCase(name, "rel") and containsNextRelation(parameter))
+                is_next = true;
+        }
+        return .{ .target = target, .is_next = is_next };
+    }
+};
+
+fn parseParameterValue(value: []const u8, index: *usize) ![]const u8 {
+    if (index.* == value.len) return error.MalformedLinkHeader;
+    if (value[index.*] != '"') {
+        const start = index.*;
+        while (index.* < value.len and
+            value[index.*] != ';' and value[index.*] != ',' and
+            value[index.*] != ' ' and value[index.*] != '\t')
+        {
+            index.* += 1;
+        }
+        if (index.* == start) return error.MalformedLinkHeader;
+        return value[start..index.*];
+    }
+
+    index.* += 1;
+    const start = index.*;
+    while (index.* < value.len and value[index.*] != '"') {
+        const byte = value[index.*];
+        if (byte == '\\' or byte == '\r' or byte == '\n')
+            return error.MalformedLinkHeader;
+        index.* += 1;
+    }
+    if (index.* == value.len) return error.MalformedLinkHeader;
+    const result = value[start..index.*];
+    index.* += 1;
+    return result;
+}
+
+fn containsNextRelation(value: []const u8) bool {
+    var iterator = std.mem.tokenizeAny(u8, value, " \t");
+    while (iterator.next()) |relation| {
+        if (std.ascii.eqlIgnoreCase(relation, "next")) return true;
+    }
+    return false;
+}
+
+fn resolveTrustedContinuation(
+    allocator: std.mem.Allocator,
+    current_url: []const u8,
+    trusted_origin: []const u8,
+    reference: []const u8,
+) ![]u8 {
+    const resolved = core.url.resolveUrl(allocator, current_url, reference) catch
+        return error.InvalidContinuationUrl;
+    errdefer allocator.free(resolved);
+    const uri = std.Uri.parse(resolved) catch return error.InvalidContinuationUrl;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https"))
+        return error.ContinuationHttpsRequired;
+    if (uri.host == null or uri.user != null or uri.password != null or uri.fragment != null)
+        return error.InvalidContinuationUrl;
+    if (!(core.url.sameOrigin(trusted_origin, resolved) catch
+        return error.InvalidContinuationUrl))
+    {
+        return error.UntrustedContinuation;
+    }
+    return resolved;
+}
+
+fn skipOws(value: []const u8, index: *usize) void {
+    while (index.* < value.len and
+        (value[index.*] == ' ' or value[index.*] == '\t'))
+    {
+        index.* += 1;
+    }
+}
+
+fn isParameterNameByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or switch (byte) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        else => false,
+    };
+}

--- a/sdk/container_registry/src/link_pager.zig
+++ b/sdk/container_registry/src/link_pager.zig
@@ -136,6 +136,8 @@ const LinkIterator = struct {
         self.index += 1;
 
         var is_next = false;
+        var rel_seen = false;
+        var has_anchor = false;
         while (true) {
             skipOws(self.value, &self.index);
             if (self.index == self.value.len) break;
@@ -151,17 +153,24 @@ const LinkIterator = struct {
                 self.index += 1;
             if (self.index == name_start) return error.MalformedLinkHeader;
             const name = self.value[name_start..self.index];
+            const is_rel = std.ascii.eqlIgnoreCase(name, "rel");
+            const is_anchor = std.ascii.eqlIgnoreCase(name, "anchor");
             skipOws(self.value, &self.index);
             if (self.index == self.value.len or self.value[self.index] != '=') {
+                if (is_rel and !rel_seen) rel_seen = true;
+                if (is_anchor) has_anchor = true;
                 continue;
             }
             self.index += 1;
             skipOws(self.value, &self.index);
             const parameter = try parseParameterValue(self.value, &self.index);
-            if (std.ascii.eqlIgnoreCase(name, "rel") and containsNextRelation(parameter))
-                is_next = true;
+            if (is_rel and !rel_seen) {
+                rel_seen = true;
+                is_next = containsNextRelation(parameter);
+            }
+            if (is_anchor) has_anchor = true;
         }
-        return .{ .target = target, .is_next = is_next };
+        return .{ .target = target, .is_next = is_next and !has_anchor };
     }
 };
 
@@ -288,4 +297,74 @@ fn isUriReferenceByte(byte: u8) bool {
         '-', '.', '_', '~', ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', '%' => true,
         else => false,
     };
+}
+
+test "Link parser uses only the first rel parameter" {
+    const cases = [_]struct {
+        value: []const u8,
+        expected_next: bool,
+    }{
+        .{
+            .value = "</first>; rel=prev; rel=next",
+            .expected_next = false,
+        },
+        .{
+            .value = "</second>; rel=next; rel=prev",
+            .expected_next = true,
+        },
+        .{
+            .value = "</third>; rel; rel=next",
+            .expected_next = false,
+        },
+    };
+
+    for (cases) |case| {
+        var iterator = LinkIterator{ .value = case.value };
+        const link = (try iterator.next()).?;
+        try std.testing.expectEqual(case.expected_next, link.is_next);
+        try std.testing.expect((try iterator.next()) == null);
+    }
+}
+
+test "Link parser ignores next links with anchor parameters" {
+    const cases = [_][]const u8{
+        "</before>; anchor=context; rel=next",
+        "</after>; rel=next; anchor=context",
+        "</quoted>; rel=next; anchor=\"https://registry.example/context\"",
+    };
+
+    for (cases) |value| {
+        var iterator = LinkIterator{ .value = value };
+        const link = (try iterator.next()).?;
+        try std.testing.expect(!link.is_next);
+        try std.testing.expect((try iterator.next()) == null);
+    }
+}
+
+test "Link continuation selects valid next beside ignored anchored link" {
+    const allocator = std.testing.allocator;
+    var response = core.http.Response{
+        .status_code = 200,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(u8, ""),
+        .allocator = allocator,
+        .response_headers = core.http.ResponseHeaders.init(allocator),
+    };
+    defer response.deinit();
+    try response.response_headers.append(
+        "Link",
+        "<https://evil.example/anchored>; rel=next; anchor=\"/context\", </safe>; rel=next",
+    );
+
+    const continuation = (try continuationFromResponse(
+        allocator,
+        "https://registry.example/current",
+        "https://registry.example",
+        &response,
+    )).?;
+    defer allocator.free(continuation);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/safe",
+        continuation,
+    );
 }

--- a/sdk/container_registry/src/link_pager.zig
+++ b/sdk/container_registry/src/link_pager.zig
@@ -116,8 +116,18 @@ const LinkIterator = struct {
         self.index += 1;
         const target_start = self.index;
         while (self.index < self.value.len and self.value[self.index] != '>') {
-            if (self.value[self.index] == '\r' or self.value[self.index] == '\n')
+            if (!isUriReferenceByte(self.value[self.index]))
                 return error.MalformedLinkHeader;
+            if (self.value[self.index] == '%') {
+                if (self.index + 2 >= self.value.len or
+                    !std.ascii.isHex(self.value[self.index + 1]) or
+                    !std.ascii.isHex(self.value[self.index + 2]))
+                {
+                    return error.MalformedLinkHeader;
+                }
+                self.index += 3;
+                continue;
+            }
             self.index += 1;
         }
         if (self.index == self.value.len or self.index == target_start)
@@ -142,8 +152,9 @@ const LinkIterator = struct {
             if (self.index == name_start) return error.MalformedLinkHeader;
             const name = self.value[name_start..self.index];
             skipOws(self.value, &self.index);
-            if (self.index == self.value.len or self.value[self.index] != '=')
-                return error.MalformedLinkHeader;
+            if (self.index == self.value.len or self.value[self.index] != '=') {
+                continue;
+            }
             self.index += 1;
             skipOws(self.value, &self.index);
             const parameter = try parseParameterValue(self.value, &self.index);
@@ -154,40 +165,74 @@ const LinkIterator = struct {
     }
 };
 
-fn parseParameterValue(value: []const u8, index: *usize) ![]const u8 {
+const ParameterValue = struct {
+    bytes: []const u8,
+    quoted: bool,
+};
+
+fn parseParameterValue(value: []const u8, index: *usize) !ParameterValue {
     if (index.* == value.len) return error.MalformedLinkHeader;
     if (value[index.*] != '"') {
         const start = index.*;
-        while (index.* < value.len and
-            value[index.*] != ';' and value[index.*] != ',' and
-            value[index.*] != ' ' and value[index.*] != '\t')
-        {
+        while (index.* < value.len and isParameterNameByte(value[index.*]))
             index.* += 1;
-        }
         if (index.* == start) return error.MalformedLinkHeader;
-        return value[start..index.*];
+        return .{ .bytes = value[start..index.*], .quoted = false };
     }
 
     index.* += 1;
     const start = index.*;
     while (index.* < value.len and value[index.*] != '"') {
         const byte = value[index.*];
-        if (byte == '\\' or byte == '\r' or byte == '\n')
+        if (byte == '\\') {
+            index.* += 1;
+            if (index.* == value.len or !isQuotedPairByte(value[index.*]))
+                return error.MalformedLinkHeader;
+        } else if (!isQuotedTextByte(byte)) {
             return error.MalformedLinkHeader;
+        }
         index.* += 1;
     }
     if (index.* == value.len) return error.MalformedLinkHeader;
-    const result = value[start..index.*];
+    const result = ParameterValue{
+        .bytes = value[start..index.*],
+        .quoted = true,
+    };
     index.* += 1;
     return result;
 }
 
-fn containsNextRelation(value: []const u8) bool {
-    var iterator = std.mem.tokenizeAny(u8, value, " \t");
-    while (iterator.next()) |relation| {
-        if (std.ascii.eqlIgnoreCase(relation, "next")) return true;
+fn containsNextRelation(value: ParameterValue) bool {
+    var index: usize = 0;
+    var relation_length: usize = 0;
+    var matches_next = true;
+    while (nextDecodedByte(value, &index)) |byte| {
+        if (byte == ' ' or byte == '\t') {
+            if (relation_length == "next".len and matches_next) return true;
+            relation_length = 0;
+            matches_next = true;
+            continue;
+        }
+        if (relation_length >= "next".len or
+            std.ascii.toLower(byte) != "next"[relation_length])
+        {
+            matches_next = false;
+        }
+        relation_length += 1;
     }
-    return false;
+    return relation_length == "next".len and matches_next;
+}
+
+fn nextDecodedByte(value: ParameterValue, index: *usize) ?u8 {
+    if (index.* == value.bytes.len) return null;
+    const byte = value.bytes[index.*];
+    index.* += 1;
+    if (value.quoted and byte == '\\') {
+        const escaped = value.bytes[index.*];
+        index.* += 1;
+        return escaped;
+    }
+    return byte;
 }
 
 fn resolveTrustedContinuation(
@@ -223,6 +268,24 @@ fn skipOws(value: []const u8, index: *usize) void {
 fn isParameterNameByte(byte: u8) bool {
     return std.ascii.isAlphanumeric(byte) or switch (byte) {
         '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        else => false,
+    };
+}
+
+fn isQuotedTextByte(byte: u8) bool {
+    return byte == '\t' or byte == ' ' or
+        (byte >= 0x21 and byte <= 0x7e and byte != '"' and byte != '\\') or
+        byte >= 0x80;
+}
+
+fn isQuotedPairByte(byte: u8) bool {
+    return byte == '\t' or byte == ' ' or
+        (byte >= 0x21 and byte <= 0x7e) or byte >= 0x80;
+}
+
+fn isUriReferenceByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or switch (byte) {
+        '-', '.', '_', '~', ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', '%' => true,
         else => false,
     };
 }

--- a/sdk/container_registry/src/metadata_test.zig
+++ b/sdk/container_registry/src/metadata_test.zig
@@ -93,6 +93,53 @@ test "repository pager follows a relative Link anonymously" {
     );
 }
 
+test "Link pager accepts valueless extensions and quoted-pair escapes" {
+    const allocator = std.testing.allocator;
+    const first_headers = [_]core.http.MockTransport.HeaderPair{
+        .{
+            .name = "Link",
+            .value =
+            \\</acr/v1/_catalog?api-version=2021-07-01&last=alpha>; extension; rel="prev\" \\ next"; title="a \"quote\" and \\ slash"
+            ,
+        },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 200,
+            .body = "{\"repositories\":[\"alpha\"]}",
+            .headers = &first_headers,
+        },
+        .{ .status = 200, .body = "{\"repositories\":[\"omega\"]}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+    var pager = try client.listRepositories(allocator, .{});
+    defer pager.deinit();
+
+    var first = (try pager.next()).?;
+    defer first.deinit();
+    try expectOk(first);
+    var second = (try pager.next()).?;
+    defer second.deinit();
+    switch (second) {
+        .ok => |page| try std.testing.expectEqualStrings("omega", page.names[0]),
+        .err => return error.UnexpectedServiceError,
+    }
+    try std.testing.expect((try pager.next()) == null);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/acr/v1/_catalog?api-version=2021-07-01&last=alpha",
+        capturedUrl(&transport, 1),
+    );
+}
+
 test "anonymous metadata reads use challenge authentication" {
     const allocator = std.testing.allocator;
     const challenge =
@@ -295,6 +342,22 @@ test "Link pager rejects unsafe and malformed continuations before sending" {
             .link = "not-a-link",
             .expected = error.MalformedLinkHeader,
         },
+        .{
+            .link = "<https://registry.example/acr/v1/bad path>; rel=\"next\"",
+            .expected = error.MalformedLinkHeader,
+        },
+        .{
+            .link = "<https://registry.example/acr/v1/%ZZ>; rel=\"next\"",
+            .expected = error.MalformedLinkHeader,
+        },
+        .{
+            .link = "<https://registry.example/acr/v1/_catalog>; rel=\"next\"; title=\"unterminated",
+            .expected = error.MalformedLinkHeader,
+        },
+        .{
+            .link = "<https://registry.example/acr/v1/_catalog?n=1>; rel=\"next\", </acr/v1/_catalog?n=2>; rel=next",
+            .expected = error.AmbiguousContinuationLink,
+        },
     };
     for (cases) |case| {
         const headers = [_]core.http.MockTransport.HeaderPair{
@@ -370,6 +433,75 @@ test "Link pager never sends credentials to an additionally trusted origin" {
     try std.testing.expectError(error.UntrustedContinuation, pager.next());
     try std.testing.expectEqual(@as(usize, 3), transport.call_count);
     try std.testing.expect(transport.captured_authorization[2]);
+}
+
+test "metadata deletes return idempotent outcomes on every surface" {
+    const allocator = std.testing.allocator;
+    const conflict =
+        \\{"errors":[{"code":"DENIED","message":"delete denied"}]}
+    ;
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 202, .body = "" },
+        .{ .status = 404, .body = "" },
+        .{ .status = 202, .body = "" },
+        .{ .status = 404, .body = "" },
+        .{ .status = 202, .body = "" },
+        .{ .status = 404, .body = "" },
+        .{ .status = 409, .body = conflict },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+
+    var repository_accepted = try client.deleteRepository(allocator, "team/app");
+    defer repository_accepted.deinit();
+    try expectDeleteOutcome(repository_accepted, .accepted);
+    var repository_missing = try client.deleteRepository(allocator, "team/app");
+    defer repository_missing.deinit();
+    try expectDeleteOutcome(repository_missing, .not_found);
+
+    var manifest_accepted = try client.deleteManifest(
+        allocator,
+        "team/app",
+        "sha256:one",
+    );
+    defer manifest_accepted.deinit();
+    try expectDeleteOutcome(manifest_accepted, .accepted);
+    var manifest_missing = try client.deleteManifest(
+        allocator,
+        "team/app",
+        "sha256:one",
+    );
+    defer manifest_missing.deinit();
+    try expectDeleteOutcome(manifest_missing, .not_found);
+
+    var tag_accepted = try client.deleteTag(allocator, "team/app", "v1");
+    defer tag_accepted.deinit();
+    try expectDeleteOutcome(tag_accepted, .accepted);
+    var tag_missing = try client.deleteTag(allocator, "team/app", "v1");
+    defer tag_missing.deinit();
+    try expectDeleteOutcome(tag_missing, .not_found);
+
+    var tag_conflict = try client.deleteTag(allocator, "team/app", "protected");
+    defer tag_conflict.deinit();
+    switch (tag_conflict) {
+        .ok => return error.ExpectedServiceError,
+        .err => |failure| {
+            try std.testing.expectEqual(@as(u16, 409), failure.status_code);
+            try std.testing.expect(failure.isCode("denied"));
+        },
+    }
+
+    for (transport.captured_methods[0..responses.len]) |method| {
+        try std.testing.expectEqual(core.http.Method.DELETE, method.?);
+    }
 }
 
 test "metadata CRUD preserves flags paths and structured not-found errors" {
@@ -616,12 +748,37 @@ fn parseErrorAllocationFixture(allocator: std.mem.Allocator) !void {
 }
 
 fn parsePageAllocationFixture(allocator: std.mem.Allocator) !void {
+    var missing_repositories = try models.parseRepositoryPage(allocator, "{}");
+    defer missing_repositories.deinit();
+    var null_repositories = try models.parseRepositoryPage(
+        allocator,
+        "{\"repositories\":null}",
+    );
+    defer null_repositories.deinit();
     var page = try models.parseManifestPage(
         allocator,
         "{\"registry\":\"registry.example\",\"imageName\":\"team/app\",\"manifests\":[{\"digest\":\"sha256:one\",\"createdTime\":\"2026-01-01T00:00:00Z\",\"lastUpdateTime\":\"2026-01-02T00:00:00Z\",\"references\":[{\"digest\":\"sha256:child\",\"architecture\":\"arm64\",\"os\":\"linux\"}],\"tags\":[\"v1\",\"latest\"],\"changeableAttributes\":{\"deleteEnabled\":true}}]}",
     );
     defer page.deinit();
     try std.testing.expectEqual(@as(usize, 1), page.items.len);
+}
+
+test "repository pages map missing and null repositories to owned empty slices" {
+    for ([_][]const u8{
+        "{}",
+        "{\"repositories\":null}",
+    }) |body| {
+        var page = try models.parseRepositoryPage(std.testing.allocator, body);
+        defer page.deinit();
+        try std.testing.expectEqual(@as(usize, 0), page.names.len);
+    }
+    try std.testing.expectError(
+        error.InvalidContainerRegistryResponse,
+        models.parseRepositoryPage(
+            std.testing.allocator,
+            "{\"repositories\":{}}",
+        ),
+    );
 }
 
 test "metadata parsers release every allocation failure path" {
@@ -674,6 +831,16 @@ fn capturedBody(
 fn expectOk(result: anytype) !void {
     switch (result) {
         .ok => {},
+        .err => return error.UnexpectedServiceError,
+    }
+}
+
+fn expectDeleteOutcome(
+    result: client_mod.DeleteResult,
+    expected: client_mod.DeleteOutcome,
+) !void {
+    switch (result) {
+        .ok => |outcome| try std.testing.expectEqual(expected, outcome),
         .err => return error.UnexpectedServiceError,
     }
 }

--- a/sdk/container_registry/src/metadata_test.zig
+++ b/sdk/container_registry/src/metadata_test.zig
@@ -1,0 +1,679 @@
+const std = @import("std");
+const core = @import("azure_core");
+const client_mod = @import("client.zig");
+const models = @import("models.zig");
+const service_error = @import("service_error.zig");
+
+const repository_body =
+    \\{"registry":"registry.example","imageName":"team/app","createdTime":"2026-01-01T00:00:00Z","lastUpdateTime":"2026-02-01T00:00:00Z","manifestCount":2,"tagCount":3,"changeableAttributes":{"deleteEnabled":true,"writeEnabled":false,"listEnabled":true,"readEnabled":true}}
+;
+
+const manifest_body =
+    \\{"registry":"registry.example","imageName":"team/app","manifest":{"digest":"sha256:one","imageSize":42,"createdTime":"2026-01-01T00:00:00Z","lastUpdateTime":"2026-02-01T00:00:00Z","architecture":"amd64","os":"linux","references":[{"digest":"sha256:child","architecture":"arm64","os":"linux"}],"configMediaType":"application/vnd.oci.image.config.v1+json","mediaType":"application/vnd.oci.image.manifest.v1+json","tags":["v1","latest"],"changeableAttributes":{"deleteEnabled":true,"writeEnabled":false,"listEnabled":true,"readEnabled":true}}}
+;
+
+const tag_body =
+    \\{"registry":"registry.example","imageName":"team/app","tag":{"name":"release/candidate","digest":"sha256:one","createdTime":"2026-01-01T00:00:00Z","lastUpdateTime":"2026-02-01T00:00:00Z","signed":false,"changeableAttributes":{"deleteEnabled":true,"writeEnabled":false,"listEnabled":true,"readEnabled":true}}}
+;
+
+test "metadata methods are public" {
+    inline for (.{
+        "listRepositories",
+        "getRepositoryProperties",
+        "updateRepositoryProperties",
+        "deleteRepository",
+        "listManifestProperties",
+        "getManifestProperties",
+        "updateManifestProperties",
+        "deleteManifest",
+        "listTagProperties",
+        "getTagProperties",
+        "updateTagProperties",
+        "deleteTag",
+    }) |method| {
+        try std.testing.expect(@hasDecl(client_mod.ContainerRegistryClient, method));
+    }
+}
+
+test "repository pager follows a relative Link anonymously" {
+    const allocator = std.testing.allocator;
+    const first_headers = [_]core.http.MockTransport.HeaderPair{
+        .{
+            .name = "Link",
+            .value = "</acr/v1/_catalog?api-version=2021-07-01&last=team%2Fapp&n=2>; rel=\"next\"",
+        },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 200,
+            .body = "{\"repositories\":[\"alpha\",\"team/app\"]}",
+            .headers = &first_headers,
+        },
+        .{ .status = 200, .body = "{\"repositories\":[\"zeta\"]}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+    var pager = try client.listRepositories(allocator, .{ .max_results = 2 });
+    defer pager.deinit();
+
+    var first = (try pager.next()).?;
+    defer first.deinit();
+    switch (first) {
+        .ok => |page| {
+            try std.testing.expectEqual(@as(usize, 2), page.names.len);
+            try std.testing.expectEqualStrings("team/app", page.names[1]);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+
+    var second = (try pager.next()).?;
+    defer second.deinit();
+    switch (second) {
+        .ok => |page| {
+            try std.testing.expectEqual(@as(usize, 1), page.names.len);
+            try std.testing.expectEqualStrings("zeta", page.names[0]);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+    try std.testing.expect((try pager.next()) == null);
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+    try std.testing.expect(!transport.captured_authorization[0]);
+    try std.testing.expect(!transport.captured_authorization[1]);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/acr/v1/_catalog?api-version=2021-07-01&last=team%2Fapp&n=2",
+        capturedUrl(&transport, 1),
+    );
+}
+
+test "anonymous metadata reads use challenge authentication" {
+    const allocator = std.testing.allocator;
+    const challenge =
+        "Bearer realm=\"https://registry.example/oauth2/token\",service=\"registry.example\",scope=\"registry:catalog:*\"";
+    const challenge_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &challenge_headers },
+        .{
+            .status = 200,
+            .body = "{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.signature\"}",
+        },
+        .{ .status = 200, .body = "{\"repositories\":[\"private\"]}" },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+    var pager = try client.listRepositories(allocator, .{});
+    defer pager.deinit();
+    var result = (try pager.next()).?;
+    defer result.deinit();
+    switch (result) {
+        .ok => |page| try std.testing.expectEqualStrings("private", page.names[0]),
+        .err => return error.UnexpectedServiceError,
+    }
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expect(!transport.captured_authorization[0]);
+    try std.testing.expect(transport.captured_authorization[2]);
+}
+
+test "manifest pager follows an absolute same-origin Link" {
+    const allocator = std.testing.allocator;
+    const first_headers = [_]core.http.MockTransport.HeaderPair{
+        .{
+            .name = "Link",
+            .value = "<https://registry.example:443/acr/v1/team/app/_manifests?api-version=2021-07-01&last=sha256%3Aone&n=1>; rel=\"next\"",
+        },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 200,
+            .body =
+            \\{"registry":"registry.example","imageName":"team/app","manifests":[{"digest":"sha256:one","imageSize":42,"createdTime":"2026-01-01T00:00:00Z","lastUpdateTime":"2026-02-01T00:00:00Z","architecture":"amd64","os":"linux","references":[{"digest":"sha256:child","architecture":"arm64","os":"linux"}],"tags":["v1"],"changeableAttributes":{"deleteEnabled":true,"writeEnabled":false,"listEnabled":true,"readEnabled":true}}]}
+            ,
+            .headers = &first_headers,
+        },
+        .{
+            .status = 200,
+            .body =
+            \\{"registry":"registry.example","imageName":"team/app","manifests":[{"digest":"sha256:two","createdTime":"2026-03-01T00:00:00Z","lastUpdateTime":"2026-03-02T00:00:00Z","tags":[],"changeableAttributes":{"deleteEnabled":false}}]}
+            ,
+        },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+    var pager = try client.listManifestProperties(
+        allocator,
+        "team/app",
+        .{ .max_results = 1, .order = .last_updated_on_descending },
+    );
+    defer pager.deinit();
+
+    var first = (try pager.next()).?;
+    defer first.deinit();
+    switch (first) {
+        .ok => |page| {
+            try std.testing.expectEqual(@as(usize, 1), page.items.len);
+            try std.testing.expectEqualStrings("sha256:one", page.items[0].digest);
+            try std.testing.expectEqualStrings(
+                "registry.example",
+                page.items[0].registry_login_server.?,
+            );
+            try std.testing.expectEqual(@as(?bool, true), page.items[0].can_delete);
+            try std.testing.expectEqual(@as(usize, 1), page.items[0].related_artifacts.len);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+
+    var second = (try pager.next()).?;
+    defer second.deinit();
+    switch (second) {
+        .ok => |page| {
+            try std.testing.expectEqualStrings("sha256:two", page.items[0].digest);
+            try std.testing.expectEqual(@as(?bool, null), page.items[0].can_read);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+    try std.testing.expect((try pager.next()) == null);
+    try std.testing.expectEqualStrings(
+        "https://registry.example:443/acr/v1/team/app/_manifests?api-version=2021-07-01&last=sha256%3Aone&n=1",
+        capturedUrl(&transport, 1),
+    );
+}
+
+test "tag pager follows a query-relative Link" {
+    const allocator = std.testing.allocator;
+    const first_headers = [_]core.http.MockTransport.HeaderPair{
+        .{
+            .name = "Link",
+            .value = "<?api-version=2021-07-01&last=one&n=1>; rel=next",
+        },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 200,
+            .body =
+            \\{"registry":"registry.example","imageName":"team/app","tags":[{"name":"one","digest":"sha256:one","createdTime":"2026-01-01T00:00:00Z","lastUpdateTime":"2026-01-02T00:00:00Z","changeableAttributes":{"deleteEnabled":true,"writeEnabled":true,"listEnabled":true,"readEnabled":true}}]}
+            ,
+            .headers = &first_headers,
+        },
+        .{
+            .status = 200,
+            .body =
+            \\{"registry":"registry.example","imageName":"team/app","tags":[{"name":"two","digest":"sha256:two","createdTime":"2026-02-01T00:00:00Z","lastUpdateTime":"2026-02-02T00:00:00Z","signed":true,"changeableAttributes":{"deleteEnabled":false,"writeEnabled":false,"listEnabled":true,"readEnabled":true}}]}
+            ,
+        },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+    var pager = try client.listTagProperties(
+        allocator,
+        "team/app",
+        .{
+            .max_results = 1,
+            .order = .last_updated_on_ascending,
+            .digest = "sha256:one",
+        },
+    );
+    defer pager.deinit();
+
+    var first = (try pager.next()).?;
+    defer first.deinit();
+    switch (first) {
+        .ok => |page| try std.testing.expectEqualStrings("one", page.items[0].name),
+        .err => return error.UnexpectedServiceError,
+    }
+    var second = (try pager.next()).?;
+    defer second.deinit();
+    switch (second) {
+        .ok => |page| {
+            try std.testing.expectEqualStrings("two", page.items[0].name);
+            try std.testing.expectEqual(@as(?bool, true), page.items[0].signed);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+    try std.testing.expect((try pager.next()) == null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedUrl(&transport, 0),
+        "&digest=sha256%3Aone",
+    ) != null);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/acr/v1/team/app/_tags?api-version=2021-07-01&last=one&n=1",
+        capturedUrl(&transport, 1),
+    );
+}
+
+test "Link pager rejects unsafe and malformed continuations before sending" {
+    const cases = [_]struct {
+        link: []const u8,
+        expected: anyerror,
+    }{
+        .{
+            .link = "<https://evil.example/acr/v1/_catalog>; rel=\"next\"",
+            .expected = error.UntrustedContinuation,
+        },
+        .{
+            .link = "<http://registry.example/acr/v1/_catalog>; rel=\"next\"",
+            .expected = error.ContinuationHttpsRequired,
+        },
+        .{
+            .link = "<https://registry.example:444/acr/v1/_catalog>; rel=\"next\"",
+            .expected = error.UntrustedContinuation,
+        },
+        .{
+            .link = "not-a-link",
+            .expected = error.MalformedLinkHeader,
+        },
+    };
+    for (cases) |case| {
+        const headers = [_]core.http.MockTransport.HeaderPair{
+            .{ .name = "Link", .value = case.link },
+        };
+        const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+            .{
+                .status = 200,
+                .body = "{\"repositories\":[\"safe\"]}",
+                .headers = &headers,
+            },
+        };
+        var transport = core.http.SequenceMockTransport.init(
+            std.testing.allocator,
+            &responses,
+        );
+        var client = try client_mod.ContainerRegistryClient.init(
+            std.testing.allocator,
+            "https://registry.example",
+            .{
+                .transport = transport.asTransport(),
+                .authentication = .anonymous,
+            },
+        );
+        defer client.deinit();
+        var pager = try client.listRepositories(std.testing.allocator, .{});
+        defer pager.deinit();
+        try std.testing.expectError(case.expected, pager.next());
+        try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    }
+}
+
+test "Link pager never sends credentials to an additionally trusted origin" {
+    const allocator = std.testing.allocator;
+    const challenge =
+        "Bearer realm=\"https://registry.example/oauth2/token\",service=\"registry.example\",scope=\"registry:catalog:*\"";
+    const challenge_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const link_headers = [_]core.http.MockTransport.HeaderPair{
+        .{
+            .name = "Link",
+            .value = "<https://evil.example/acr/v1/_catalog>; rel=\"next\"",
+        },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &challenge_headers },
+        .{
+            .status = 200,
+            .body = "{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.signature\"}",
+        },
+        .{
+            .status = 200,
+            .body = "{\"repositories\":[\"private\"]}",
+            .headers = &link_headers,
+        },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+            .authentication_options = .{
+                .expected_hosts = &.{"evil.example"},
+            },
+        },
+    );
+    defer client.deinit();
+    var pager = try client.listRepositories(allocator, .{});
+    defer pager.deinit();
+    try std.testing.expectError(error.UntrustedContinuation, pager.next());
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expect(transport.captured_authorization[2]);
+}
+
+test "metadata CRUD preserves flags paths and structured not-found errors" {
+    const allocator = std.testing.allocator;
+    const not_found =
+        \\{"errors":[{"code":"TAG_UNKNOWN","message":"tag missing","detail":{"name":"missing"}}]}
+    ;
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body = repository_body },
+        .{ .status = 200, .body = repository_body },
+        .{ .status = 202, .body = "" },
+        .{ .status = 200, .body = manifest_body },
+        .{ .status = 200, .body = manifest_body },
+        .{ .status = 202, .body = "" },
+        .{ .status = 200, .body = tag_body },
+        .{ .status = 200, .body = tag_body },
+        .{ .status = 202, .body = "" },
+        .{ .status = 404, .body = not_found },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+
+    var repository = try client.getRepositoryProperties(allocator, "team/app");
+    defer repository.deinit();
+    switch (repository) {
+        .ok => |properties| {
+            try std.testing.expectEqual(@as(?bool, true), properties.can_delete);
+            try std.testing.expectEqual(@as(?bool, false), properties.can_write);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+    var updated_repository = try client.updateRepositoryProperties(
+        allocator,
+        "team/app",
+        .{ .can_delete = false, .can_read = true },
+    );
+    defer updated_repository.deinit();
+    try expectOk(updated_repository);
+    var deleted_repository = try client.deleteRepository(allocator, "team/app");
+    defer deleted_repository.deinit();
+    try expectOk(deleted_repository);
+
+    var manifest = try client.getManifestProperties(
+        allocator,
+        "team/app",
+        "sha256:one",
+    );
+    defer manifest.deinit();
+    switch (manifest) {
+        .ok => |properties| {
+            try std.testing.expectEqualStrings("sha256:one", properties.digest);
+            try std.testing.expectEqual(@as(?i64, 42), properties.size_in_bytes);
+            try std.testing.expectEqual(@as(usize, 2), properties.tags.len);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+    var updated_manifest = try client.updateManifestProperties(
+        allocator,
+        "team/app",
+        "sha256:one",
+        .{ .can_write = false, .can_list = true },
+    );
+    defer updated_manifest.deinit();
+    try expectOk(updated_manifest);
+    var deleted_manifest = try client.deleteManifest(
+        allocator,
+        "team/app",
+        "sha256:one",
+    );
+    defer deleted_manifest.deinit();
+    try expectOk(deleted_manifest);
+
+    var tag = try client.getTagProperties(
+        allocator,
+        "team/app",
+        "release/candidate",
+    );
+    defer tag.deinit();
+    switch (tag) {
+        .ok => |properties| {
+            try std.testing.expectEqualStrings("release/candidate", properties.name);
+            try std.testing.expectEqual(@as(?bool, false), properties.signed);
+        },
+        .err => return error.UnexpectedServiceError,
+    }
+    var updated_tag = try client.updateTagProperties(
+        allocator,
+        "team/app",
+        "release/candidate",
+        .{ .can_delete = true, .can_read = false },
+    );
+    defer updated_tag.deinit();
+    try expectOk(updated_tag);
+    var deleted_tag = try client.deleteTag(
+        allocator,
+        "team/app",
+        "release/candidate",
+    );
+    defer deleted_tag.deinit();
+    try expectOk(deleted_tag);
+
+    var missing = try client.getTagProperties(allocator, "team/app", "missing");
+    defer missing.deinit();
+    switch (missing) {
+        .ok => return error.ExpectedServiceError,
+        .err => |failure| {
+            try std.testing.expect(failure.isNotFound());
+            try std.testing.expect(failure.isCode("tag_unknown"));
+            try std.testing.expectEqualStrings("TAG_UNKNOWN", failure.code.?);
+            try std.testing.expectEqualStrings("tag missing", failure.message.?);
+            try std.testing.expectEqualStrings("{\"name\":\"missing\"}", failure.detail.?);
+            try std.testing.expectEqual(@as(usize, 1), failure.errors.len);
+        },
+    }
+
+    try std.testing.expectEqualStrings(
+        "{\"deleteEnabled\":false,\"readEnabled\":true}",
+        capturedBody(&transport, 1),
+    );
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedUrl(&transport, 3),
+        "/_manifests/sha256%3Aone",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedUrl(&transport, 5),
+        "/v2/team/app/manifests/sha256%3Aone",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        capturedUrl(&transport, 6),
+        "/_tags/release%2Fcandidate",
+    ) != null);
+}
+
+test "authenticated metadata writes use challenge authentication" {
+    const allocator = std.testing.allocator;
+    const challenge =
+        "Bearer realm=\"https://registry.example/oauth2/token\",service=\"registry.example\",scope=\"repository:team/app:metadata_write\"";
+    const challenge_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "WWW-Authenticate", .value = challenge },
+    };
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 401, .body = "", .headers = &challenge_headers },
+        .{
+            .status = 200,
+            .body = "{\"refresh_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.signature\"}",
+        },
+        .{
+            .status = 200,
+            .body = "{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.signature\"}",
+        },
+        .{ .status = 200, .body = repository_body },
+    };
+    var credential = TestCredential.init();
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try client_mod.ContainerRegistryClient.init(
+        allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .{ .credential = &credential.credential },
+        },
+    );
+    defer client.deinit();
+
+    var result = try client.updateRepositoryProperties(
+        allocator,
+        "team/app",
+        .{ .can_write = false },
+    );
+    defer result.deinit();
+    try expectOk(result);
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
+    try std.testing.expectEqual(core.http.Method.PATCH, transport.captured_methods[0].?);
+    try std.testing.expectEqual(core.http.Method.POST, transport.captured_methods[1].?);
+    try std.testing.expectEqual(core.http.Method.POST, transport.captured_methods[2].?);
+    try std.testing.expectEqual(core.http.Method.PATCH, transport.captured_methods[3].?);
+    try std.testing.expect(!transport.captured_authorization[0]);
+    try std.testing.expect(transport.captured_authorization[3]);
+    try std.testing.expectEqualStrings(
+        "{\"writeEnabled\":false}",
+        capturedBody(&transport, 3),
+    );
+}
+
+test "malformed ACR errors retain status and raw body" {
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 502, .body = "gateway said no" },
+    };
+    var transport = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &responses,
+    );
+    var client = try client_mod.ContainerRegistryClient.init(
+        std.testing.allocator,
+        "https://registry.example",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+    var result = try client.getRepositoryProperties(
+        std.testing.allocator,
+        "team/app",
+    );
+    defer result.deinit();
+    switch (result) {
+        .ok => return error.ExpectedServiceError,
+        .err => |failure| {
+            try std.testing.expectEqual(@as(u16, 502), failure.status_code);
+            try std.testing.expect(failure.malformed);
+            try std.testing.expectEqualStrings("gateway said no", failure.raw_body.?);
+            try std.testing.expect(failure.code == null);
+        },
+    }
+}
+
+fn parseErrorAllocationFixture(allocator: std.mem.Allocator) !void {
+    var response = core.http.Response{
+        .status_code = 404,
+        .headers = std.StringHashMap([]const u8).init(allocator),
+        .body = try allocator.dupe(
+            u8,
+            "{\"errors\":[{\"code\":\"MANIFEST_UNKNOWN\",\"message\":\"missing\",\"detail\":{\"digest\":\"sha256:none\"}},{\"code\":\"NAME_UNKNOWN\",\"message\":\"repository missing\"}]}",
+        ),
+        .allocator = allocator,
+    };
+    defer response.deinit();
+    var failure = try service_error.ServiceError.fromResponse(allocator, &response);
+    defer failure.deinit();
+    try std.testing.expectEqual(@as(usize, 2), failure.errors.len);
+}
+
+fn parsePageAllocationFixture(allocator: std.mem.Allocator) !void {
+    var page = try models.parseManifestPage(
+        allocator,
+        "{\"registry\":\"registry.example\",\"imageName\":\"team/app\",\"manifests\":[{\"digest\":\"sha256:one\",\"createdTime\":\"2026-01-01T00:00:00Z\",\"lastUpdateTime\":\"2026-01-02T00:00:00Z\",\"references\":[{\"digest\":\"sha256:child\",\"architecture\":\"arm64\",\"os\":\"linux\"}],\"tags\":[\"v1\",\"latest\"],\"changeableAttributes\":{\"deleteEnabled\":true}}]}",
+    );
+    defer page.deinit();
+    try std.testing.expectEqual(@as(usize, 1), page.items.len);
+}
+
+test "metadata parsers release every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parseErrorAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parsePageAllocationFixture,
+        .{},
+    );
+}
+
+const TestCredential = struct {
+    credential: core.credentials.TokenCredential,
+    calls: usize = 0,
+
+    fn init() TestCredential {
+        return .{ .credential = .{ .getTokenFn = &getToken } };
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        _: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+    ) anyerror!core.credentials.AccessToken {
+        const self: *TestCredential =
+            @alignCast(@fieldParentPtr("credential", credential));
+        self.calls += 1;
+        return .{ .token = "aad-token", .expires_on = 4_102_444_800 };
+    }
+};
+
+fn capturedUrl(
+    transport: *const core.http.SequenceMockTransport,
+    index: usize,
+) []const u8 {
+    return transport.captured_urls[index][0..transport.captured_url_lengths[index]];
+}
+
+fn capturedBody(
+    transport: *const core.http.SequenceMockTransport,
+    index: usize,
+) []const u8 {
+    return transport.captured_bodies[index][0..transport.captured_body_lengths[index]];
+}
+
+fn expectOk(result: anytype) !void {
+    switch (result) {
+        .ok => {},
+        .err => return error.UnexpectedServiceError,
+    }
+}

--- a/sdk/container_registry/src/models.zig
+++ b/sdk/container_registry/src/models.zig
@@ -1,0 +1,566 @@
+const std = @import("std");
+
+pub const ChangeableProperties = struct {
+    can_delete: ?bool = null,
+    can_write: ?bool = null,
+    can_list: ?bool = null,
+    can_read: ?bool = null,
+};
+
+pub const ContainerRepositoryProperties = struct {
+    allocator: std.mem.Allocator,
+    registry_login_server: []u8,
+    name: []u8,
+    created_on: []u8,
+    last_updated_on: []u8,
+    manifest_count: i32,
+    tag_count: i32,
+    can_delete: ?bool,
+    can_write: ?bool,
+    can_list: ?bool,
+    can_read: ?bool,
+
+    pub fn deinit(self: *ContainerRepositoryProperties) void {
+        self.allocator.free(self.registry_login_server);
+        self.allocator.free(self.name);
+        self.allocator.free(self.created_on);
+        self.allocator.free(self.last_updated_on);
+        self.* = undefined;
+    }
+};
+
+pub const ArtifactManifestPlatform = struct {
+    allocator: std.mem.Allocator,
+    digest: []u8,
+    architecture: ?[]u8,
+    operating_system: ?[]u8,
+
+    pub fn deinit(self: *ArtifactManifestPlatform) void {
+        self.allocator.free(self.digest);
+        if (self.architecture) |value| self.allocator.free(value);
+        if (self.operating_system) |value| self.allocator.free(value);
+        self.* = undefined;
+    }
+};
+
+pub const ArtifactManifestProperties = struct {
+    allocator: std.mem.Allocator,
+    registry_login_server: ?[]u8,
+    repository_name: ?[]u8,
+    digest: []u8,
+    size_in_bytes: ?i64,
+    created_on: []u8,
+    last_updated_on: []u8,
+    architecture: ?[]u8,
+    operating_system: ?[]u8,
+    related_artifacts: []ArtifactManifestPlatform,
+    config_media_type: ?[]u8,
+    media_type: ?[]u8,
+    tags: [][]u8,
+    can_delete: ?bool,
+    can_write: ?bool,
+    can_list: ?bool,
+    can_read: ?bool,
+
+    pub fn deinit(self: *ArtifactManifestProperties) void {
+        if (self.registry_login_server) |value| self.allocator.free(value);
+        if (self.repository_name) |value| self.allocator.free(value);
+        self.allocator.free(self.digest);
+        self.allocator.free(self.created_on);
+        self.allocator.free(self.last_updated_on);
+        if (self.architecture) |value| self.allocator.free(value);
+        if (self.operating_system) |value| self.allocator.free(value);
+        for (self.related_artifacts) |*artifact| artifact.deinit();
+        self.allocator.free(self.related_artifacts);
+        if (self.config_media_type) |value| self.allocator.free(value);
+        if (self.media_type) |value| self.allocator.free(value);
+        for (self.tags) |tag| self.allocator.free(tag);
+        self.allocator.free(self.tags);
+        self.* = undefined;
+    }
+};
+
+pub const ArtifactTagProperties = struct {
+    allocator: std.mem.Allocator,
+    registry_login_server: []u8,
+    repository_name: []u8,
+    name: []u8,
+    digest: []u8,
+    created_on: []u8,
+    last_updated_on: []u8,
+    signed: ?bool,
+    can_delete: ?bool,
+    can_write: ?bool,
+    can_list: ?bool,
+    can_read: ?bool,
+
+    pub fn deinit(self: *ArtifactTagProperties) void {
+        self.allocator.free(self.registry_login_server);
+        self.allocator.free(self.repository_name);
+        self.allocator.free(self.name);
+        self.allocator.free(self.digest);
+        self.allocator.free(self.created_on);
+        self.allocator.free(self.last_updated_on);
+        self.* = undefined;
+    }
+};
+
+pub const RepositoryPage = struct {
+    allocator: std.mem.Allocator,
+    names: [][]u8,
+
+    pub fn deinit(self: *RepositoryPage) void {
+        for (self.names) |name| self.allocator.free(name);
+        self.allocator.free(self.names);
+        self.* = undefined;
+    }
+};
+
+pub const ManifestPage = struct {
+    allocator: std.mem.Allocator,
+    items: []ArtifactManifestProperties,
+
+    pub fn deinit(self: *ManifestPage) void {
+        for (self.items) |*item| item.deinit();
+        self.allocator.free(self.items);
+        self.* = undefined;
+    }
+};
+
+pub const TagPage = struct {
+    allocator: std.mem.Allocator,
+    items: []ArtifactTagProperties,
+
+    pub fn deinit(self: *TagPage) void {
+        for (self.items) |*item| item.deinit();
+        self.allocator.free(self.items);
+        self.* = undefined;
+    }
+};
+
+pub fn parseRepositoryProperties(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !ContainerRepositoryProperties {
+    const parsed = try parseJson(allocator, body);
+    defer parsed.deinit();
+    return parseRepositoryPropertiesValue(allocator, parsed.value);
+}
+
+pub fn parseManifestProperties(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !ArtifactManifestProperties {
+    const parsed = try parseJson(allocator, body);
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidContainerRegistryResponse;
+    const registry = try optionalString(parsed.value.object, "registry");
+    const repository = try optionalString(parsed.value.object, "imageName");
+    const manifest = parsed.value.object.get("manifest") orelse
+        return error.InvalidContainerRegistryResponse;
+    return parseManifestValue(allocator, manifest, registry, repository);
+}
+
+pub fn parseTagProperties(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !ArtifactTagProperties {
+    const parsed = try parseJson(allocator, body);
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidContainerRegistryResponse;
+    const registry = try requiredString(parsed.value.object, "registry");
+    const repository = try requiredString(parsed.value.object, "imageName");
+    const tag = parsed.value.object.get("tag") orelse
+        return error.InvalidContainerRegistryResponse;
+    return parseTagValue(allocator, tag, registry, repository);
+}
+
+pub fn parseRepositoryPage(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !RepositoryPage {
+    const parsed = try parseJson(allocator, body);
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidContainerRegistryResponse;
+    const repositories = parsed.value.object.get("repositories") orelse
+        return error.InvalidContainerRegistryResponse;
+    if (repositories != .array) return error.InvalidContainerRegistryResponse;
+
+    const names = try allocator.alloc([]u8, repositories.array.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (names[0..initialized]) |name| allocator.free(name);
+        allocator.free(names);
+    }
+    for (repositories.array.items, 0..) |value, index| {
+        if (value != .string) return error.InvalidContainerRegistryResponse;
+        names[index] = try allocator.dupe(u8, value.string);
+        initialized += 1;
+    }
+    return .{ .allocator = allocator, .names = names };
+}
+
+pub fn parseManifestPage(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !ManifestPage {
+    const parsed = try parseJson(allocator, body);
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidContainerRegistryResponse;
+
+    const registry = try optionalString(parsed.value.object, "registry");
+    const repository = try optionalString(parsed.value.object, "imageName");
+    const manifests_value = parsed.value.object.get("manifests");
+    const manifest_values = if (manifests_value) |value| switch (value) {
+        .null => &[_]std.json.Value{},
+        .array => |array| array.items,
+        else => return error.InvalidContainerRegistryResponse,
+    } else &[_]std.json.Value{};
+
+    const items = try allocator.alloc(ArtifactManifestProperties, manifest_values.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (items[0..initialized]) |*item| item.deinit();
+        allocator.free(items);
+    }
+    for (manifest_values, 0..) |value, index| {
+        items[index] = try parseManifestValue(
+            allocator,
+            value,
+            registry,
+            repository,
+        );
+        initialized += 1;
+    }
+    return .{ .allocator = allocator, .items = items };
+}
+
+pub fn parseTagPage(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !TagPage {
+    const parsed = try parseJson(allocator, body);
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidContainerRegistryResponse;
+
+    const registry = try requiredString(parsed.value.object, "registry");
+    const repository = try requiredString(parsed.value.object, "imageName");
+    const tags = parsed.value.object.get("tags") orelse
+        return error.InvalidContainerRegistryResponse;
+    if (tags != .array) return error.InvalidContainerRegistryResponse;
+
+    const items = try allocator.alloc(ArtifactTagProperties, tags.array.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (items[0..initialized]) |*item| item.deinit();
+        allocator.free(items);
+    }
+    for (tags.array.items, 0..) |value, index| {
+        items[index] = try parseTagValue(
+            allocator,
+            value,
+            registry,
+            repository,
+        );
+        initialized += 1;
+    }
+    return .{ .allocator = allocator, .items = items };
+}
+
+fn parseRepositoryPropertiesValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !ContainerRepositoryProperties {
+    if (value != .object) return error.InvalidContainerRegistryResponse;
+    const registry = try requiredOwnedString(allocator, value.object, "registry");
+    errdefer allocator.free(registry);
+    const name = try requiredOwnedString(allocator, value.object, "imageName");
+    errdefer allocator.free(name);
+    const created_on = try requiredOwnedString(allocator, value.object, "createdTime");
+    errdefer allocator.free(created_on);
+    const last_updated_on = try requiredOwnedString(
+        allocator,
+        value.object,
+        "lastUpdateTime",
+    );
+    errdefer allocator.free(last_updated_on);
+    const attributes = value.object.get("changeableAttributes") orelse
+        return error.InvalidContainerRegistryResponse;
+    const flags = try parseChangeableProperties(attributes);
+
+    return .{
+        .allocator = allocator,
+        .registry_login_server = registry,
+        .name = name,
+        .created_on = created_on,
+        .last_updated_on = last_updated_on,
+        .manifest_count = try requiredI32(value.object, "manifestCount"),
+        .tag_count = try requiredI32(value.object, "tagCount"),
+        .can_delete = flags.can_delete,
+        .can_write = flags.can_write,
+        .can_list = flags.can_list,
+        .can_read = flags.can_read,
+    };
+}
+
+fn parseManifestValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+    registry: ?[]const u8,
+    repository: ?[]const u8,
+) !ArtifactManifestProperties {
+    if (value != .object) return error.InvalidContainerRegistryResponse;
+    const owned_registry = if (registry) |field|
+        try allocator.dupe(u8, field)
+    else
+        null;
+    errdefer if (owned_registry) |field| allocator.free(field);
+    const owned_repository = if (repository) |field|
+        try allocator.dupe(u8, field)
+    else
+        null;
+    errdefer if (owned_repository) |field| allocator.free(field);
+
+    const digest = try requiredOwnedString(allocator, value.object, "digest");
+    errdefer allocator.free(digest);
+    const created_on = try requiredOwnedString(allocator, value.object, "createdTime");
+    errdefer allocator.free(created_on);
+    const last_updated_on = try requiredOwnedString(
+        allocator,
+        value.object,
+        "lastUpdateTime",
+    );
+    errdefer allocator.free(last_updated_on);
+    const architecture = try optionalOwnedString(allocator, value.object, "architecture");
+    errdefer if (architecture) |field| allocator.free(field);
+    const operating_system = try optionalOwnedString(allocator, value.object, "os");
+    errdefer if (operating_system) |field| allocator.free(field);
+    const related_artifacts = try parseRelatedArtifacts(allocator, value.object);
+    errdefer {
+        for (related_artifacts) |*artifact| artifact.deinit();
+        allocator.free(related_artifacts);
+    }
+    const config_media_type = try optionalOwnedString(
+        allocator,
+        value.object,
+        "configMediaType",
+    );
+    errdefer if (config_media_type) |field| allocator.free(field);
+    const media_type = try optionalOwnedString(allocator, value.object, "mediaType");
+    errdefer if (media_type) |field| allocator.free(field);
+    const tags = try parseStringArray(allocator, value.object, "tags");
+    errdefer {
+        for (tags) |tag| allocator.free(tag);
+        allocator.free(tags);
+    }
+    const flags = if (value.object.get("changeableAttributes")) |attributes|
+        try parseChangeableProperties(attributes)
+    else
+        ChangeableProperties{};
+
+    return .{
+        .allocator = allocator,
+        .registry_login_server = owned_registry,
+        .repository_name = owned_repository,
+        .digest = digest,
+        .size_in_bytes = try optionalI64(value.object, "imageSize"),
+        .created_on = created_on,
+        .last_updated_on = last_updated_on,
+        .architecture = architecture,
+        .operating_system = operating_system,
+        .related_artifacts = related_artifacts,
+        .config_media_type = config_media_type,
+        .media_type = media_type,
+        .tags = tags,
+        .can_delete = flags.can_delete,
+        .can_write = flags.can_write,
+        .can_list = flags.can_list,
+        .can_read = flags.can_read,
+    };
+}
+
+fn parseTagValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+    registry: []const u8,
+    repository: []const u8,
+) !ArtifactTagProperties {
+    if (value != .object) return error.InvalidContainerRegistryResponse;
+    const owned_registry = try allocator.dupe(u8, registry);
+    errdefer allocator.free(owned_registry);
+    const owned_repository = try allocator.dupe(u8, repository);
+    errdefer allocator.free(owned_repository);
+    const name = try requiredOwnedString(allocator, value.object, "name");
+    errdefer allocator.free(name);
+    const digest = try requiredOwnedString(allocator, value.object, "digest");
+    errdefer allocator.free(digest);
+    const created_on = try requiredOwnedString(allocator, value.object, "createdTime");
+    errdefer allocator.free(created_on);
+    const last_updated_on = try requiredOwnedString(
+        allocator,
+        value.object,
+        "lastUpdateTime",
+    );
+    errdefer allocator.free(last_updated_on);
+    const attributes = value.object.get("changeableAttributes") orelse
+        return error.InvalidContainerRegistryResponse;
+    const flags = try parseChangeableProperties(attributes);
+
+    return .{
+        .allocator = allocator,
+        .registry_login_server = owned_registry,
+        .repository_name = owned_repository,
+        .name = name,
+        .digest = digest,
+        .created_on = created_on,
+        .last_updated_on = last_updated_on,
+        .signed = try optionalBool(value.object, "signed"),
+        .can_delete = flags.can_delete,
+        .can_write = flags.can_write,
+        .can_list = flags.can_list,
+        .can_read = flags.can_read,
+    };
+}
+
+fn parseRelatedArtifacts(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) ![]ArtifactManifestPlatform {
+    const value = object.get("references") orelse
+        return allocator.alloc(ArtifactManifestPlatform, 0);
+    if (value == .null) return allocator.alloc(ArtifactManifestPlatform, 0);
+    if (value != .array) return error.InvalidContainerRegistryResponse;
+
+    const artifacts = try allocator.alloc(ArtifactManifestPlatform, value.array.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (artifacts[0..initialized]) |*artifact| artifact.deinit();
+        allocator.free(artifacts);
+    }
+    for (value.array.items, 0..) |item, index| {
+        if (item != .object) return error.InvalidContainerRegistryResponse;
+        const digest = try requiredOwnedString(allocator, item.object, "digest");
+        errdefer allocator.free(digest);
+        const architecture = try optionalOwnedString(
+            allocator,
+            item.object,
+            "architecture",
+        );
+        errdefer if (architecture) |field| allocator.free(field);
+        const operating_system = try optionalOwnedString(allocator, item.object, "os");
+        errdefer if (operating_system) |field| allocator.free(field);
+        artifacts[index] = .{
+            .allocator = allocator,
+            .digest = digest,
+            .architecture = architecture,
+            .operating_system = operating_system,
+        };
+        initialized += 1;
+    }
+    return artifacts;
+}
+
+fn parseStringArray(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    field: []const u8,
+) ![][]u8 {
+    const value = object.get(field) orelse return allocator.alloc([]u8, 0);
+    if (value == .null) return allocator.alloc([]u8, 0);
+    if (value != .array) return error.InvalidContainerRegistryResponse;
+
+    const items = try allocator.alloc([]u8, value.array.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (items[0..initialized]) |item| allocator.free(item);
+        allocator.free(items);
+    }
+    for (value.array.items, 0..) |item, index| {
+        if (item != .string) return error.InvalidContainerRegistryResponse;
+        items[index] = try allocator.dupe(u8, item.string);
+        initialized += 1;
+    }
+    return items;
+}
+
+fn parseChangeableProperties(value: std.json.Value) !ChangeableProperties {
+    if (value == .null) return .{};
+    if (value != .object) return error.InvalidContainerRegistryResponse;
+    return .{
+        .can_delete = try optionalBool(value.object, "deleteEnabled"),
+        .can_write = try optionalBool(value.object, "writeEnabled"),
+        .can_list = try optionalBool(value.object, "listEnabled"),
+        .can_read = try optionalBool(value.object, "readEnabled"),
+    };
+}
+
+fn parseJson(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch |err|
+        switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.InvalidContainerRegistryResponse,
+        };
+}
+
+fn requiredString(object: std.json.ObjectMap, field: []const u8) ![]const u8 {
+    const value = object.get(field) orelse return error.InvalidContainerRegistryResponse;
+    if (value != .string) return error.InvalidContainerRegistryResponse;
+    return value.string;
+}
+
+fn optionalString(
+    object: std.json.ObjectMap,
+    field: []const u8,
+) !?[]const u8 {
+    const value = object.get(field) orelse return null;
+    return switch (value) {
+        .null => null,
+        .string => |string| string,
+        else => error.InvalidContainerRegistryResponse,
+    };
+}
+
+fn requiredOwnedString(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    field: []const u8,
+) ![]u8 {
+    return allocator.dupe(u8, try requiredString(object, field));
+}
+
+fn optionalOwnedString(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    field: []const u8,
+) !?[]u8 {
+    const value = try optionalString(object, field);
+    return if (value) |string| try allocator.dupe(u8, string) else null;
+}
+
+fn requiredI32(object: std.json.ObjectMap, field: []const u8) !i32 {
+    const value = object.get(field) orelse return error.InvalidContainerRegistryResponse;
+    if (value != .integer) return error.InvalidContainerRegistryResponse;
+    return std.math.cast(i32, value.integer) orelse
+        error.InvalidContainerRegistryResponse;
+}
+
+fn optionalI64(object: std.json.ObjectMap, field: []const u8) !?i64 {
+    const value = object.get(field) orelse return null;
+    return switch (value) {
+        .null => null,
+        .integer => |integer| integer,
+        else => error.InvalidContainerRegistryResponse,
+    };
+}
+
+fn optionalBool(object: std.json.ObjectMap, field: []const u8) !?bool {
+    const value = object.get(field) orelse return null;
+    return switch (value) {
+        .null => null,
+        .bool => |boolean| boolean,
+        else => error.InvalidContainerRegistryResponse,
+    };
+}

--- a/sdk/container_registry/src/models.zig
+++ b/sdk/container_registry/src/models.zig
@@ -182,17 +182,20 @@ pub fn parseRepositoryPage(
     const parsed = try parseJson(allocator, body);
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidContainerRegistryResponse;
-    const repositories = parsed.value.object.get("repositories") orelse
-        return error.InvalidContainerRegistryResponse;
-    if (repositories != .array) return error.InvalidContainerRegistryResponse;
+    const repositories_value = parsed.value.object.get("repositories");
+    const repository_values = if (repositories_value) |value| switch (value) {
+        .null => &[_]std.json.Value{},
+        .array => |array| array.items,
+        else => return error.InvalidContainerRegistryResponse,
+    } else &[_]std.json.Value{};
 
-    const names = try allocator.alloc([]u8, repositories.array.items.len);
+    const names = try allocator.alloc([]u8, repository_values.len);
     var initialized: usize = 0;
     errdefer {
         for (names[0..initialized]) |name| allocator.free(name);
         allocator.free(names);
     }
-    for (repositories.array.items, 0..) |value, index| {
+    for (repository_values, 0..) |value, index| {
         if (value != .string) return error.InvalidContainerRegistryResponse;
         names[index] = try allocator.dupe(u8, value.string);
         initialized += 1;

--- a/sdk/container_registry/src/root.zig
+++ b/sdk/container_registry/src/root.zig
@@ -25,6 +25,7 @@ pub const TagPager = client.TagPager;
 pub const RepositoryPropertiesResult = client.RepositoryPropertiesResult;
 pub const ManifestPropertiesResult = client.ManifestPropertiesResult;
 pub const TagPropertiesResult = client.TagPropertiesResult;
+pub const DeleteOutcome = client.DeleteOutcome;
 pub const DeleteResult = client.DeleteResult;
 pub const ChangeableProperties = models.ChangeableProperties;
 pub const ContainerRepositoryProperties = models.ContainerRepositoryProperties;

--- a/sdk/container_registry/src/root.zig
+++ b/sdk/container_registry/src/root.zig
@@ -5,6 +5,8 @@ pub const protocol = @import("azure_rest_container_registry");
 const challenge = @import("challenge.zig");
 const auth = @import("auth_policy.zig");
 const client = @import("client.zig");
+const models = @import("models.zig");
+const service_error = @import("service_error.zig");
 
 pub const BearerChallenge = challenge.BearerChallenge;
 pub const parseBearerChallenge = challenge.parseBearerChallenge;
@@ -14,7 +16,32 @@ pub const ChallengeAuthenticationPolicyOptions = auth.Options;
 pub const TimeSource = auth.TimeSource;
 pub const ContainerRegistryClient = client.ContainerRegistryClient;
 pub const ContainerRegistryClientOptions = client.ContainerRegistryClientOptions;
+pub const ListRepositoriesOptions = client.ListRepositoriesOptions;
+pub const ListManifestPropertiesOptions = client.ListManifestPropertiesOptions;
+pub const ListTagPropertiesOptions = client.ListTagPropertiesOptions;
+pub const RepositoryPager = client.RepositoryPager;
+pub const ManifestPager = client.ManifestPager;
+pub const TagPager = client.TagPager;
+pub const RepositoryPropertiesResult = client.RepositoryPropertiesResult;
+pub const ManifestPropertiesResult = client.ManifestPropertiesResult;
+pub const TagPropertiesResult = client.TagPropertiesResult;
+pub const DeleteResult = client.DeleteResult;
+pub const ChangeableProperties = models.ChangeableProperties;
+pub const ContainerRepositoryProperties = models.ContainerRepositoryProperties;
+pub const ArtifactManifestPlatform = models.ArtifactManifestPlatform;
+pub const ArtifactManifestProperties = models.ArtifactManifestProperties;
+pub const ArtifactTagProperties = models.ArtifactTagProperties;
+pub const RepositoryPage = models.RepositoryPage;
+pub const ManifestPage = models.ManifestPage;
+pub const TagPage = models.TagPage;
+pub const ServiceErrorInfo = service_error.ServiceErrorInfo;
+pub const ServiceError = service_error.ServiceError;
+pub const ContainerRegistryServiceError = service_error.ServiceError;
+pub const Result = service_error.Result;
+pub const ArtifactManifestOrder = protocol.enums.ArtifactManifestOrder;
+pub const ArtifactTagOrder = protocol.enums.ArtifactTagOrder;
 
 test {
     @import("std").testing.refAllDecls(@This());
+    _ = @import("metadata_test.zig");
 }

--- a/sdk/container_registry/src/service_error.zig
+++ b/sdk/container_registry/src/service_error.zig
@@ -1,0 +1,234 @@
+const std = @import("std");
+const core = @import("azure_core");
+
+pub const ServiceErrorInfo = struct {
+    allocator: std.mem.Allocator,
+    code: ?[]u8,
+    message: ?[]u8,
+    detail: ?[]u8,
+
+    pub fn deinit(self: *ServiceErrorInfo) void {
+        if (self.code) |value| self.allocator.free(value);
+        if (self.message) |value| self.allocator.free(value);
+        if (self.detail) |value| self.allocator.free(value);
+        self.* = undefined;
+    }
+};
+
+pub const ServiceError = struct {
+    allocator: std.mem.Allocator,
+    status_code: u16,
+    code: ?[]u8,
+    message: ?[]u8,
+    detail: ?[]u8,
+    errors: []ServiceErrorInfo,
+    malformed: bool,
+    raw_body: ?[]u8,
+
+    pub fn fromResponse(
+        allocator: std.mem.Allocator,
+        response: *const core.http.Response,
+    ) !ServiceError {
+        const parsed = std.json.parseFromSlice(
+            std.json.Value,
+            allocator,
+            response.body,
+            .{},
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return err,
+            else => return malformedError(
+                allocator,
+                response.status_code,
+                response.body,
+            ),
+        };
+        defer parsed.deinit();
+        if (parsed.value != .object) {
+            return malformedError(allocator, response.status_code, response.body);
+        }
+        const error_values = parsed.value.object.get("errors") orelse
+            return malformedError(allocator, response.status_code, response.body);
+        if (error_values != .array) {
+            return malformedError(allocator, response.status_code, response.body);
+        }
+
+        var errors: std.ArrayList(ServiceErrorInfo) = .empty;
+        errdefer {
+            for (errors.items) |*item| item.deinit();
+            errors.deinit(allocator);
+        }
+        for (error_values.array.items) |value| {
+            var item = parseErrorInfo(allocator, value) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                error.InvalidContainerRegistryError => {
+                    const malformed = try malformedError(
+                        allocator,
+                        response.status_code,
+                        response.body,
+                    );
+                    for (errors.items) |*existing| existing.deinit();
+                    errors.deinit(allocator);
+                    return malformed;
+                },
+            };
+            errdefer item.deinit();
+            try errors.append(allocator, item);
+        }
+        const owned_errors = try errors.toOwnedSlice(allocator);
+        errdefer {
+            for (owned_errors) |*item| item.deinit();
+            allocator.free(owned_errors);
+        }
+        const first = if (owned_errors.len > 0) &owned_errors[0] else null;
+        const code = if (first) |item| if (item.code) |value|
+            try allocator.dupe(u8, value)
+        else
+            null else null;
+        errdefer if (code) |value| allocator.free(value);
+        const message = if (first) |item| if (item.message) |value|
+            try allocator.dupe(u8, value)
+        else
+            null else null;
+        errdefer if (message) |value| allocator.free(value);
+        const detail = if (first) |item| if (item.detail) |value|
+            try allocator.dupe(u8, value)
+        else
+            null else null;
+        return .{
+            .allocator = allocator,
+            .status_code = response.status_code,
+            .code = code,
+            .message = message,
+            .detail = detail,
+            .errors = owned_errors,
+            .malformed = false,
+            .raw_body = null,
+        };
+    }
+
+    pub fn deinit(self: *ServiceError) void {
+        if (self.code) |value| self.allocator.free(value);
+        if (self.message) |value| self.allocator.free(value);
+        if (self.detail) |value| self.allocator.free(value);
+        for (self.errors) |*item| item.deinit();
+        self.allocator.free(self.errors);
+        if (self.raw_body) |body| self.allocator.free(body);
+        self.* = undefined;
+    }
+
+    pub fn isNotFound(self: ServiceError) bool {
+        return self.status_code == 404;
+    }
+
+    pub fn isCode(self: ServiceError, code: []const u8) bool {
+        for (self.errors) |item| {
+            if (item.code) |value| {
+                if (std.ascii.eqlIgnoreCase(value, code)) return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn format(self: ServiceError, writer: anytype) !void {
+        try writer.print("ContainerRegistryServiceError(status={d}", .{self.status_code});
+        if (self.code) |value| try writer.print(", code={s}", .{value});
+        if (self.message) |value| try writer.print(", message={s}", .{value});
+        if (self.malformed) try writer.writeAll(", malformed=true");
+        try writer.writeAll(")");
+    }
+};
+
+pub fn Result(comptime T: type) type {
+    return union(enum) {
+        ok: T,
+        err: ServiceError,
+
+        const Self = @This();
+
+        pub fn deinit(self: *Self) void {
+            switch (self.*) {
+                .ok => |*value| {
+                    if (comptime hasDeinit(T)) value.deinit();
+                },
+                .err => |*service_error| service_error.deinit(),
+            }
+            self.* = undefined;
+        }
+
+        pub fn isOk(self: Self) bool {
+            return self == .ok;
+        }
+    };
+}
+
+fn parseErrorInfo(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) (error{ OutOfMemory, InvalidContainerRegistryError })!ServiceErrorInfo {
+    if (value != .object) return error.InvalidContainerRegistryError;
+    const code = try optionalOwnedString(allocator, value.object, "code");
+    errdefer if (code) |field| allocator.free(field);
+    const message = try optionalOwnedString(allocator, value.object, "message");
+    errdefer if (message) |field| allocator.free(field);
+    const detail = if (value.object.get("detail")) |field|
+        try stringifyDetail(allocator, field)
+    else
+        null;
+    return .{
+        .allocator = allocator,
+        .code = code,
+        .message = message,
+        .detail = detail,
+    };
+}
+
+fn optionalOwnedString(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    field: []const u8,
+) (error{ OutOfMemory, InvalidContainerRegistryError })!?[]u8 {
+    const value = object.get(field) orelse return null;
+    return switch (value) {
+        .null => null,
+        .string => |string| try allocator.dupe(u8, string),
+        else => error.InvalidContainerRegistryError,
+    };
+}
+
+fn stringifyDetail(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) (error{OutOfMemory})!?[]u8 {
+    if (value == .null) return null;
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    var stringify = std.json.Stringify{ .writer = &output.writer };
+    stringify.write(value) catch return error.OutOfMemory;
+    return @as(?[]u8, try output.toOwnedSlice());
+}
+
+fn malformedError(
+    allocator: std.mem.Allocator,
+    status_code: u16,
+    body: []const u8,
+) !ServiceError {
+    const raw_body = try allocator.dupe(u8, body);
+    errdefer allocator.free(raw_body);
+    return .{
+        .allocator = allocator,
+        .status_code = status_code,
+        .code = null,
+        .message = null,
+        .detail = null,
+        .errors = try allocator.alloc(ServiceErrorInfo, 0),
+        .malformed = true,
+        .raw_body = raw_body,
+    };
+}
+
+fn hasDeinit(comptime T: type) bool {
+    if (@typeInfo(T) != .@"struct") return false;
+    if (!@hasDecl(T, "deinit")) return false;
+    const info = @typeInfo(@TypeOf(T.deinit));
+    return info == .@"fn" and info.@"fn".params.len == 1;
+}


### PR DESCRIPTION
Adds allocator-owned repository, manifest, and tag metadata operations; secure RFC 8288 Link pagination; structured ACR service errors; and idempotent delete outcomes.

Closes #85