### PR TITLE
sdk/container_registry: add streaming and ranged blob downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ azure-core-amqp: azure-uamqp-zig (pure Zig AMQP 1.0)
 
 | Package | Clients |
 |---------|---------|
-| `azure_sdk_container_registry` | `ContainerRegistryClient` and `ContainerRegistryContentClient` with ACR auth, manifests, and resumable blob upload; generated APIs under `protocol` |
+| `azure_sdk_container_registry` | Challenge-authenticated metadata, manifest content, resumable blob uploads, and bounded/resumable blob downloads; generated APIs under `protocol` |
 | `azure_storage_blobs` | `BlobClient`, `BlobContainerClient`, `SasBlobClient` |
 | `azure_storage_queues` | `QueueClient`, `QueueServiceClient`, `SasQueueClient` |
 | `azure_storage_files_shares` | `ShareClient`, `ShareDirectoryClient`, `ShareFileClient` |

--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -171,7 +171,9 @@ the configured decoded-byte bound. Writer downloads request sequential ranges
 and retry only classified HTTP/read/transport failures from the last
 successfully written offset, so retries never replay confirmed bytes. A server
 may return a full `200`, ranged `206`, or terminal `416`; every length, range,
-total, requested digest, and returned service digest is checked.
+total, requested digest, and returned service digest is checked. Blob responses
+may omit `Docker-Content-Digest`; full decoded bytes are always verified against
+the requested digest, and any service digest that is present is also validated.
 
 Core redirect handling follows ACR `307` responses over HTTPS, removes
 `Authorization`, cookies, proxy authorization, and `Host` on cross-origin

--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -2,8 +2,9 @@
 
 `azure_sdk_container_registry` adds secure ACR challenge authentication,
 token caching, metadata operations, Link-header paging, structured service
-errors, exact-byte manifests, and bounded-memory resumable blob uploads to the
-generated `azure_rest_container_registry` protocol package.
+errors, exact-byte manifest operations, bounded-memory resumable blob uploads,
+and bounded blob downloads to the generated
+`azure_rest_container_registry` protocol package.
 
 ```zig
 const acr = @import("azure_sdk_container_registry");
@@ -132,6 +133,50 @@ session, final service digests are validated, and cancellation remains an outer
 Use `uploadBlobResult` when structured service errors are required. Generated
 mount, upload-status, and cancel operations remain available through
 `client.protocolClient().containerRegistryBlob()` and `acr.protocol`.
+
+Use `BlobDownloadClient` for digest-safe blob downloads:
+
+```zig
+var blobs = try acr.BlobDownloadClient.init(
+    allocator,
+    registry_endpoint,
+    "team/app",
+    .{
+        .transport = transport,
+        .authentication = .{ .credential = credential },
+    },
+);
+defer blobs.deinit();
+
+// Buffered downloads are capped at 16 MiB by default.
+var small = try blobs.downloadBlob(digest, .{ .max_size = 2 * 1024 * 1024 });
+defer small.deinit();
+
+// Streaming callers own one active HTTP operation.
+var stream = try blobs.downloadBlobStreaming(digest, .{});
+defer stream.deinit();
+const reader = try stream.reader();
+// Read from reader, then finish to drain and validate length and SHA-256.
+_ = reader;
+try stream.finish();
+
+// Large downloads use sequential 4 MiB ranges and bounded copy memory.
+var downloaded = try blobs.downloadBlobToWriter(digest, writer, .{});
+defer downloaded.deinit();
+```
+
+Streaming downloads require `finish`, `abort`, or `cancel`, followed by
+`deinit`; active operations are aborted by `deinit`. Buffered downloads enforce
+the configured decoded-byte bound. Writer downloads request sequential ranges
+and retry only classified HTTP/read/transport failures from the last
+successfully written offset, so retries never replay confirmed bytes. A server
+may return a full `200`, ranged `206`, or terminal `416`; every length, range,
+total, requested digest, and returned service digest is checked.
+
+Core redirect handling follows ACR `307` responses over HTTPS, removes
+`Authorization`, cookies, proxy authorization, and `Host` on cross-origin
+requests, and rejects insecure targets. Ranged retries always restart from the
+registry URL rather than retaining a storage redirect.
 
 Long-lived clients use bounded LRU caches: 128 routes, 128 scoped access
 tokens, and 32 refresh tokens. Tokens that reach the configured expiry skew

--- a/sdk/container_registry/src/blob_download.zig
+++ b/sdk/container_registry/src/blob_download.zig
@@ -115,15 +115,18 @@ pub const BlobDownloadStream = struct {
         allocator: std.mem.Allocator,
         operation: *core.http.HttpOperation,
         requested_digest: []const u8,
-        service_digest: []const u8,
+        service_digest: ?[]const u8,
         content_length: u64,
         decoded_content_length: ?u64,
         cancellation: ?*const core.http.CancellationToken,
     ) !BlobDownloadStream {
         const owned_digest = try allocator.dupe(u8, requested_digest);
         errdefer allocator.free(owned_digest);
-        const owned_service_digest = try allocator.dupe(u8, service_digest);
-        errdefer allocator.free(owned_service_digest);
+        const owned_service_digest = if (service_digest) |value|
+            try allocator.dupe(u8, value)
+        else
+            null;
+        errdefer if (owned_service_digest) |value| allocator.free(value);
 
         return .{
             .allocator = allocator,
@@ -212,7 +215,7 @@ pub const BlobDownloadStream = struct {
 
     pub fn deinit(self: *BlobDownloadStream) void {
         self.operation.deinit();
-        self.allocator.free(self.reader_impl.service_digest);
+        if (self.reader_impl.service_digest) |value| self.allocator.free(value);
         self.allocator.free(self.digest);
         self.* = undefined;
     }
@@ -223,7 +226,7 @@ const ValidatingReader = struct {
     operation: *core.http.HttpOperation,
     source: *std.Io.Reader,
     requested_digest: []const u8,
-    service_digest: []u8,
+    service_digest: ?[]u8,
     expected_length: ?u64,
     cancellation: ?*const core.http.CancellationToken,
     hasher: digest_mod.Sha256Digest = .{},
@@ -235,7 +238,7 @@ const ValidatingReader = struct {
     fn init(
         operation: *core.http.HttpOperation,
         requested_digest: []const u8,
-        service_digest: []u8,
+        service_digest: ?[]u8,
         expected_length: ?u64,
         cancellation: ?*const core.http.CancellationToken,
     ) ValidatingReader {
@@ -313,9 +316,11 @@ const ValidatingReader = struct {
             self.failure = error.RequestedDigestMismatch;
             return error.RequestedDigestMismatch;
         }
-        if (!std.ascii.eqlIgnoreCase(&self.computed_digest, self.service_digest)) {
-            self.failure = error.DigestMismatch;
-            return error.DigestMismatch;
+        if (self.service_digest) |service_digest| {
+            if (!std.ascii.eqlIgnoreCase(&self.computed_digest, service_digest)) {
+                self.failure = error.DigestMismatch;
+                return error.DigestMismatch;
+            }
         }
         self.complete = true;
     }
@@ -459,7 +464,6 @@ pub const BlobDownloadClient = struct {
         const service_digest = try serviceDigest(
             self.allocator,
             operation,
-            true,
             requested_digest,
         );
 
@@ -467,7 +471,7 @@ pub const BlobDownloadClient = struct {
             self.allocator,
             operation,
             requested_digest,
-            service_digest.?,
+            service_digest,
             content_length,
             expected_decoded_length,
             options.cancellation,
@@ -538,7 +542,6 @@ pub const BlobDownloadClient = struct {
                     _ = try serviceDigest(
                         self.allocator,
                         operation,
-                        true,
                         requested_digest,
                     );
                     const content_length = try requiredContentLength(
@@ -608,7 +611,6 @@ pub const BlobDownloadClient = struct {
                     _ = try serviceDigest(
                         self.allocator,
                         operation,
-                        false,
                         requested_digest,
                     );
 
@@ -662,7 +664,6 @@ pub const BlobDownloadClient = struct {
                     _ = try serviceDigest(
                         self.allocator,
                         operation,
-                        false,
                         requested_digest,
                     );
                     try ensureEmptyBody(operation, options.cancellation);
@@ -849,7 +850,6 @@ fn requiredContentRange(
 fn serviceDigest(
     allocator: std.mem.Allocator,
     operation: *const core.http.HttpOperation,
-    required: bool,
     requested_digest: []const u8,
 ) !?[]const u8 {
     const values = try operation.getHeaderValues(
@@ -857,10 +857,7 @@ fn serviceDigest(
         "Docker-Content-Digest",
     );
     defer allocator.free(values);
-    if (values.len == 0) {
-        if (required) return error.MissingDockerContentDigest;
-        return null;
-    }
+    if (values.len == 0) return null;
     if (values.len != 1) return error.AmbiguousResponseHeader;
     try digest_mod.validateSha256Digest(values[0]);
     if (!(try digest_mod.sha256DigestsEqual(values[0], requested_digest)))

--- a/sdk/container_registry/src/blob_download.zig
+++ b/sdk/container_registry/src/blob_download.zig
@@ -1,0 +1,1048 @@
+const std = @import("std");
+const core = @import("azure_core");
+const client_mod = @import("client.zig");
+const digest_mod = @import("digest.zig");
+const service_error = @import("service_error.zig");
+
+pub const default_buffered_blob_limit: usize = 16 * 1024 * 1024;
+pub const default_range_size: usize = 4 * 1024 * 1024;
+const copy_buffer_size: usize = 64 * 1024;
+const max_error_body_size: usize = 1024 * 1024;
+
+pub const BlobDownloadClientOptions = client_mod.ContainerRegistryClientOptions;
+
+pub const BufferedBlobDownloadOptions = struct {
+    max_size: usize = default_buffered_blob_limit,
+    cancellation: ?*const core.http.CancellationToken = null,
+};
+
+pub const StreamingBlobDownloadOptions = struct {
+    cancellation: ?*const core.http.CancellationToken = null,
+};
+
+pub const DownloadBlobToWriterOptions = struct {
+    range_size: usize = default_range_size,
+    max_retries: u32 = 3,
+    cancellation: ?*const core.http.CancellationToken = null,
+};
+
+pub const DownloadedBlob = struct {
+    allocator: std.mem.Allocator,
+    bytes: []u8,
+    digest: []u8,
+
+    pub fn deinit(self: *DownloadedBlob) void {
+        self.allocator.free(self.bytes);
+        self.allocator.free(self.digest);
+        self.* = undefined;
+    }
+};
+
+pub const BlobDownloadDetails = struct {
+    allocator: std.mem.Allocator,
+    digest: []u8,
+    size: u64,
+
+    pub fn deinit(self: *BlobDownloadDetails) void {
+        self.allocator.free(self.digest);
+        self.* = undefined;
+    }
+};
+
+pub const BufferedBlobDownloadResponse = BlobDownloadResponse(DownloadedBlob);
+pub const StreamingBlobDownloadResponse = BlobDownloadResponse(BlobDownloadStream);
+pub const DownloadBlobToWriterResponse = BlobDownloadResponse(BlobDownloadDetails);
+
+pub fn BlobDownloadResponse(comptime T: type) type {
+    return union(enum) {
+        ok: T,
+        err: service_error.ServiceError,
+
+        const Self = @This();
+
+        pub fn deinit(self: *Self) void {
+            switch (self.*) {
+                .ok => |*value| value.deinit(),
+                .err => |*failure| failure.deinit(),
+            }
+            self.* = undefined;
+        }
+
+        pub fn isOk(self: Self) bool {
+            return self == .ok;
+        }
+
+        pub fn errorCode(self: Self) ?[]const u8 {
+            return switch (self) {
+                .ok => null,
+                .err => |failure| failure.code,
+            };
+        }
+
+        pub fn unwrap(self: *Self, failure_error: anyerror) anyerror!T {
+            switch (self.*) {
+                .ok => |value| {
+                    self.* = undefined;
+                    return value;
+                },
+                .err => |*failure| {
+                    failure.deinit();
+                    self.* = undefined;
+                    return failure_error;
+                },
+            }
+        }
+    };
+}
+
+const DownloadState = enum {
+    active,
+    finished,
+    aborted,
+    cancelled,
+};
+
+pub const BlobDownloadStream = struct {
+    allocator: std.mem.Allocator,
+    operation: *core.http.HttpOperation,
+    digest: []u8,
+    content_length: u64,
+    decoded_content_length: ?u64,
+    reader_impl: ValidatingReader,
+    state: DownloadState = .active,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        operation: *core.http.HttpOperation,
+        requested_digest: []const u8,
+        service_digest: []const u8,
+        content_length: u64,
+        decoded_content_length: ?u64,
+        cancellation: ?*const core.http.CancellationToken,
+    ) !BlobDownloadStream {
+        const owned_digest = try allocator.dupe(u8, requested_digest);
+        errdefer allocator.free(owned_digest);
+        const owned_service_digest = try allocator.dupe(u8, service_digest);
+        errdefer allocator.free(owned_service_digest);
+
+        return .{
+            .allocator = allocator,
+            .operation = operation,
+            .digest = owned_digest,
+            .content_length = content_length,
+            .decoded_content_length = decoded_content_length,
+            .reader_impl = ValidatingReader.init(
+                operation,
+                owned_digest,
+                owned_service_digest,
+                decoded_content_length,
+                cancellation,
+            ),
+        };
+    }
+
+    /// Returns a validating reader over the decoded response bytes.
+    ///
+    /// Read failures are reported as `error.ReadFailed`; call `lastError` for
+    /// the specific transport, cancellation, length, or digest failure.
+    pub fn reader(self: *BlobDownloadStream) !*std.Io.Reader {
+        if (self.state != .active) return error.BlobDownloadNotActive;
+        return &self.reader_impl.interface;
+    }
+
+    pub fn lastError(self: *const BlobDownloadStream) ?anyerror {
+        return self.reader_impl.failure;
+    }
+
+    /// Drains and validates the response, then releases the HTTP connection.
+    pub fn finish(self: *BlobDownloadStream) !void {
+        if (self.state != .active) return error.BlobDownloadNotActive;
+        var buffer: [copy_buffer_size]u8 = undefined;
+        while (true) {
+            const count = self.reader_impl.interface.readSliceShort(&buffer) catch {
+                self.operation.abort();
+                const failure = self.reader_impl.failure orelse error.ReadFailed;
+                self.state = if (failure == error.OperationCancelled)
+                    .cancelled
+                else
+                    .aborted;
+                return failure;
+            };
+            if (count == 0) break;
+        }
+        if (self.reader_impl.failure) |failure| {
+            self.operation.abort();
+            self.state = if (failure == error.OperationCancelled)
+                .cancelled
+            else
+                .aborted;
+            return failure;
+        }
+        self.operation.finish() catch |err| {
+            self.state = .aborted;
+            return err;
+        };
+        self.state = .finished;
+    }
+
+    pub fn computedDigest(
+        self: *const BlobDownloadStream,
+    ) ![digest_mod.sha256_formatted_length]u8 {
+        if (!self.reader_impl.complete) return error.BlobDownloadIncomplete;
+        if (self.reader_impl.failure) |failure| return failure;
+        return self.reader_impl.computed_digest;
+    }
+
+    pub fn decodedLength(self: *const BlobDownloadStream) u64 {
+        return self.reader_impl.total;
+    }
+
+    pub fn abort(self: *BlobDownloadStream) void {
+        if (self.state != .active) return;
+        self.operation.abort();
+        self.state = .aborted;
+    }
+
+    pub fn cancel(self: *BlobDownloadStream) void {
+        if (self.state != .active) return;
+        self.operation.cancel();
+        self.reader_impl.failure = error.OperationCancelled;
+        self.state = .cancelled;
+    }
+
+    pub fn deinit(self: *BlobDownloadStream) void {
+        self.operation.deinit();
+        self.allocator.free(self.reader_impl.service_digest);
+        self.allocator.free(self.digest);
+        self.* = undefined;
+    }
+};
+
+const ValidatingReader = struct {
+    interface: std.Io.Reader,
+    operation: *core.http.HttpOperation,
+    source: *std.Io.Reader,
+    requested_digest: []const u8,
+    service_digest: []u8,
+    expected_length: ?u64,
+    cancellation: ?*const core.http.CancellationToken,
+    hasher: digest_mod.Sha256Digest = .{},
+    computed_digest: [digest_mod.sha256_formatted_length]u8 = undefined,
+    total: u64 = 0,
+    complete: bool = false,
+    failure: ?anyerror = null,
+
+    fn init(
+        operation: *core.http.HttpOperation,
+        requested_digest: []const u8,
+        service_digest: []u8,
+        expected_length: ?u64,
+        cancellation: ?*const core.http.CancellationToken,
+    ) ValidatingReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .operation = operation,
+            .source = operation.body_reader,
+            .requested_digest = requested_digest,
+            .service_digest = service_digest,
+            .expected_length = expected_length,
+            .cancellation = cancellation,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *ValidatingReader = @alignCast(@fieldParentPtr("interface", interface));
+        if (self.failure != null) return error.ReadFailed;
+        if (self.complete) return error.EndOfStream;
+        self.checkCancellation() catch return error.ReadFailed;
+
+        var buffer: [copy_buffer_size]u8 = undefined;
+        const read_limit = limit.minInt(buffer.len);
+        if (read_limit == 0) return 0;
+        const count = readSome(self.source, buffer[0..read_limit]) catch |err| {
+            self.failure = switch (err) {
+                error.ReadFailed => self.operation.bodyError() orelse error.ReadFailed,
+            };
+            return error.ReadFailed;
+        };
+        if (count == 0) {
+            self.completeAndValidate() catch return error.ReadFailed;
+            return error.EndOfStream;
+        }
+        if (self.expected_length) |expected| {
+            if (self.total > expected or count > expected - self.total) {
+                self.failure = error.ContentLengthMismatch;
+                return error.ReadFailed;
+            }
+        }
+        self.checkCancellation() catch return error.ReadFailed;
+        try writer.writeAll(buffer[0..count]);
+        self.hasher.update(buffer[0..count]);
+        self.total += count;
+        return count;
+    }
+
+    fn checkCancellation(self: *ValidatingReader) !void {
+        if (self.cancellation) |token| {
+            if (token.isCancelled()) {
+                self.operation.cancel();
+                self.failure = error.OperationCancelled;
+                return error.OperationCancelled;
+            }
+        }
+    }
+
+    fn completeAndValidate(self: *ValidatingReader) !void {
+        if (self.expected_length) |expected| {
+            if (self.total != expected) {
+                self.failure = error.ContentLengthMismatch;
+                return error.ContentLengthMismatch;
+            }
+        }
+        self.computed_digest = self.hasher.final();
+        if (!std.ascii.eqlIgnoreCase(&self.computed_digest, self.requested_digest)) {
+            self.failure = error.RequestedDigestMismatch;
+            return error.RequestedDigestMismatch;
+        }
+        if (!std.ascii.eqlIgnoreCase(&self.computed_digest, self.service_digest)) {
+            self.failure = error.DigestMismatch;
+            return error.DigestMismatch;
+        }
+        self.complete = true;
+    }
+};
+
+/// High-level, digest-safe blob downloader for one ACR repository.
+pub const BlobDownloadClient = struct {
+    allocator: std.mem.Allocator,
+    repository_name: []u8,
+    registry_client: client_mod.ContainerRegistryClient,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        endpoint: []const u8,
+        repository_name: []const u8,
+        options: BlobDownloadClientOptions,
+    ) !BlobDownloadClient {
+        try validateRepositoryName(repository_name);
+        const owned_repository = try allocator.dupe(u8, repository_name);
+        errdefer allocator.free(owned_repository);
+        const registry_client = try client_mod.ContainerRegistryClient.init(
+            allocator,
+            endpoint,
+            options,
+        );
+        return .{
+            .allocator = allocator,
+            .repository_name = owned_repository,
+            .registry_client = registry_client,
+        };
+    }
+
+    pub fn deinit(self: *BlobDownloadClient) void {
+        self.registry_client.deinit();
+        self.allocator.free(self.repository_name);
+        self.* = undefined;
+    }
+
+    pub fn downloadBlob(
+        self: *BlobDownloadClient,
+        digest: []const u8,
+        options: BufferedBlobDownloadOptions,
+    ) !DownloadedBlob {
+        var result = try self.downloadBlobResult(digest, options);
+        return result.unwrap(error.BlobDownloadFailed);
+    }
+
+    /// Buffers a blob only up to `options.max_size`.
+    pub fn downloadBlobResult(
+        self: *BlobDownloadClient,
+        digest: []const u8,
+        options: BufferedBlobDownloadOptions,
+    ) !BufferedBlobDownloadResponse {
+        const opened = try self.downloadBlobStreamingResult(digest, .{
+            .cancellation = options.cancellation,
+        });
+        switch (opened) {
+            .err => |failure| return .{ .err = failure },
+            .ok => |stream_value| {
+                var stream = stream_value;
+                defer stream.deinit();
+
+                if (stream.decoded_content_length) |length| {
+                    if (length > options.max_size) return error.BlobTooLarge;
+                }
+
+                var body: std.ArrayList(u8) = .empty;
+                defer body.deinit(self.allocator);
+                if (stream.decoded_content_length) |length| {
+                    const capacity: usize = @intCast(length);
+                    if (capacity > 0) {
+                        try body.ensureTotalCapacityPrecise(self.allocator, capacity);
+                    }
+                }
+
+                const reader = try stream.reader();
+                var buffer: [copy_buffer_size]u8 = undefined;
+                while (true) {
+                    const count = reader.readSliceShort(&buffer) catch
+                        return stream.lastError() orelse error.ReadFailed;
+                    if (count == 0) break;
+                    if (count > options.max_size -| body.items.len)
+                        return error.BlobTooLarge;
+                    try body.appendSlice(self.allocator, buffer[0..count]);
+                }
+                try stream.finish();
+                const computed = try stream.computedDigest();
+                const owned_digest = try self.allocator.dupe(u8, &computed);
+                errdefer self.allocator.free(owned_digest);
+                return .{ .ok = .{
+                    .allocator = self.allocator,
+                    .bytes = try body.toOwnedSlice(self.allocator),
+                    .digest = owned_digest,
+                } };
+            },
+        }
+    }
+
+    pub fn downloadBlobStreaming(
+        self: *BlobDownloadClient,
+        digest: []const u8,
+        options: StreamingBlobDownloadOptions,
+    ) !BlobDownloadStream {
+        var result = try self.downloadBlobStreamingResult(digest, options);
+        return result.unwrap(error.BlobDownloadFailed);
+    }
+
+    /// Opens a single-owner validating stream. Call `finish`, `abort`, or
+    /// `cancel`, then always call `deinit`.
+    pub fn downloadBlobStreamingResult(
+        self: *BlobDownloadClient,
+        requested_digest: []const u8,
+        options: StreamingBlobDownloadOptions,
+    ) !StreamingBlobDownloadResponse {
+        try digest_mod.validateSha256Digest(requested_digest);
+        try checkCancellation(options.cancellation);
+
+        const url = try self.buildBlobUrl(requested_digest);
+        defer self.allocator.free(url);
+        var request = core.http.Request.init(self.allocator, .GET, url);
+        defer request.deinit();
+        try request.setHeader("Accept", "application/octet-stream");
+
+        const operation = try self.pipeline().open(
+            &request,
+            .{ .cancellation = options.cancellation },
+        );
+        var operation_owned = true;
+        defer if (operation_owned) operation.deinit();
+        if (operation.status_code != 200) {
+            if (operation.isSuccess()) return error.UnexpectedResponseStatus;
+            return .{ .err = try self.serviceErrorFromOperation(operation) };
+        }
+
+        const content_length = try requiredContentLength(self.allocator, operation);
+        const encoding = try responseBodyEncoding(self.allocator, operation);
+        const expected_decoded_length = switch (encoding) {
+            .identity => content_length,
+            .encoded => null,
+        };
+        const service_digest = try serviceDigest(
+            self.allocator,
+            operation,
+            true,
+            requested_digest,
+        );
+
+        const stream = try BlobDownloadStream.init(
+            self.allocator,
+            operation,
+            requested_digest,
+            service_digest.?,
+            content_length,
+            expected_decoded_length,
+            options.cancellation,
+        );
+        operation_owned = false;
+        return .{ .ok = stream };
+    }
+
+    pub fn downloadBlobToWriter(
+        self: *BlobDownloadClient,
+        digest: []const u8,
+        writer: *std.Io.Writer,
+        options: DownloadBlobToWriterOptions,
+    ) !BlobDownloadDetails {
+        var result = try self.downloadBlobToWriterResult(digest, writer, options);
+        return result.unwrap(error.BlobDownloadFailed);
+    }
+
+    /// Downloads sequential ranges. Only bytes accepted by `writer.writeAll`
+    /// advance the confirmed offset and digest, so read/transport retries
+    /// resume without duplicating confirmed output.
+    pub fn downloadBlobToWriterResult(
+        self: *BlobDownloadClient,
+        requested_digest: []const u8,
+        writer: *std.Io.Writer,
+        options: DownloadBlobToWriterOptions,
+    ) !DownloadBlobToWriterResponse {
+        try digest_mod.validateSha256Digest(requested_digest);
+        if (options.range_size == 0) return error.InvalidRangeSize;
+        try checkCancellation(options.cancellation);
+
+        var hasher = digest_mod.Sha256Digest{};
+        var confirmed: u64 = 0;
+        var total_size: ?u64 = null;
+        var retries: u32 = 0;
+
+        while (total_size == null or confirmed < total_size.?) {
+            try checkCancellation(options.cancellation);
+            const request_end = rangeEnd(confirmed, options.range_size, total_size);
+            var operation = self.openRange(
+                requested_digest,
+                confirmed,
+                request_end,
+                options.cancellation,
+            ) catch |err| {
+                if (isRetryableDownloadError(err) and retries < options.max_retries) {
+                    retries += 1;
+                    continue;
+                }
+                return err;
+            };
+            var operation_owned = true;
+            defer if (operation_owned) operation.deinit();
+
+            if (isRetryableStatus(operation.status_code) and
+                retries < options.max_retries)
+            {
+                operation.abort();
+                operation.deinit();
+                operation_owned = false;
+                retries += 1;
+                continue;
+            }
+
+            switch (operation.status_code) {
+                200 => {
+                    if (confirmed != 0) return error.RangeNotHonored;
+                    _ = try serviceDigest(
+                        self.allocator,
+                        operation,
+                        true,
+                        requested_digest,
+                    );
+                    const content_length = try requiredContentLength(
+                        self.allocator,
+                        operation,
+                    );
+                    const encoding = try responseBodyEncoding(self.allocator, operation);
+                    const expected_length: ?u64 = switch (encoding) {
+                        .identity => content_length,
+                        .encoded => null,
+                    };
+                    if (expected_length) |length| total_size = length;
+
+                    copyOperationBody(
+                        operation,
+                        writer,
+                        &hasher,
+                        &confirmed,
+                        expected_length,
+                        options.cancellation,
+                    ) catch |err| {
+                        operation.abort();
+                        operation.deinit();
+                        operation_owned = false;
+                        if (isRetryableDownloadError(err) and
+                            retries < options.max_retries)
+                        {
+                            retries += 1;
+                            continue;
+                        }
+                        return err;
+                    };
+                    operation.finish() catch |err| {
+                        operation.deinit();
+                        operation_owned = false;
+                        if (isRetryableDownloadError(err) and
+                            retries < options.max_retries)
+                        {
+                            retries += 1;
+                            continue;
+                        }
+                        return err;
+                    };
+                    operation.deinit();
+                    operation_owned = false;
+                    total_size = confirmed;
+                    break;
+                },
+                206 => {
+                    if (try responseBodyEncoding(self.allocator, operation) != .identity)
+                        return error.EncodedRangeResponse;
+                    const content_range = try requiredContentRange(
+                        self.allocator,
+                        operation,
+                    );
+                    const parsed = try parseSatisfiedContentRange(content_range);
+                    if (parsed.start != confirmed) return error.ContentRangeOffsetMismatch;
+                    if (parsed.end > request_end) return error.ContentRangeOutsideRequest;
+                    if (total_size) |known_total| {
+                        if (parsed.total != known_total) return error.TotalSizeMismatch;
+                    } else {
+                        total_size = parsed.total;
+                    }
+                    const span = parsed.end - parsed.start + 1;
+                    if (try requiredContentLength(self.allocator, operation) != span)
+                        return error.ContentLengthMismatch;
+                    _ = try serviceDigest(
+                        self.allocator,
+                        operation,
+                        false,
+                        requested_digest,
+                    );
+
+                    copyOperationBody(
+                        operation,
+                        writer,
+                        &hasher,
+                        &confirmed,
+                        span,
+                        options.cancellation,
+                    ) catch |err| {
+                        operation.abort();
+                        operation.deinit();
+                        operation_owned = false;
+                        if (isRetryableDownloadError(err) and
+                            retries < options.max_retries)
+                        {
+                            retries += 1;
+                            continue;
+                        }
+                        return err;
+                    };
+                    operation.finish() catch |err| {
+                        operation.deinit();
+                        operation_owned = false;
+                        if (isRetryableDownloadError(err) and
+                            retries < options.max_retries)
+                        {
+                            retries += 1;
+                            continue;
+                        }
+                        return err;
+                    };
+                    operation.deinit();
+                    operation_owned = false;
+                    retries = 0;
+                },
+                416 => {
+                    const content_range = try requiredContentRange(
+                        self.allocator,
+                        operation,
+                    );
+                    const parsed_total = try parseUnsatisfiedContentRange(content_range);
+                    if (total_size) |known_total| {
+                        if (parsed_total != known_total) return error.TotalSizeMismatch;
+                    }
+                    if (confirmed != parsed_total) return error.RangeNotSatisfiable;
+                    if (try optionalContentLength(self.allocator, operation)) |length| {
+                        if (length != 0) return error.ContentLengthMismatch;
+                    }
+                    _ = try serviceDigest(
+                        self.allocator,
+                        operation,
+                        false,
+                        requested_digest,
+                    );
+                    try ensureEmptyBody(operation, options.cancellation);
+                    try operation.finish();
+                    operation.deinit();
+                    operation_owned = false;
+                    total_size = parsed_total;
+                    break;
+                },
+                else => {
+                    if (operation.isSuccess()) return error.UnexpectedResponseStatus;
+                    const failure = try self.serviceErrorFromOperation(operation);
+                    operation.deinit();
+                    operation_owned = false;
+                    return .{ .err = failure };
+                },
+            }
+        }
+
+        const computed = hasher.final();
+        if (!std.ascii.eqlIgnoreCase(&computed, requested_digest))
+            return error.RequestedDigestMismatch;
+        const owned_digest = try self.allocator.dupe(u8, &computed);
+        return .{ .ok = .{
+            .allocator = self.allocator,
+            .digest = owned_digest,
+            .size = total_size orelse confirmed,
+        } };
+    }
+
+    fn pipeline(self: *BlobDownloadClient) *core.pipeline.HttpPipeline {
+        return &self.registry_client.protocolClient().pipeline;
+    }
+
+    fn buildBlobUrl(
+        self: *BlobDownloadClient,
+        digest: []const u8,
+    ) ![]u8 {
+        const protocol_client = self.registry_client.protocolClient();
+        const repository = try core.url.encodeRepositoryName(
+            self.allocator,
+            self.repository_name,
+        );
+        defer self.allocator.free(repository);
+        const encoded_digest = try core.url.encodePathSegment(
+            self.allocator,
+            digest,
+        );
+        defer self.allocator.free(encoded_digest);
+        const api_version = try core.url.percentEncode(
+            self.allocator,
+            protocol_client.api_version,
+        );
+        defer self.allocator.free(api_version);
+        return std.fmt.allocPrint(
+            self.allocator,
+            "{s}/v2/{s}/blobs/{s}?api-version={s}",
+            .{
+                protocol_client.endpoint,
+                repository,
+                encoded_digest,
+                api_version,
+            },
+        );
+    }
+
+    fn openRange(
+        self: *BlobDownloadClient,
+        digest: []const u8,
+        start: u64,
+        end: u64,
+        cancellation: ?*const core.http.CancellationToken,
+    ) !*core.http.HttpOperation {
+        const url = try self.buildBlobUrl(digest);
+        defer self.allocator.free(url);
+        var request = core.http.Request.init(self.allocator, .GET, url);
+        defer request.deinit();
+        try request.setHeader("Accept", "application/octet-stream");
+        try request.setHeader("Accept-Encoding", "identity");
+        var range_buffer: [96]u8 = undefined;
+        const range = try std.fmt.bufPrint(
+            &range_buffer,
+            "bytes={d}-{d}",
+            .{ start, end },
+        );
+        try request.setHeader("Range", range);
+        return self.pipeline().open(
+            &request,
+            .{ .cancellation = cancellation },
+        );
+    }
+
+    fn serviceErrorFromOperation(
+        self: *BlobDownloadClient,
+        operation: *core.http.HttpOperation,
+    ) !service_error.ServiceError {
+        const reader = try operation.reader();
+        const body = reader.allocRemaining(
+            self.allocator,
+            .limited(max_error_body_size),
+        ) catch |err| switch (err) {
+            error.ReadFailed => return operation.bodyError() orelse error.ReadFailed,
+            error.StreamTooLong => return error.ErrorResponseTooLarge,
+            else => |other| return other,
+        };
+        var response = core.http.Response{
+            .status_code = operation.status_code,
+            .headers = std.StringHashMap([]const u8).init(self.allocator),
+            .body = body,
+            .allocator = self.allocator,
+        };
+        defer response.deinit();
+        var failure = try service_error.ServiceError.fromResponse(
+            self.allocator,
+            &response,
+        );
+        errdefer failure.deinit();
+        try operation.finish();
+        return failure;
+    }
+};
+
+const ResponseBodyEncoding = enum {
+    identity,
+    encoded,
+};
+
+fn responseBodyEncoding(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+) !ResponseBodyEncoding {
+    const values = try operation.getHeaderValues(allocator, "Content-Encoding");
+    defer allocator.free(values);
+    if (values.len == 0) return .identity;
+
+    var saw_encoding = false;
+    var encoded = false;
+    for (values) |value| {
+        var encodings = std.mem.splitScalar(u8, value, ',');
+        while (encodings.next()) |raw_encoding| {
+            const encoding = std.mem.trim(u8, raw_encoding, " \t");
+            if (encoding.len == 0) return error.InvalidContentEncoding;
+            saw_encoding = true;
+            if (!std.ascii.eqlIgnoreCase(encoding, "identity")) encoded = true;
+        }
+    }
+    if (!saw_encoding) return error.InvalidContentEncoding;
+    return if (encoded) .encoded else .identity;
+}
+
+fn requiredContentLength(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+) !u64 {
+    return (try optionalContentLength(allocator, operation)) orelse
+        error.MissingContentLength;
+}
+
+fn optionalContentLength(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+) !?u64 {
+    const values = try operation.getHeaderValues(allocator, "Content-Length");
+    defer allocator.free(values);
+    if (values.len == 0) return null;
+    if (values.len != 1) return error.AmbiguousResponseHeader;
+    if (values[0].len == 0) return error.InvalidContentLength;
+    return std.fmt.parseInt(u64, values[0], 10) catch
+        return error.InvalidContentLength;
+}
+
+fn requiredContentRange(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+) ![]const u8 {
+    const values = try operation.getHeaderValues(allocator, "Content-Range");
+    defer allocator.free(values);
+    if (values.len == 0) return error.MissingContentRange;
+    if (values.len != 1) return error.AmbiguousResponseHeader;
+    if (values[0].len == 0) return error.InvalidContentRange;
+    return values[0];
+}
+
+fn serviceDigest(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+    required: bool,
+    requested_digest: []const u8,
+) !?[]const u8 {
+    const values = try operation.getHeaderValues(
+        allocator,
+        "Docker-Content-Digest",
+    );
+    defer allocator.free(values);
+    if (values.len == 0) {
+        if (required) return error.MissingDockerContentDigest;
+        return null;
+    }
+    if (values.len != 1) return error.AmbiguousResponseHeader;
+    try digest_mod.validateSha256Digest(values[0]);
+    if (!(try digest_mod.sha256DigestsEqual(values[0], requested_digest)))
+        return error.ServiceDigestMismatch;
+    return values[0];
+}
+
+const SatisfiedContentRange = struct {
+    start: u64,
+    end: u64,
+    total: u64,
+};
+
+fn parseSatisfiedContentRange(value: []const u8) !SatisfiedContentRange {
+    if (value.len < "bytes 0-0/1".len or
+        !std.ascii.eqlIgnoreCase(value[0.."bytes ".len], "bytes "))
+    {
+        return error.InvalidContentRange;
+    }
+    const range_and_total = value["bytes ".len..];
+    const slash = std.mem.indexOfScalar(u8, range_and_total, '/') orelse
+        return error.InvalidContentRange;
+    if (slash == 0 or slash + 1 == range_and_total.len)
+        return error.InvalidContentRange;
+    const range = range_and_total[0..slash];
+    const total_text = range_and_total[slash + 1 ..];
+    if (std.mem.indexOfScalar(u8, total_text, '*') != null)
+        return error.InvalidContentRange;
+    const dash = std.mem.indexOfScalar(u8, range, '-') orelse
+        return error.InvalidContentRange;
+    if (dash == 0 or dash + 1 == range.len) return error.InvalidContentRange;
+    const start = std.fmt.parseInt(u64, range[0..dash], 10) catch
+        return error.InvalidContentRange;
+    const end = std.fmt.parseInt(u64, range[dash + 1 ..], 10) catch
+        return error.InvalidContentRange;
+    const total = std.fmt.parseInt(u64, total_text, 10) catch
+        return error.InvalidContentRange;
+    if (start > end or total == 0 or end >= total)
+        return error.InvalidContentRange;
+    return .{ .start = start, .end = end, .total = total };
+}
+
+fn parseUnsatisfiedContentRange(value: []const u8) !u64 {
+    if (value.len <= "bytes */".len or
+        !std.ascii.eqlIgnoreCase(value[0.."bytes */".len], "bytes */"))
+    {
+        return error.InvalidContentRange;
+    }
+    return std.fmt.parseInt(u64, value["bytes */".len..], 10) catch
+        return error.InvalidContentRange;
+}
+
+fn rangeEnd(start: u64, range_size: usize, total_size: ?u64) u64 {
+    const size_minus_one: u64 = @intCast(range_size - 1);
+    const uncapped = std.math.add(u64, start, size_minus_one) catch
+        std.math.maxInt(u64);
+    if (total_size) |total| {
+        if (total == 0) return 0;
+        return @min(uncapped, total - 1);
+    }
+    return uncapped;
+}
+
+fn copyOperationBody(
+    operation: *core.http.HttpOperation,
+    writer: *std.Io.Writer,
+    hasher: *digest_mod.Sha256Digest,
+    confirmed: *u64,
+    expected_length: ?u64,
+    cancellation: ?*const core.http.CancellationToken,
+) !void {
+    const reader = try operation.reader();
+    var copied: u64 = 0;
+    var buffer: [copy_buffer_size]u8 = undefined;
+    while (expected_length == null or copied < expected_length.?) {
+        try checkCancellationAndCancel(cancellation, operation);
+        const limit = if (expected_length) |expected|
+            @min(buffer.len, @as(usize, @intCast(expected - copied)))
+        else
+            buffer.len;
+        const count = readSome(reader, buffer[0..limit]) catch
+            return operation.bodyError() orelse error.ReadFailed;
+        if (count == 0) {
+            if (expected_length != null) return error.UnexpectedEndOfStream;
+            return;
+        }
+        try checkCancellationAndCancel(cancellation, operation);
+        try writer.writeAll(buffer[0..count]);
+        hasher.update(buffer[0..count]);
+        confirmed.* += count;
+        copied += count;
+    }
+
+    var extra: [1]u8 = undefined;
+    const extra_count = readSome(reader, &extra) catch
+        return operation.bodyError() orelse error.ReadFailed;
+    if (extra_count != 0) return error.ContentLengthMismatch;
+}
+
+fn ensureEmptyBody(
+    operation: *core.http.HttpOperation,
+    cancellation: ?*const core.http.CancellationToken,
+) !void {
+    try checkCancellationAndCancel(cancellation, operation);
+    const reader = try operation.reader();
+    var extra: [1]u8 = undefined;
+    const count = readSome(reader, &extra) catch
+        return operation.bodyError() orelse error.ReadFailed;
+    if (count != 0) return error.ContentLengthMismatch;
+}
+
+fn readSome(reader: *std.Io.Reader, buffer: []u8) error{ReadFailed}!usize {
+    if (buffer.len == 0) return 0;
+    var writer = std.Io.Writer.fixed(buffer);
+    return reader.stream(&writer, .limited(buffer.len)) catch |err| switch (err) {
+        error.EndOfStream => 0,
+        error.ReadFailed => error.ReadFailed,
+        error.WriteFailed => error.ReadFailed,
+    };
+}
+
+fn checkCancellation(
+    cancellation: ?*const core.http.CancellationToken,
+) !void {
+    if (cancellation) |token| {
+        if (token.isCancelled()) return error.OperationCancelled;
+    }
+}
+
+fn checkCancellationAndCancel(
+    cancellation: ?*const core.http.CancellationToken,
+    operation: *core.http.HttpOperation,
+) !void {
+    checkCancellation(cancellation) catch |err| {
+        operation.cancel();
+        return err;
+    };
+}
+
+pub fn isRetryableDownloadError(err: anyerror) bool {
+    return switch (err) {
+        error.ReadFailed,
+        error.UnexpectedEndOfStream,
+        error.ConnectionResetByPeer,
+        error.ConnectionTimedOut,
+        error.ConnectionRefused,
+        error.NetworkUnreachable,
+        error.HostUnreachable,
+        error.TemporaryNameServerFailure,
+        error.NameServerFailure,
+        error.BrokenPipe,
+        error.SocketNotConnected,
+        error.WouldBlock,
+        => true,
+        else => false,
+    };
+}
+
+pub fn isRetryableStatus(status_code: u16) bool {
+    return status_code == 408 or status_code == 429 or
+        status_code == 500 or status_code == 502 or
+        status_code == 503 or status_code == 504;
+}
+
+fn validateRepositoryName(repository_name: []const u8) !void {
+    if (repository_name.len == 0) return error.RepositoryNameRequired;
+    if (repository_name.len > 255) return error.RepositoryNameTooLong;
+    if (repository_name[0] == '/' or repository_name[repository_name.len - 1] == '/')
+        return error.InvalidRepositoryName;
+
+    var previous_slash = false;
+    for (repository_name) |byte| {
+        if (byte == '/') {
+            if (previous_slash) return error.InvalidRepositoryName;
+            previous_slash = true;
+            continue;
+        }
+        previous_slash = false;
+        if (!std.ascii.isLower(byte) and !std.ascii.isDigit(byte) and
+            byte != '.' and byte != '_' and byte != '-')
+        {
+            return error.InvalidRepositoryName;
+        }
+    }
+}

--- a/sdk/container_registry/src/blob_download_test.zig
+++ b/sdk/container_registry/src/blob_download_test.zig
@@ -1,0 +1,1059 @@
+const std = @import("std");
+const core = @import("azure_core");
+const blob_download = @import("blob_download.zig");
+const digest_mod = @import("digest.zig");
+
+const BlobDownloadClient = blob_download.BlobDownloadClient;
+const isRetryableDownloadError = blob_download.isRetryableDownloadError;
+const isRetryableStatus = blob_download.isRetryableStatus;
+const copy_buffer_size: usize = 64 * 1024;
+
+fn checkCancellation(cancellation: ?*const core.http.CancellationToken) !void {
+    if (cancellation) |token| {
+        if (token.isCancelled()) return error.OperationCancelled;
+    }
+}
+
+fn testClient(
+    allocator: std.mem.Allocator,
+    transport: *core.http.HttpTransport,
+) !BlobDownloadClient {
+    return BlobDownloadClient.init(
+        allocator,
+        "https://registry.example",
+        "team/app",
+        .{
+            .transport = transport,
+            .authentication = .anonymous,
+        },
+    );
+}
+
+fn capturedHeader(
+    headers: *const std.StringHashMap([]const u8),
+    name: []const u8,
+) ?[]const u8 {
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, name))
+            return entry.value_ptr.*;
+    }
+    return null;
+}
+
+const DownloadTestTransport = struct {
+    const Header = core.http.MockTransport.HeaderPair;
+    const ResponseSpec = struct {
+        status: u16,
+        body: []const u8 = "",
+        headers: []const Header = &.{},
+        fail_after: ?usize = null,
+        body_error: ?anyerror = null,
+        open_error: ?anyerror = null,
+        read_size: usize = 2,
+    };
+
+    allocator: std.mem.Allocator,
+    responses: []const ResponseSpec,
+    transport: core.http.HttpTransport,
+    call_count: usize = 0,
+    ranges: [32][96]u8 = undefined,
+    range_lengths: [32]usize = .{0} ** 32,
+    urls: [32][512]u8 = undefined,
+    url_lengths: [32]usize = .{0} ** 32,
+    captured_authorization: [32]bool = .{false} ** 32,
+    captured_cookie: [32]bool = .{false} ** 32,
+    captured_proxy_authorization: [32]bool = .{false} ** 32,
+    captured_host: [32]bool = .{false} ** 32,
+    finish_count: usize = 0,
+    abort_count: usize = 0,
+    cancel_count: usize = 0,
+    deinit_count: usize = 0,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        responses: []const ResponseSpec,
+    ) DownloadTestTransport {
+        return .{
+            .allocator = allocator,
+            .responses = responses,
+            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
+        };
+    }
+
+    fn asTransport(self: *DownloadTestTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn capturedRange(self: *const DownloadTestTransport, index: usize) []const u8 {
+        return self.ranges[index][0..self.range_lengths[index]];
+    }
+
+    fn capturedUrl(self: *const DownloadTestTransport, index: usize) []const u8 {
+        return self.urls[index][0..self.url_lengths[index]];
+    }
+
+    fn capture(
+        self: *DownloadTestTransport,
+        request: *const core.http.Request,
+    ) !usize {
+        if (self.responses.len == 0) return error.NoCannedResponses;
+        if (self.call_count >= self.ranges.len) return error.TooManyMockRequests;
+        const call = self.call_count;
+        if (request.url.len > self.urls[call].len) return error.MockRequestUrlTooLong;
+        @memcpy(self.urls[call][0..request.url.len], request.url);
+        self.url_lengths[call] = request.url.len;
+        if (request.getHeader("Range")) |range| {
+            if (range.len > self.ranges[call].len) return error.MockRangeTooLong;
+            @memcpy(self.ranges[call][0..range.len], range);
+            self.range_lengths[call] = range.len;
+        }
+        self.captured_authorization[call] = request.getHeader("Authorization") != null;
+        self.captured_cookie[call] = request.getHeader("Cookie") != null;
+        self.captured_proxy_authorization[call] =
+            request.getHeader("Proxy-Authorization") != null;
+        self.captured_host[call] = request.getHeader("Host") != null;
+        self.call_count += 1;
+        return @min(call, self.responses.len - 1);
+    }
+
+    fn sendImpl(
+        transport: *core.http.HttpTransport,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const self: *DownloadTestTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        const index = try self.capture(request);
+        const spec = self.responses[index];
+        if (spec.open_error) |failure| return failure;
+        const body = try self.allocator.dupe(u8, spec.body);
+        errdefer self.allocator.free(body);
+        var headers = try testHeaderSet(self.allocator, spec.headers);
+        errdefer headers.deinit(self.allocator);
+        return .{
+            .status_code = spec.status,
+            .headers = headers.map,
+            .body = body,
+            .allocator = self.allocator,
+            .response_headers = headers.values,
+        };
+    }
+
+    fn openImpl(
+        transport: *core.http.HttpTransport,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *DownloadTestTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        try checkCancellation(options.cancellation);
+        const index = try self.capture(request);
+        const spec = self.responses[index];
+        if (spec.open_error) |failure| return failure;
+        return DownloadTestOperation.open(self, spec);
+    }
+};
+
+const TestHeaderSet = struct {
+    map: std.StringHashMap([]const u8),
+    values: core.http.ResponseHeaders,
+
+    fn deinit(self: *TestHeaderSet, allocator: std.mem.Allocator) void {
+        var iterator = self.map.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        self.map.deinit();
+        self.values.deinit();
+    }
+};
+
+fn testHeaderSet(
+    allocator: std.mem.Allocator,
+    headers: []const DownloadTestTransport.Header,
+) !TestHeaderSet {
+    var map = std.StringHashMap([]const u8).init(allocator);
+    errdefer {
+        var iterator = map.iterator();
+        while (iterator.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        map.deinit();
+    }
+    var values = core.http.ResponseHeaders.init(allocator);
+    errdefer values.deinit();
+    for (headers) |header| {
+        try values.append(header.name, header.value);
+        const name = try allocator.dupe(u8, header.name);
+        errdefer allocator.free(name);
+        const value = try allocator.dupe(u8, header.value);
+        errdefer allocator.free(value);
+        const entry = try map.getOrPut(name);
+        if (entry.found_existing) {
+            allocator.free(name);
+            allocator.free(entry.value_ptr.*);
+        } else {
+            entry.key_ptr.* = name;
+        }
+        entry.value_ptr.* = value;
+    }
+    return .{ .map = map, .values = values };
+}
+
+const DownloadTestOperation = struct {
+    operation: core.http.HttpOperation,
+    allocator: std.mem.Allocator,
+    owner: *DownloadTestTransport,
+    body: []u8,
+    reader_impl: DownloadTestReader,
+
+    fn open(
+        owner: *DownloadTestTransport,
+        spec: DownloadTestTransport.ResponseSpec,
+    ) !*core.http.HttpOperation {
+        const self = try owner.allocator.create(DownloadTestOperation);
+        errdefer owner.allocator.destroy(self);
+        const body = try owner.allocator.dupe(u8, spec.body);
+        errdefer owner.allocator.free(body);
+        var headers = try testHeaderSet(owner.allocator, spec.headers);
+        errdefer headers.deinit(owner.allocator);
+        self.* = .{
+            .operation = undefined,
+            .allocator = owner.allocator,
+            .owner = owner,
+            .body = body,
+            .reader_impl = DownloadTestReader.init(
+                body,
+                spec.read_size,
+                spec.fail_after,
+                spec.body_error,
+            ),
+        };
+        self.operation = .{
+            .status_code = spec.status,
+            .headers = headers.map,
+            .response_headers = headers.values,
+            .body_reader = &self.reader_impl.interface,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &cancelImpl,
+            .deinitFn = &deinitImpl,
+            .bodyErrorFn = &bodyErrorImpl,
+        };
+        return &self.operation;
+    }
+
+    fn finishImpl(operation: *core.http.HttpOperation) !void {
+        const self: *DownloadTestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.finish_count += 1;
+        _ = try self.reader_impl.interface.discardRemaining();
+    }
+
+    fn abortImpl(operation: *core.http.HttpOperation) void {
+        const self: *DownloadTestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.abort_count += 1;
+    }
+
+    fn cancelImpl(operation: *core.http.HttpOperation) void {
+        const self: *DownloadTestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.cancel_count += 1;
+    }
+
+    fn bodyErrorImpl(operation: *const core.http.HttpOperation) ?anyerror {
+        const self: *const DownloadTestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        return self.reader_impl.body_error;
+    }
+
+    fn deinitImpl(operation: *core.http.HttpOperation) void {
+        const self: *DownloadTestOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.deinit_count += 1;
+        var headers = TestHeaderSet{
+            .map = self.operation.headers,
+            .values = self.operation.response_headers,
+        };
+        headers.deinit(self.allocator);
+        self.allocator.free(self.body);
+        self.allocator.destroy(self);
+    }
+};
+
+const DownloadTestReader = struct {
+    interface: std.Io.Reader,
+    body: []const u8,
+    offset: usize = 0,
+    read_size: usize,
+    fail_after: ?usize,
+    body_error: ?anyerror,
+
+    fn init(
+        body: []const u8,
+        read_size: usize,
+        fail_after: ?usize,
+        body_error: ?anyerror,
+    ) DownloadTestReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .body = body,
+            .read_size = @max(read_size, 1),
+            .fail_after = fail_after,
+            .body_error = body_error,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *DownloadTestReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        if (self.fail_after) |fail_after| {
+            if (self.offset >= fail_after) return error.ReadFailed;
+        }
+        if (self.offset >= self.body.len) return error.EndOfStream;
+        var count = @min(
+            self.body.len - self.offset,
+            limit.minInt(self.read_size),
+        );
+        if (self.fail_after) |fail_after| {
+            count = @min(count, fail_after - self.offset);
+        }
+        if (count == 0) return 0;
+        try writer.writeAll(self.body[self.offset .. self.offset + count]);
+        self.offset += count;
+        return count;
+    }
+};
+
+test "buffered blob download validates exact identity bytes and bound" {
+    const allocator = std.testing.allocator;
+    const body = "small blob";
+    const expected_digest = digest_mod.computeSha256Digest(body);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "10" },
+        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
+    };
+    var transport = core.http.MockTransport.init(allocator, 200, body);
+    defer transport.deinit();
+    transport.response_headers_list = &headers;
+    transport.stream_response_chunk_size = 3;
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+
+    var result = try client.downloadBlob(&expected_digest, .{});
+    defer result.deinit();
+    try std.testing.expectEqualStrings(body, result.bytes);
+    try std.testing.expectEqualStrings(&expected_digest, result.digest);
+    try std.testing.expectEqualStrings(
+        "application/octet-stream",
+        capturedHeader(&transport.last_headers, "Accept").?,
+    );
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_finish_count);
+
+    try std.testing.expectError(
+        error.BlobTooLarge,
+        client.downloadBlob(&expected_digest, .{ .max_size = body.len - 1 }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_abort_count);
+}
+
+test "buffered and streaming downloads distinguish identity and compressed lengths" {
+    const allocator = std.testing.allocator;
+    const body = "decoded bytes";
+    const expected_digest = digest_mod.computeSha256Digest(body);
+    var headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "3" },
+        .{ .name = "Content-Encoding", .value = "gzip" },
+        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
+    };
+    var transport = core.http.MockTransport.init(allocator, 200, body);
+    defer transport.deinit();
+    transport.response_headers_list = &headers;
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+
+    var compressed = try client.downloadBlob(&expected_digest, .{});
+    defer compressed.deinit();
+    try std.testing.expectEqualStrings(body, compressed.bytes);
+
+    headers[1].value = "identity";
+    try std.testing.expectError(
+        error.ContentLengthMismatch,
+        client.downloadBlob(&expected_digest, .{}),
+    );
+}
+
+test "streaming blob ownership supports finish abort cancellation and exact failures" {
+    const allocator = std.testing.allocator;
+    const body = "streamed";
+    const expected_digest = digest_mod.computeSha256Digest(body);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "8" },
+        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
+    };
+    var transport = core.http.MockTransport.init(allocator, 200, body);
+    defer transport.deinit();
+    transport.response_headers_list = &headers;
+    transport.stream_response_chunk_size = 2;
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+
+    {
+        var stream = try client.downloadBlobStreaming(&expected_digest, .{});
+        defer stream.deinit();
+        var first: [3]u8 = undefined;
+        const count = try (try stream.reader()).readSliceShort(&first);
+        try std.testing.expectEqualStrings("str", first[0..count]);
+    }
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_abort_count);
+
+    {
+        var stream = try client.downloadBlobStreaming(&expected_digest, .{});
+        defer stream.deinit();
+        stream.abort();
+    }
+    try std.testing.expectEqual(@as(usize, 2), transport.stream_abort_count);
+
+    {
+        var stream = try client.downloadBlobStreaming(&expected_digest, .{});
+        defer stream.deinit();
+        try stream.finish();
+        try std.testing.expectEqual(@as(u64, body.len), stream.decodedLength());
+        try std.testing.expectEqualSlices(
+            u8,
+            &expected_digest,
+            &(try stream.computedDigest()),
+        );
+    }
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_finish_count);
+
+    var cancellation = core.http.CancellationToken{};
+    {
+        var stream = try client.downloadBlobStreaming(
+            &expected_digest,
+            .{ .cancellation = &cancellation },
+        );
+        defer stream.deinit();
+        cancellation.cancel();
+        var byte: [1]u8 = undefined;
+        try std.testing.expectError(
+            error.ReadFailed,
+            (try stream.reader()).readSliceShort(&byte),
+        );
+        try std.testing.expectEqual(error.OperationCancelled, stream.lastError().?);
+    }
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_cancel_count);
+    try std.testing.expectEqual(@as(usize, 4), transport.stream_deinit_count);
+}
+
+test "blob response content length headers are required unique and numeric" {
+    const allocator = std.testing.allocator;
+    const body = "length";
+    const digest = digest_mod.computeSha256Digest(body);
+    var transport = core.http.MockTransport.init(allocator, 200, body);
+    defer transport.deinit();
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+
+    const missing = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Docker-Content-Digest", .value = &digest },
+    };
+    transport.response_headers_list = &missing;
+    try std.testing.expectError(
+        error.MissingContentLength,
+        client.downloadBlob(&digest, .{}),
+    );
+
+    const invalid = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "-1" },
+        .{ .name = "Docker-Content-Digest", .value = &digest },
+    };
+    transport.response_headers_list = &invalid;
+    try std.testing.expectError(
+        error.InvalidContentLength,
+        client.downloadBlob(&digest, .{}),
+    );
+
+    const duplicate = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "6" },
+        .{ .name = "content-length", .value = "6" },
+        .{ .name = "Docker-Content-Digest", .value = &digest },
+    };
+    transport.response_headers_list = &duplicate;
+    try std.testing.expectError(
+        error.AmbiguousResponseHeader,
+        client.downloadBlob(&digest, .{}),
+    );
+}
+
+test "sequential ranged download validates 206 ranges and exact digest" {
+    const allocator = std.testing.allocator;
+    const body = "abcdefghij";
+    const expected_digest = digest_mod.computeSha256Digest(body);
+    const headers_1 = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "4" },
+        .{ .name = "Content-Range", .value = "bytes 0-3/10" },
+        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
+    };
+    const headers_2 = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "4" },
+        .{ .name = "Content-Range", .value = "bytes 4-7/10" },
+    };
+    const headers_3 = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "2" },
+        .{ .name = "Content-Range", .value = "bytes 8-9/10" },
+    };
+    const responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = body[0..4], .headers = &headers_1 },
+        .{ .status = 206, .body = body[4..8], .headers = &headers_2 },
+        .{ .status = 206, .body = body[8..10], .headers = &headers_3 },
+    };
+    var transport = DownloadTestTransport.init(allocator, &responses);
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+
+    var details = try client.downloadBlobToWriter(
+        &expected_digest,
+        &output.writer,
+        .{ .range_size = 4 },
+    );
+    defer details.deinit();
+
+    try std.testing.expectEqualStrings(body, output.writer.buffered());
+    try std.testing.expectEqualStrings(&expected_digest, details.digest);
+    try std.testing.expectEqual(@as(u64, body.len), details.size);
+    try std.testing.expectEqualStrings("bytes=0-3", transport.capturedRange(0));
+    try std.testing.expectEqualStrings("bytes=4-7", transport.capturedRange(1));
+    try std.testing.expectEqualStrings("bytes=8-9", transport.capturedRange(2));
+}
+
+test "ranged download accepts full 200 and terminal 416" {
+    const allocator = std.testing.allocator;
+    const body = "full body";
+    const expected_digest = digest_mod.computeSha256Digest(body);
+    const full_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "9" },
+        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
+    };
+    const full_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 200, .body = body, .headers = &full_headers },
+    };
+    var full_transport = DownloadTestTransport.init(allocator, &full_responses);
+    var full_client = try testClient(allocator, full_transport.asTransport());
+    defer full_client.deinit();
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+    var details = try full_client.downloadBlobToWriter(
+        &expected_digest,
+        &output.writer,
+        .{ .range_size = 4 },
+    );
+    defer details.deinit();
+    try std.testing.expectEqualStrings(body, output.writer.buffered());
+    try std.testing.expectEqualStrings("bytes=0-3", full_transport.capturedRange(0));
+
+    const empty_digest = digest_mod.computeSha256Digest("");
+    const empty_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "0" },
+        .{ .name = "Content-Range", .value = "bytes */0" },
+        .{ .name = "Docker-Content-Digest", .value = &empty_digest },
+    };
+    const empty_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 416, .headers = &empty_headers },
+    };
+    var empty_transport = DownloadTestTransport.init(allocator, &empty_responses);
+    var empty_client = try testClient(allocator, empty_transport.asTransport());
+    defer empty_client.deinit();
+    var empty_output: std.Io.Writer.Allocating = .init(allocator);
+    defer empty_output.deinit();
+    var empty_details = try empty_client.downloadBlobToWriter(
+        &empty_digest,
+        &empty_output.writer,
+        .{},
+    );
+    defer empty_details.deinit();
+    try std.testing.expectEqual(@as(u64, 0), empty_details.size);
+
+    const invalid_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Range", .value = "bytes */5" },
+    };
+    const invalid_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 416, .headers = &invalid_headers },
+    };
+    var invalid_transport = DownloadTestTransport.init(allocator, &invalid_responses);
+    var invalid_client = try testClient(allocator, invalid_transport.asTransport());
+    defer invalid_client.deinit();
+    try std.testing.expectError(
+        error.RangeNotSatisfiable,
+        invalid_client.downloadBlobToWriter(
+            &empty_digest,
+            &empty_output.writer,
+            .{},
+        ),
+    );
+}
+
+test "partial ranged reads resume at confirmed writer offset without duplication" {
+    const allocator = std.testing.allocator;
+    const body = "abcdefghij";
+    const expected_digest = digest_mod.computeSha256Digest(body);
+    const first_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "6" },
+        .{ .name = "Content-Range", .value = "bytes 0-5/10" },
+    };
+    const resumed_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "6" },
+        .{ .name = "Content-Range", .value = "bytes 3-8/10" },
+    };
+    const final_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "1" },
+        .{ .name = "Content-Range", .value = "bytes 9-9/10" },
+    };
+    const responses = [_]DownloadTestTransport.ResponseSpec{
+        .{
+            .status = 206,
+            .body = body[0..6],
+            .headers = &first_headers,
+            .fail_after = 3,
+            .body_error = error.ConnectionResetByPeer,
+        },
+        .{ .status = 206, .body = body[3..9], .headers = &resumed_headers },
+        .{ .status = 206, .body = body[9..10], .headers = &final_headers },
+    };
+    var transport = DownloadTestTransport.init(allocator, &responses);
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+
+    var details = try client.downloadBlobToWriter(
+        &expected_digest,
+        &output.writer,
+        .{ .range_size = 6 },
+    );
+    defer details.deinit();
+    try std.testing.expectEqualStrings(body, output.writer.buffered());
+    try std.testing.expectEqualStrings("bytes=0-5", transport.capturedRange(0));
+    try std.testing.expectEqualStrings("bytes=3-8", transport.capturedRange(1));
+    try std.testing.expectEqualStrings("bytes=9-9", transport.capturedRange(2));
+    try std.testing.expectEqual(@as(usize, 1), transport.abort_count);
+}
+
+test "range retries classify open status and read failures without broad fallback" {
+    const allocator = std.testing.allocator;
+    const body = "retry";
+    const expected_digest = digest_mod.computeSha256Digest(body);
+    const headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "5" },
+        .{ .name = "Content-Range", .value = "bytes 0-4/5" },
+    };
+    const responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 0, .open_error = error.ConnectionTimedOut },
+        .{ .status = 503, .body = "{\"errors\":[]}" },
+        .{ .status = 206, .body = body, .headers = &headers },
+    };
+    var transport = DownloadTestTransport.init(allocator, &responses);
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+    var details = try client.downloadBlobToWriter(
+        &expected_digest,
+        &output.writer,
+        .{ .range_size = 5, .max_retries = 2 },
+    );
+    defer details.deinit();
+    try std.testing.expectEqualStrings(body, output.writer.buffered());
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+
+    try std.testing.expect(isRetryableDownloadError(error.ReadFailed));
+    try std.testing.expect(isRetryableDownloadError(error.UnexpectedEndOfStream));
+    try std.testing.expect(isRetryableDownloadError(error.ConnectionResetByPeer));
+    try std.testing.expect(!isRetryableDownloadError(error.OperationCancelled));
+    try std.testing.expect(!isRetryableDownloadError(error.InvalidContentRange));
+    try std.testing.expect(!isRetryableDownloadError(error.RequestedDigestMismatch));
+    try std.testing.expect(isRetryableStatus(408));
+    try std.testing.expect(isRetryableStatus(429));
+    try std.testing.expect(isRetryableStatus(503));
+    try std.testing.expect(!isRetryableStatus(416));
+}
+
+test "range validation rejects malformed offsets spans lengths encodings and totals" {
+    const allocator = std.testing.allocator;
+    const digest = digest_mod.computeSha256Digest("abcd");
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+
+    const malformed_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "4" },
+        .{ .name = "Content-Range", .value = "items 0-3/4" },
+    };
+    const malformed_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = "abcd", .headers = &malformed_headers },
+    };
+    var malformed_transport = DownloadTestTransport.init(allocator, &malformed_responses);
+    var malformed_client = try testClient(allocator, malformed_transport.asTransport());
+    defer malformed_client.deinit();
+    try std.testing.expectError(
+        error.InvalidContentRange,
+        malformed_client.downloadBlobToWriter(&digest, &output.writer, .{ .range_size = 4 }),
+    );
+
+    const offset_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "3" },
+        .{ .name = "Content-Range", .value = "bytes 1-3/4" },
+    };
+    const offset_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = "bcd", .headers = &offset_headers },
+    };
+    var offset_transport = DownloadTestTransport.init(allocator, &offset_responses);
+    var offset_client = try testClient(allocator, offset_transport.asTransport());
+    defer offset_client.deinit();
+    try std.testing.expectError(
+        error.ContentRangeOffsetMismatch,
+        offset_client.downloadBlobToWriter(&digest, &output.writer, .{ .range_size = 4 }),
+    );
+
+    const span_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "4" },
+        .{ .name = "Content-Range", .value = "bytes 0-3/4" },
+    };
+    const span_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = "abcd", .headers = &span_headers },
+    };
+    var span_transport = DownloadTestTransport.init(allocator, &span_responses);
+    var span_client = try testClient(allocator, span_transport.asTransport());
+    defer span_client.deinit();
+    try std.testing.expectError(
+        error.ContentRangeOutsideRequest,
+        span_client.downloadBlobToWriter(&digest, &output.writer, .{ .range_size = 3 }),
+    );
+
+    const length_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "3" },
+        .{ .name = "Content-Range", .value = "bytes 0-3/4" },
+    };
+    const length_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = "abcd", .headers = &length_headers },
+    };
+    var length_transport = DownloadTestTransport.init(allocator, &length_responses);
+    var length_client = try testClient(allocator, length_transport.asTransport());
+    defer length_client.deinit();
+    try std.testing.expectError(
+        error.ContentLengthMismatch,
+        length_client.downloadBlobToWriter(&digest, &output.writer, .{ .range_size = 4 }),
+    );
+
+    const encoded_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Encoding", .value = "gzip" },
+        .{ .name = "Content-Length", .value = "4" },
+        .{ .name = "Content-Range", .value = "bytes 0-3/4" },
+    };
+    const encoded_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = "abcd", .headers = &encoded_headers },
+    };
+    var encoded_transport = DownloadTestTransport.init(allocator, &encoded_responses);
+    var encoded_client = try testClient(allocator, encoded_transport.asTransport());
+    defer encoded_client.deinit();
+    try std.testing.expectError(
+        error.EncodedRangeResponse,
+        encoded_client.downloadBlobToWriter(&digest, &output.writer, .{ .range_size = 4 }),
+    );
+
+    const total_headers_1 = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "2" },
+        .{ .name = "Content-Range", .value = "bytes 0-1/4" },
+    };
+    const total_headers_2 = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "2" },
+        .{ .name = "Content-Range", .value = "bytes 2-3/5" },
+    };
+    const total_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = "ab", .headers = &total_headers_1 },
+        .{ .status = 206, .body = "cd", .headers = &total_headers_2 },
+    };
+    var total_transport = DownloadTestTransport.init(allocator, &total_responses);
+    var total_client = try testClient(allocator, total_transport.asTransport());
+    defer total_client.deinit();
+    try std.testing.expectError(
+        error.TotalSizeMismatch,
+        total_client.downloadBlobToWriter(&digest, &output.writer, .{ .range_size = 2 }),
+    );
+}
+
+test "blob downloads validate requested and service SHA-256 digests" {
+    const allocator = std.testing.allocator;
+    const body = "digest bytes";
+    const requested_digest = digest_mod.computeSha256Digest(body);
+    const other_digest = digest_mod.computeSha256Digest("other");
+    const service_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "12" },
+        .{ .name = "Docker-Content-Digest", .value = &other_digest },
+    };
+    var service_transport = core.http.MockTransport.init(allocator, 200, body);
+    defer service_transport.deinit();
+    service_transport.response_headers_list = &service_headers;
+    var service_client = try testClient(allocator, service_transport.asTransport());
+    defer service_client.deinit();
+    try std.testing.expectError(
+        error.ServiceDigestMismatch,
+        service_client.downloadBlob(&requested_digest, .{}),
+    );
+
+    const content_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "12" },
+        .{ .name = "Docker-Content-Digest", .value = &requested_digest },
+    };
+    var content_transport = core.http.MockTransport.init(allocator, 200, "wrong bytes!");
+    defer content_transport.deinit();
+    content_transport.response_headers_list = &content_headers;
+    var content_client = try testClient(allocator, content_transport.asTransport());
+    defer content_client.deinit();
+    try std.testing.expectError(
+        error.RequestedDigestMismatch,
+        content_client.downloadBlob(&requested_digest, .{}),
+    );
+}
+
+test "blob download preserves structured ACR service errors" {
+    const allocator = std.testing.allocator;
+    const digest = digest_mod.computeSha256Digest("missing");
+    const body =
+        "{\"errors\":[{\"code\":\"BLOB_UNKNOWN\",\"message\":\"missing blob\"}]}";
+    var transport = core.http.MockTransport.init(allocator, 404, body);
+    defer transport.deinit();
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+
+    var response = try client.downloadBlobResult(&digest, .{});
+    defer response.deinit();
+    switch (response) {
+        .ok => return error.ExpectedServiceError,
+        .err => |failure| {
+            try std.testing.expectEqual(@as(u16, 404), failure.status_code);
+            try std.testing.expectEqualStrings("BLOB_UNKNOWN", failure.code.?);
+            try std.testing.expectEqualStrings("missing blob", failure.message.?);
+        },
+    }
+}
+
+test "cross-origin blob redirects strip credentials and insecure redirects fail" {
+    const allocator = std.testing.allocator;
+    const digest = digest_mod.computeSha256Digest("redirected");
+    const redirect_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Location", .value = "https://storage.example/blob#fragment" },
+    };
+    const success_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "10" },
+        .{ .name = "Docker-Content-Digest", .value = &digest },
+    };
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 307, .body = "", .headers = &redirect_headers },
+        .{ .status = 200, .body = "redirected", .headers = &success_headers },
+    });
+    var request = core.http.Request.init(
+        allocator,
+        .GET,
+        "https://registry.example/v2/team/app/blobs/test",
+    );
+    defer request.deinit();
+    try request.setHeader("Authorization", "******");
+    try request.setHeader("Cookie", "session=test");
+    try request.setHeader("Proxy-Authorization", "Basic test");
+    try request.setHeader("Host", "registry.example");
+    var operation = try sequence.asTransport().open(&request, .{});
+    defer operation.deinit();
+    try std.testing.expectEqual(@as(u16, 200), operation.status_code);
+    try std.testing.expect(sequence.captured_authorization[0]);
+    try std.testing.expect(!sequence.captured_authorization[1]);
+    try std.testing.expect(sequence.captured_cookie[0]);
+    try std.testing.expect(!sequence.captured_cookie[1]);
+    try std.testing.expect(sequence.captured_proxy_authorization[0]);
+    try std.testing.expect(!sequence.captured_proxy_authorization[1]);
+    try std.testing.expect(sequence.captured_host[0]);
+    try std.testing.expect(!sequence.captured_host[1]);
+    try std.testing.expectEqualStrings(
+        "https://storage.example/blob",
+        sequence.capturedUrl(1),
+    );
+    try operation.finish();
+
+    const insecure_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Location", .value = "http://storage.example/blob" },
+    };
+    var insecure = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 307, .body = "", .headers = &insecure_headers },
+    });
+    var client = try testClient(allocator, insecure.asTransport());
+    defer client.deinit();
+    try std.testing.expectError(
+        error.HttpsRequired,
+        client.downloadBlob(&digest, .{}),
+    );
+}
+
+test "ranged resume restarts from registry instead of retaining redirect continuation" {
+    const allocator = std.testing.allocator;
+    const body = "abcd";
+    const digest = digest_mod.computeSha256Digest(body);
+    const redirect_1 = [_]DownloadTestTransport.Header{
+        .{ .name = "Location", .value = "https://storage-one.example/blob" },
+    };
+    const partial_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "4" },
+        .{ .name = "Content-Range", .value = "bytes 0-3/4" },
+    };
+    const redirect_2 = [_]DownloadTestTransport.Header{
+        .{ .name = "Location", .value = "https://storage-two.example/blob" },
+    };
+    const resume_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "2" },
+        .{ .name = "Content-Range", .value = "bytes 2-3/4" },
+    };
+    const responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 307, .headers = &redirect_1 },
+        .{
+            .status = 206,
+            .body = body,
+            .headers = &partial_headers,
+            .fail_after = 2,
+            .body_error = error.ConnectionResetByPeer,
+        },
+        .{ .status = 307, .headers = &redirect_2 },
+        .{ .status = 206, .body = body[2..4], .headers = &resume_headers },
+    };
+    var transport = DownloadTestTransport.init(allocator, &responses);
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+    var details = try client.downloadBlobToWriter(
+        &digest,
+        &output.writer,
+        .{ .range_size = 4 },
+    );
+    defer details.deinit();
+
+    try std.testing.expectEqualStrings(body, output.writer.buffered());
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        transport.capturedUrl(0),
+        "https://registry.example/",
+    ));
+    try std.testing.expectEqualStrings(
+        "https://storage-one.example/blob",
+        transport.capturedUrl(1),
+    );
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        transport.capturedUrl(2),
+        "https://registry.example/",
+    ));
+    try std.testing.expectEqualStrings(
+        "https://storage-two.example/blob",
+        transport.capturedUrl(3),
+    );
+    try std.testing.expectEqualStrings("bytes=2-3", transport.capturedRange(2));
+}
+
+test "large ranged writer path keeps SDK copy and request sizes bounded" {
+    const allocator = std.testing.allocator;
+    const body = try allocator.alloc(u8, 140 * 1024);
+    defer allocator.free(body);
+    for (body, 0..) |*byte, index| byte.* = @truncate(index);
+    const digest = digest_mod.computeSha256Digest(body);
+    var range_1_buffer: [64]u8 = undefined;
+    const range_1 = try std.fmt.bufPrint(
+        &range_1_buffer,
+        "bytes 0-{d}/{d}",
+        .{ (70 * 1024) - 1, body.len },
+    );
+    var range_2_buffer: [64]u8 = undefined;
+    const range_2 = try std.fmt.bufPrint(
+        &range_2_buffer,
+        "bytes {d}-{d}/{d}",
+        .{ 70 * 1024, body.len - 1, body.len },
+    );
+    const headers_1 = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "71680" },
+        .{ .name = "Content-Range", .value = range_1 },
+    };
+    const headers_2 = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "71680" },
+        .{ .name = "Content-Range", .value = range_2 },
+    };
+    const responses = [_]DownloadTestTransport.ResponseSpec{
+        .{
+            .status = 206,
+            .body = body[0 .. 70 * 1024],
+            .headers = &headers_1,
+            .read_size = copy_buffer_size,
+        },
+        .{
+            .status = 206,
+            .body = body[70 * 1024 ..],
+            .headers = &headers_2,
+            .read_size = copy_buffer_size,
+        },
+    };
+    var transport = DownloadTestTransport.init(allocator, &responses);
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+    var discard_buffer: [256]u8 = undefined;
+    var discard: std.Io.Writer.Discarding = .init(&discard_buffer);
+
+    var details = try client.downloadBlobToWriter(
+        &digest,
+        &discard.writer,
+        .{ .range_size = 70 * 1024 },
+    );
+    defer details.deinit();
+    try std.testing.expectEqual(@as(u64, body.len), discard.fullCount());
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+    try std.testing.expectEqualStrings(
+        "bytes=0-71679",
+        transport.capturedRange(0),
+    );
+    try std.testing.expectEqualStrings(
+        "bytes=71680-143359",
+        transport.capturedRange(1),
+    );
+}
+
+fn bufferedAllocationFixture(allocator: std.mem.Allocator) !void {
+    const body = "allocation";
+    const digest = digest_mod.computeSha256Digest(body);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "10" },
+        .{ .name = "Docker-Content-Digest", .value = &digest },
+    };
+    var transport = core.http.MockTransport.init(allocator, 200, body);
+    defer transport.deinit();
+    transport.response_headers_list = &headers;
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+    var result = try client.downloadBlob(&digest, .{});
+    result.deinit();
+}
+
+test "blob download allocation failures release all ownership" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        bufferedAllocationFixture,
+        .{},
+    );
+}

--- a/sdk/container_registry/src/blob_download_test.zig
+++ b/sdk/container_registry/src/blob_download_test.zig
@@ -41,6 +41,60 @@ fn capturedHeader(
     return null;
 }
 
+fn expectRedirectedBlobDownload(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    requested_digest: []const u8,
+    service_digest: ?[]const u8,
+    expected_error: ?anyerror,
+) !void {
+    const redirect_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Location", .value = "https://storage.example/blob" },
+    };
+    var content_length_buffer: [32]u8 = undefined;
+    const content_length = try std.fmt.bufPrint(
+        &content_length_buffer,
+        "{d}",
+        .{body.len},
+    );
+    var final_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = content_length },
+        .{
+            .name = "Docker-Content-Digest",
+            .value = service_digest orelse "",
+        },
+    };
+    const final_header_count: usize = if (service_digest == null) 1 else 2;
+    const responses = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{ .status = 307, .body = "", .headers = &redirect_headers },
+        .{
+            .status = 200,
+            .body = body,
+            .headers = final_headers[0..final_header_count],
+        },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses);
+    var client = try testClient(allocator, transport.asTransport());
+    defer client.deinit();
+
+    if (expected_error) |expected| {
+        try std.testing.expectError(
+            expected,
+            client.downloadBlob(requested_digest, .{}),
+        );
+    } else {
+        var result = try client.downloadBlob(requested_digest, .{});
+        defer result.deinit();
+        try std.testing.expectEqualStrings(body, result.bytes);
+        try std.testing.expectEqualStrings(requested_digest, result.digest);
+    }
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+    try std.testing.expectEqualStrings(
+        "https://storage.example/blob",
+        transport.capturedUrl(1),
+    );
+}
+
 const DownloadTestTransport = struct {
     const Header = core.http.MockTransport.HeaderPair;
     const ResponseSpec = struct {
@@ -401,7 +455,6 @@ test "streaming blob ownership supports finish abort cancellation and exact fail
     const expected_digest = digest_mod.computeSha256Digest(body);
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "8" },
-        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
     };
     var transport = core.http.MockTransport.init(allocator, 200, body);
     defer transport.deinit();
@@ -505,7 +558,6 @@ test "sequential ranged download validates 206 ranges and exact digest" {
     const headers_1 = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "4" },
         .{ .name = "Content-Range", .value = "bytes 0-3/10" },
-        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
     };
     const headers_2 = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "4" },
@@ -547,7 +599,6 @@ test "ranged download accepts full 200 and terminal 416" {
     const expected_digest = digest_mod.computeSha256Digest(body);
     const full_headers = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "9" },
-        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
     };
     const full_responses = [_]DownloadTestTransport.ResponseSpec{
         .{ .status = 200, .body = body, .headers = &full_headers },
@@ -603,6 +654,115 @@ test "ranged download accepts full 200 and terminal 416" {
             &empty_digest,
             &empty_output.writer,
             .{},
+        ),
+    );
+}
+
+test "ranged and fallback downloads validate optional service digest and full bytes" {
+    const allocator = std.testing.allocator;
+    const requested_digest = digest_mod.computeSha256Digest("range");
+    const other_digest = digest_mod.computeSha256Digest("other");
+    const range_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "5" },
+        .{ .name = "Content-Range", .value = "bytes 0-4/5" },
+    };
+    const range_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 206, .body = "wrong", .headers = &range_headers },
+    };
+    var range_transport = DownloadTestTransport.init(allocator, &range_responses);
+    var range_client = try testClient(allocator, range_transport.asTransport());
+    defer range_client.deinit();
+    var range_output: std.Io.Writer.Allocating = .init(allocator);
+    defer range_output.deinit();
+    try std.testing.expectError(
+        error.RequestedDigestMismatch,
+        range_client.downloadBlobToWriter(
+            &requested_digest,
+            &range_output.writer,
+            .{ .range_size = 5 },
+        ),
+    );
+
+    const mismatched_range_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "5" },
+        .{ .name = "Content-Range", .value = "bytes 0-4/5" },
+        .{ .name = "Docker-Content-Digest", .value = &other_digest },
+    };
+    const mismatched_range_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{
+            .status = 206,
+            .body = "range",
+            .headers = &mismatched_range_headers,
+        },
+    };
+    var mismatched_range_transport = DownloadTestTransport.init(
+        allocator,
+        &mismatched_range_responses,
+    );
+    var mismatched_range_client = try testClient(
+        allocator,
+        mismatched_range_transport.asTransport(),
+    );
+    defer mismatched_range_client.deinit();
+    var mismatched_range_output: std.Io.Writer.Allocating = .init(allocator);
+    defer mismatched_range_output.deinit();
+    try std.testing.expectError(
+        error.ServiceDigestMismatch,
+        mismatched_range_client.downloadBlobToWriter(
+            &requested_digest,
+            &mismatched_range_output.writer,
+            .{ .range_size = 5 },
+        ),
+    );
+
+    const fallback_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "5" },
+    };
+    const fallback_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{ .status = 200, .body = "wrong", .headers = &fallback_headers },
+    };
+    var fallback_transport = DownloadTestTransport.init(allocator, &fallback_responses);
+    var fallback_client = try testClient(allocator, fallback_transport.asTransport());
+    defer fallback_client.deinit();
+    var fallback_output: std.Io.Writer.Allocating = .init(allocator);
+    defer fallback_output.deinit();
+    try std.testing.expectError(
+        error.RequestedDigestMismatch,
+        fallback_client.downloadBlobToWriter(
+            &requested_digest,
+            &fallback_output.writer,
+            .{ .range_size = 5 },
+        ),
+    );
+
+    const mismatched_fallback_headers = [_]DownloadTestTransport.Header{
+        .{ .name = "Content-Length", .value = "5" },
+        .{ .name = "Docker-Content-Digest", .value = &other_digest },
+    };
+    const mismatched_fallback_responses = [_]DownloadTestTransport.ResponseSpec{
+        .{
+            .status = 200,
+            .body = "range",
+            .headers = &mismatched_fallback_headers,
+        },
+    };
+    var mismatched_fallback_transport = DownloadTestTransport.init(
+        allocator,
+        &mismatched_fallback_responses,
+    );
+    var mismatched_fallback_client = try testClient(
+        allocator,
+        mismatched_fallback_transport.asTransport(),
+    );
+    defer mismatched_fallback_client.deinit();
+    var mismatched_fallback_output: std.Io.Writer.Allocating = .init(allocator);
+    defer mismatched_fallback_output.deinit();
+    try std.testing.expectError(
+        error.ServiceDigestMismatch,
+        mismatched_fallback_client.downloadBlobToWriter(
+            &requested_digest,
+            &mismatched_fallback_output.writer,
+            .{ .range_size = 5 },
         ),
     );
 }
@@ -795,11 +955,39 @@ test "range validation rejects malformed offsets spans lengths encodings and tot
     );
 }
 
-test "blob downloads validate requested and service SHA-256 digests" {
+test "direct blob downloads allow absent service digest and validate present digests" {
     const allocator = std.testing.allocator;
     const body = "digest bytes";
     const requested_digest = digest_mod.computeSha256Digest(body);
     const other_digest = digest_mod.computeSha256Digest("other");
+    const missing_headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "12" },
+    };
+    var missing_transport = core.http.MockTransport.init(allocator, 200, body);
+    defer missing_transport.deinit();
+    missing_transport.response_headers_list = &missing_headers;
+    var missing_client = try testClient(allocator, missing_transport.asTransport());
+    defer missing_client.deinit();
+    var missing_result = try missing_client.downloadBlob(&requested_digest, .{});
+    missing_result.deinit();
+
+    var missing_content_transport = core.http.MockTransport.init(
+        allocator,
+        200,
+        "wrong bytes!",
+    );
+    defer missing_content_transport.deinit();
+    missing_content_transport.response_headers_list = &missing_headers;
+    var missing_content_client = try testClient(
+        allocator,
+        missing_content_transport.asTransport(),
+    );
+    defer missing_content_client.deinit();
+    try std.testing.expectError(
+        error.RequestedDigestMismatch,
+        missing_content_client.downloadBlob(&requested_digest, .{}),
+    );
+
     const service_headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "12" },
         .{ .name = "Docker-Content-Digest", .value = &other_digest },
@@ -903,6 +1091,42 @@ test "cross-origin blob redirects strip credentials and insecure redirects fail"
     try std.testing.expectError(
         error.HttpsRequired,
         client.downloadBlob(&digest, .{}),
+    );
+}
+
+test "redirected blob downloads allow absent service digest and validate present digests" {
+    const allocator = std.testing.allocator;
+    const body = "redirected";
+    const requested_digest = digest_mod.computeSha256Digest(body);
+    const other_digest = digest_mod.computeSha256Digest("other");
+
+    try expectRedirectedBlobDownload(
+        allocator,
+        body,
+        &requested_digest,
+        null,
+        null,
+    );
+    try expectRedirectedBlobDownload(
+        allocator,
+        body,
+        &requested_digest,
+        &requested_digest,
+        null,
+    );
+    try expectRedirectedBlobDownload(
+        allocator,
+        body,
+        &requested_digest,
+        &other_digest,
+        error.ServiceDigestMismatch,
+    );
+    try expectRedirectedBlobDownload(
+        allocator,
+        "wrong body",
+        &requested_digest,
+        null,
+        error.RequestedDigestMismatch,
     );
 }
 

--- a/sdk/container_registry/src/root.zig
+++ b/sdk/container_registry/src/root.zig
@@ -8,6 +8,7 @@ const client = @import("client.zig");
 const models = @import("models.zig");
 const service_error = @import("service_error.zig");
 const content = @import("content_client.zig");
+const blob_download = @import("blob_download.zig");
 const digest = @import("digest.zig");
 const blob_upload = @import("blob_upload.zig");
 
@@ -55,6 +56,21 @@ pub const DownloadManifestResponse = content.DownloadManifestResponse;
 pub const DeleteManifestResponse = content.DeleteManifestResponse;
 pub const max_manifest_size = content.max_manifest_size;
 pub const manifest_accept = content.manifest_accept;
+pub const BlobDownloadClient = blob_download.BlobDownloadClient;
+pub const BlobDownloadClientOptions = blob_download.BlobDownloadClientOptions;
+pub const BufferedBlobDownloadOptions = blob_download.BufferedBlobDownloadOptions;
+pub const StreamingBlobDownloadOptions = blob_download.StreamingBlobDownloadOptions;
+pub const DownloadBlobToWriterOptions = blob_download.DownloadBlobToWriterOptions;
+pub const DownloadedBlob = blob_download.DownloadedBlob;
+pub const BlobDownloadDetails = blob_download.BlobDownloadDetails;
+pub const BlobDownloadStream = blob_download.BlobDownloadStream;
+pub const BufferedBlobDownloadResponse = blob_download.BufferedBlobDownloadResponse;
+pub const StreamingBlobDownloadResponse = blob_download.StreamingBlobDownloadResponse;
+pub const DownloadBlobToWriterResponse = blob_download.DownloadBlobToWriterResponse;
+pub const default_buffered_blob_limit = blob_download.default_buffered_blob_limit;
+pub const default_range_size = blob_download.default_range_size;
+pub const isRetryableDownloadError = blob_download.isRetryableDownloadError;
+pub const isRetryableDownloadStatus = blob_download.isRetryableStatus;
 pub const Sha256Digest = digest.Sha256Digest;
 pub const computeSha256Digest = digest.computeSha256Digest;
 pub const formatSha256Digest = digest.formatSha256Digest;
@@ -72,4 +88,5 @@ test {
     @import("std").testing.refAllDecls(@This());
     _ = @import("metadata_test.zig");
     _ = @import("blob_upload_test.zig");
+    _ = @import("blob_download_test.zig");
 }

--- a/sdk/core/http/transport.zig
+++ b/sdk/core/http/transport.zig
@@ -913,7 +913,16 @@ const StdStreamingOperation = struct {
         self.redirect_buffer = try allocator.alloc(u8, 8 * 1024);
 
         const uri = try std.Uri.parse(request.url);
+        const accept_encoding = getHeaderFromMap(
+            &self.request_headers,
+            "Accept-Encoding",
+        );
+        var standard_headers: std.http.Client.Request.Headers = .{};
+        if (accept_encoding) |value| {
+            standard_headers.accept_encoding = .{ .override = value };
+        }
         self.request = try self.shared_client.client.request(request.method.toStd(), uri, .{
+            .headers = standard_headers,
             .extra_headers = self.extra_headers,
             .redirect_behavior = .unhandled,
         });
@@ -986,7 +995,9 @@ const StdStreamingOperation = struct {
             errdefer self.allocator.free(name);
             const value = try self.allocator.dupe(u8, entry.value_ptr.*);
             errdefer self.allocator.free(value);
-            try extra.append(self.allocator, .{ .name = name, .value = value });
+            if (!std.ascii.eqlIgnoreCase(name, "Accept-Encoding")) {
+                try extra.append(self.allocator, .{ .name = name, .value = value });
+            }
             try self.request_headers.put(name, value);
         }
         self.extra_headers = try extra.toOwnedSlice(self.allocator);
@@ -2248,8 +2259,26 @@ test "standard transport preserves configured client for streaming uploads and d
             case.encoding,
             case.encoded_response,
             case.chunked_response,
+            null,
         );
     }
+}
+
+test "standard transport explicit accept encoding overrides defaults" {
+    try runStdStreamingCase(
+        null,
+        "gzip",
+        "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03\x2b\x2e\x29\x4a\x4d\xcc\x4d\x4d\x51\x48\xce\xcf\x2d\x28\x4a\x2d\x2e\x06\x32\x81\x54\x41\x7e\x5e\x71\x2a\x00\xa6\x80\xb4\x50\x1c\x00\x00\x00",
+        false,
+        "identity",
+    );
+    try runStdStreamingCase(
+        null,
+        "zstd",
+        "\x28\xb5\x2f\xfd\x04\x58\xe1\x00\x00\x73\x74\x72\x65\x61\x6d\x65\x64\x20\x63\x6f\x6d\x70\x72\x65\x73\x73\x65\x64\x20\x72\x65\x73\x70\x6f\x6e\x73\x65\xa9\xca\xdc\xf0",
+        false,
+        "zstd",
+    );
 }
 
 fn runStdStreamingCase(
@@ -2257,6 +2286,7 @@ fn runStdStreamingCase(
     encoding: []const u8,
     encoded_response: []const u8,
     chunked_response: bool,
+    explicit_accept_encoding: ?[]const u8,
 ) !void {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
@@ -2286,6 +2316,9 @@ fn runStdStreamingCase(
     var transport = StdHttpTransport.initWithClient(allocator, configured_client);
     var request = Request.init(allocator, .POST, url);
     defer request.deinit();
+    if (explicit_accept_encoding) |value| {
+        try request.setHeader("Accept-Encoding", value);
+    }
     var source = std.Io.Reader.fixed("streaming upload body");
     var operation = transport.asTransport().open(&request, .{
         .body = .{ .reader = &source, .content_length = content_length },
@@ -2323,6 +2356,11 @@ fn runStdStreamingCase(
     if (context.failure) |failure| return failure;
     try std.testing.expectEqualStrings("streaming upload body", context.received[0..context.received_len]);
     try std.testing.expectEqual(content_length == null, context.saw_chunked);
+    try std.testing.expectEqual(@as(usize, 1), context.accept_encoding_count);
+    try std.testing.expectEqualStrings(
+        explicit_accept_encoding orelse "zstd, gzip, deflate",
+        context.acceptEncoding(),
+    );
 }
 
 const LocalHttpServer = struct {
@@ -2334,7 +2372,14 @@ const LocalHttpServer = struct {
     received: [128]u8 = undefined,
     received_len: usize = 0,
     saw_chunked: bool = false,
+    accept_encoding: [128]u8 = undefined,
+    accept_encoding_len: usize = 0,
+    accept_encoding_count: usize = 0,
     failure: ?anyerror = null,
+
+    fn acceptEncoding(self: *const LocalHttpServer) []const u8 {
+        return self.accept_encoding[0..self.accept_encoding_len];
+    }
 
     fn run(self: *LocalHttpServer) void {
         self.serve() catch |err| {
@@ -2363,6 +2408,15 @@ const LocalHttpServer = struct {
             } else if (std.ascii.startsWithIgnoreCase(line, "transfer-encoding:")) {
                 const value = std.mem.trim(u8, line["transfer-encoding:".len..], " ");
                 self.saw_chunked = std.ascii.eqlIgnoreCase(value, "chunked");
+            } else if (std.ascii.startsWithIgnoreCase(line, "accept-encoding:")) {
+                const value = std.mem.trim(u8, line["accept-encoding:".len..], " ");
+                self.accept_encoding_count += 1;
+                if (self.accept_encoding_count == 1) {
+                    if (value.len > self.accept_encoding.len)
+                        return error.AcceptEncodingTooLong;
+                    @memcpy(self.accept_encoding[0..value.len], value);
+                    self.accept_encoding_len = value.len;
+                }
             }
         }
 


### PR DESCRIPTION
Adds bounded buffered, owned streaming, and resumable ranged blob downloads with strict range/length/digest validation, deterministic cleanup, safe redirects, and explicit identity encoding for ranges.

Closes #88