### PR TITLE
sdk/container_registry: add resumable blob uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 
 | Package | Clients |
 |---------|---------|
-| `azure_sdk_container_registry` | `ContainerRegistryClient` with ACR challenge authentication; generated APIs under `protocol` |
+| `azure_sdk_container_registry` | `ContainerRegistryClient` and `ContainerRegistryContentClient` with ACR auth, manifests, and resumable blob upload; generated APIs under `protocol` |
 | `azure_storage_blobs` | `BlobClient`, `BlobContainerClient`, `SasBlobClient` |
 | `azure_storage_queues` | `QueueClient`, `QueueServiceClient`, `SasQueueClient` |
 | `azure_storage_files_shares` | `ShareClient`, `ShareDirectoryClient`, `ShareFileClient` |

--- a/codegen/fixtures/container_registry_test.zig
+++ b/codegen/fixtures/container_registry_test.zig
@@ -422,7 +422,11 @@ test "Container Registry golden preserves protocol fidelity" {
     try testing.expect(std.mem.indexOf(u8, clients, "status_404: struct") != null);
     try testing.expect(std.mem.indexOf(u8, clients, "status_206: struct") != null);
     try testing.expect(std.mem.indexOf(u8, clients, "pub const CancelUploadResult") == null);
-    try testing.expect(std.mem.indexOf(u8, clients, "pub fn cancelUpload(") != null);
+    const cancel_start = std.mem.indexOf(u8, clients, "pub fn cancelUpload(").?;
+    const cancel_end = std.mem.indexOfPos(u8, clients, cancel_start, "pub fn startUpload(").?;
+    const cancel_operation = clients[cancel_start..cancel_end];
+    try testing.expect(std.mem.indexOf(u8, cancel_operation, "req.body") == null);
+    try testing.expect(std.mem.indexOf(u8, cancel_operation, "req.setHeader") == null);
     try testing.expect(std.mem.indexOf(u8, clients, "const response_body = try bufferRawResponseBody(alloc, resp.body);") != null);
 
     const models = try emitter.renderModels(allocator, parsed.value);

--- a/codegen/fixtures/generate_container_registry_package.zig
+++ b/codegen/fixtures/generate_container_registry_package.zig
@@ -154,7 +154,7 @@ const generated_tests =
     \\            },
     \\            .cancel => .{
     \\                204,
-    \\                try self.allocator.alloc(u8, 0),
+    \\                try self.cancelResponse(request),
     \\            },
     \\        };
     \\        return .{
@@ -209,6 +209,14 @@ const generated_tests =
     \\            std.mem.indexOf(u8, request.body.?, "access_token") != null,
     \\        );
     \\        return self.allocator.dupe(u8, "{\"refresh_token\":\"token\"}");
+    \\    }
+    \\
+    \\    fn cancelResponse(self: *@This(), request: *core.http.Request) ![]u8 {
+    \\        try std.testing.expectEqual(core.http.Method.DELETE, request.method);
+    \\        try std.testing.expect(request.body == null);
+    \\        try std.testing.expect(request.getHeader("Content-Length") == null);
+    \\        try std.testing.expect(request.getHeader("Transfer-Encoding") == null);
+    \\        return self.allocator.alloc(u8, 0);
     \\    }
     \\};
     \\

--- a/rest/container_registry/src/clients_test.zig
+++ b/rest/container_registry/src/clients_test.zig
@@ -85,7 +85,7 @@ const Mock = struct {
             },
             .cancel => .{
                 204,
-                try self.allocator.alloc(u8, 0),
+                try self.cancelResponse(request),
             },
         };
         return .{
@@ -140,6 +140,14 @@ const Mock = struct {
             std.mem.indexOf(u8, request.body.?, "access_token") != null,
         );
         return self.allocator.dupe(u8, "{\"refresh_token\":\"token\"}");
+    }
+
+    fn cancelResponse(self: *@This(), request: *core.http.Request) ![]u8 {
+        try std.testing.expectEqual(core.http.Method.DELETE, request.method);
+        try std.testing.expect(request.body == null);
+        try std.testing.expect(request.getHeader("Content-Length") == null);
+        try std.testing.expect(request.getHeader("Transfer-Encoding") == null);
+        return self.allocator.alloc(u8, 0);
     }
 };
 

--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -2,8 +2,8 @@
 
 `azure_sdk_container_registry` adds secure ACR challenge authentication,
 token caching, metadata operations, Link-header paging, structured service
-errors, and exact-byte manifest content operations to the generated
-`azure_rest_container_registry` protocol package.
+errors, exact-byte manifests, and bounded-memory resumable blob uploads to the
+generated `azure_rest_container_registry` protocol package.
 
 ```zig
 const acr = @import("azure_sdk_container_registry");
@@ -100,6 +100,15 @@ defer downloaded.deinit(allocator);
 const delete_outcome = try content.deleteManifest(uploaded.digest);
 // Both .accepted and .not_found are successful, idempotent outcomes.
 _ = delete_outcome;
+
+var blob_reader = std.Io.Reader.fixed(blob_bytes);
+var blob = try content.uploadBlob(&blob_reader, .{
+    // Defaults to 4 MiB and is the maximum upload buffer allocation.
+    .chunk_size = 8 * 1024 * 1024,
+    .cancellation = cancellation,
+});
+defer blob.deinit();
+// blob.digest, blob.location, and blob.size are owned result values.
 ```
 
 Manifest bytes are never parsed or reserialized. Upload and download validate
@@ -108,6 +117,21 @@ both directions enforce the 4 MiB manifest limit. Omitting the upload
 reference uses the computed digest; deletes require a digest. Download limits
 apply to decoded bytes; `Content-Length` is exact only for identity responses.
 The `*Result` variants preserve structured ACR service errors.
+
+Blob uploads start a resumable session, send sequential inclusive
+`Content-Range` chunks with exact `Content-Length`, then complete using the
+incrementally computed SHA-256 digest. Seekable and non-seekable readers are
+supported without buffering more than one configured chunk. Retryable
+pre-transport failures replay the buffered chunk; uncertain transport outcomes
+first query upload status and resume only from the strictly validated confirmed
+offset. Every continuation `Location` must remain HTTPS on the original
+registry origin, including its effective port. Upload failures cancel the
+session, final service digests are validated, and cancellation remains an outer
+`error.OperationCancelled`.
+
+Use `uploadBlobResult` when structured service errors are required. Generated
+mount, upload-status, and cancel operations remain available through
+`client.protocolClient().containerRegistryBlob()` and `acr.protocol`.
 
 Long-lived clients use bounded LRU caches: 128 routes, 128 scoped access
 tokens, and 32 refresh tokens. Tokens that reach the configured expiry skew

--- a/sdk/container_registry/src/blob_upload.zig
+++ b/sdk/container_registry/src/blob_upload.zig
@@ -790,7 +790,6 @@ fn cleanupUpload(context: UploadContext, session: *Session) !void {
     var request = core.http.Request.init(context.allocator, .DELETE, request_url);
     defer request.deinit();
     request.redirect_policy = .not_allowed;
-    try request.setHeader("Content-Length", "0");
 
     var operation = try context.pipeline.open(&request, .{});
     defer operation.deinit();
@@ -804,7 +803,7 @@ fn failAfterCleanup(
     session: *Session,
     failure: anyerror,
 ) anyerror!BlobUploadResponse {
-    cleanupUpload(context, session) catch |cleanup_error| return cleanup_error;
+    cleanupUpload(context, session) catch {};
     return failure;
 }
 
@@ -813,12 +812,8 @@ fn serviceFailureAfterCleanup(
     session: *Session,
     failure_value: service_error.ServiceError,
 ) !BlobUploadResponse {
-    var failure = failure_value;
-    cleanupUpload(context, session) catch |cleanup_error| {
-        failure.deinit();
-        return cleanup_error;
-    };
-    return .{ .err = failure };
+    cleanupUpload(context, session) catch {};
+    return .{ .err = failure_value };
 }
 
 fn buildStartUrl(context: UploadContext) ![]u8 {
@@ -1117,4 +1112,104 @@ fn isRetryablePreTransportError(failure: anyerror) bool {
         => false,
         else => true,
     };
+}
+
+const CleanupTestServer = struct {
+    io: std.Io,
+    server: *std.Io.net.Server,
+    saw_delete: bool = false,
+    saw_content_length: bool = false,
+    saw_transfer_encoding: bool = false,
+    failure: ?anyerror = null,
+
+    fn run(self: *CleanupTestServer) void {
+        self.serve() catch |err| {
+            self.failure = err;
+        };
+    }
+
+    fn serve(self: *CleanupTestServer) !void {
+        const stream = try self.server.accept(self.io);
+        defer stream.close(self.io);
+        var read_buffer: [1024]u8 = undefined;
+        var reader = std.Io.net.Stream.Reader.init(stream, self.io, &read_buffer);
+        var write_buffer: [512]u8 = undefined;
+        var writer = std.Io.net.Stream.Writer.init(stream, self.io, &write_buffer);
+
+        const request_line = (reader.interface.takeDelimiter('\n') catch
+            return error.ServerHeaderReadFailed) orelse
+            return error.ServerHeaderReadFailed;
+        self.saw_delete = std.mem.startsWith(u8, request_line, "DELETE ");
+        while (true) {
+            const raw_line = (reader.interface.takeDelimiter('\n') catch
+                return error.ServerHeaderReadFailed) orelse
+                return error.ServerHeaderReadFailed;
+            const line = std.mem.trimEnd(u8, raw_line, "\r");
+            if (line.len == 0) break;
+            if (std.ascii.startsWithIgnoreCase(line, "content-length:"))
+                self.saw_content_length = true;
+            if (std.ascii.startsWithIgnoreCase(line, "transfer-encoding:"))
+                self.saw_transfer_encoding = true;
+        }
+
+        try writer.interface.writeAll(
+            "HTTP/1.1 500 Internal Server Error\r\n" ++
+                "Content-Length: 0\r\n" ++
+                "Connection: close\r\n\r\n",
+        );
+        try writer.interface.flush();
+    }
+};
+
+test "cleanup uses standard bodiless DELETE framing and reports its own failure" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    var address: std.Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var server = try address.listen(io, .{ .reuse_address = true });
+    var server_active = true;
+    defer if (server_active) server.deinit(io);
+    var server_context = CleanupTestServer{
+        .io = io,
+        .server = &server,
+    };
+    const endpoint = try std.fmt.allocPrint(
+        allocator,
+        "http://127.0.0.1:{d}",
+        .{server.socket.address.getPort()},
+    );
+    defer allocator.free(endpoint);
+    const location = try std.fmt.allocPrint(
+        allocator,
+        "{s}/v2/team/app/blobs/uploads/id",
+        .{endpoint},
+    );
+    var session = Session{
+        .allocator = allocator,
+        .location = location,
+        .upload_uuid = try allocator.dupe(u8, "id"),
+    };
+    defer session.deinit();
+    var transport = core.http.StdHttpTransport.init(allocator, io);
+    defer transport.deinit();
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+
+    const thread = try std.Thread.spawn(.{}, CleanupTestServer.run, .{&server_context});
+    const cleanup_result = cleanupUpload(.{
+        .allocator = allocator,
+        .pipeline = &pipeline,
+        .endpoint = endpoint,
+        .api_version = "2021-07-01",
+        .repository_name = "team/app",
+    }, &session);
+    server.deinit(io);
+    server_active = false;
+    thread.join();
+    if (server_context.failure) |failure| return failure;
+    try std.testing.expectError(error.UploadCleanupFailed, cleanup_result);
+    try std.testing.expect(server_context.saw_delete);
+    try std.testing.expect(!server_context.saw_content_length);
+    try std.testing.expect(!server_context.saw_transfer_encoding);
 }

--- a/sdk/container_registry/src/blob_upload.zig
+++ b/sdk/container_registry/src/blob_upload.zig
@@ -1,0 +1,1120 @@
+const std = @import("std");
+const core = @import("azure_core");
+const digest_mod = @import("digest.zig");
+const service_error = @import("service_error.zig");
+
+pub const default_chunk_size: usize = 4 * 1024 * 1024;
+pub const max_chunk_size: usize = 100 * 1024 * 1024;
+const max_location_length: usize = 8 * 1024;
+const max_upload_uuid_length: usize = 1024;
+const max_error_body_length: usize = 64 * 1024;
+
+pub const BlobUploadOptions = struct {
+    /// Maximum bytes buffered and sent in one PATCH request. Valid values are
+    /// `1..max_chunk_size`.
+    chunk_size: usize = default_chunk_size,
+    /// Retries after an initial retryable failure.
+    max_retries: u32 = 3,
+    cancellation: ?*const core.http.CancellationToken = null,
+};
+
+pub const BlobUploadResult = struct {
+    allocator: std.mem.Allocator,
+    digest: []u8,
+    location: []u8,
+    size: u64,
+
+    pub fn deinit(self: *BlobUploadResult) void {
+        self.allocator.free(self.digest);
+        self.allocator.free(self.location);
+        self.* = undefined;
+    }
+};
+
+pub const BlobUploadResponse = service_error.Result(BlobUploadResult);
+
+pub const UploadContext = struct {
+    allocator: std.mem.Allocator,
+    pipeline: *core.pipeline.HttpPipeline,
+    endpoint: []const u8,
+    api_version: []const u8,
+    repository_name: []const u8,
+};
+
+pub fn upload(
+    context: UploadContext,
+    reader: *std.Io.Reader,
+    options: BlobUploadOptions,
+) !BlobUploadResponse {
+    try validateOptions(options);
+    try checkCancelled(options.cancellation);
+
+    const buffer = try context.allocator.alloc(u8, options.chunk_size);
+    defer context.allocator.free(buffer);
+
+    var start_result = try startUpload(context, options);
+    switch (start_result) {
+        .err => |failure| return .{ .err = failure },
+        .ok => |*session_value| {
+            var session = session_value.*;
+            start_result = undefined;
+            defer session.deinit();
+
+            var digest = digest_mod.Sha256Digest{};
+            var total: u64 = 0;
+            while (true) {
+                checkCancelled(options.cancellation) catch |err| {
+                    return failAfterCleanup(context, &session, err);
+                };
+                const count = readChunk(
+                    reader,
+                    buffer,
+                    options.cancellation,
+                ) catch |err| {
+                    return failAfterCleanup(context, &session, err);
+                };
+                if (count == 0) break;
+                if (count > std.math.maxInt(u64) - total)
+                    return failAfterCleanup(
+                        context,
+                        &session,
+                        error.BlobUploadTooLarge,
+                    );
+
+                const chunk_result = uploadChunk(
+                    context,
+                    &session,
+                    buffer[0..count],
+                    total,
+                    &digest,
+                    options,
+                ) catch |err| {
+                    return failAfterCleanup(context, &session, err);
+                };
+                switch (chunk_result) {
+                    .ok => {},
+                    .err => |failure| {
+                        return serviceFailureAfterCleanup(
+                            context,
+                            &session,
+                            failure,
+                        );
+                    },
+                }
+                total += count;
+            }
+
+            const computed_digest = digest.final();
+            const completion_result = completeUpload(
+                context,
+                &session,
+                &computed_digest,
+                total,
+                options,
+            ) catch |err| {
+                return failAfterCleanup(context, &session, err);
+            };
+            switch (completion_result) {
+                .err => |failure| {
+                    return serviceFailureAfterCleanup(
+                        context,
+                        &session,
+                        failure,
+                    );
+                },
+                .ok => |completion| {
+                    errdefer context.allocator.free(completion.location);
+                    const owned_digest = try context.allocator.dupe(
+                        u8,
+                        &computed_digest,
+                    );
+                    errdefer context.allocator.free(owned_digest);
+                    return .{ .ok = .{
+                        .allocator = context.allocator,
+                        .digest = owned_digest,
+                        .location = completion.location,
+                        .size = total,
+                    } };
+                },
+            }
+        },
+    }
+}
+
+const Session = struct {
+    allocator: std.mem.Allocator,
+    location: []u8,
+    upload_uuid: []u8,
+    confirmed_offset: u64 = 0,
+
+    fn deinit(self: *Session) void {
+        self.allocator.free(self.location);
+        self.allocator.free(self.upload_uuid);
+        self.* = undefined;
+    }
+
+    fn replaceLocation(self: *Session, location: []u8) void {
+        self.allocator.free(self.location);
+        self.location = location;
+    }
+};
+
+const Completion = struct {
+    location: []u8,
+};
+
+fn Step(comptime T: type) type {
+    return union(enum) {
+        ok: T,
+        err: service_error.ServiceError,
+    };
+}
+
+fn validateOptions(options: BlobUploadOptions) !void {
+    if (options.chunk_size == 0) return error.InvalidBlobUploadChunkSize;
+    if (options.chunk_size > max_chunk_size)
+        return error.InvalidBlobUploadChunkSize;
+}
+
+fn checkCancelled(cancellation: ?*const core.http.CancellationToken) !void {
+    if (cancellation) |token| {
+        if (token.isCancelled()) return error.OperationCancelled;
+    }
+}
+
+fn readChunk(
+    reader: *std.Io.Reader,
+    buffer: []u8,
+    cancellation: ?*const core.http.CancellationToken,
+) !usize {
+    var total: usize = 0;
+    while (total < buffer.len) {
+        try checkCancelled(cancellation);
+        const count = try reader.readSliceShort(buffer[total..]);
+        try checkCancelled(cancellation);
+        if (count == 0) break;
+        total += count;
+    }
+    return total;
+}
+
+fn startUpload(
+    context: UploadContext,
+    options: BlobUploadOptions,
+) !Step(Session) {
+    const url = try buildStartUrl(context);
+    defer context.allocator.free(url);
+    var request = core.http.Request.init(context.allocator, .POST, url);
+    defer request.deinit();
+    request.retryable = false;
+    request.redirect_policy = .not_allowed;
+    try request.setHeader("Content-Length", "0");
+
+    var operation = context.pipeline.open(
+        &request,
+        .{ .cancellation = options.cancellation },
+    ) catch |err| {
+        if (request.transport_started) return error.UploadStartOutcomeUnknown;
+        return err;
+    };
+    defer operation.deinit();
+    if (operation.status_code != 202) {
+        if (operation.isSuccess()) return error.UnexpectedResponseStatus;
+        return .{ .err = try serviceErrorFromOperation(context, operation) };
+    }
+
+    const raw_location = try requiredHeader(
+        context.allocator,
+        operation,
+        "Location",
+        error.MissingUploadLocation,
+    );
+    const range = try requiredHeader(
+        context.allocator,
+        operation,
+        "Range",
+        error.MissingUploadRange,
+    );
+    const upload_uuid = try requiredHeader(
+        context.allocator,
+        operation,
+        "Docker-Upload-UUID",
+        error.MissingUploadUuid,
+    );
+    if (upload_uuid.len > max_upload_uuid_length)
+        return error.UploadUuidTooLong;
+    try validateInitialRange(range);
+    const location = try resolveUploadLocation(
+        context.allocator,
+        context.endpoint,
+        url,
+        raw_location,
+    );
+    errdefer context.allocator.free(location);
+    const owned_uuid = try context.allocator.dupe(u8, upload_uuid);
+    errdefer context.allocator.free(owned_uuid);
+    try operation.finish();
+    return .{ .ok = .{
+        .allocator = context.allocator,
+        .location = location,
+        .upload_uuid = owned_uuid,
+    } };
+}
+
+fn uploadChunk(
+    context: UploadContext,
+    session: *Session,
+    chunk: []const u8,
+    chunk_start: u64,
+    digest: *digest_mod.Sha256Digest,
+    options: BlobUploadOptions,
+) !Step(void) {
+    if (session.confirmed_offset != chunk_start)
+        return error.ServerUploadOffsetDiverged;
+    const chunk_length: u64 = @intCast(chunk.len);
+    const chunk_end = std.math.add(u64, chunk_start, chunk_length) catch
+        return error.BlobUploadTooLarge;
+    var cursor: usize = 0;
+    var retry_count: u32 = 0;
+
+    while (cursor < chunk.len) {
+        try checkCancelled(options.cancellation);
+        const attempt_start = session.confirmed_offset;
+        const attempt = chunk[cursor..];
+        const attempt_end = std.math.add(
+            u64,
+            attempt_start,
+            @as(u64, @intCast(attempt.len)),
+        ) catch return error.BlobUploadTooLarge;
+        const digest_snapshot = digest.*;
+        const cursor_snapshot = cursor;
+        digest.update(attempt);
+
+        const request_url = try buildContinuationUrl(
+            context,
+            session.location,
+            null,
+        );
+        defer context.allocator.free(request_url);
+        var request = core.http.Request.init(
+            context.allocator,
+            .PATCH,
+            request_url,
+        );
+        defer request.deinit();
+        request.retryable = false;
+        request.redirect_policy = .not_allowed;
+        try request.setHeader("Content-Type", "application/octet-stream");
+        var content_length_buffer: [32]u8 = undefined;
+        const content_length = try std.fmt.bufPrint(
+            &content_length_buffer,
+            "{d}",
+            .{attempt.len},
+        );
+        try request.setHeader("Content-Length", content_length);
+        var content_range_buffer: [64]u8 = undefined;
+        const content_range = try std.fmt.bufPrint(
+            &content_range_buffer,
+            "{d}-{d}",
+            .{ attempt_start, attempt_end - 1 },
+        );
+        try request.setHeader("Content-Range", content_range);
+        var replayable = core.http.ReplayableBytes.init(attempt);
+
+        var operation = context.pipeline.open(
+            &request,
+            .{
+                .body = replayable.body(),
+                .cancellation = options.cancellation,
+            },
+        ) catch |err| {
+            digest.* = digest_snapshot;
+            cursor = cursor_snapshot;
+            if (err == error.OperationCancelled) return err;
+            if (!request.transport_started) {
+                if (!isRetryablePreTransportError(err) or
+                    retry_count >= options.max_retries)
+                {
+                    return err;
+                }
+                retry_count += 1;
+                continue;
+            }
+
+            const recovery = try recoverUploadStatus(
+                context,
+                session,
+                attempt_end,
+                false,
+                options,
+            );
+            switch (recovery) {
+                .err => |failure| return .{ .err = failure },
+                .lost => return error.UploadSessionLost,
+                .offset => |offset| {
+                    const progressed = try applyRecoveredOffset(
+                        session,
+                        chunk,
+                        chunk_start,
+                        &cursor,
+                        digest,
+                        offset,
+                    );
+                    if (session.confirmed_offset == chunk_end)
+                        return .{ .ok = {} };
+                    if (progressed) {
+                        retry_count = 0;
+                    } else {
+                        if (retry_count >= options.max_retries)
+                            return error.BlobUploadRetryExhausted;
+                        retry_count += 1;
+                    }
+                    continue;
+                },
+            }
+        };
+        defer operation.deinit();
+
+        if (operation.status_code == 202) {
+            const response_offset = try responseUploadOffset(
+                context.allocator,
+                operation,
+                false,
+            );
+            if (response_offset != attempt_end)
+                return error.ServerUploadOffsetDiverged;
+            try validateUploadUuid(
+                context.allocator,
+                operation,
+                session.upload_uuid,
+            );
+            const next_location = try responseUploadLocation(
+                context,
+                operation,
+                request_url,
+            );
+            errdefer context.allocator.free(next_location);
+            try operation.finish();
+            session.replaceLocation(next_location);
+            session.confirmed_offset = response_offset;
+            cursor = chunk.len;
+            return .{ .ok = {} };
+        }
+
+        digest.* = digest_snapshot;
+        cursor = cursor_snapshot;
+        if (operation.status_code == 416) {
+            const range = try requiredHeader(
+                context.allocator,
+                operation,
+                "Range",
+                error.MissingUploadRange,
+            );
+            const response_offset = try parseStatusRange(
+                range,
+                session.confirmed_offset,
+                attempt_end,
+                false,
+            );
+            try validateUploadUuid(
+                context.allocator,
+                operation,
+                session.upload_uuid,
+            );
+            const next_location = try responseUploadLocation(
+                context,
+                operation,
+                request_url,
+            );
+            errdefer context.allocator.free(next_location);
+            try operation.finish();
+            session.replaceLocation(next_location);
+            const progressed = try applyRecoveredOffset(
+                session,
+                chunk,
+                chunk_start,
+                &cursor,
+                digest,
+                response_offset,
+            );
+            if (session.confirmed_offset == chunk_end)
+                return .{ .ok = {} };
+            if (progressed) {
+                retry_count = 0;
+            } else {
+                if (retry_count >= options.max_retries)
+                    return error.BlobUploadRetryExhausted;
+                retry_count += 1;
+            }
+            continue;
+        }
+        if (isRetryableStatus(operation.status_code)) {
+            operation.abort();
+            const recovery = try recoverUploadStatus(
+                context,
+                session,
+                attempt_end,
+                false,
+                options,
+            );
+            switch (recovery) {
+                .err => |failure| return .{ .err = failure },
+                .lost => return error.UploadSessionLost,
+                .offset => |offset| {
+                    const progressed = try applyRecoveredOffset(
+                        session,
+                        chunk,
+                        chunk_start,
+                        &cursor,
+                        digest,
+                        offset,
+                    );
+                    if (session.confirmed_offset == chunk_end)
+                        return .{ .ok = {} };
+                    if (progressed) {
+                        retry_count = 0;
+                    } else {
+                        if (retry_count >= options.max_retries)
+                            return error.BlobUploadRetryExhausted;
+                        retry_count += 1;
+                    }
+                    continue;
+                },
+            }
+        }
+        if (operation.isSuccess()) return error.UnexpectedResponseStatus;
+        return .{ .err = try serviceErrorFromOperation(context, operation) };
+    }
+    return .{ .ok = {} };
+}
+
+fn applyRecoveredOffset(
+    session: *Session,
+    chunk: []const u8,
+    chunk_start: u64,
+    cursor: *usize,
+    digest: *digest_mod.Sha256Digest,
+    recovered_offset: u64,
+) !bool {
+    const current_offset = std.math.add(
+        u64,
+        chunk_start,
+        @as(u64, @intCast(cursor.*)),
+    ) catch return error.BlobUploadTooLarge;
+    const chunk_end = std.math.add(
+        u64,
+        chunk_start,
+        @as(u64, @intCast(chunk.len)),
+    ) catch return error.BlobUploadTooLarge;
+    if (recovered_offset < current_offset or recovered_offset > chunk_end)
+        return error.ServerUploadOffsetDiverged;
+    const delta: usize = @intCast(recovered_offset - current_offset);
+    if (delta > 0) {
+        digest.update(chunk[cursor.* .. cursor.* + delta]);
+        cursor.* += delta;
+    }
+    session.confirmed_offset = recovered_offset;
+    return delta > 0;
+}
+
+const Recovery = union(enum) {
+    offset: u64,
+    lost,
+    err: service_error.ServiceError,
+};
+
+fn recoverUploadStatus(
+    context: UploadContext,
+    session: *Session,
+    attempted_end: u64,
+    completion: bool,
+    options: BlobUploadOptions,
+) !Recovery {
+    var retry_count: u32 = 0;
+    while (true) {
+        try checkCancelled(options.cancellation);
+        const request_url = try buildContinuationUrl(
+            context,
+            session.location,
+            null,
+        );
+        defer context.allocator.free(request_url);
+        var request = core.http.Request.init(context.allocator, .GET, request_url);
+        defer request.deinit();
+        request.redirect_policy = .not_allowed;
+
+        var operation = context.pipeline.open(
+            &request,
+            .{ .cancellation = options.cancellation },
+        ) catch |err| {
+            if (err == error.OperationCancelled) return err;
+            if (retry_count >= options.max_retries) return err;
+            retry_count += 1;
+            continue;
+        };
+        defer operation.deinit();
+        if (operation.status_code == 204) {
+            try validateUploadUuid(
+                context.allocator,
+                operation,
+                session.upload_uuid,
+            );
+            const range = try requiredHeader(
+                context.allocator,
+                operation,
+                "Range",
+                error.MissingUploadRange,
+            );
+            const offset = try parseStatusRange(
+                range,
+                session.confirmed_offset,
+                attempted_end,
+                completion,
+            );
+            if (offset < session.confirmed_offset or offset > attempted_end)
+                return error.ServerUploadOffsetDiverged;
+            if (try optionalHeader(
+                context.allocator,
+                operation,
+                "Location",
+            )) |raw_location| {
+                const next_location = try resolveUploadLocation(
+                    context.allocator,
+                    context.endpoint,
+                    request_url,
+                    raw_location,
+                );
+                errdefer context.allocator.free(next_location);
+                try operation.finish();
+                session.replaceLocation(next_location);
+            } else {
+                try operation.finish();
+            }
+            return .{ .offset = offset };
+        }
+        if (operation.status_code == 404) {
+            try operation.finish();
+            return .lost;
+        }
+        if (isRetryableStatus(operation.status_code) and
+            retry_count < options.max_retries)
+        {
+            retry_count += 1;
+            continue;
+        }
+        if (operation.isSuccess()) return error.UnexpectedResponseStatus;
+        return .{ .err = try serviceErrorFromOperation(context, operation) };
+    }
+}
+
+fn completeUpload(
+    context: UploadContext,
+    session: *Session,
+    digest: []const u8,
+    total: u64,
+    options: BlobUploadOptions,
+) !Step(Completion) {
+    if (session.confirmed_offset != total)
+        return error.ServerUploadOffsetDiverged;
+    var retry_count: u32 = 0;
+    while (true) {
+        try checkCancelled(options.cancellation);
+        const request_url = try buildContinuationUrl(
+            context,
+            session.location,
+            digest,
+        );
+        defer context.allocator.free(request_url);
+        var request = core.http.Request.init(context.allocator, .PUT, request_url);
+        defer request.deinit();
+        request.retryable = false;
+        request.redirect_policy = .not_allowed;
+        try request.setHeader("Content-Length", "0");
+
+        var operation = context.pipeline.open(
+            &request,
+            .{ .cancellation = options.cancellation },
+        ) catch |err| {
+            if (err == error.OperationCancelled) return err;
+            if (!request.transport_started) {
+                if (!isRetryablePreTransportError(err) or
+                    retry_count >= options.max_retries)
+                {
+                    return err;
+                }
+                retry_count += 1;
+                continue;
+            }
+            const recovery = try recoverUploadStatus(
+                context,
+                session,
+                total,
+                true,
+                options,
+            );
+            switch (recovery) {
+                .err => |failure| return .{ .err = failure },
+                .offset => |offset| {
+                    if (offset != total)
+                        return error.ServerUploadOffsetDiverged;
+                    if (retry_count >= options.max_retries)
+                        return error.BlobUploadRetryExhausted;
+                    retry_count += 1;
+                    continue;
+                },
+                .lost => return verifyCompletedBlob(
+                    context,
+                    digest,
+                    total,
+                    options,
+                ),
+            }
+        };
+        defer operation.deinit();
+        if (operation.status_code == 201) {
+            const returned_digest = try requiredHeader(
+                context.allocator,
+                operation,
+                "Docker-Content-Digest",
+                error.MissingDockerContentDigest,
+            );
+            try digest_mod.validateSha256Digest(returned_digest);
+            if (!(try digest_mod.sha256DigestsEqual(digest, returned_digest)))
+                return error.DigestMismatch;
+            const range = try requiredHeader(
+                context.allocator,
+                operation,
+                "Range",
+                error.MissingUploadRange,
+            );
+            try validateCompletionRange(range, total);
+            const final_location = try responseUploadLocation(
+                context,
+                operation,
+                request_url,
+            );
+            errdefer context.allocator.free(final_location);
+            try operation.finish();
+            return .{ .ok = .{
+                .location = final_location,
+            } };
+        }
+        if (isRetryableStatus(operation.status_code)) {
+            operation.abort();
+            const recovery = try recoverUploadStatus(
+                context,
+                session,
+                total,
+                true,
+                options,
+            );
+            switch (recovery) {
+                .err => |failure| return .{ .err = failure },
+                .offset => |offset| {
+                    if (offset != total)
+                        return error.ServerUploadOffsetDiverged;
+                    if (retry_count >= options.max_retries)
+                        return error.BlobUploadRetryExhausted;
+                    retry_count += 1;
+                    continue;
+                },
+                .lost => return verifyCompletedBlob(
+                    context,
+                    digest,
+                    total,
+                    options,
+                ),
+            }
+        }
+        if (operation.isSuccess()) return error.UnexpectedResponseStatus;
+        return .{ .err = try serviceErrorFromOperation(context, operation) };
+    }
+}
+
+fn verifyCompletedBlob(
+    context: UploadContext,
+    digest: []const u8,
+    total: u64,
+    options: BlobUploadOptions,
+) !Step(Completion) {
+    const url = try buildBlobUrl(context, digest);
+    var owns_url = true;
+    defer if (owns_url) context.allocator.free(url);
+    var request = core.http.Request.init(context.allocator, .HEAD, url);
+    defer request.deinit();
+    request.redirect_policy = .not_allowed;
+
+    var operation = try context.pipeline.open(
+        &request,
+        .{ .cancellation = options.cancellation },
+    );
+    defer operation.deinit();
+    if (operation.status_code == 200) {
+        const returned_digest = try requiredHeader(
+            context.allocator,
+            operation,
+            "Docker-Content-Digest",
+            error.MissingDockerContentDigest,
+        );
+        try digest_mod.validateSha256Digest(returned_digest);
+        if (!(try digest_mod.sha256DigestsEqual(digest, returned_digest)))
+            return error.DigestMismatch;
+        const content_length = try requiredHeader(
+            context.allocator,
+            operation,
+            "Content-Length",
+            error.MissingContentLength,
+        );
+        const returned_size = std.fmt.parseInt(u64, content_length, 10) catch
+            return error.InvalidContentLength;
+        if (returned_size != total) return error.ContentLengthMismatch;
+        try operation.finish();
+        owns_url = false;
+        return .{ .ok = .{
+            .location = url,
+        } };
+    }
+    if (operation.status_code == 404)
+        return error.CompletionOutcomeUnknown;
+    if (operation.isSuccess()) return error.UnexpectedResponseStatus;
+    return .{ .err = try serviceErrorFromOperation(context, operation) };
+}
+
+fn cleanupUpload(context: UploadContext, session: *Session) !void {
+    const request_url = try buildContinuationUrl(
+        context,
+        session.location,
+        null,
+    );
+    defer context.allocator.free(request_url);
+    var request = core.http.Request.init(context.allocator, .DELETE, request_url);
+    defer request.deinit();
+    request.redirect_policy = .not_allowed;
+    try request.setHeader("Content-Length", "0");
+
+    var operation = try context.pipeline.open(&request, .{});
+    defer operation.deinit();
+    if (operation.status_code != 204 and operation.status_code != 404)
+        return error.UploadCleanupFailed;
+    try operation.finish();
+}
+
+fn failAfterCleanup(
+    context: UploadContext,
+    session: *Session,
+    failure: anyerror,
+) anyerror!BlobUploadResponse {
+    cleanupUpload(context, session) catch |cleanup_error| return cleanup_error;
+    return failure;
+}
+
+fn serviceFailureAfterCleanup(
+    context: UploadContext,
+    session: *Session,
+    failure_value: service_error.ServiceError,
+) !BlobUploadResponse {
+    var failure = failure_value;
+    cleanupUpload(context, session) catch |cleanup_error| {
+        failure.deinit();
+        return cleanup_error;
+    };
+    return .{ .err = failure };
+}
+
+fn buildStartUrl(context: UploadContext) ![]u8 {
+    const repository = try core.url.encodeRepositoryName(
+        context.allocator,
+        context.repository_name,
+    );
+    defer context.allocator.free(repository);
+    const api_version = try core.url.percentEncode(
+        context.allocator,
+        context.api_version,
+    );
+    defer context.allocator.free(api_version);
+    return std.fmt.allocPrint(
+        context.allocator,
+        "{s}/v2/{s}/blobs/uploads/?api-version={s}",
+        .{ context.endpoint, repository, api_version },
+    );
+}
+
+fn buildBlobUrl(context: UploadContext, digest: []const u8) ![]u8 {
+    const repository = try core.url.encodeRepositoryName(
+        context.allocator,
+        context.repository_name,
+    );
+    defer context.allocator.free(repository);
+    const encoded_digest = try core.url.encodePathSegment(
+        context.allocator,
+        digest,
+    );
+    defer context.allocator.free(encoded_digest);
+    const api_version = try core.url.percentEncode(
+        context.allocator,
+        context.api_version,
+    );
+    defer context.allocator.free(api_version);
+    return std.fmt.allocPrint(
+        context.allocator,
+        "{s}/v2/{s}/blobs/{s}?api-version={s}",
+        .{
+            context.endpoint,
+            repository,
+            encoded_digest,
+            api_version,
+        },
+    );
+}
+
+fn buildContinuationUrl(
+    context: UploadContext,
+    location: []const u8,
+    digest: ?[]const u8,
+) ![]u8 {
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(context.allocator);
+    try output.appendSlice(context.allocator, location);
+    var separator: []const u8 = if (std.mem.indexOfScalar(u8, location, '?') == null)
+        "?"
+    else
+        "&";
+    if (!hasQueryParameter(location, "api-version")) {
+        const encoded = try core.url.percentEncode(
+            context.allocator,
+            context.api_version,
+        );
+        defer context.allocator.free(encoded);
+        try output.print(
+            context.allocator,
+            "{s}api-version={s}",
+            .{ separator, encoded },
+        );
+        separator = "&";
+    }
+    if (digest) |value| {
+        if (hasQueryParameter(location, "digest"))
+            return error.AmbiguousUploadLocation;
+        const encoded = try core.url.percentEncode(context.allocator, value);
+        defer context.allocator.free(encoded);
+        try output.print(
+            context.allocator,
+            "{s}digest={s}",
+            .{ separator, encoded },
+        );
+    }
+    return output.toOwnedSlice(context.allocator);
+}
+
+fn hasQueryParameter(url: []const u8, name: []const u8) bool {
+    const query_start = std.mem.indexOfScalar(u8, url, '?') orelse return false;
+    var parameters = std.mem.splitScalar(u8, url[query_start + 1 ..], '&');
+    while (parameters.next()) |parameter| {
+        const end = std.mem.indexOfScalar(u8, parameter, '=') orelse
+            parameter.len;
+        const key = parameter[0..end];
+        if (std.ascii.eqlIgnoreCase(key, name)) return true;
+        if (std.ascii.eqlIgnoreCase(name, "api-version") and
+            std.ascii.eqlIgnoreCase(key, "api%2dversion"))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn resolveUploadLocation(
+    allocator: std.mem.Allocator,
+    endpoint: []const u8,
+    request_url: []const u8,
+    location: []const u8,
+) ![]u8 {
+    if (location.len > max_location_length)
+        return error.UploadLocationTooLong;
+    const resolved = try core.url.resolveUrl(allocator, request_url, location);
+    errdefer allocator.free(resolved);
+    if (resolved.len > max_location_length)
+        return error.UploadLocationTooLong;
+    try core.url.validateHttpsUrl(resolved, &.{});
+    if (!(try core.url.sameOrigin(endpoint, resolved)))
+        return error.UntrustedUploadLocation;
+    return resolved;
+}
+
+fn responseUploadLocation(
+    context: UploadContext,
+    operation: *const core.http.HttpOperation,
+    request_url: []const u8,
+) ![]u8 {
+    const raw_location = try requiredHeader(
+        context.allocator,
+        operation,
+        "Location",
+        error.MissingUploadLocation,
+    );
+    return resolveUploadLocation(
+        context.allocator,
+        context.endpoint,
+        request_url,
+        raw_location,
+    );
+}
+
+fn responseUploadOffset(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+    zero_is_empty: bool,
+) !u64 {
+    const range = try requiredHeader(
+        allocator,
+        operation,
+        "Range",
+        error.MissingUploadRange,
+    );
+    return parseRange(range, zero_is_empty);
+}
+
+fn validateUploadUuid(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+    expected: []const u8,
+) !void {
+    const actual = try requiredHeader(
+        allocator,
+        operation,
+        "Docker-Upload-UUID",
+        error.MissingUploadUuid,
+    );
+    if (actual.len > max_upload_uuid_length)
+        return error.UploadUuidTooLong;
+    if (!std.mem.eql(u8, expected, actual))
+        return error.UploadUuidChanged;
+}
+
+fn validateInitialRange(value: []const u8) !void {
+    if (try parseRange(value, true) != 0)
+        return error.ServerUploadOffsetDiverged;
+}
+
+fn validateCompletionRange(value: []const u8, total: u64) !void {
+    const offset = try parseRange(value, total == 0);
+    if (offset != total) return error.ServerUploadOffsetDiverged;
+}
+
+fn parseStatusRange(
+    value: []const u8,
+    confirmed_offset: u64,
+    attempted_end: u64,
+    completion: bool,
+) !u64 {
+    const trimmed = std.mem.trim(u8, value, " \t");
+    const raw = if (std.ascii.startsWithIgnoreCase(trimmed, "bytes="))
+        trimmed["bytes=".len..]
+    else
+        trimmed;
+    if (std.mem.eql(u8, raw, "0-0") and confirmed_offset == 0) {
+        if (completion and attempted_end == 0) return 0;
+        return error.AmbiguousUploadRange;
+    }
+    return parseRange(value, false);
+}
+
+fn parseRange(value: []const u8, zero_is_empty: bool) !u64 {
+    const trimmed = std.mem.trim(u8, value, " \t");
+    const raw = if (std.ascii.startsWithIgnoreCase(trimmed, "bytes="))
+        trimmed["bytes=".len..]
+    else
+        trimmed;
+    const separator = std.mem.indexOfScalar(u8, raw, '-') orelse
+        return error.InvalidUploadRange;
+    if (separator == 0 or separator == raw.len - 1 or
+        std.mem.indexOfScalar(u8, raw[separator + 1 ..], '-') != null)
+    {
+        return error.InvalidUploadRange;
+    }
+    const start = std.fmt.parseInt(u64, raw[0..separator], 10) catch
+        return error.InvalidUploadRange;
+    const end = std.fmt.parseInt(u64, raw[separator + 1 ..], 10) catch
+        return error.InvalidUploadRange;
+    if (start != 0 or end < start) return error.InvalidUploadRange;
+    if (zero_is_empty and end == 0) return 0;
+    return std.math.add(u64, end, 1) catch error.InvalidUploadRange;
+}
+
+fn requiredHeader(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+    name: []const u8,
+    missing_error: anyerror,
+) ![]const u8 {
+    const values = try operation.getHeaderValues(allocator, name);
+    defer allocator.free(values);
+    if (values.len == 0) return missing_error;
+    if (values.len != 1) return error.AmbiguousResponseHeader;
+    if (values[0].len == 0) return error.InvalidResponseHeader;
+    return values[0];
+}
+
+fn optionalHeader(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+    name: []const u8,
+) !?[]const u8 {
+    const values = try operation.getHeaderValues(allocator, name);
+    defer allocator.free(values);
+    if (values.len == 0) return null;
+    if (values.len != 1) return error.AmbiguousResponseHeader;
+    if (values[0].len == 0) return error.InvalidResponseHeader;
+    return values[0];
+}
+
+fn serviceErrorFromOperation(
+    context: UploadContext,
+    operation: *core.http.HttpOperation,
+) !service_error.ServiceError {
+    const reader = try operation.reader();
+    const body = reader.allocRemaining(
+        context.allocator,
+        .limited(max_error_body_length),
+    ) catch |err| switch (err) {
+        error.ReadFailed => return operation.bodyError() orelse error.ReadFailed,
+        error.StreamTooLong => return error.ErrorResponseTooLarge,
+        else => |other| return other,
+    };
+    var response = core.http.Response{
+        .status_code = operation.status_code,
+        .headers = std.StringHashMap([]const u8).init(context.allocator),
+        .body = body,
+        .allocator = context.allocator,
+    };
+    defer response.deinit();
+    var failure = try service_error.ServiceError.fromResponse(
+        context.allocator,
+        &response,
+    );
+    errdefer failure.deinit();
+    try operation.finish();
+    return failure;
+}
+
+fn isRetryableStatus(status: u16) bool {
+    return status == 408 or status == 429 or status == 500 or
+        status == 502 or status == 503 or status == 504;
+}
+
+fn isRetryablePreTransportError(failure: anyerror) bool {
+    return switch (failure) {
+        error.OutOfMemory,
+        error.OperationCancelled,
+        error.StreamingRequestUnsupported,
+        error.RequestBodyNotReplayable,
+        error.InvalidHttpHeaderName,
+        error.InvalidHttpHeaderValue,
+        error.InvalidUrl,
+        error.HttpsRequired,
+        error.UnexpectedHost,
+        error.UntrustedUploadLocation,
+        => false,
+        else => true,
+    };
+}

--- a/sdk/container_registry/src/blob_upload_test.zig
+++ b/sdk/container_registry/src/blob_upload_test.zig
@@ -1,0 +1,1540 @@
+const std = @import("std");
+const core = @import("azure_core");
+const digest_mod = @import("digest.zig");
+const content_client = @import("content_client.zig");
+const upload_mod = @import("blob_upload.zig");
+
+const BlobUploadOptions = upload_mod.BlobUploadOptions;
+const BlobUploadResponse = upload_mod.BlobUploadResponse;
+const BlobUploadResult = upload_mod.BlobUploadResult;
+const UploadContext = upload_mod.UploadContext;
+const max_chunk_size = upload_mod.max_chunk_size;
+const upload = upload_mod.upload;
+
+const TestHeader = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+const TestAction = union(enum) {
+    response: struct {
+        status: u16,
+        headers: []const TestHeader = &.{},
+        body: []const u8 = "",
+    },
+    fail: struct {
+        after_bytes: usize = 0,
+        cause: anyerror = error.InjectedTransportFailure,
+        cancel: bool = false,
+    },
+};
+
+const TestCapture = struct {
+    method: core.http.Method = .GET,
+    url: [1024]u8 = undefined,
+    url_len: usize = 0,
+    body: [256]u8 = undefined,
+    body_len: usize = 0,
+    content_range: [64]u8 = undefined,
+    content_range_len: usize = 0,
+    content_length: [32]u8 = undefined,
+    content_length_len: usize = 0,
+
+    fn urlSlice(self: *const TestCapture) []const u8 {
+        return self.url[0..self.url_len];
+    }
+
+    fn bodySlice(self: *const TestCapture) []const u8 {
+        return self.body[0..@min(self.body_len, self.body.len)];
+    }
+
+    fn contentRange(self: *const TestCapture) ?[]const u8 {
+        if (self.content_range_len == 0) return null;
+        return self.content_range[0..self.content_range_len];
+    }
+
+    fn contentLength(self: *const TestCapture) ?[]const u8 {
+        if (self.content_length_len == 0) return null;
+        return self.content_length[0..self.content_length_len];
+    }
+};
+
+const ScriptedTransport = struct {
+    allocator: std.mem.Allocator,
+    actions: []const TestAction,
+    transport: core.http.HttpTransport,
+    call_count: usize = 0,
+    captures: [64]TestCapture = [_]TestCapture{.{}} ** 64,
+    finish_count: usize = 0,
+    abort_count: usize = 0,
+    deinit_count: usize = 0,
+    cancellation: ?*core.http.CancellationToken = null,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        actions: []const TestAction,
+    ) ScriptedTransport {
+        return .{
+            .allocator = allocator,
+            .actions = actions,
+            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
+        };
+    }
+
+    fn asTransport(self: *ScriptedTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn sendImpl(
+        _: *core.http.HttpTransport,
+        _: *core.http.Request,
+    ) !core.http.Response {
+        return error.UnexpectedBufferedSend;
+    }
+
+    fn openImpl(
+        transport: *core.http.HttpTransport,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *ScriptedTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        if (self.call_count >= self.actions.len)
+            return error.NoScriptedResponse;
+        if (self.call_count >= self.captures.len)
+            return error.TooManyTestRequests;
+        const action = self.actions[self.call_count];
+        const capture = &self.captures[self.call_count];
+        self.call_count += 1;
+        try captureRequest(capture, request);
+
+        var body_length: usize = 0;
+        if (options.body) |body| {
+            var scratch: [13]u8 = undefined;
+            while (true) {
+                const count = try body.reader.readSliceShort(&scratch);
+                if (count == 0) break;
+                const copy_start = @min(body_length, capture.body.len);
+                const copy_end = @min(body_length + count, capture.body.len);
+                if (copy_end > copy_start) {
+                    @memcpy(
+                        capture.body[copy_start..copy_end],
+                        scratch[0 .. copy_end - copy_start],
+                    );
+                }
+                body_length += count;
+                if (action == .fail and
+                    body_length >= action.fail.after_bytes)
+                {
+                    capture.body_len = body_length;
+                    if (action.fail.cancel) {
+                        if (self.cancellation) |token| token.cancel();
+                    }
+                    return action.fail.cause;
+                }
+            }
+        }
+        capture.body_len = body_length;
+
+        return switch (action) {
+            .fail => |failure| blk: {
+                if (failure.cancel) {
+                    if (self.cancellation) |token| token.cancel();
+                }
+                break :blk failure.cause;
+            },
+            .response => |response| TestOperation.create(
+                self,
+                response.status,
+                response.headers,
+                response.body,
+            ),
+        };
+    }
+
+    fn captureRequest(
+        capture: *TestCapture,
+        request: *const core.http.Request,
+    ) !void {
+        if (request.url.len > capture.url.len) return error.TestUrlTooLong;
+        capture.method = request.method;
+        @memcpy(capture.url[0..request.url.len], request.url);
+        capture.url_len = request.url.len;
+        if (request.getHeader("Content-Range")) |value| {
+            if (value.len > capture.content_range.len)
+                return error.TestHeaderTooLong;
+            @memcpy(capture.content_range[0..value.len], value);
+            capture.content_range_len = value.len;
+        }
+        if (request.getHeader("Content-Length")) |value| {
+            if (value.len > capture.content_length.len)
+                return error.TestHeaderTooLong;
+            @memcpy(capture.content_length[0..value.len], value);
+            capture.content_length_len = value.len;
+        }
+    }
+};
+
+const TestOperation = struct {
+    operation: core.http.HttpOperation,
+    owner: *ScriptedTransport,
+    allocator: std.mem.Allocator,
+    body: []u8,
+    reader: std.Io.Reader,
+
+    fn create(
+        owner: *ScriptedTransport,
+        status: u16,
+        headers: []const TestHeader,
+        body_value: []const u8,
+    ) !*core.http.HttpOperation {
+        const self = try owner.allocator.create(TestOperation);
+        errdefer owner.allocator.destroy(self);
+        const body = try owner.allocator.dupe(u8, body_value);
+        errdefer owner.allocator.free(body);
+        var header_map = std.StringHashMap([]const u8).init(owner.allocator);
+        errdefer deinitTestHeaderMap(owner.allocator, &header_map);
+        var response_headers = core.http.ResponseHeaders.init(owner.allocator);
+        errdefer response_headers.deinit();
+        for (headers) |header| {
+            try response_headers.append(header.name, header.value);
+            const name = try owner.allocator.dupe(u8, header.name);
+            errdefer owner.allocator.free(name);
+            const value = try owner.allocator.dupe(u8, header.value);
+            errdefer owner.allocator.free(value);
+            const entry = try header_map.getOrPut(name);
+            if (entry.found_existing) {
+                owner.allocator.free(name);
+                owner.allocator.free(entry.value_ptr.*);
+            } else {
+                entry.key_ptr.* = name;
+            }
+            entry.value_ptr.* = value;
+        }
+        self.* = .{
+            .operation = undefined,
+            .owner = owner,
+            .allocator = owner.allocator,
+            .body = body,
+            .reader = std.Io.Reader.fixed(body),
+        };
+        self.operation = .{
+            .status_code = status,
+            .headers = header_map,
+            .response_headers = response_headers,
+            .body_reader = &self.reader,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &abortImpl,
+            .deinitFn = &deinitImpl,
+        };
+        return &self.operation;
+    }
+
+    fn finishImpl(operation: *core.http.HttpOperation) !void {
+        const self: *TestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.finish_count += 1;
+        _ = try self.reader.discardRemaining();
+    }
+
+    fn abortImpl(operation: *core.http.HttpOperation) void {
+        const self: *TestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.abort_count += 1;
+    }
+
+    fn deinitImpl(operation: *core.http.HttpOperation) void {
+        const self: *TestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.deinit_count += 1;
+        self.operation.response_headers.deinit();
+        deinitTestHeaderMap(self.allocator, &self.operation.headers);
+        self.allocator.free(self.body);
+        self.allocator.destroy(self);
+    }
+};
+
+fn deinitTestHeaderMap(
+    allocator: std.mem.Allocator,
+    headers: *std.StringHashMap([]const u8),
+) void {
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+        allocator.free(entry.value_ptr.*);
+    }
+    headers.deinit();
+}
+
+fn testUpload(
+    allocator: std.mem.Allocator,
+    transport: *ScriptedTransport,
+    reader: *std.Io.Reader,
+    options: BlobUploadOptions,
+) !BlobUploadResponse {
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    return upload(.{
+        .allocator = allocator,
+        .pipeline = &pipeline,
+        .endpoint = "https://registry.example",
+        .api_version = "2021-07-01",
+        .repository_name = "team/app",
+    }, reader, options);
+}
+
+fn expectUpload(
+    allocator: std.mem.Allocator,
+    transport: *ScriptedTransport,
+    bytes: []const u8,
+    options: BlobUploadOptions,
+) !BlobUploadResult {
+    var reader = std.Io.Reader.fixed(bytes);
+    var response = try testUpload(allocator, transport, &reader, options);
+    return switch (response) {
+        .ok => |result| result,
+        .err => |*failure| {
+            defer failure.deinit();
+            return error.UnexpectedServiceError;
+        },
+    };
+}
+
+fn successHeaders(
+    comptime location: []const u8,
+    comptime range: []const u8,
+    comptime uuid: []const u8,
+) []const TestHeader {
+    return &.{
+        .{ .name = "Location", .value = location },
+        .{ .name = "Range", .value = range },
+        .{ .name = "Docker-Upload-UUID", .value = uuid },
+    };
+}
+
+fn completionHeaders(
+    comptime location: []const u8,
+    comptime range: []const u8,
+    digest: []const u8,
+) [3]TestHeader {
+    return .{
+        .{ .name = "Location", .value = location },
+        .{ .name = "Range", .value = range },
+        .{ .name = "Docker-Content-Digest", .value = digest },
+    };
+}
+
+test "blob upload accepts empty content" {
+    const allocator = std.testing.allocator;
+    const digest = digest_mod.computeSha256Digest("");
+    const complete_headers = completionHeaders(
+        "/v2/team/app/blobs/empty",
+        "0-0",
+        &digest,
+    );
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders(
+                "/v2/team/app/blobs/uploads/id?_state=start",
+                "bytes=0-0",
+                "id",
+            ),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(allocator, &transport, "", .{});
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(u64, 0), result.size);
+    try std.testing.expectEqualStrings(&digest, result.digest);
+    try std.testing.expectEqual(core.http.Method.PUT, transport.captures[1].method);
+    try std.testing.expectEqualStrings("0", transport.captures[1].contentLength().?);
+    try std.testing.expect(
+        std.mem.indexOf(u8, transport.captures[1].urlSlice(), "digest=sha256%3A") != null,
+    );
+    try std.testing.expectEqual(@as(usize, 2), transport.finish_count);
+    try std.testing.expectEqual(transport.call_count, transport.deinit_count);
+}
+
+test "content client exposes high-level blob upload" {
+    const allocator = std.testing.allocator;
+    const digest = digest_mod.computeSha256Digest("public");
+    const complete_headers = completionHeaders("/blob/final", "0-5", &digest);
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-5", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var client = try content_client.ContainerRegistryContentClient.init(
+        allocator,
+        "https://registry.example",
+        "team/app",
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+
+    var result = try client.uploadBlobBytes("public", .{});
+    defer result.deinit();
+    try std.testing.expectEqualStrings(&digest, result.digest);
+    try std.testing.expectEqual(@as(u64, 6), result.size);
+}
+
+test "blob upload sends one exact ranged chunk" {
+    const allocator = std.testing.allocator;
+    const bytes = "hello";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders(
+        "/v2/team/app/blobs/final",
+        "0-4",
+        &digest,
+    );
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?_state=a", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?_state=b", "bytes=0-4", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(allocator, &transport, bytes, .{});
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("0-4", transport.captures[1].contentRange().?);
+    try std.testing.expectEqualStrings("5", transport.captures[1].contentLength().?);
+    try std.testing.expectEqualStrings(bytes, transport.captures[1].bodySlice());
+    try std.testing.expect(
+        std.mem.indexOf(u8, transport.captures[1].urlSlice(), "_state=a") != null,
+    );
+}
+
+test "blob upload sends sequential multiple chunks" {
+    const allocator = std.testing.allocator;
+    const bytes = "abcdefghij";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-9", &digest);
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?s=0", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?s=1", "0-3", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?s=2", "0-7", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?s=3", "0-9", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(
+        allocator,
+        &transport,
+        bytes,
+        .{ .chunk_size = 4 },
+    );
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("0-3", transport.captures[1].contentRange().?);
+    try std.testing.expectEqualStrings("4-7", transport.captures[2].contentRange().?);
+    try std.testing.expectEqualStrings("8-9", transport.captures[3].contentRange().?);
+    try std.testing.expectEqualStrings("abcd", transport.captures[1].bodySlice());
+    try std.testing.expectEqualStrings("efgh", transport.captures[2].bodySlice());
+    try std.testing.expectEqualStrings("ij", transport.captures[3].bodySlice());
+}
+
+test "blob upload exact chunk boundary does not send an empty patch" {
+    const allocator = std.testing.allocator;
+    const bytes = "abcdefgh";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-7", &digest);
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-3", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-7", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(
+        allocator,
+        &transport,
+        bytes,
+        .{ .chunk_size = 4 },
+    );
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+    try std.testing.expectEqual(core.http.Method.PUT, transport.captures[3].method);
+}
+
+const PartialReader = struct {
+    interface: std.Io.Reader,
+    bytes: []const u8,
+    offset: usize = 0,
+    max_per_read: usize,
+    max_requested: usize = 0,
+
+    fn init(bytes: []const u8, max_per_read: usize) PartialReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .bytes = bytes,
+            .max_per_read = max_per_read,
+        };
+    }
+
+    fn stream(
+        reader: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *PartialReader =
+            @alignCast(@fieldParentPtr("interface", reader));
+        const requested = limit.minInt(std.math.maxInt(usize));
+        self.max_requested = @max(self.max_requested, requested);
+        if (self.offset == self.bytes.len) return error.EndOfStream;
+        const count = @min(
+            self.bytes.len - self.offset,
+            @min(self.max_per_read, requested),
+        );
+        try writer.writeAll(self.bytes[self.offset .. self.offset + count]);
+        self.offset += count;
+        return count;
+    }
+};
+
+test "blob upload supports non-seekable partial readers" {
+    const allocator = std.testing.allocator;
+    const bytes = "partial-reader";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-13", &digest);
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-4", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-9", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-13", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var source = PartialReader.init(bytes, 2);
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var response = try testUpload(
+        allocator,
+        &transport,
+        &source.interface,
+        .{ .chunk_size = 5 },
+    );
+    defer response.deinit();
+
+    try std.testing.expect(response == .ok);
+    try std.testing.expect(source.max_requested <= 5);
+    try std.testing.expectEqual(bytes.len, source.offset);
+}
+
+const FailBeforeTransportPolicy = struct {
+    policy: core.pipeline.HttpPolicy,
+    remaining_failures: usize,
+    failure_count: usize = 0,
+
+    fn init(failures: usize) FailBeforeTransportPolicy {
+        return .{
+            .policy = .{
+                .processFn = &processImpl,
+                .prepareFn = &prepareImpl,
+                .openFn = &openImpl,
+            },
+            .remaining_failures = failures,
+        };
+    }
+
+    fn asPolicy(self: *FailBeforeTransportPolicy) *core.pipeline.HttpPolicy {
+        return &self.policy;
+    }
+
+    fn prepareImpl(_: *core.pipeline.HttpPolicy, _: *core.http.Request) !void {}
+
+    fn processImpl(
+        _: *core.pipeline.HttpPolicy,
+        request: *core.http.Request,
+        next: []*core.pipeline.HttpPolicy,
+        transport: *core.http.HttpTransport,
+    ) !core.http.Response {
+        if (next.len == 0) return transport.send(request);
+        return next[0].process(request, next[1..], transport);
+    }
+
+    fn openImpl(
+        policy: *core.pipeline.HttpPolicy,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+        next: []*core.pipeline.HttpPolicy,
+        transport: *core.http.HttpTransport,
+    ) !*core.http.HttpOperation {
+        const self: *FailBeforeTransportPolicy =
+            @alignCast(@fieldParentPtr("policy", policy));
+        if (request.method == .PATCH and self.remaining_failures > 0) {
+            self.remaining_failures -= 1;
+            self.failure_count += 1;
+            return error.InjectedPreTransportFailure;
+        }
+        if (next.len == 0) return transport.open(request, options);
+        return next[0].open(request, options, next[1..], transport);
+    }
+};
+
+test "blob upload retries failures before transport starts" {
+    const allocator = std.testing.allocator;
+    const bytes = "retry";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-4", &digest);
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-4", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var failure_policy = FailBeforeTransportPolicy.init(1);
+    var policies = [_]*core.pipeline.HttpPolicy{failure_policy.asPolicy()};
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &policies,
+        .transport_impl = transport.asTransport(),
+    };
+    var reader = std.Io.Reader.fixed(bytes);
+    var response = try upload(.{
+        .allocator = allocator,
+        .pipeline = &pipeline,
+        .endpoint = "https://registry.example",
+        .api_version = "2021-07-01",
+        .repository_name = "team/app",
+    }, &reader, .{});
+    defer response.deinit();
+
+    try std.testing.expect(response == .ok);
+    try std.testing.expectEqual(@as(usize, 1), failure_policy.failure_count);
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expectEqual(core.http.Method.PATCH, transport.captures[1].method);
+}
+
+test "blob upload recovers a fully accepted uncertain chunk" {
+    const allocator = std.testing.allocator;
+    const bytes = "recover";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-6", &digest);
+    const status_headers = [_]TestHeader{
+        .{ .name = "Range", .value = "bytes=0-6" },
+        .{ .name = "Docker-Upload-UUID", .value = "id" },
+        .{ .name = "Location", .value = "/upload/id?_state=recovered" },
+    };
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?_state=start", "0-0", "id"),
+        } },
+        .{ .fail = .{ .after_bytes = bytes.len } },
+        .{ .response = .{ .status = 204, .headers = &status_headers } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(allocator, &transport, bytes, .{});
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 4), transport.call_count);
+    try std.testing.expectEqual(core.http.Method.GET, transport.captures[2].method);
+    try std.testing.expectEqual(core.http.Method.PUT, transport.captures[3].method);
+    try std.testing.expect(
+        std.mem.indexOf(u8, transport.captures[3].urlSlice(), "_state=recovered") != null,
+    );
+}
+
+test "blob upload resumes the confirmed suffix after uncertain transport" {
+    const allocator = std.testing.allocator;
+    const bytes = "abcdef";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-5", &digest);
+    const status_headers = [_]TestHeader{
+        .{ .name = "Range", .value = "0-1" },
+        .{ .name = "Docker-Upload-UUID", .value = "id" },
+    };
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .fail = .{ .after_bytes = 2 } },
+        .{ .response = .{ .status = 204, .headers = &status_headers } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-5", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(
+        allocator,
+        &transport,
+        bytes,
+        .{ .chunk_size = 6 },
+    );
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("2-5", transport.captures[3].contentRange().?);
+    try std.testing.expectEqualStrings("cdef", transport.captures[3].bodySlice());
+    try std.testing.expectEqualStrings(&digest, result.digest);
+    try std.testing.expect(
+        std.mem.indexOf(u8, transport.captures[4].urlSlice(), "digest=sha256%3A") != null,
+    );
+}
+
+test "blob upload restores digest and chunk cursor before retry" {
+    const allocator = std.testing.allocator;
+    const bytes = "abcdefgh";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-7", &digest);
+    const status_headers = [_]TestHeader{
+        .{ .name = "Range", .value = "0-3" },
+        .{ .name = "Docker-Upload-UUID", .value = "id" },
+    };
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-3", "id"),
+        } },
+        .{ .fail = .{ .after_bytes = 4 } },
+        .{ .response = .{ .status = 204, .headers = &status_headers } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-7", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(
+        allocator,
+        &transport,
+        bytes,
+        .{ .chunk_size = 4 },
+    );
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("4-7", transport.captures[2].contentRange().?);
+    try std.testing.expectEqualStrings("4-7", transport.captures[4].contentRange().?);
+    try std.testing.expectEqualStrings("efgh", transport.captures[4].bodySlice());
+    try std.testing.expectEqualStrings(&digest, result.digest);
+}
+
+test "blob upload rejects server offset divergence" {
+    const allocator = std.testing.allocator;
+    const bytes = "abcdefgh";
+    const status_headers = [_]TestHeader{
+        .{ .name = "Range", .value = "0-8" },
+        .{ .name = "Docker-Upload-UUID", .value = "id" },
+    };
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-3", "id"),
+        } },
+        .{ .fail = .{ .after_bytes = 4 } },
+        .{ .response = .{ .status = 204, .headers = &status_headers } },
+        .{ .response = .{ .status = 204 } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var reader = std.Io.Reader.fixed(bytes);
+    try std.testing.expectError(
+        error.ServerUploadOffsetDiverged,
+        testUpload(
+            allocator,
+            &transport,
+            &reader,
+            .{ .chunk_size = 4 },
+        ),
+    );
+    try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[4].method);
+}
+
+test "blob upload rejects malformed ranges and changed upload UUIDs" {
+    const allocator = std.testing.allocator;
+    const cases = [_]struct {
+        range: []const u8,
+        uuid: []const u8,
+        expected: anyerror,
+    }{
+        .{ .range = "1-4", .uuid = "id", .expected = error.InvalidUploadRange },
+        .{ .range = "0-four", .uuid = "id", .expected = error.InvalidUploadRange },
+        .{ .range = "0-3", .uuid = "other", .expected = error.UploadUuidChanged },
+    };
+    for (cases) |case| {
+        const response_headers = [_]TestHeader{
+            .{ .name = "Location", .value = "/upload/id" },
+            .{ .name = "Range", .value = case.range },
+            .{ .name = "Docker-Upload-UUID", .value = case.uuid },
+        };
+        const actions = [_]TestAction{
+            .{ .response = .{
+                .status = 202,
+                .headers = successHeaders("/upload/id", "0-0", "id"),
+            } },
+            .{ .response = .{ .status = 202, .headers = &response_headers } },
+            .{ .response = .{ .status = 204 } },
+        };
+        var transport = ScriptedTransport.init(allocator, &actions);
+        var reader = std.Io.Reader.fixed("data");
+        try std.testing.expectError(
+            case.expected,
+            testUpload(allocator, &transport, &reader, .{}),
+        );
+        try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
+    }
+}
+
+test "blob upload validates every continuation Location origin" {
+    const allocator = std.testing.allocator;
+    const invalid_locations = [_]struct {
+        value: []const u8,
+        expected: anyerror,
+    }{
+        .{ .value = "http://registry.example/upload/id", .expected = error.HttpsRequired },
+        .{ .value = "https://evil.example/upload/id", .expected = error.UntrustedUploadLocation },
+        .{ .value = "https://registry.example:444/upload/id", .expected = error.UntrustedUploadLocation },
+        .{ .value = "https://user@registry.example/upload/id", .expected = error.InvalidUrl },
+        .{ .value = "https://registry.example/upload/id#fragment", .expected = error.InvalidUrl },
+    };
+    for (invalid_locations) |invalid| {
+        const start_headers = [_]TestHeader{
+            .{ .name = "Location", .value = invalid.value },
+            .{ .name = "Range", .value = "0-0" },
+            .{ .name = "Docker-Upload-UUID", .value = "id" },
+        };
+        const actions = [_]TestAction{
+            .{ .response = .{ .status = 202, .headers = &start_headers } },
+        };
+        var transport = ScriptedTransport.init(allocator, &actions);
+        var reader = std.Io.Reader.fixed("");
+        try std.testing.expectError(
+            invalid.expected,
+            testUpload(allocator, &transport, &reader, .{}),
+        );
+    }
+}
+
+test "blob upload origin comparison includes effective HTTPS port" {
+    const allocator = std.testing.allocator;
+    const digest = digest_mod.computeSha256Digest("");
+    const complete_headers = completionHeaders(
+        "https://REGISTRY.example:8443/blob/final",
+        "0-0",
+        &digest,
+    );
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders(
+                "https://registry.example:8443/upload/id",
+                "0-0",
+                "id",
+            ),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    var reader = std.Io.Reader.fixed("");
+    var response = try upload(.{
+        .allocator = allocator,
+        .pipeline = &pipeline,
+        .endpoint = "https://registry.example:8443",
+        .api_version = "2021-07-01",
+        .repository_name = "team/app",
+    }, &reader, .{});
+    defer response.deinit();
+    try std.testing.expect(response == .ok);
+
+    const wrong_port_headers = [_]TestHeader{
+        .{ .name = "Location", .value = "https://registry.example/upload/id" },
+        .{ .name = "Range", .value = "0-0" },
+        .{ .name = "Docker-Upload-UUID", .value = "id" },
+    };
+    const wrong_actions = [_]TestAction{
+        .{ .response = .{ .status = 202, .headers = &wrong_port_headers } },
+    };
+    var wrong_transport = ScriptedTransport.init(allocator, &wrong_actions);
+    var wrong_pipeline = core.pipeline.HttpPipeline{
+        .policies = &.{},
+        .transport_impl = wrong_transport.asTransport(),
+    };
+    var wrong_reader = std.Io.Reader.fixed("");
+    try std.testing.expectError(
+        error.UntrustedUploadLocation,
+        upload(.{
+            .allocator = allocator,
+            .pipeline = &wrong_pipeline,
+            .endpoint = "https://registry.example:8443",
+            .api_version = "2021-07-01",
+            .repository_name = "team/app",
+        }, &wrong_reader, .{}),
+    );
+}
+
+test "blob upload recovers uncertain completion through upload status" {
+    const allocator = std.testing.allocator;
+    const bytes = "done";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-3", &digest);
+    const status_headers = [_]TestHeader{
+        .{ .name = "Range", .value = "0-3" },
+        .{ .name = "Docker-Upload-UUID", .value = "id" },
+    };
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-3", "id"),
+        } },
+        .{ .fail = .{} },
+        .{ .response = .{ .status = 204, .headers = &status_headers } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(allocator, &transport, bytes, .{});
+    defer result.deinit();
+
+    try std.testing.expectEqual(core.http.Method.PUT, transport.captures[2].method);
+    try std.testing.expectEqual(core.http.Method.GET, transport.captures[3].method);
+    try std.testing.expectEqual(core.http.Method.PUT, transport.captures[4].method);
+}
+
+test "blob upload verifies the final blob when completion closed the session" {
+    const allocator = std.testing.allocator;
+    const bytes = "done";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const head_headers = [_]TestHeader{
+        .{ .name = "Docker-Content-Digest", .value = &digest },
+        .{ .name = "Content-Length", .value = "4" },
+    };
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-3", "id"),
+        } },
+        .{ .fail = .{} },
+        .{ .response = .{ .status = 404 } },
+        .{ .response = .{ .status = 200, .headers = &head_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(allocator, &transport, bytes, .{});
+    defer result.deinit();
+
+    try std.testing.expectEqual(core.http.Method.HEAD, transport.captures[4].method);
+    try std.testing.expectEqualStrings(&digest, result.digest);
+    try std.testing.expect(
+        std.mem.indexOf(u8, result.location, "/blobs/sha256%3A") != null,
+    );
+}
+
+test "blob upload rejects a mismatched final service digest" {
+    const allocator = std.testing.allocator;
+    const bytes = "expected";
+    const wrong_digest = digest_mod.computeSha256Digest("different");
+    const complete_headers = completionHeaders(
+        "/blob/final",
+        "0-7",
+        &wrong_digest,
+    );
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-7", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+        .{ .response = .{ .status = 404 } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var reader = std.Io.Reader.fixed(bytes);
+    try std.testing.expectError(
+        error.DigestMismatch,
+        testUpload(allocator, &transport, &reader, .{}),
+    );
+    try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[3].method);
+}
+
+test "blob upload preserves cancellation and cancels the session" {
+    const allocator = std.testing.allocator;
+    var cancellation = core.http.CancellationToken{};
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .fail = .{
+            .after_bytes = 2,
+            .cause = error.OperationCancelled,
+            .cancel = true,
+        } },
+        .{ .response = .{ .status = 204 } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    transport.cancellation = &cancellation;
+    var reader = std.Io.Reader.fixed("cancel");
+    try std.testing.expectError(
+        error.OperationCancelled,
+        testUpload(
+            allocator,
+            &transport,
+            &reader,
+            .{ .cancellation = &cancellation },
+        ),
+    );
+    try std.testing.expect(cancellation.isCancelled());
+    try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
+}
+
+test "blob upload returns structured service errors after cleanup" {
+    const allocator = std.testing.allocator;
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 400,
+            .body = "{\"errors\":[{\"code\":\"BLOB_UPLOAD_INVALID\",\"message\":\"bad range\"}]}",
+        } },
+        .{ .response = .{ .status = 204 } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var reader = std.Io.Reader.fixed("bad");
+    var response = try testUpload(allocator, &transport, &reader, .{});
+    defer response.deinit();
+    switch (response) {
+        .err => |failure| {
+            try std.testing.expectEqual(@as(u16, 400), failure.status_code);
+            try std.testing.expectEqualStrings("BLOB_UPLOAD_INVALID", failure.code.?);
+        },
+        .ok => return error.ExpectedServiceError,
+    }
+    try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
+}
+
+test "blob upload reports deterministic cleanup failure" {
+    const allocator = std.testing.allocator;
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 400,
+            .body = "{\"errors\":[{\"code\":\"BLOB_UPLOAD_INVALID\"}]}",
+        } },
+        .{ .response = .{ .status = 500 } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var reader = std.Io.Reader.fixed("bad");
+    try std.testing.expectError(
+        error.UploadCleanupFailed,
+        testUpload(allocator, &transport, &reader, .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 3), transport.deinit_count);
+}
+
+test "blob upload validates configured chunk size before transport" {
+    const allocator = std.testing.allocator;
+    var transport = ScriptedTransport.init(allocator, &.{});
+    var reader = std.Io.Reader.fixed("");
+    try std.testing.expectError(
+        error.InvalidBlobUploadChunkSize,
+        testUpload(
+            allocator,
+            &transport,
+            &reader,
+            .{ .chunk_size = 0 },
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidBlobUploadChunkSize,
+        testUpload(
+            allocator,
+            &transport,
+            &reader,
+            .{ .chunk_size = max_chunk_size + 1 },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
+
+const SeekableTestReader = struct {
+    interface: std.Io.Reader,
+    bytes: []const u8,
+    offset: usize = 0,
+
+    fn init(bytes: []const u8) SeekableTestReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .bytes = bytes,
+        };
+    }
+
+    fn seekTo(self: *SeekableTestReader, offset: u64) !void {
+        if (offset > self.bytes.len) return error.InvalidSeek;
+        self.offset = @intCast(offset);
+    }
+
+    fn stream(
+        reader: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *SeekableTestReader =
+            @alignCast(@fieldParentPtr("interface", reader));
+        if (self.offset == self.bytes.len) return error.EndOfStream;
+        const count = @min(
+            self.bytes.len - self.offset,
+            limit.minInt(std.math.maxInt(usize)),
+        );
+        try writer.writeAll(self.bytes[self.offset .. self.offset + count]);
+        self.offset += count;
+        return count;
+    }
+};
+
+test "blob upload accepts a seekable reader at its current position" {
+    const allocator = std.testing.allocator;
+    const bytes = "prefix-content";
+    const uploaded = "content";
+    const digest = digest_mod.computeSha256Digest(uploaded);
+    const complete_headers = completionHeaders("/blob/final", "0-6", &digest);
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-6", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var source = SeekableTestReader.init(bytes);
+    try source.seekTo("prefix-".len);
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var response = try testUpload(
+        allocator,
+        &transport,
+        &source.interface,
+        .{},
+    );
+    defer response.deinit();
+
+    try std.testing.expect(response == .ok);
+    try std.testing.expectEqual(bytes.len, source.offset);
+    try std.testing.expectEqualStrings(uploaded, transport.captures[1].bodySlice());
+}
+
+test "blob upload resumes from a 416 confirmed range" {
+    const allocator = std.testing.allocator;
+    const bytes = "abcdef";
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders("/blob/final", "0-5", &digest);
+    const range_headers = [_]TestHeader{
+        .{ .name = "Location", .value = "/upload/id?_state=range" },
+        .{ .name = "Range", .value = "0-1" },
+        .{ .name = "Docker-Upload-UUID", .value = "id" },
+    };
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{ .status = 416, .headers = &range_headers } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id?_state=next", "0-5", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var result = try expectUpload(allocator, &transport, bytes, .{});
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("2-5", transport.captures[2].contentRange().?);
+    try std.testing.expectEqualStrings("cdef", transport.captures[2].bodySlice());
+    try std.testing.expect(
+        std.mem.indexOf(u8, transport.captures[2].urlSlice(), "_state=range") != null,
+    );
+}
+
+const TrackingAllocator = struct {
+    backing: std.mem.Allocator,
+    current_bytes: usize = 0,
+    max_bytes: usize = 0,
+    max_allocation: usize = 0,
+
+    fn allocator(self: *TrackingAllocator) std.mem.Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = &alloc,
+                .resize = &resize,
+                .remap = &remap,
+                .free = &free,
+            },
+        };
+    }
+
+    fn recordGrowth(self: *TrackingAllocator, amount: usize) void {
+        self.current_bytes += amount;
+        self.max_bytes = @max(self.max_bytes, self.current_bytes);
+    }
+
+    fn alloc(
+        context: *anyopaque,
+        len: usize,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(context));
+        const pointer = self.backing.rawAlloc(
+            len,
+            alignment,
+            return_address,
+        ) orelse return null;
+        self.recordGrowth(len);
+        self.max_allocation = @max(self.max_allocation, len);
+        return pointer;
+    }
+
+    fn resize(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) bool {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(context));
+        if (!self.backing.rawResize(
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        )) return false;
+        if (new_len > memory.len) {
+            self.recordGrowth(new_len - memory.len);
+        } else {
+            self.current_bytes -= memory.len - new_len;
+        }
+        self.max_allocation = @max(self.max_allocation, new_len);
+        return true;
+    }
+
+    fn remap(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(context));
+        const pointer = self.backing.rawRemap(
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        ) orelse return null;
+        if (new_len > memory.len) {
+            self.recordGrowth(new_len - memory.len);
+        } else {
+            self.current_bytes -= memory.len - new_len;
+        }
+        self.max_allocation = @max(self.max_allocation, new_len);
+        return pointer;
+    }
+
+    fn free(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) void {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(context));
+        self.current_bytes -= memory.len;
+        self.backing.rawFree(memory, alignment, return_address);
+    }
+};
+
+test "blob upload allocations stay bounded by one configured chunk" {
+    const backing = std.testing.allocator;
+    const chunk_size = 64 * 1024;
+    const bytes = try backing.alloc(u8, chunk_size * 3 + 17);
+    defer backing.free(bytes);
+    @memset(bytes, 'x');
+    const digest = digest_mod.computeSha256Digest(bytes);
+    const complete_headers = completionHeaders(
+        "/blob/final",
+        "0-196624",
+        &digest,
+    );
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-65535", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-131071", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-196607", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-196624", "id"),
+        } },
+        .{ .response = .{ .status = 201, .headers = &complete_headers } },
+    };
+    var tracking = TrackingAllocator{ .backing = backing };
+    const allocator = tracking.allocator();
+    var transport = ScriptedTransport.init(backing, &actions);
+    var reader = std.Io.Reader.fixed(bytes);
+    var response = try testUpload(
+        allocator,
+        &transport,
+        &reader,
+        .{ .chunk_size = chunk_size },
+    );
+
+    try std.testing.expect(response == .ok);
+    try std.testing.expect(tracking.max_allocation <= chunk_size);
+    try std.testing.expect(tracking.max_bytes <= chunk_size + 16 * 1024);
+    response.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tracking.current_bytes);
+}
+
+const AllocationTransport = struct {
+    allocator: std.mem.Allocator,
+    transport: core.http.HttpTransport,
+    finish_count: usize = 0,
+    abort_count: usize = 0,
+    deinit_count: usize = 0,
+
+    fn init(allocator: std.mem.Allocator) AllocationTransport {
+        return .{
+            .allocator = allocator,
+            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
+        };
+    }
+
+    fn asTransport(self: *AllocationTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn sendImpl(
+        _: *core.http.HttpTransport,
+        _: *core.http.Request,
+    ) !core.http.Response {
+        return error.UnexpectedBufferedSend;
+    }
+
+    fn openImpl(
+        transport: *core.http.HttpTransport,
+        request: *core.http.Request,
+        _: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *AllocationTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        const empty_digest = digest_mod.computeSha256Digest("");
+        return switch (request.method) {
+            .POST => AllocationOperation.create(self, 202, &.{
+                .{ .name = "Location", .value = "/upload/id" },
+                .{ .name = "Range", .value = "0-0" },
+                .{ .name = "Docker-Upload-UUID", .value = "id" },
+            }),
+            .PUT => AllocationOperation.create(self, 201, &.{
+                .{ .name = "Location", .value = "/blob/final" },
+                .{ .name = "Range", .value = "0-0" },
+                .{ .name = "Docker-Content-Digest", .value = &empty_digest },
+            }),
+            .DELETE => AllocationOperation.create(self, 204, &.{}),
+            else => error.UnexpectedTestMethod,
+        };
+    }
+};
+
+const AllocationOperation = struct {
+    operation: core.http.HttpOperation,
+    owner: *AllocationTransport,
+    allocator: std.mem.Allocator,
+    reader: std.Io.Reader,
+
+    fn create(
+        owner: *AllocationTransport,
+        status: u16,
+        headers: []const TestHeader,
+    ) !*core.http.HttpOperation {
+        const self = try owner.allocator.create(AllocationOperation);
+        errdefer owner.allocator.destroy(self);
+        var header_map = std.StringHashMap([]const u8).init(owner.allocator);
+        errdefer deinitTestHeaderMap(owner.allocator, &header_map);
+        var response_headers = core.http.ResponseHeaders.init(owner.allocator);
+        errdefer response_headers.deinit();
+        for (headers) |header| {
+            try response_headers.append(header.name, header.value);
+            const name = try owner.allocator.dupe(u8, header.name);
+            errdefer owner.allocator.free(name);
+            const value = try owner.allocator.dupe(u8, header.value);
+            errdefer owner.allocator.free(value);
+            try header_map.put(name, value);
+        }
+        self.* = .{
+            .operation = undefined,
+            .owner = owner,
+            .allocator = owner.allocator,
+            .reader = std.Io.Reader.fixed(""),
+        };
+        self.operation = .{
+            .status_code = status,
+            .headers = header_map,
+            .response_headers = response_headers,
+            .body_reader = &self.reader,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &abortImpl,
+            .deinitFn = &deinitImpl,
+        };
+        return &self.operation;
+    }
+
+    fn finishImpl(operation: *core.http.HttpOperation) !void {
+        const self: *AllocationOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.finish_count += 1;
+    }
+
+    fn abortImpl(operation: *core.http.HttpOperation) void {
+        const self: *AllocationOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.abort_count += 1;
+    }
+
+    fn deinitImpl(operation: *core.http.HttpOperation) void {
+        const self: *AllocationOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.deinit_count += 1;
+        self.operation.response_headers.deinit();
+        deinitTestHeaderMap(self.allocator, &self.operation.headers);
+        self.allocator.destroy(self);
+    }
+};
+
+fn uploadAllocationFixture(allocator: std.mem.Allocator) !void {
+    var transport = AllocationTransport.init(std.testing.allocator);
+    var pipeline = core.pipeline.HttpPipeline{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    var reader = std.Io.Reader.fixed("");
+    var response = upload(.{
+        .allocator = allocator,
+        .pipeline = &pipeline,
+        .endpoint = "https://registry.example",
+        .api_version = "2021-07-01",
+        .repository_name = "team/app",
+    }, &reader, .{ .chunk_size = 16 }) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
+        else => |other| return other,
+    };
+    response.deinit();
+}
+
+test "blob upload is leak free across allocation failures" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        uploadAllocationFixture,
+        .{},
+    );
+}

--- a/sdk/container_registry/src/blob_upload_test.zig
+++ b/sdk/container_registry/src/blob_upload_test.zig
@@ -1064,6 +1064,36 @@ test "blob upload preserves cancellation and cancels the session" {
     try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
 }
 
+test "blob upload preserves cancellation when cleanup fails" {
+    const allocator = std.testing.allocator;
+    var cancellation = core.http.CancellationToken{};
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .fail = .{
+            .after_bytes = 2,
+            .cause = error.OperationCancelled,
+            .cancel = true,
+        } },
+        .{ .response = .{ .status = 500 } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    transport.cancellation = &cancellation;
+    var reader = std.Io.Reader.fixed("cancel");
+    try std.testing.expectError(
+        error.OperationCancelled,
+        testUpload(
+            allocator,
+            &transport,
+            &reader,
+            .{ .cancellation = &cancellation },
+        ),
+    );
+    try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
+}
+
 test "blob upload returns structured service errors after cleanup" {
     const allocator = std.testing.allocator;
     const actions = [_]TestAction{
@@ -1091,7 +1121,7 @@ test "blob upload returns structured service errors after cleanup" {
     try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
 }
 
-test "blob upload reports deterministic cleanup failure" {
+test "blob upload preserves structured service errors when cleanup fails" {
     const allocator = std.testing.allocator;
     const actions = [_]TestAction{
         .{ .response = .{
@@ -1106,10 +1136,15 @@ test "blob upload reports deterministic cleanup failure" {
     };
     var transport = ScriptedTransport.init(allocator, &actions);
     var reader = std.Io.Reader.fixed("bad");
-    try std.testing.expectError(
-        error.UploadCleanupFailed,
-        testUpload(allocator, &transport, &reader, .{}),
-    );
+    var response = try testUpload(allocator, &transport, &reader, .{});
+    defer response.deinit();
+    switch (response) {
+        .err => |failure| {
+            try std.testing.expectEqual(@as(u16, 400), failure.status_code);
+            try std.testing.expectEqualStrings("BLOB_UPLOAD_INVALID", failure.code.?);
+        },
+        .ok => return error.ExpectedServiceError,
+    }
     try std.testing.expectEqual(@as(usize, 3), transport.deinit_count);
 }
 

--- a/sdk/container_registry/src/content_client.zig
+++ b/sdk/container_registry/src/content_client.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const core = @import("azure_core");
 const client_mod = @import("client.zig");
+const blob_upload = @import("blob_upload.zig");
 const digest_mod = @import("digest.zig");
 const service_error = @import("service_error.zig");
 
@@ -306,6 +307,49 @@ pub const ContainerRegistryContentClient = struct {
             self.allocator,
             &response,
         ) };
+    }
+
+    /// Uploads a blob from a seekable or non-seekable reader using bounded,
+    /// sequential chunks.
+    pub fn uploadBlob(
+        self: *ContainerRegistryContentClient,
+        reader: *std.Io.Reader,
+        options: blob_upload.BlobUploadOptions,
+    ) !blob_upload.BlobUploadResult {
+        var result = try self.uploadBlobResult(reader, options);
+        switch (result) {
+            .ok => |value| return value,
+            .err => |*failure| {
+                std.log.warn("{f}", .{failure.*});
+                failure.deinit();
+                return error.BlobUploadFailed;
+            },
+        }
+    }
+
+    /// Structured-result variant of `uploadBlob`.
+    pub fn uploadBlobResult(
+        self: *ContainerRegistryContentClient,
+        reader: *std.Io.Reader,
+        options: blob_upload.BlobUploadOptions,
+    ) !blob_upload.BlobUploadResponse {
+        return blob_upload.upload(.{
+            .allocator = self.allocator,
+            .pipeline = self.pipeline(),
+            .endpoint = self.registry_client.endpoint,
+            .api_version = self.registry_client.api_version,
+            .repository_name = self.repository_name,
+        }, reader, options);
+    }
+
+    /// Convenience wrapper for in-memory blob bytes.
+    pub fn uploadBlobBytes(
+        self: *ContainerRegistryContentClient,
+        bytes: []const u8,
+        options: blob_upload.BlobUploadOptions,
+    ) !blob_upload.BlobUploadResult {
+        var reader = std.Io.Reader.fixed(bytes);
+        return self.uploadBlob(&reader, options);
     }
 
     fn pipeline(self: *ContainerRegistryContentClient) *core.pipeline.HttpPipeline {

--- a/sdk/container_registry/src/root.zig
+++ b/sdk/container_registry/src/root.zig
@@ -9,6 +9,7 @@ const models = @import("models.zig");
 const service_error = @import("service_error.zig");
 const content = @import("content_client.zig");
 const digest = @import("digest.zig");
+const blob_upload = @import("blob_upload.zig");
 
 pub const BearerChallenge = challenge.BearerChallenge;
 pub const parseBearerChallenge = challenge.parseBearerChallenge;
@@ -61,8 +62,14 @@ pub const validateSha256Digest = digest.validateSha256Digest;
 pub const sha256DigestsEqual = digest.sha256DigestsEqual;
 pub const sha256_digest_length = digest.sha256_digest_length;
 pub const sha256_formatted_length = digest.sha256_formatted_length;
+pub const BlobUploadOptions = blob_upload.BlobUploadOptions;
+pub const BlobUploadResult = blob_upload.BlobUploadResult;
+pub const BlobUploadResponse = blob_upload.BlobUploadResponse;
+pub const default_blob_upload_chunk_size = blob_upload.default_chunk_size;
+pub const max_blob_upload_chunk_size = blob_upload.max_chunk_size;
 
 test {
     @import("std").testing.refAllDecls(@This());
     _ = @import("metadata_test.zig");
+    _ = @import("blob_upload_test.zig");
 }


### PR DESCRIPTION
Adds bounded-memory chunked blob upload with SHA-256 state rollback, strict upload Location/range validation, uncertain-outcome status recovery, cancellation cleanup, and final digest verification.

Closes #87