### PR TITLE
sdk/container_registry: add examples, live tests, and release packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -374,6 +374,7 @@ CMakeUserPresets.json
 
 zig-out/
 zig-pkg/
+.release/
 # codegen local-dev scratch output
 .tsp-generated/
 codegen/tcgc-component/.tsp-staging/

--- a/build.zig
+++ b/build.zig
@@ -37,7 +37,7 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    _ = b.addModule("azure_sdk_container_registry", .{
+    const container_registry_sdk_mod = b.addModule("azure_sdk_container_registry", .{
         .root_source_file = b.path("sdk/container_registry/src/root.zig"),
         .target = target,
         .imports = &.{
@@ -630,6 +630,87 @@ pub fn build(b: *std.Build) void {
         "Run opt-in Kusto live tests; unconfigured tests skip",
     );
     kusto_live_test_step.dependOn(&run_kusto_live_tests.step);
+
+    const acr_example_support_mod = b.createModule(.{
+        .root_source_file = b.path("sdk/container_registry/examples/support.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "azure_core", .module = core_mod },
+            .{
+                .name = "azure_sdk_container_registry",
+                .module = container_registry_sdk_mod,
+            },
+        },
+    });
+    const acr_examples_step = b.step(
+        "container-registry-examples",
+        "Compile all Container Registry examples",
+    );
+    const acr_example_sources = [_]struct {
+        name: []const u8,
+        source: []const u8,
+    }{
+        .{
+            .name = "acr-list-repositories-tags",
+            .source = "sdk/container_registry/examples/list_repositories_tags.zig",
+        },
+        .{
+            .name = "acr-anonymous-read",
+            .source = "sdk/container_registry/examples/anonymous_read.zig",
+        },
+        .{
+            .name = "acr-oci-push-pull",
+            .source = "sdk/container_registry/examples/oci_push_pull.zig",
+        },
+        .{
+            .name = "acr-delete-artifact",
+            .source = "sdk/container_registry/examples/delete_artifact.zig",
+        },
+    };
+    for (acr_example_sources) |acr_example| {
+        const executable = b.addExecutable(.{
+            .name = acr_example.name,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(acr_example.source),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "azure_core", .module = core_mod },
+                    .{
+                        .name = "azure_sdk_container_registry",
+                        .module = container_registry_sdk_mod,
+                    },
+                    .{
+                        .name = "acr_example_support",
+                        .module = acr_example_support_mod,
+                    },
+                },
+            }),
+        });
+        acr_examples_step.dependOn(&executable.step);
+        test_step.dependOn(&executable.step);
+    }
+
+    const acr_live_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("sdk/container_registry/live_tests/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = core_mod },
+                .{
+                    .name = "azure_sdk_container_registry",
+                    .module = container_registry_sdk_mod,
+                },
+            },
+        }),
+    });
+    const acr_live_test_step = b.step(
+        "container-registry-live-test",
+        "Run destructive opt-in Container Registry live tests; unconfigured tests skip",
+    );
+    acr_live_test_step.dependOn(&b.addRunArtifact(acr_live_tests).step);
 
     // -- tspconfigs tool --
     //

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -1995,6 +1995,7 @@ fn renderBuildZigZon(
         \\    .dependencies = .{{
         \\{[sdk]s}{[serde]s}    }},
         \\    .paths = .{{
+        \\        ".gitignore",
         \\        "build.zig",
         \\        "build.zig.zon",
         \\        "src",

--- a/codegen/fixtures/generate_container_registry_package.zig
+++ b/codegen/fixtures/generate_container_registry_package.zig
@@ -64,7 +64,64 @@ pub fn main(init: std.process.Init) !void {
         .sub_path = "src/clients_test.zig",
         .data = generated_tests,
     });
+    try output.writeFile(io, .{
+        .sub_path = "README.md",
+        .data = generated_readme,
+    });
 }
+
+const generated_readme =
+    \\# Azure Container Registry REST for Zig
+    \\
+    \\`azure_rest_container_registry` is the generated protocol package for
+    \\Azure Container Registry data-plane API version **2021-07-01**.
+    \\It is produced from the checked-in TypeSpec code model and is entirely
+    \\generator-owned. Do not edit this package by hand; change the emitter or
+    \\fixture and regenerate it instead.
+    \\
+    \\## Protocol surface
+    \\
+    \\The generated clients expose all 29 stable operations through:
+    \\
+    \\- `ContainerRegistryClient`
+    \\- `ContainerRegistry`
+    \\- `ContainerRegistryBlob`
+    \\- `Authentication`
+    \\
+    \\This layer preserves raw protocol request/response types and status
+    \\unions. It does not add challenge authentication, safe continuation
+    \\validation, digest verification, transfer replay, or domain ownership
+    \\helpers. Use `azure_sdk_container_registry` for those behaviors.
+    \\
+    \\The generated `initWithPipeline` constructor is the protocol escape
+    \\hatch for callers that need custom policies or operations not surfaced
+    \\by the hand-written package. The supplied pipeline and transport are
+    \\borrowed and must outlive every generated client and active operation.
+    \\Generated result fields follow their declared allocator ownership; free
+    \\or deinitialize every owned body/header/model value shown by the type.
+    \\
+    \\## Media types
+    \\
+    \\The REST package transports caller-provided media types. The hand-written
+    \\package has first-class upload support for OCI image manifests and Docker
+    \\schema-2 manifests and accepts OCI image/index, Docker schema-2
+    \\manifest/list/config, ORAS artifact manifest, and wildcard manifest
+    \\responses.
+    \\
+    \\## Build and regeneration
+    \\
+    \\```bash
+    \\zig build test --summary all
+    \\(cd ../../codegen/cli && zig build generate-container-registry-package)
+    \\../../scripts/verify-container-registry-regeneration.sh
+    \\```
+    \\
+    \\Local development uses the repository-relative `azure_sdk` dependency.
+    \\Release staging replaces it with the immutable commit/hash recorded in
+    \\`eng/container_registry_release/metadata.sh`; see
+    \\`doc/package-branch-model.md`.
+    \\
+;
 
 const generated_tests =
     \\const std = @import("std");

--- a/doc/package-branch-model.md
+++ b/doc/package-branch-model.md
@@ -185,29 +185,84 @@ dependencies during development:
 (cd sdk/container_registry && zig build test --summary all)
 ```
 
-Before publishing `sdk/container_registry`, replace both local paths in its
-`build.zig.zon` with immutable `azure_sdk` and
-`azure_rest_container_registry` commit/hash pins, then rerun the same package
-test command from the orphan branch.
-
-For a release commit, generate complete immutable dependency metadata before
-splitting the package to its orphan branch:
+The checked-in packages intentionally retain relative paths so monorepo
+development never depends on an unpublished orphan branch. Immutable release
+metadata is staged outside the tracked tree:
 
 ```bash
-SDK_COMMIT="$(git rev-parse origin/main)"
-SDK_HASH="$(zig fetch "git+https://github.com/cataggar/azure-sdk-for-zig#$SDK_COMMIT")"
-(cd codegen/cli && zig build generate-container-registry-package \
-  -Dazure-core-commit="$SDK_COMMIT" \
-  -Dazure-core-hash="$SDK_HASH")
-(cd rest/container_registry && zig build test --summary all)
-git add rest/container_registry
-git commit -m "rest/container_registry: release generated package"
-REST_COMMIT="$(git subtree split --prefix=rest/container_registry HEAD)"
-git push origin "$REST_COMMIT:refs/heads/rest/container_registry"
+# Verifies the recorded main commit/hash, generates the pinned REST package,
+# stages the SDK beside it, validates exact package/module names, independently
+# tests both packages, compiles all examples, and checks the unconfigured live
+# test skip. `dry-run` is an alias.
+scripts/container-registry-release.sh verify
+
+# Also verify that canonical regeneration is deterministic and cannot touch the
+# handwritten SDK package.
+scripts/verify-container-registry-regeneration.sh
+
+# Stage the publishable REST package. This creates no ref.
+scripts/container-registry-release.sh prepare-rest
 ```
 
-The release generation is still deterministic: the commit and Zig package
-hash are explicit inputs, and no generated package file is edited afterward.
+The common dependency pin is recorded in
+`eng/container_registry_release/metadata.sh`. It is the immutable
+`origin/main` commit immediately after PR #100 and its verified Zig package
+hash. The REST stage is
+`.release/container_registry/publish/rest`.
+
+Publish the staged REST package from a disposable worktree (the commands below
+are intentionally explicit and are not run by the preparation tool):
+
+```bash
+ROOT="$(git rev-parse --show-toplevel)"
+REST_STAGE="$ROOT/.release/container_registry/publish/rest"
+REST_WORKTREE="${ROOT}-rest-container-registry-release"
+git worktree add --detach "$REST_WORKTREE" HEAD
+(
+  cd "$REST_WORKTREE"
+  git switch --orphan rest-container-registry-release
+  git rm -rf .
+  cp -R "$REST_STAGE/." .
+  git add -A
+  git commit -m "rest/container_registry: release generated package"
+  git push origin HEAD:refs/heads/rest/container_registry
+)
+REST_COMMIT="$(git ls-remote origin refs/heads/rest/container_registry | cut -f1)"
+git worktree remove "$REST_WORKTREE"
+```
+
+The SDK cannot contain an honest immutable REST hash until that orphan commit
+exists. After REST publication, the second stage fetches that exact commit,
+computes (or verifies a supplied) Zig package hash, applies both immutable
+dependency pins, and tests the publishable SDK package:
+
+```bash
+scripts/container-registry-release.sh prepare-sdk "$REST_COMMIT"
+```
+
+The SDK stage is `.release/container_registry/publish/sdk`. Publish it only
+after inspecting its two URL/hash pins:
+
+```bash
+ROOT="$(git rev-parse --show-toplevel)"
+SDK_STAGE="$ROOT/.release/container_registry/publish/sdk"
+SDK_WORKTREE="${ROOT}-sdk-container-registry-release"
+git worktree add --detach "$SDK_WORKTREE" HEAD
+(
+  cd "$SDK_WORKTREE"
+  git switch --orphan sdk-container-registry-release
+  git rm -rf .
+  cp -R "$SDK_STAGE/." .
+  git add -A
+  git commit -m "sdk/container_registry: release package"
+  git push origin HEAD:refs/heads/sdk/container_registry
+)
+git worktree remove "$SDK_WORKTREE"
+```
+
+This two-stage process never invents a REST commit or hash. Both preparation
+commands are deterministic, create only ignored `.release/` staging, and never
+create branches, tags, commits, or remote refs themselves.
 
 ## Versioning
 

--- a/doc/package-branch-model.md
+++ b/doc/package-branch-model.md
@@ -210,31 +210,23 @@ The common dependency pin is recorded in
 hash. The REST stage is
 `.release/container_registry/publish/rest`.
 
-Publish the staged REST package from a disposable worktree (the commands below
-are intentionally explicit and are not run by the preparation tool):
+Preview the exact initial-or-descendant REST commit without changing the
+remote, then publish it:
 
 ```bash
-ROOT="$(git rev-parse --show-toplevel)"
-REST_STAGE="$ROOT/.release/container_registry/publish/rest"
-REST_WORKTREE="${ROOT}-rest-container-registry-release"
-git worktree add --detach "$REST_WORKTREE" HEAD
-(
-  cd "$REST_WORKTREE"
-  git switch --orphan rest-container-registry-release
-  git rm -rf .
-  cp -R "$REST_STAGE/." .
-  git add -A
-  git commit -m "rest/container_registry: release generated package"
-  git push origin HEAD:refs/heads/rest/container_registry
-)
-REST_COMMIT="$(git ls-remote origin refs/heads/rest/container_registry | cut -f1)"
-git worktree remove "$REST_WORKTREE"
+scripts/container-registry-release.sh publish-rest --dry-run
+scripts/container-registry-release.sh publish-rest
+REST_COMMIT="$(
+  git ls-remote origin refs/heads/rest/container_registry | cut -f1
+)"
 ```
 
 The SDK cannot contain an honest immutable REST hash until that orphan commit
 exists. After REST publication, the second stage fetches that exact commit,
-computes (or verifies a supplied) Zig package hash, applies both immutable
-dependency pins, and tests the publishable SDK package:
+requires it to equal the current remote release-branch tip, archives and
+validates the package root/name/dependency structure, computes (or verifies a
+supplied) Zig package hash from those exact bytes, applies both immutable
+dependency pins, and tests a disposable copy of the publishable SDK package:
 
 ```bash
 scripts/container-registry-release.sh prepare-sdk "$REST_COMMIT"
@@ -244,25 +236,36 @@ The SDK stage is `.release/container_registry/publish/sdk`. Publish it only
 after inspecting its two URL/hash pins:
 
 ```bash
-ROOT="$(git rev-parse --show-toplevel)"
-SDK_STAGE="$ROOT/.release/container_registry/publish/sdk"
-SDK_WORKTREE="${ROOT}-sdk-container-registry-release"
-git worktree add --detach "$SDK_WORKTREE" HEAD
-(
-  cd "$SDK_WORKTREE"
-  git switch --orphan sdk-container-registry-release
-  git rm -rf .
-  cp -R "$SDK_STAGE/." .
-  git add -A
-  git commit -m "sdk/container_registry: release package"
-  git push origin HEAD:refs/heads/sdk/container_registry
-)
-git worktree remove "$SDK_WORKTREE"
+scripts/container-registry-release.sh publish-sdk --dry-run
+scripts/container-registry-release.sh publish-sdk
 ```
 
-This two-stage process never invents a REST commit or hash. Both preparation
-commands are deterministic, create only ignored `.release/` staging, and never
-create branches, tags, commits, or remote refs themselves.
+The publication commands create disposable no-checkout worktrees and install
+only validated stage files. Cleanup traps remove temporary worktrees and local
+branches on success or failure. A missing release branch gets an orphan root;
+an existing release branch is fetched and the new commit must descend directly
+from its current tip. Pushes are ordinary fast-forwards and never force.
+
+Staging uses only tracked SDK files in the package's explicit `.paths`
+manifest. Generated REST output is checked against its own `.paths` manifest.
+Neither staging nor publication copies ignored/untracked trees, and validation
+rejects `.zig-cache`, `zig-pkg`, `zig-out`, `.release`, or any undeclared
+top-level entry. Builds run from disposable copies with external local/global
+Zig caches, so publishable directories remain byte-clean.
+
+Run the isolated workflow regression tests at any time:
+
+```bash
+scripts/container-registry-release.sh self-test
+```
+
+They use a local bare remote to prove that a main commit and a mismatched REST
+package are rejected, initial and subsequent publication dry-runs have the
+correct parentage, cleanup succeeds, and a normal local fast-forward push
+works. They never create GitHub branches or tags.
+
+This two-stage process never invents a REST commit or hash. Preparation creates
+only ignored `.release/` staging; publication is always an explicit command.
 
 ## Versioning
 

--- a/eng/container_registry_release/README.md
+++ b/eng/container_registry_release/README.md
@@ -1,0 +1,25 @@
+# Container Registry release staging
+
+`metadata.sh` records the immutable common `azure_sdk` commit and Zig package
+hash used by both independently published ACR packages. The commit is
+`origin/main` immediately after PR #100, which contains the complete shared
+core required by the REST and hand-written packages.
+
+The release is intentionally two-stage:
+
+1. `scripts/container-registry-release.sh prepare-rest` regenerates
+   `.release/container_registry/publish/rest` with the common SDK pin and tests
+   it independently.
+2. Publish that directory to `rest/container_registry`.
+3. `scripts/container-registry-release.sh prepare-sdk <rest-commit>` fetches
+   the published REST commit, computes its Zig package hash, writes both
+   immutable pins into `.release/container_registry/publish/sdk`, and tests
+   the SDK, examples, and unconfigured live-test skip.
+4. Publish the SDK directory to `sdk/container_registry`.
+
+No REST hash is guessed before the REST orphan commit exists. `verify` (also
+available as `dry-run`) uses the same generated REST package and a sibling path
+dependency for the SDK, exactly mirroring the two package roots without
+creating branches or tags.
+
+See `doc/package-branch-model.md` for exact publication commands.

--- a/eng/container_registry_release/README.md
+++ b/eng/container_registry_release/README.md
@@ -9,17 +9,29 @@ The release is intentionally two-stage:
 
 1. `scripts/container-registry-release.sh prepare-rest` regenerates
    `.release/container_registry/publish/rest` with the common SDK pin and tests
-   it independently.
-2. Publish that directory to `rest/container_registry`.
+   a disposable copy independently.
+2. `scripts/container-registry-release.sh publish-rest --dry-run` validates the
+   prospective commit; rerun without `--dry-run` to publish it to
+   `rest/container_registry`.
 3. `scripts/container-registry-release.sh prepare-sdk <rest-commit>` fetches
-   the published REST commit, computes its Zig package hash, writes both
-   immutable pins into `.release/container_registry/publish/sdk`, and tests
-   the SDK, examples, and unconfigured live-test skip.
-4. Publish the SDK directory to `sdk/container_registry`.
+   the current remote REST branch tip, requires exact commit equality, validates
+   the archived package root/name/dependencies, computes its Zig package hash,
+   writes both immutable pins into `.release/container_registry/publish/sdk`,
+   and tests a disposable copy, examples, and unconfigured live-test skip.
+4. Use `publish-sdk --dry-run`, then `publish-sdk`, for
+   `sdk/container_registry`.
 
-No REST hash is guessed before the REST orphan commit exists. `verify` (also
-available as `dry-run`) uses the same generated REST package and a sibling path
-dependency for the SDK, exactly mirroring the two package roots without
-creating branches or tags.
+Staging copies only tracked files explicitly declared by each package's
+`build.zig.zon`; generation and tests use external disposable caches. Stage
+validation rejects undeclared files, `.zig-cache`, `zig-pkg`, `zig-out`, and
+other publication artifacts. Publication is fail-fast and trap-cleaned:
+missing branches get one initial orphan commit, while existing branches get
+normal descendant commits and fast-forward pushes. Force-push is never used;
+forced removal is limited to trap cleanup of the disposable worktree.
 
-See `doc/package-branch-model.md` for exact publication commands.
+No REST hash is guessed before the REST release commit exists. `verify` (also
+available as `dry-run`) mirrors both package roots without creating remote refs.
+`self-test` exercises invalid main/mismatched REST commits plus initial and
+subsequent publication dry-runs against an isolated local bare remote.
+
+See `doc/package-branch-model.md` for the complete workflow.

--- a/eng/container_registry_release/metadata.sh
+++ b/eng/container_registry_release/metadata.sh
@@ -1,0 +1,10 @@
+# Immutable common SDK package used by both Container Registry release packages.
+# This is origin/main immediately after PR #100.
+AZURE_SDK_COMMIT=c2d7812c683ae5d2cb3d769939d2027a200d7284
+AZURE_SDK_HASH=azure_sdk-0.1.0--PMlNXKHJwC-jWWN3uEDAhxGVU0CMEXEc-ZPZ4ikXCGL
+AZURE_SDK_URL=git+https://github.com/cataggar/azure-sdk-for-zig
+
+REST_BRANCH=rest/container_registry
+REST_PACKAGE=azure_rest_container_registry
+SDK_BRANCH=sdk/container_registry
+SDK_PACKAGE=azure_sdk_container_registry

--- a/eng/container_registry_release/metadata.sh
+++ b/eng/container_registry_release/metadata.sh
@@ -1,10 +1,12 @@
 # Immutable common SDK package used by both Container Registry release packages.
-# This is origin/main immediately after PR #100.
-AZURE_SDK_COMMIT=c2d7812c683ae5d2cb3d769939d2027a200d7284
-AZURE_SDK_HASH=azure_sdk-0.1.0--PMlNXKHJwC-jWWN3uEDAhxGVU0CMEXEc-ZPZ4ikXCGL
-AZURE_SDK_URL=git+https://github.com/cataggar/azure-sdk-for-zig
+# Defaults are origin/main immediately after PR #100. Environment overrides are
+# used only by the release workflow's isolated local-remote self-tests.
+AZURE_SDK_COMMIT="${AZURE_SDK_COMMIT:-c2d7812c683ae5d2cb3d769939d2027a200d7284}"
+AZURE_SDK_HASH="${AZURE_SDK_HASH:-azure_sdk-0.1.0--PMlNXKHJwC-jWWN3uEDAhxGVU0CMEXEc-ZPZ4ikXCGL}"
+AZURE_SDK_URL="${AZURE_SDK_URL:-git+https://github.com/cataggar/azure-sdk-for-zig}"
+AZURE_SDK_GIT_URL="${AZURE_SDK_GIT_URL:-${AZURE_SDK_URL#git+}}"
 
-REST_BRANCH=rest/container_registry
-REST_PACKAGE=azure_rest_container_registry
-SDK_BRANCH=sdk/container_registry
-SDK_PACKAGE=azure_sdk_container_registry
+REST_BRANCH="${REST_BRANCH:-rest/container_registry}"
+REST_PACKAGE="${REST_PACKAGE:-azure_rest_container_registry}"
+SDK_BRANCH="${SDK_BRANCH:-sdk/container_registry}"
+SDK_PACKAGE="${SDK_PACKAGE:-azure_sdk_container_registry}"

--- a/rest/container_registry/README.md
+++ b/rest/container_registry/README.md
@@ -1,14 +1,49 @@
-# container-registry
+# Azure Container Registry REST for Zig
 
-Generated Azure SDK client for Zig.
+`azure_rest_container_registry` is the generated protocol package for
+Azure Container Registry data-plane API version **2021-07-01**.
+It is produced from the checked-in TypeSpec code model and is entirely
+generator-owned. Do not edit this package by hand; change the emitter or
+fixture and regenerate it instead.
 
-This package is produced by `codegen` from the TypeSpec
-specification in [`Azure/azure-rest-api-specs`](https://github.com/Azure/azure-rest-api-specs).
-Do not edit generated package files by hand — they will be
-overwritten on the next regeneration.
+## Protocol surface
 
-## Clients
+The generated clients expose all 29 stable operations through:
+
 - `ContainerRegistryClient`
 - `ContainerRegistry`
 - `ContainerRegistryBlob`
 - `Authentication`
+
+This layer preserves raw protocol request/response types and status
+unions. It does not add challenge authentication, safe continuation
+validation, digest verification, transfer replay, or domain ownership
+helpers. Use `azure_sdk_container_registry` for those behaviors.
+
+The generated `initWithPipeline` constructor is the protocol escape
+hatch for callers that need custom policies or operations not surfaced
+by the hand-written package. The supplied pipeline and transport are
+borrowed and must outlive every generated client and active operation.
+Generated result fields follow their declared allocator ownership; free
+or deinitialize every owned body/header/model value shown by the type.
+
+## Media types
+
+The REST package transports caller-provided media types. The hand-written
+package has first-class upload support for OCI image manifests and Docker
+schema-2 manifests and accepts OCI image/index, Docker schema-2
+manifest/list/config, ORAS artifact manifest, and wildcard manifest
+responses.
+
+## Build and regeneration
+
+```bash
+zig build test --summary all
+(cd ../../codegen/cli && zig build generate-container-registry-package)
+../../scripts/verify-container-registry-regeneration.sh
+```
+
+Local development uses the repository-relative `azure_sdk` dependency.
+Release staging replaces it with the immutable commit/hash recorded in
+`eng/container_registry_release/metadata.sh`; see
+`doc/package-branch-model.md`.

--- a/rest/container_registry/build.zig.zon
+++ b/rest/container_registry/build.zig.zon
@@ -13,6 +13,7 @@
         },
     },
     .paths = .{
+        ".gitignore",
         "build.zig",
         "build.zig.zon",
         "src",

--- a/scripts/container-registry-release.sh
+++ b/scripts/container-registry-release.sh
@@ -2,10 +2,55 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/container-registry-release.sh"
 METADATA="$ROOT/eng/container_registry_release/metadata.sh"
-STAGE_ROOT="$ROOT/.release/container_registry"
 # shellcheck source=/dev/null
 source "$METADATA"
+
+STAGE_ROOT="${CONTAINER_REGISTRY_RELEASE_ROOT:-$ROOT/.release/container_registry}"
+WORK_ROOT="$STAGE_ROOT/work"
+ACTIVE_REPO=""
+ACTIVE_WORKTREE=""
+ACTIVE_BRANCH=""
+SELF_TEST_ROOT=""
+PUBLISHED_COMMIT=""
+REMOVE_CODEGEN_ZIG_PKG=0
+
+cleanup_active_publication() {
+  set +e
+  if [[ -n "$ACTIVE_REPO" && -n "$ACTIVE_WORKTREE" ]]; then
+    git -C "$ACTIVE_REPO" worktree remove --force "$ACTIVE_WORKTREE" \
+      >/dev/null 2>&1
+    case "$ACTIVE_WORKTREE" in
+      "$STAGE_ROOT"/worktrees/*|"$SELF_TEST_ROOT"/worktrees/*)
+        rm -rf "$ACTIVE_WORKTREE"
+        ;;
+    esac
+  fi
+  if [[ -n "$ACTIVE_REPO" && -n "$ACTIVE_BRANCH" ]]; then
+    git -C "$ACTIVE_REPO" branch -D "$ACTIVE_BRANCH" >/dev/null 2>&1
+  fi
+  ACTIVE_REPO=""
+  ACTIVE_WORKTREE=""
+  ACTIVE_BRANCH=""
+  set -e
+}
+
+cleanup_on_exit() {
+  local status=$?
+  trap - EXIT INT TERM HUP
+  cleanup_active_publication
+  if [[ "$REMOVE_CODEGEN_ZIG_PKG" == 1 ]]; then
+    rm -rf "$ROOT/codegen/cli/zig-pkg"
+  fi
+  if [[ -n "$SELF_TEST_ROOT" ]]; then
+    case "$SELF_TEST_ROOT" in
+      "$STAGE_ROOT"/self-test) rm -rf "$SELF_TEST_ROOT" ;;
+    esac
+  fi
+  exit "$status"
+}
+trap cleanup_on_exit EXIT INT TERM HUP
 
 usage() {
   cat <<'EOF'
@@ -15,14 +60,27 @@ Usage:
   scripts/container-registry-release.sh dry-run
   scripts/container-registry-release.sh prepare-rest
   scripts/container-registry-release.sh prepare-sdk <rest-commit> [rest-hash]
+  scripts/container-registry-release.sh publish-rest [--dry-run] [--remote <remote>]
+  scripts/container-registry-release.sh publish-sdk [--dry-run] [--remote <remote>]
+  scripts/container-registry-release.sh self-test
 
-All generated files stay under ignored .release/container_registry. No branch,
-tag, commit, or remote ref is created or changed.
+Preparation stages only declared package files. Builds and fetch caches use
+disposable work directories outside package stages. Publication creates an
+initial orphan commit only when the release branch is absent; later releases
+create normal descendant commits and push without force. --dry-run creates and
+validates the prospective commit but does not push it.
 EOF
 }
 
+reset_work() {
+  rm -rf "$WORK_ROOT"
+  mkdir -p "$WORK_ROOT"
+}
+
 fetch_hash() {
-  zig fetch "$1"
+  local source="$1"
+  mkdir -p "$WORK_ROOT/global-cache"
+  zig fetch --global-cache-dir "$WORK_ROOT/global-cache" "$source"
 }
 
 check_hash() {
@@ -31,13 +89,13 @@ check_hash() {
   local actual
   actual="$(fetch_hash "$url")"
   if [[ "$actual" != "$expected" ]]; then
-    printf 'package hash mismatch\n  URL:      %s\n  expected: %s\n  actual:   %s\n' \
-      "$url" "$expected" "$actual" >&2
-    exit 1
+    printf 'package hash mismatch\n  expected: %s\n  actual:   %s\n' \
+      "$expected" "$actual" >&2
+    return 1
   fi
 }
 
-validate_identity() {
+validate_package() {
   local directory="$1"
   local package="$2"
   python3 - "$directory" "$package" <<'PY'
@@ -47,32 +105,116 @@ import sys
 
 root = Path(sys.argv[1])
 package = sys.argv[2]
-zon = (root / "build.zig.zon").read_text()
-build = (root / "build.zig").read_text()
-if not re.search(rf"\.name\s*=\s*\.{re.escape(package)}\s*,", zon):
+for path in root.rglob("*"):
+    if path.is_symlink():
+        raise SystemExit(f"{root}: symlinks are not allowed in release packages")
+zon_path = root / "build.zig.zon"
+build_path = root / "build.zig"
+if not zon_path.is_file() or not build_path.is_file():
+    raise SystemExit(f"{root}: package root is missing build.zig or build.zig.zon")
+
+zon = zon_path.read_text()
+build = build_path.read_text()
+if not re.search(rf"(?m)^\s*\.name\s*=\s*\.{re.escape(package)}\s*,\s*$", zon):
     raise SystemExit(f"{root}: build.zig.zon package name is not {package}")
+if not re.search(r"(?m)^\s*\.version\s*=\s*\"[^\"]+\"\s*,\s*$", zon):
+    raise SystemExit(f"{root}: build.zig.zon is missing version")
+if not re.search(r"(?m)^\s*\.fingerprint\s*=\s*0x[0-9a-fA-F]+\s*,\s*$", zon):
+    raise SystemExit(f"{root}: build.zig.zon is missing fingerprint")
+if not re.search(r"(?m)^\s*\.minimum_zig_version\s*=\s*\"[^\"]+\"\s*,\s*$", zon):
+    raise SystemExit(f"{root}: build.zig.zon is missing minimum_zig_version")
 if f'addModule("{package}"' not in build:
     raise SystemExit(f"{root}: build.zig module name is not {package}")
+
+paths_match = re.search(r"(?ms)^\s*\.paths\s*=\s*\.\{(.*?)^\s*\},\s*$", zon)
+if not paths_match:
+    raise SystemExit(f"{root}: build.zig.zon is missing .paths")
+declared = set(re.findall(r'"([^"]+)"', paths_match.group(1)))
+expected = {
+    ".gitignore",
+    "build.zig",
+    "build.zig.zon",
+    "README.md",
+    "src",
+}
 if package == "azure_sdk_container_registry":
-    if '.azure_rest_container_registry = .{' not in zon:
-        raise SystemExit(f"{root}: missing azure_rest_container_registry dependency")
-    if 'module("azure_rest_container_registry")' not in build:
-        raise SystemExit(f"{root}: missing azure_rest_container_registry module import")
-print(f"verified package/module identity: {package}")
+    expected.update({".gitignore", "examples", "live_tests"})
+if declared != expected:
+    raise SystemExit(
+        f"{root}: declared package paths differ: "
+        f"expected {sorted(expected)}, got {sorted(declared)}"
+    )
+
+for entry in declared:
+    if not (root / entry).exists() and not (root / entry).is_symlink():
+        raise SystemExit(f"{root}: declared package path is missing: {entry}")
+
+for path in root.rglob("*"):
+    relative = path.relative_to(root)
+    if any(part in {".git", ".zig-cache", "zig-pkg", "zig-out", ".release"}
+           for part in relative.parts):
+        raise SystemExit(f"{root}: forbidden release artifact: {relative}")
+    if path.is_dir():
+        continue
+    first = relative.parts[0]
+    if first not in declared:
+        raise SystemExit(f"{root}: undeclared package file: {relative}")
+
+top_level = {path.name for path in root.iterdir()}
+if top_level != declared:
+    raise SystemExit(
+        f"{root}: staged top-level entries differ: "
+        f"expected {sorted(declared)}, got {sorted(top_level)}"
+    )
+print(f"verified declared package content: {package}", file=sys.stderr)
 PY
 }
 
-generate_rest() {
-  local output="$1"
-  rm -rf "$output"
-  mkdir -p "$(dirname "$output")"
-  (
-    cd "$ROOT/codegen/cli"
-    zig build generate-container-registry-package \
-      -Dcontainer-registry-output="$output" \
-      -Dazure-core-commit="$AZURE_SDK_COMMIT" \
-      -Dazure-core-hash="$AZURE_SDK_HASH"
-  )
+validate_rest_archive() {
+  local directory="$1"
+  validate_package "$directory" "$REST_PACKAGE"
+  python3 - "$directory/build.zig.zon" \
+    "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+expected_sdk_url, expected_sdk_hash = sys.argv[2:]
+text = path.read_text()
+
+dependencies = re.search(
+    r"(?ms)^\s*\.dependencies\s*=\s*\.\{(.*?)^\s*\},\s*^\s*\.paths",
+    text,
+)
+if not dependencies:
+    raise SystemExit(f"{path}: missing dependencies block")
+block = dependencies.group(1)
+names = set(re.findall(r"(?m)^\s{8}\.([A-Za-z0-9_]+)\s*=\s*\.\{\s*$", block))
+if names != {"azure_sdk", "serde"}:
+    raise SystemExit(
+        f"{path}: expected azure_sdk and serde dependencies, got {sorted(names)}"
+    )
+if re.search(r"(?m)^\s*\.path\s*=", block):
+    raise SystemExit(f"{path}: published REST package contains a path dependency")
+
+sdk = re.search(
+    r"(?ms)^\s{8}\.azure_sdk\s*=\s*\.\{(.*?)^\s{8}\},\s*$",
+    block,
+)
+if not sdk:
+    raise SystemExit(f"{path}: malformed azure_sdk dependency")
+sdk_block = sdk.group(1)
+url = re.search(r'(?m)^\s*\.url\s*=\s*"([^"]+)"\s*,\s*$', sdk_block)
+package_hash = re.search(
+    r'(?m)^\s*\.hash\s*=\s*"([^"]+)"\s*,\s*$',
+    sdk_block,
+)
+if not url or url.group(1) != expected_sdk_url:
+    raise SystemExit(f"{path}: azure_sdk URL/commit pin differs")
+if not package_hash or package_hash.group(1) != expected_sdk_hash:
+    raise SystemExit(f"{path}: azure_sdk package hash differs")
+PY
 }
 
 stage_sdk() {
@@ -82,16 +224,47 @@ stage_sdk() {
   local rest_hash="${4:-}"
   rm -rf "$output"
   mkdir -p "$output"
-  cp \
-    "$ROOT/sdk/container_registry/build.zig" \
-    "$ROOT/sdk/container_registry/build.zig.zon" \
-    "$ROOT/sdk/container_registry/README.md" \
-    "$output/"
-  cp -R \
-    "$ROOT/sdk/container_registry/src" \
-    "$ROOT/sdk/container_registry/examples" \
-    "$ROOT/sdk/container_registry/live_tests" \
-    "$output/"
+
+  python3 - "$ROOT" "$output" <<'PY'
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import sys
+
+root = Path(sys.argv[1])
+output = Path(sys.argv[2])
+subtree = Path("sdk/container_registry")
+declared = {
+    ".gitignore",
+    "README.md",
+    "build.zig",
+    "build.zig.zon",
+    "examples",
+    "live_tests",
+    "src",
+}
+raw = subprocess.check_output(
+    ["git", "-C", str(root), "ls-files", "-z", "--", str(subtree)]
+)
+files = [Path(item.decode()) for item in raw.split(b"\0") if item]
+if not files:
+    raise SystemExit("no tracked SDK package files found")
+for tracked in files:
+    relative = tracked.relative_to(subtree)
+    if relative.parts[0] not in declared:
+        raise SystemExit(f"tracked but undeclared SDK package file: {relative}")
+    source = root / tracked
+    target = output / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_symlink():
+        target.symlink_to(os.readlink(source))
+    elif source.is_file():
+        shutil.copy2(source, target)
+    else:
+        raise SystemExit(f"tracked SDK package file is missing: {tracked}")
+PY
+
   python3 - "$output/build.zig.zon" "$rest_mode" \
     "$AZURE_SDK_URL" "$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH" \
     "$rest_commit" "$rest_hash" <<'PY'
@@ -132,68 +305,593 @@ if text.count(rest_old) != 1:
     raise SystemExit(f"{path}: expected one local REST dependency")
 path.write_text(text.replace(rest_old, rest_new))
 PY
+  validate_package "$output" "$SDK_PACKAGE"
+}
+
+generate_rest() {
+  local output="$1"
+  if [[ ! -e "$ROOT/codegen/cli/zig-pkg" ]]; then
+    REMOVE_CODEGEN_ZIG_PKG=1
+  fi
+  rm -rf "$output"
+  mkdir -p "$(dirname "$output")" "$WORK_ROOT/codegen-cache" \
+    "$WORK_ROOT/global-cache"
+  (
+    cd "$ROOT/codegen/cli"
+    zig build \
+      --cache-dir "$WORK_ROOT/codegen-cache" \
+      --global-cache-dir "$WORK_ROOT/global-cache" \
+      generate-container-registry-package \
+      -Dcontainer-registry-output="$output" \
+      -Dazure-core-commit="$AZURE_SDK_COMMIT" \
+      -Dazure-core-hash="$AZURE_SDK_HASH"
+  )
+  if [[ "$REMOVE_CODEGEN_ZIG_PKG" == 1 ]]; then
+    rm -rf "$ROOT/codegen/cli/zig-pkg"
+    REMOVE_CODEGEN_ZIG_PKG=0
+  fi
+  validate_rest_archive "$output"
+}
+
+copy_declared_stage() {
+  local source="$1"
+  local destination="$2"
+  rm -rf "$destination"
+  mkdir -p "$destination"
+  (
+    cd "$source"
+    tar -cf - .
+  ) | (
+    cd "$destination"
+    tar -xf -
+  )
+}
+
+install_declared_stage() {
+  local source="$1"
+  local worktree="$2"
+  (
+    cd "$source"
+    tar -cf - .
+  ) | (
+    cd "$worktree"
+    tar -xf -
+  )
+}
+
+zig_build() {
+  local directory="$1"
+  local cache_name="$2"
+  shift 2
+  mkdir -p "$WORK_ROOT/caches/$cache_name/local" \
+    "$WORK_ROOT/caches/global"
+  (
+    cd "$directory"
+    zig build \
+      --cache-dir "$WORK_ROOT/caches/$cache_name/local" \
+      --global-cache-dir "$WORK_ROOT/caches/global" \
+      "$@"
+  )
 }
 
 test_rest() {
   local directory="$1"
-  validate_identity "$directory" "$REST_PACKAGE"
-  (cd "$directory" && zig build test --summary all)
+  validate_package "$directory" "$REST_PACKAGE"
+  zig_build "$directory" rest test --summary all
 }
 
 test_sdk() {
   local directory="$1"
-  validate_identity "$directory" "$SDK_PACKAGE"
+  validate_package "$directory" "$SDK_PACKAGE"
+  zig_build "$directory" sdk-test test --summary all
+  zig_build "$directory" sdk-examples examples
   (
-    cd "$directory"
-    zig build test --summary all
-    zig build examples
-    env \
-      -u AZURE_CONTAINER_REGISTRY_LIVE_TESTS \
-      -u AZURE_CONTAINER_REGISTRY_ENDPOINT \
-      -u AZURE_CONTAINER_REGISTRY_LIVE_TEST_RUN_ID \
-      -u AZURE_CONTAINER_REGISTRY_LIVE_TEST_REPOSITORY_PREFIX \
-      zig build live-test --summary all
+    unset AZURE_CONTAINER_REGISTRY_LIVE_TESTS
+    unset AZURE_CONTAINER_REGISTRY_ENDPOINT
+    unset AZURE_CONTAINER_REGISTRY_LIVE_TEST_RUN_ID
+    unset AZURE_CONTAINER_REGISTRY_LIVE_TEST_REPOSITORY_PREFIX
+    zig_build "$directory" sdk-live live-test --summary all
   )
+}
+
+test_local_stages() {
+  local rest_stage="$1"
+  local sdk_stage="$2"
+  local test_root="$WORK_ROOT/test-packages"
+  copy_declared_stage "$rest_stage" "$test_root/rest"
+  copy_declared_stage "$sdk_stage" "$test_root/sdk"
+  test_rest "$test_root/rest"
+  test_sdk "$test_root/sdk"
+  rm -rf "$test_root" "$WORK_ROOT/caches"
+  validate_rest_archive "$rest_stage"
+  validate_package "$sdk_stage" "$SDK_PACKAGE"
+}
+
+test_published_sdk_stage() {
+  local sdk_stage="$1"
+  local test_root="$WORK_ROOT/test-packages"
+  copy_declared_stage "$sdk_stage" "$test_root/sdk"
+  test_sdk "$test_root/sdk"
+  rm -rf "$test_root" "$WORK_ROOT/caches"
+  validate_package "$sdk_stage" "$SDK_PACKAGE"
+}
+
+remote_ref_commit() {
+  local git_url="$1"
+  local branch="$2"
+  local result
+  result="$(git ls-remote "$git_url" "refs/heads/$branch")"
+  if [[ -z "$result" ]]; then
+    printf 'remote release branch does not exist: %s\n' "$branch" >&2
+    return 1
+  fi
+  printf '%s\n' "$result" | awk 'NR == 1 { print $1 }'
+}
+
+resolve_rest_package() {
+  local requested_commit="$1"
+  local archive_output="$2"
+  local verify_url_hash="${3:-1}"
+  local remote_commit
+  remote_commit="$(remote_ref_commit "$AZURE_SDK_GIT_URL" "$REST_BRANCH")"
+  if [[ "$requested_commit" != "$remote_commit" ]]; then
+    printf 'REST commit must equal remote refs/heads/%s\n' "$REST_BRANCH" >&2
+    printf '  requested: %s\n  remote:    %s\n' \
+      "$requested_commit" "$remote_commit" >&2
+    return 1
+  fi
+
+  local fetch_repo="$WORK_ROOT/fetched-rest-repo"
+  rm -rf "$fetch_repo" "$archive_output"
+  mkdir -p "$archive_output"
+  git init --quiet "$fetch_repo"
+  git -C "$fetch_repo" fetch --quiet --depth=1 \
+    "$AZURE_SDK_GIT_URL" "refs/heads/$REST_BRANCH"
+  local fetched_commit
+  fetched_commit="$(git -C "$fetch_repo" rev-parse FETCH_HEAD)"
+  if [[ "$fetched_commit" != "$requested_commit" ]]; then
+    printf 'fetched REST branch changed during validation\n' >&2
+    return 1
+  fi
+  git -C "$fetch_repo" archive "$fetched_commit" | tar -x -C "$archive_output"
+  validate_rest_archive "$archive_output"
+
+  local archive_hash
+  archive_hash="$(fetch_hash "$archive_output")"
+  if [[ "$verify_url_hash" == 1 ]]; then
+    local url_hash
+    url_hash="$(fetch_hash "$AZURE_SDK_URL#$requested_commit")"
+    if [[ "$archive_hash" != "$url_hash" ]]; then
+      printf 'REST archive hash differs from immutable Git URL hash\n' >&2
+      return 1
+    fi
+  fi
+  printf '%s\n' "$archive_hash"
 }
 
 verify_local_stage() {
   local stage="$STAGE_ROOT/verify"
+  reset_work
   rm -rf "$stage"
   mkdir -p "$stage"
   check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
   generate_rest "$stage/rest"
   stage_sdk "$stage/sdk" local
-  test_rest "$stage/rest"
-  test_sdk "$stage/sdk"
+  test_local_stages "$stage/rest" "$stage/sdk"
+  rm -rf "$WORK_ROOT"
   printf 'release dry-run verified at %s\n' "$stage"
+}
+
+verify_index_matches_stage() {
+  local repository="$1"
+  local stage="$2"
+  python3 - "$repository" "$stage" <<'PY'
+from pathlib import Path
+import os
+import subprocess
+import sys
+
+repository = Path(sys.argv[1])
+stage = Path(sys.argv[2])
+stage_files = {}
+for path in stage.rglob("*"):
+    if path.is_dir():
+        continue
+    relative = path.relative_to(stage).as_posix()
+    stage_files[relative] = (
+        os.readlink(path).encode() if path.is_symlink() else path.read_bytes()
+    )
+
+raw = subprocess.check_output(
+    ["git", "-C", str(repository), "ls-files", "-z"]
+)
+tracked = {item.decode() for item in raw.split(b"\0") if item}
+if tracked != set(stage_files):
+    raise SystemExit(
+        "publication index differs from declared stage: "
+        f"stage={sorted(stage_files)}, index={sorted(tracked)}"
+    )
+for relative, expected in stage_files.items():
+    actual = subprocess.check_output(
+        ["git", "-C", str(repository), "show", f":{relative}"]
+    )
+    if actual != expected:
+        raise SystemExit(f"publication index bytes differ: {relative}")
+PY
+}
+
+package_name_from_zon() {
+  local zon="$1"
+  python3 - "$zon" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+match = re.search(r"(?m)^\s*\.name\s*=\s*\.([A-Za-z0-9_]+)\s*,\s*$", text)
+if not match:
+    raise SystemExit("package name missing")
+print(match.group(1))
+PY
+}
+
+publish_stage() {
+  local repository="$1"
+  local stage="$2"
+  local branch="$3"
+  local message="$4"
+  local remote="$5"
+  local dry_run="$6"
+  local existing_commit=""
+  local temp_branch=""
+  local package=""
+
+  case "$branch" in
+    "$REST_BRANCH") package="$REST_PACKAGE" ;;
+    "$SDK_BRANCH") package="$SDK_PACKAGE" ;;
+    *) package="$(package_name_from_zon "$stage/build.zig.zon")" ;;
+  esac
+  validate_package "$stage" "$package"
+
+  existing_commit="$(
+    git -C "$repository" ls-remote "$remote" "refs/heads/$branch" |
+      awk 'NR == 1 { print $1 }'
+  )"
+  ACTIVE_REPO="$repository"
+  ACTIVE_WORKTREE="$STAGE_ROOT/worktrees/$(printf '%s' "$branch" | tr / _)-$$"
+  mkdir -p "$(dirname "$ACTIVE_WORKTREE")"
+  git -C "$repository" worktree add --detach --no-checkout \
+    "$ACTIVE_WORKTREE" HEAD >/dev/null
+
+  if [[ -z "$existing_commit" ]]; then
+    temp_branch="container-registry-release-$$"
+    ACTIVE_BRANCH="$temp_branch"
+    git -C "$ACTIVE_WORKTREE" switch --orphan "$temp_branch" >/dev/null
+    if [[ -n "$(git -C "$ACTIVE_WORKTREE" status --porcelain --untracked-files=all)" ]]; then
+      printf 'new orphan publication worktree is not empty\n' >&2
+      return 1
+    fi
+  else
+    git -C "$ACTIVE_WORKTREE" fetch --quiet "$remote" "refs/heads/$branch"
+    if [[ "$(git -C "$ACTIVE_WORKTREE" rev-parse FETCH_HEAD)" != "$existing_commit" ]]; then
+      printf 'release branch changed during publication setup\n' >&2
+      return 1
+    fi
+    git -C "$ACTIVE_WORKTREE" switch --detach FETCH_HEAD >/dev/null
+    git -C "$ACTIVE_WORKTREE" rm -r --ignore-unmatch -- . >/dev/null
+    git -C "$ACTIVE_WORKTREE" clean -fdx -- . >/dev/null
+  fi
+
+  install_declared_stage "$stage" "$ACTIVE_WORKTREE"
+  git -C "$ACTIVE_WORKTREE" add --all -- .
+  verify_index_matches_stage "$ACTIVE_WORKTREE" "$stage"
+  git -C "$ACTIVE_WORKTREE" commit --quiet -m "$message"
+  PUBLISHED_COMMIT="$(git -C "$ACTIVE_WORKTREE" rev-parse HEAD)"
+
+  if [[ -z "$existing_commit" ]]; then
+    if [[ "$(git -C "$ACTIVE_WORKTREE" rev-list --parents -n 1 HEAD | awk '{print NF}')" != 1 ]]; then
+      printf 'initial release commit unexpectedly has a parent\n' >&2
+      return 1
+    fi
+  elif [[ "$(git -C "$ACTIVE_WORKTREE" rev-parse HEAD^)" != "$existing_commit" ]]; then
+    printf 'subsequent release commit is not a descendant of the remote tip\n' >&2
+    return 1
+  fi
+
+  if [[ "$dry_run" == 1 ]]; then
+    printf 'dry-run release commit validated: %s\n' "$PUBLISHED_COMMIT"
+  else
+    git -C "$ACTIVE_WORKTREE" push --quiet "$remote" \
+      "HEAD:refs/heads/$branch"
+    printf 'published %s at %s\n' "$branch" "$PUBLISHED_COMMIT"
+  fi
+  cleanup_active_publication
+}
+
+parse_publish_args() {
+  PUBLISH_DRY_RUN=0
+  PUBLISH_REMOTE=origin
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)
+        PUBLISH_DRY_RUN=1
+        ;;
+      --remote)
+        shift
+        if [[ $# -eq 0 ]]; then
+          printf '%s\n' '--remote requires a value' >&2
+          return 2
+        fi
+        PUBLISH_REMOTE="$1"
+        ;;
+      *)
+        printf 'unknown publication option: %s\n' "$1" >&2
+        return 2
+        ;;
+    esac
+    shift
+  done
+}
+
+write_fixture_package() {
+  local directory="$1"
+  local package="$2"
+  local sdk_url="${3:-}"
+  local sdk_hash="${4:-}"
+  local fingerprint="0x1234567890abcdef"
+  case "$package" in
+    azure_sdk) fingerprint="0x27c178e4bf582df6" ;;
+    azure_rest_container_registry) fingerprint="0x5dd0e10aa1e38a93" ;;
+    wrong_rest_package) fingerprint="0xb618af810095b2e1" ;;
+  esac
+  rm -rf "$directory"
+  mkdir -p "$directory/src"
+  printf '.zig-cache/\nzig-out/\nzig-pkg/\n' >"$directory/.gitignore"
+  printf '# fixture %s\n' "$package" >"$directory/README.md"
+  printf 'pub const fixture = true;\n' >"$directory/src/root.zig"
+  cat >"$directory/build.zig" <<EOF
+const std = @import("std");
+pub fn build(b: *std.Build) void {
+    _ = b.addModule("$package", .{ .root_source_file = b.path("src/root.zig") });
+}
+EOF
+  if [[ "$package" == "$REST_PACKAGE" ]]; then
+    cat >"$directory/build.zig.zon" <<EOF
+.{
+    .name = .$package,
+    .version = "0.1.0",
+    .fingerprint = $fingerprint,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .azure_sdk = .{
+            .url = "$sdk_url",
+            .hash = "$sdk_hash",
+        },
+        .serde = .{
+            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
+            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+        },
+    },
+    .paths = .{
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+    },
+}
+EOF
+  else
+    cat >"$directory/build.zig.zon" <<EOF
+.{
+    .name = .$package,
+    .version = "0.1.0",
+    .fingerprint = $fingerprint,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{},
+    .paths = .{
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+    },
+}
+EOF
+  fi
+}
+
+run_self_test() {
+  reset_work
+  SELF_TEST_ROOT="$STAGE_ROOT/self-test"
+  rm -rf "$SELF_TEST_ROOT"
+  mkdir -p "$SELF_TEST_ROOT"
+  local source_repo="$SELF_TEST_ROOT/source"
+  local bare_remote="$SELF_TEST_ROOT/remote.git"
+  local package_dir="$source_repo/package"
+  local fixture_stage="$SELF_TEST_ROOT/stage"
+  local main_commit
+  local bad_commit
+  local good_commit
+  local main_hash
+  local resolved_hash
+  local fixture_sdk_url="git+https://example.invalid/azure-sdk-for-zig"
+
+  git init --quiet "$source_repo"
+  git -C "$source_repo" config user.name "Container Registry release test"
+  git -C "$source_repo" config user.email "release-test@example.invalid"
+  write_fixture_package "$package_dir" azure_sdk
+  cp -R "$package_dir/." "$source_repo/"
+  rm -rf "$package_dir"
+  git -C "$source_repo" add --all
+  git -C "$source_repo" commit --quiet -m "main fixture"
+  git -C "$source_repo" branch -M main
+  main_commit="$(git -C "$source_repo" rev-parse HEAD)"
+
+  git init --bare --quiet "$bare_remote"
+  git -C "$source_repo" push --quiet "$bare_remote" \
+    "main:refs/heads/main"
+  mkdir -p "$SELF_TEST_ROOT/main-archive"
+  git -C "$source_repo" archive "$main_commit" |
+    tar -x -C "$SELF_TEST_ROOT/main-archive"
+  main_hash="$(
+    zig fetch --global-cache-dir "$SELF_TEST_ROOT/cache" \
+      "$SELF_TEST_ROOT/main-archive"
+  )"
+
+  git -C "$source_repo" switch -c rest-fixture >/dev/null
+  write_fixture_package "$package_dir" wrong_rest_package
+  cp -R "$package_dir/." "$source_repo/"
+  rm -rf "$package_dir"
+  git -C "$source_repo" add --all
+  git -C "$source_repo" commit --quiet -m "mismatched REST fixture"
+  bad_commit="$(git -C "$source_repo" rev-parse HEAD)"
+  git -C "$source_repo" push --quiet "$bare_remote" \
+    "HEAD:refs/heads/$REST_BRANCH"
+
+  if env \
+    AZURE_SDK_GIT_URL="$bare_remote" \
+    AZURE_SDK_URL="$fixture_sdk_url" \
+    AZURE_SDK_COMMIT="$main_commit" \
+    AZURE_SDK_HASH="$main_hash" \
+    CONTAINER_REGISTRY_RELEASE_SKIP_URL_HASH_CHECK=1 \
+    CONTAINER_REGISTRY_RELEASE_ROOT="$SELF_TEST_ROOT/main-negative" \
+    "$SCRIPT" _resolve-rest "$main_commit" >/dev/null 2>&1
+  then
+    printf 'self-test: main commit was accepted as REST release\n' >&2
+    return 1
+  fi
+  if env \
+    AZURE_SDK_GIT_URL="$bare_remote" \
+    AZURE_SDK_URL="$fixture_sdk_url" \
+    AZURE_SDK_COMMIT="$main_commit" \
+    AZURE_SDK_HASH="$main_hash" \
+    CONTAINER_REGISTRY_RELEASE_SKIP_URL_HASH_CHECK=1 \
+    CONTAINER_REGISTRY_RELEASE_ROOT="$SELF_TEST_ROOT/package-negative" \
+    "$SCRIPT" _resolve-rest "$bad_commit" >/dev/null 2>&1
+  then
+    printf 'self-test: mismatched REST package was accepted\n' >&2
+    return 1
+  fi
+
+  write_fixture_package \
+    "$package_dir" "$REST_PACKAGE" \
+    "$fixture_sdk_url#$main_commit" "$main_hash"
+  cp -R "$package_dir/." "$source_repo/"
+  rm -rf "$package_dir"
+  git -C "$source_repo" add --all
+  git -C "$source_repo" commit --quiet -m "valid REST fixture"
+  good_commit="$(git -C "$source_repo" rev-parse HEAD)"
+  git -C "$source_repo" push --quiet "$bare_remote" \
+    "HEAD:refs/heads/$REST_BRANCH"
+  resolved_hash="$(env \
+    AZURE_SDK_GIT_URL="$bare_remote" \
+    AZURE_SDK_URL="$fixture_sdk_url" \
+    AZURE_SDK_COMMIT="$main_commit" \
+    AZURE_SDK_HASH="$main_hash" \
+    CONTAINER_REGISTRY_RELEASE_SKIP_URL_HASH_CHECK=1 \
+    CONTAINER_REGISTRY_RELEASE_ROOT="$SELF_TEST_ROOT/package-positive" \
+    "$SCRIPT" _resolve-rest "$good_commit")"
+  case "$resolved_hash" in
+    "$REST_PACKAGE"-*) ;;
+    *)
+      printf 'self-test: exact REST archive did not produce a package hash\n' >&2
+      return 1
+      ;;
+  esac
+
+  rm -rf "$fixture_stage"
+  mkdir -p "$fixture_stage"
+  git -C "$source_repo" archive HEAD | tar -x -C "$fixture_stage"
+  validate_package "$fixture_stage" "$REST_PACKAGE"
+
+  local publication_branch="test/container_registry"
+  local initial_commit
+  local subsequent_commit
+  publish_stage \
+    "$source_repo" "$fixture_stage" "$publication_branch" \
+    "initial fixture publication" "$bare_remote" 1
+  initial_commit="$PUBLISHED_COMMIT"
+  if [[ "$(git -C "$source_repo" rev-list --parents -n 1 "$initial_commit" | awk '{print NF}')" != 1 ]]; then
+    printf 'self-test: initial dry-run publication was not orphaned\n' >&2
+    return 1
+  fi
+  git -C "$source_repo" push --quiet "$bare_remote" \
+    "$initial_commit:refs/heads/$publication_branch"
+
+  printf '# fixture %s v2\n' "$REST_PACKAGE" >"$fixture_stage/README.md"
+  publish_stage \
+    "$source_repo" "$fixture_stage" "$publication_branch" \
+    "subsequent fixture publication" "$bare_remote" 1
+  subsequent_commit="$PUBLISHED_COMMIT"
+  if [[ "$(git -C "$source_repo" rev-parse "$subsequent_commit^")" != "$initial_commit" ]]; then
+    printf 'self-test: subsequent dry-run was not a descendant\n' >&2
+    return 1
+  fi
+  if [[ "$(remote_ref_commit "$bare_remote" "$publication_branch")" != "$initial_commit" ]]; then
+    printf 'self-test: dry-run unexpectedly changed the remote\n' >&2
+    return 1
+  fi
+
+  publish_stage \
+    "$source_repo" "$fixture_stage" "$publication_branch" \
+    "subsequent fixture publication" "$bare_remote" 0
+  if [[ "$(git -C "$source_repo" rev-parse "$PUBLISHED_COMMIT^")" != "$initial_commit" ]]; then
+    printf 'self-test: local fast-forward publication parent differs\n' >&2
+    return 1
+  fi
+  if [[ "$(remote_ref_commit "$bare_remote" "$publication_branch")" != "$PUBLISHED_COMMIT" ]]; then
+    printf 'self-test: local fast-forward publication did not update remote\n' >&2
+    return 1
+  fi
+  if git -C "$source_repo" branch --list 'container-registry-release-*' |
+      grep -q .
+  then
+    printf 'self-test: temporary publication branch was not removed\n' >&2
+    return 1
+  fi
+
+  rm -rf "$SELF_TEST_ROOT"
+  SELF_TEST_ROOT=""
+  rm -rf "$WORK_ROOT"
+  printf '%s\n' \
+    'release self-test passed: exact REST ref/package rejection, initial and subsequent dry-runs, cleanup, and local fast-forward push'
 }
 
 command="${1:-}"
 case "$command" in
   hash-check)
+    reset_work
     check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
+    rm -rf "$WORK_ROOT"
     printf 'verified immutable azure_sdk pin %s\n' "$AZURE_SDK_COMMIT"
     ;;
   verify|dry-run)
     verify_local_stage
     ;;
   prepare-rest)
+    reset_work
     check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
     output="$STAGE_ROOT/publish/rest"
     generate_rest "$output"
-    test_rest "$output"
+    copy_declared_stage "$output" "$WORK_ROOT/test-packages/rest"
+    test_rest "$WORK_ROOT/test-packages/rest"
+    rm -rf "$WORK_ROOT/test-packages" "$WORK_ROOT/caches"
+    validate_rest_archive "$output"
+    rm -rf "$WORK_ROOT"
     printf 'REST release package ready: %s\n' "$output"
-    printf 'Publish it first to %s, then prepare the SDK with that commit.\n' \
-      "$REST_BRANCH"
+    printf 'Publish it with: %s publish-rest\n' "$SCRIPT"
     ;;
   prepare-sdk)
     rest_commit="${2:-}"
     if [[ ! "$rest_commit" =~ ^[0-9a-f]{40}$ ]]; then
-      printf 'prepare-sdk requires a full 40-character REST commit ID\n' >&2
+      printf 'prepare-sdk requires a full lowercase 40-character REST commit ID\n' >&2
       exit 1
     fi
-    rest_url="$AZURE_SDK_URL#$rest_commit"
-    computed_hash="$(fetch_hash "$rest_url")"
+    reset_work
+    rest_archive="$WORK_ROOT/rest-archive"
+    computed_hash="$(resolve_rest_package "$rest_commit" "$rest_archive")"
     supplied_hash="${3:-$computed_hash}"
     if [[ "$computed_hash" != "$supplied_hash" ]]; then
       printf 'REST package hash mismatch\n  computed: %s\n  supplied: %s\n' \
@@ -203,10 +901,44 @@ case "$command" in
     check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
     output="$STAGE_ROOT/publish/sdk"
     stage_sdk "$output" published "$rest_commit" "$computed_hash"
-    test_sdk "$output"
+    test_published_sdk_stage "$output"
+    rm -rf "$WORK_ROOT"
     printf 'SDK release package ready: %s\n' "$output"
     printf 'Pinned REST commit: %s\nPinned REST hash: %s\n' \
       "$rest_commit" "$computed_hash"
+    printf 'Publish it with: %s publish-sdk\n' "$SCRIPT"
+    ;;
+  publish-rest)
+    parse_publish_args "$@"
+    validate_rest_archive "$STAGE_ROOT/publish/rest"
+    publish_stage \
+      "$ROOT" "$STAGE_ROOT/publish/rest" "$REST_BRANCH" \
+      "rest/container_registry: release generated package" \
+      "$PUBLISH_REMOTE" "$PUBLISH_DRY_RUN"
+    ;;
+  publish-sdk)
+    parse_publish_args "$@"
+    validate_package "$STAGE_ROOT/publish/sdk" "$SDK_PACKAGE"
+    publish_stage \
+      "$ROOT" "$STAGE_ROOT/publish/sdk" "$SDK_BRANCH" \
+      "sdk/container_registry: release package" \
+      "$PUBLISH_REMOTE" "$PUBLISH_DRY_RUN"
+    ;;
+  self-test)
+    run_self_test
+    ;;
+  _resolve-rest)
+    rest_commit="${2:-}"
+    if [[ ! "$rest_commit" =~ ^[0-9a-f]{40}$ ]]; then
+      exit 1
+    fi
+    reset_work
+    verify_url_hash=1
+    if [[ "${CONTAINER_REGISTRY_RELEASE_SKIP_URL_HASH_CHECK:-0}" == 1 ]]; then
+      verify_url_hash=0
+    fi
+    resolve_rest_package \
+      "$rest_commit" "$WORK_ROOT/rest-archive" "$verify_url_hash"
     ;;
   *)
     usage

--- a/scripts/container-registry-release.sh
+++ b/scripts/container-registry-release.sh
@@ -15,6 +15,10 @@ ACTIVE_BRANCH=""
 SELF_TEST_ROOT=""
 PUBLISHED_COMMIT=""
 REMOVE_CODEGEN_ZIG_PKG=0
+ROOT_ZIG_PKG_EXISTED=0
+if [[ -e "$ROOT/zig-pkg" ]]; then
+  ROOT_ZIG_PKG_EXISTED=1
+fi
 
 cleanup_active_publication() {
   set +e
@@ -42,6 +46,9 @@ cleanup_on_exit() {
   cleanup_active_publication
   if [[ "$REMOVE_CODEGEN_ZIG_PKG" == 1 ]]; then
     rm -rf "$ROOT/codegen/cli/zig-pkg"
+  fi
+  if [[ "$ROOT_ZIG_PKG_EXISTED" == 0 ]]; then
+    rm -rf "$ROOT/zig-pkg"
   fi
   if [[ -n "$SELF_TEST_ROOT" ]]; then
     case "$SELF_TEST_ROOT" in
@@ -79,8 +86,11 @@ reset_work() {
 
 fetch_hash() {
   local source="$1"
-  mkdir -p "$WORK_ROOT/global-cache"
-  zig fetch --global-cache-dir "$WORK_ROOT/global-cache" "$source"
+  mkdir -p "$WORK_ROOT/fetch-cwd" "$WORK_ROOT/global-cache"
+  (
+    cd "$WORK_ROOT/fetch-cwd"
+    zig fetch --global-cache-dir "$WORK_ROOT/global-cache" "$source"
+  )
 }
 
 check_hash() {
@@ -736,8 +746,8 @@ run_self_test() {
   git -C "$source_repo" archive "$main_commit" |
     tar -x -C "$SELF_TEST_ROOT/main-archive"
   main_hash="$(
-    zig fetch --global-cache-dir "$SELF_TEST_ROOT/cache" \
-      "$SELF_TEST_ROOT/main-archive"
+    cd "$SELF_TEST_ROOT"
+    zig fetch --global-cache-dir "$SELF_TEST_ROOT/cache" main-archive
   )"
 
   git -C "$source_repo" switch -c rest-fixture >/dev/null

--- a/scripts/container-registry-release.sh
+++ b/scripts/container-registry-release.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+METADATA="$ROOT/eng/container_registry_release/metadata.sh"
+STAGE_ROOT="$ROOT/.release/container_registry"
+# shellcheck source=/dev/null
+source "$METADATA"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/container-registry-release.sh hash-check
+  scripts/container-registry-release.sh verify
+  scripts/container-registry-release.sh dry-run
+  scripts/container-registry-release.sh prepare-rest
+  scripts/container-registry-release.sh prepare-sdk <rest-commit> [rest-hash]
+
+All generated files stay under ignored .release/container_registry. No branch,
+tag, commit, or remote ref is created or changed.
+EOF
+}
+
+fetch_hash() {
+  zig fetch "$1"
+}
+
+check_hash() {
+  local url="$1"
+  local expected="$2"
+  local actual
+  actual="$(fetch_hash "$url")"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'package hash mismatch\n  URL:      %s\n  expected: %s\n  actual:   %s\n' \
+      "$url" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+validate_identity() {
+  local directory="$1"
+  local package="$2"
+  python3 - "$directory" "$package" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+package = sys.argv[2]
+zon = (root / "build.zig.zon").read_text()
+build = (root / "build.zig").read_text()
+if not re.search(rf"\.name\s*=\s*\.{re.escape(package)}\s*,", zon):
+    raise SystemExit(f"{root}: build.zig.zon package name is not {package}")
+if f'addModule("{package}"' not in build:
+    raise SystemExit(f"{root}: build.zig module name is not {package}")
+if package == "azure_sdk_container_registry":
+    if '.azure_rest_container_registry = .{' not in zon:
+        raise SystemExit(f"{root}: missing azure_rest_container_registry dependency")
+    if 'module("azure_rest_container_registry")' not in build:
+        raise SystemExit(f"{root}: missing azure_rest_container_registry module import")
+print(f"verified package/module identity: {package}")
+PY
+}
+
+generate_rest() {
+  local output="$1"
+  rm -rf "$output"
+  mkdir -p "$(dirname "$output")"
+  (
+    cd "$ROOT/codegen/cli"
+    zig build generate-container-registry-package \
+      -Dcontainer-registry-output="$output" \
+      -Dazure-core-commit="$AZURE_SDK_COMMIT" \
+      -Dazure-core-hash="$AZURE_SDK_HASH"
+  )
+}
+
+stage_sdk() {
+  local output="$1"
+  local rest_mode="$2"
+  local rest_commit="${3:-}"
+  local rest_hash="${4:-}"
+  rm -rf "$output"
+  mkdir -p "$output"
+  cp \
+    "$ROOT/sdk/container_registry/build.zig" \
+    "$ROOT/sdk/container_registry/build.zig.zon" \
+    "$ROOT/sdk/container_registry/README.md" \
+    "$output/"
+  cp -R \
+    "$ROOT/sdk/container_registry/src" \
+    "$ROOT/sdk/container_registry/examples" \
+    "$ROOT/sdk/container_registry/live_tests" \
+    "$output/"
+  python3 - "$output/build.zig.zon" "$rest_mode" \
+    "$AZURE_SDK_URL" "$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH" \
+    "$rest_commit" "$rest_hash" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+mode, sdk_url, sdk_commit, sdk_hash, rest_commit, rest_hash = sys.argv[2:]
+text = path.read_text()
+sdk_old = '''        .azure_sdk = .{
+            .path = "../..",
+        },'''
+sdk_new = f'''        .azure_sdk = .{{
+            .url = "{sdk_url}#{sdk_commit}",
+            .hash = "{sdk_hash}",
+        }},'''
+if text.count(sdk_old) != 1:
+    raise SystemExit(f"{path}: expected one local azure_sdk dependency")
+text = text.replace(sdk_old, sdk_new)
+
+rest_old = '''        .azure_rest_container_registry = .{
+            .path = "../../rest/container_registry",
+        },'''
+if mode == "local":
+    rest_new = '''        .azure_rest_container_registry = .{
+            .path = "../rest",
+        },'''
+elif mode == "published":
+    if not rest_commit or not rest_hash:
+        raise SystemExit("published REST staging requires commit and hash")
+    rest_new = f'''        .azure_rest_container_registry = .{{
+            .url = "{sdk_url}#{rest_commit}",
+            .hash = "{rest_hash}",
+        }},'''
+else:
+    raise SystemExit(f"unknown REST dependency mode: {mode}")
+if text.count(rest_old) != 1:
+    raise SystemExit(f"{path}: expected one local REST dependency")
+path.write_text(text.replace(rest_old, rest_new))
+PY
+}
+
+test_rest() {
+  local directory="$1"
+  validate_identity "$directory" "$REST_PACKAGE"
+  (cd "$directory" && zig build test --summary all)
+}
+
+test_sdk() {
+  local directory="$1"
+  validate_identity "$directory" "$SDK_PACKAGE"
+  (
+    cd "$directory"
+    zig build test --summary all
+    zig build examples
+    env \
+      -u AZURE_CONTAINER_REGISTRY_LIVE_TESTS \
+      -u AZURE_CONTAINER_REGISTRY_ENDPOINT \
+      -u AZURE_CONTAINER_REGISTRY_LIVE_TEST_RUN_ID \
+      -u AZURE_CONTAINER_REGISTRY_LIVE_TEST_REPOSITORY_PREFIX \
+      zig build live-test --summary all
+  )
+}
+
+verify_local_stage() {
+  local stage="$STAGE_ROOT/verify"
+  rm -rf "$stage"
+  mkdir -p "$stage"
+  check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
+  generate_rest "$stage/rest"
+  stage_sdk "$stage/sdk" local
+  test_rest "$stage/rest"
+  test_sdk "$stage/sdk"
+  printf 'release dry-run verified at %s\n' "$stage"
+}
+
+command="${1:-}"
+case "$command" in
+  hash-check)
+    check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
+    printf 'verified immutable azure_sdk pin %s\n' "$AZURE_SDK_COMMIT"
+    ;;
+  verify|dry-run)
+    verify_local_stage
+    ;;
+  prepare-rest)
+    check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
+    output="$STAGE_ROOT/publish/rest"
+    generate_rest "$output"
+    test_rest "$output"
+    printf 'REST release package ready: %s\n' "$output"
+    printf 'Publish it first to %s, then prepare the SDK with that commit.\n' \
+      "$REST_BRANCH"
+    ;;
+  prepare-sdk)
+    rest_commit="${2:-}"
+    if [[ ! "$rest_commit" =~ ^[0-9a-f]{40}$ ]]; then
+      printf 'prepare-sdk requires a full 40-character REST commit ID\n' >&2
+      exit 1
+    fi
+    rest_url="$AZURE_SDK_URL#$rest_commit"
+    computed_hash="$(fetch_hash "$rest_url")"
+    supplied_hash="${3:-$computed_hash}"
+    if [[ "$computed_hash" != "$supplied_hash" ]]; then
+      printf 'REST package hash mismatch\n  computed: %s\n  supplied: %s\n' \
+        "$computed_hash" "$supplied_hash" >&2
+      exit 1
+    fi
+    check_hash "$AZURE_SDK_URL#$AZURE_SDK_COMMIT" "$AZURE_SDK_HASH"
+    output="$STAGE_ROOT/publish/sdk"
+    stage_sdk "$output" published "$rest_commit" "$computed_hash"
+    test_sdk "$output"
+    printf 'SDK release package ready: %s\n' "$output"
+    printf 'Pinned REST commit: %s\nPinned REST hash: %s\n' \
+      "$rest_commit" "$computed_hash"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/verify-container-registry-regeneration.sh
+++ b/scripts/verify-container-registry-regeneration.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRATCH="$ROOT/.release/container_registry/regeneration"
+mkdir -p "$SCRATCH"
+
+snapshot_tree() {
+  local path="$1"
+  local output="$2"
+  (
+    cd "$ROOT"
+    git ls-files --cached --others --exclude-standard -z -- "$path" |
+      python3 -c '
+import hashlib
+from pathlib import Path
+import sys
+
+paths = sorted(filter(None, sys.stdin.buffer.read().split(b"\0")))
+for raw in paths:
+    path = Path(raw.decode())
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    print(f"{digest}  {path.as_posix()}")
+'
+  ) >"$output"
+}
+
+snapshot_status() {
+  local output="$1"
+  (
+    cd "$ROOT"
+    git status --porcelain=v1 --untracked-files=all |
+      python3 -c '
+import sys
+
+allowed = ("rest/container_registry/", "codegen/fixtures/container_registry.json")
+for line in sys.stdin:
+    path = line[3:].strip()
+    if " -> " in path:
+        path = path.split(" -> ", 1)[1]
+    if path.startswith(allowed[0]) or path == allowed[1]:
+        continue
+    print(line, end="")
+'
+  ) >"$output"
+}
+
+snapshot_tree "rest/container_registry" "$SCRATCH/rest.before"
+snapshot_tree "sdk/container_registry" "$SCRATCH/sdk.before"
+snapshot_status "$SCRATCH/status.before"
+
+(
+  cd "$ROOT/codegen/cli"
+  zig build generate-container-registry-package
+)
+
+snapshot_tree "rest/container_registry" "$SCRATCH/rest.after"
+snapshot_tree "sdk/container_registry" "$SCRATCH/sdk.after"
+snapshot_status "$SCRATCH/status.after"
+
+if ! cmp -s "$SCRATCH/sdk.before" "$SCRATCH/sdk.after"; then
+  echo "ERROR: ACR regeneration modified handwritten sdk/container_registry files." >&2
+  diff -u "$SCRATCH/sdk.before" "$SCRATCH/sdk.after" || true
+  exit 1
+fi
+if ! cmp -s "$SCRATCH/status.before" "$SCRATCH/status.after"; then
+  echo "ERROR: ACR regeneration changed files outside generator-owned REST outputs." >&2
+  diff -u "$SCRATCH/status.before" "$SCRATCH/status.after" || true
+  exit 1
+fi
+if ! cmp -s "$SCRATCH/rest.before" "$SCRATCH/rest.after"; then
+  echo "ERROR: rest/container_registry is not deterministic; inspect generator drift." >&2
+  diff -u "$SCRATCH/rest.before" "$SCRATCH/rest.after" || true
+  (cd "$ROOT" && git --no-pager diff -- rest/container_registry) || true
+  exit 1
+fi
+
+python3 - "$ROOT/rest/container_registry" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+zon = (root / "build.zig.zon").read_text()
+build = (root / "build.zig").read_text()
+if ".name = .azure_rest_container_registry," not in zon:
+    raise SystemExit("ERROR: regenerated REST package name drifted")
+if 'addModule("azure_rest_container_registry"' not in build:
+    raise SystemExit("ERROR: regenerated REST module name drifted")
+PY
+
+rm -rf "$SCRATCH"
+echo "ACR regeneration is deterministic and isolated to generator-owned REST outputs."

--- a/scripts/verify-container-registry-regeneration.sh
+++ b/scripts/verify-container-registry-regeneration.sh
@@ -3,6 +3,24 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRATCH="$ROOT/.release/container_registry/regeneration"
+CODEGEN_ZIG_PKG="$ROOT/codegen/cli/zig-pkg"
+ZIG_PKG_EXISTED=0
+if [[ -e "$CODEGEN_ZIG_PKG" ]]; then
+  ZIG_PKG_EXISTED=1
+fi
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  rm -rf "$SCRATCH"
+  if [[ "$ZIG_PKG_EXISTED" == 0 ]]; then
+    rm -rf "$CODEGEN_ZIG_PKG"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+rm -rf "$SCRATCH"
 mkdir -p "$SCRATCH"
 
 snapshot_tree() {
@@ -51,7 +69,10 @@ snapshot_status "$SCRATCH/status.before"
 
 (
   cd "$ROOT/codegen/cli"
-  zig build generate-container-registry-package
+  zig build \
+    --cache-dir "$SCRATCH/codegen-cache" \
+    --global-cache-dir "$SCRATCH/global-cache" \
+    generate-container-registry-package
 )
 
 snapshot_tree "rest/container_registry" "$SCRATCH/rest.after"
@@ -88,5 +109,4 @@ if 'addModule("azure_rest_container_registry"' not in build:
     raise SystemExit("ERROR: regenerated REST module name drifted")
 PY
 
-rm -rf "$SCRATCH"
 echo "ACR regeneration is deterministic and isolated to generator-owned REST outputs."

--- a/sdk/container_registry/.gitignore
+++ b/sdk/container_registry/.gitignore
@@ -1,0 +1,3 @@
+.zig-cache/
+zig-out/
+zig-pkg/

--- a/sdk/container_registry/README.md
+++ b/sdk/container_registry/README.md
@@ -6,6 +6,12 @@ errors, exact-byte manifest operations, bounded-memory resumable blob uploads,
 and bounded blob downloads to the generated
 `azure_rest_container_registry` protocol package.
 
+The stable public data-plane version is **2021-07-01**. Both high-level
+clients default to that version; override `api_version` only when intentionally
+using a compatible service contract. `acr.protocol` re-exports
+`azure_rest_container_registry` as the protocol escape hatch for raw generated
+operations, status unions, and custom-pipeline scenarios.
+
 ```zig
 const acr = @import("azure_sdk_container_registry");
 
@@ -67,6 +73,12 @@ userinfo, fragments, malformed links, alternate ports, and untrusted hosts
 before the authentication policy can attach credentials.
 
 Use `.authentication = .anonymous` only for intentional anonymous access.
+Anonymous mode never acquires an Azure credential or attaches an
+`Authorization` header. It succeeds only when the target repository permits
+the requested public pull/catalog operation. Authenticated mode uses the
+supplied `TokenCredential`, performs the AAD-to-ACR challenge exchange, and
+caches bounded refresh/access tokens. Authentication, repository visibility,
+and write/delete authorization remain registry configuration concerns.
 The generated dependency is available as `acr.protocol`.
 By default only the endpoint HTTPS origin is trusted. Hostname-only
 `authentication_options.expected_hosts` entries imply port 443; use an
@@ -118,6 +130,17 @@ both directions enforce the 4 MiB manifest limit. Omitting the upload
 reference uses the computed digest; deletes require a digest. Download limits
 apply to decoded bytes; `Content-Length` is exact only for identity responses.
 The `*Result` variants preserve structured ACR service errors.
+
+Uploads directly support these manifest `Content-Type` values:
+
+- `application/vnd.oci.image.manifest.v1+json`
+- `application/vnd.docker.distribution.manifest.v2+json`
+
+Downloads advertise and preserve OCI image manifests/indexes, Docker schema-2
+manifests/lists/config, ORAS artifact manifests, wildcard-compatible
+manifests, and the exact returned media type. Blob and layer bodies use
+`application/octet-stream`; callers define the layer/config descriptors in
+their manifest bytes.
 
 Blob uploads start a resumable session, send sequential inclusive
 `Content-Range` chunks with exact `Content-Length`, then complete using the
@@ -187,3 +210,101 @@ are pruned before lookup or insertion.
 Local development uses relative package dependencies. Release branches replace
 them with immutable `azure_sdk` and `azure_rest_container_registry` Git
 commit/hash pins as described in `doc/package-branch-model.md`.
+
+## Ownership and lifetime rules
+
+- Clients own their copied endpoint/repository/auth-policy state and must be
+  deinitialized before their borrowed transport and credential.
+- Pagers borrow the originating client pipeline. Keep the client alive until
+  `pager.deinit()`, and deinitialize every page result before requesting or
+  discarding more pages.
+- Metadata and service-error results own allocator-backed strings and arrays;
+  call their `deinit()` exactly once.
+- Manifest results use the allocator passed to the client and require
+  `deinit(allocator)`. Blob results remember their allocator and use
+  parameterless `deinit()`.
+- A streaming blob operation exclusively owns one HTTP operation. Call
+  `finish`, `abort`, or `cancel`, then `deinit`; `deinit` aborts an operation
+  that is still active.
+- Writers/readers and request byte slices are borrowed only for the documented
+  call duration. Returned owned bytes remain valid until result deinit.
+
+## Transfer bounds and replay semantics
+
+- Manifests are limited to 4 MiB in both directions.
+- Buffered blob downloads default to 16 MiB and fail before exceeding
+  `max_size`.
+- Blob uploads allocate one configured chunk (4 MiB default, 100 MiB maximum)
+  and support seekable or non-seekable readers. A buffered chunk can be
+  replayed after a definitely pre-transport failure. After an uncertain
+  outcome the client queries and strictly validates the server offset before
+  resuming; it never blindly replays bytes.
+- Writer downloads use 4 MiB sequential ranges by default plus a 64 KiB copy
+  buffer. Only bytes accepted by the writer advance the digest and confirmed
+  offset, so retryable transport/read failures resume without duplicating
+  output. Redirected range retries restart at the registry URL.
+- Request bodies that must survive core HTTP redirects/retries are replayable
+  only when the body supplies rewind state. Non-replayable streaming request
+  bodies are not automatically resent.
+
+## Examples
+
+Compile all examples with:
+
+```bash
+zig build examples
+```
+
+The examples are deliberately environment-driven and never embed credentials
+or registry names:
+
+| Example | Required environment |
+| --- | --- |
+| `list_repositories_tags.zig` | `AZURE_CONTAINER_REGISTRY_ENDPOINT`; optional `AZURE_CONTAINER_REGISTRY_REPOSITORY` |
+| `anonymous_read.zig` | endpoint, repository, `AZURE_CONTAINER_REGISTRY_MANIFEST_REFERENCE`; always anonymous |
+| `oci_push_pull.zig` | endpoint, repository, `AZURE_CONTAINER_REGISTRY_ALLOW_WRITES=1`; optional `AZURE_CONTAINER_REGISTRY_TAG` |
+| `delete_artifact.zig` | endpoint, repository, `AZURE_CONTAINER_REGISTRY_ALLOW_DELETE=1`, and `AZURE_CONTAINER_REGISTRY_CONFIRM_DELETE_REPOSITORY` exactly equal to the repository; one or more delete target variables |
+
+Authenticated examples use `DefaultAzureCredential`. The delete example accepts
+`AZURE_CONTAINER_REGISTRY_DELETE_TAG`,
+`AZURE_CONTAINER_REGISTRY_DELETE_DIGEST`, and the additional explicit
+`AZURE_CONTAINER_REGISTRY_DELETE_WHOLE_REPOSITORY=1` gate.
+
+## Destructive live tests
+
+`zig build live-test` skips cleanly unless
+`AZURE_CONTAINER_REGISTRY_LIVE_TESTS=1`. A configured run also requires:
+
+- `AZURE_CONTAINER_REGISTRY_ENDPOINT` — exact HTTPS registry origin without a
+  trailing slash.
+- `AZURE_CONTAINER_REGISTRY_LIVE_TEST_RUN_ID` — a unique lowercase
+  alphanumeric/hyphen identifier (maximum 40 bytes) for this run.
+- Optional `AZURE_CONTAINER_REGISTRY_LIVE_TEST_REPOSITORY_PREFIX` — defaults
+  to `azure-sdk-for-zig-live`.
+
+The suite creates only
+`<prefix>/azure-sdk-for-zig-live-issue-89-<run-id>`, exercises metadata properties, OCI
+manifest/blob transfer, a non-seekable upload, injected live ranged-resume
+recovery, real ACR HTTPS redirects, and idempotent deletion. A deferred cleanup
+deletes that exact unique repository on every exit; no prefix-wide/list-based
+deletion is performed.
+
+The principal needs data-plane catalog, pull, push, metadata-update, and delete
+permissions. For a non-ABAC registry, `AcrPush` plus repository catalog-list
+permission is sufficient. For an ABAC-enabled registry, assign
+`Container Registry Repository Contributor` and
+`Container Registry Repository Catalog Lister` scoped as narrowly as
+practical. `DefaultAzureCredential` may use the standard `AZURE_TENANT_ID`,
+`AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`, workload identity, managed
+identity, or Azure CLI login; the tests never print or persist credential
+values.
+
+## Independent release preparation
+
+The checked-in package keeps local path dependencies for monorepo development.
+Run `scripts/container-registry-release.sh verify` for deterministic local
+release-layout staging. Publish REST first, then run
+`scripts/container-registry-release.sh prepare-sdk <rest-commit>` so Zig
+computes and applies the immutable REST package hash. Exact commands and the
+pinned common SDK revision are documented in
+`doc/package-branch-model.md` and `release/container_registry/README.md`.

--- a/sdk/container_registry/build.zig
+++ b/sdk/container_registry/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
     });
     const rest_mod = rest_dep.module("azure_rest_container_registry");
 
-    _ = b.addModule("azure_sdk_container_registry", .{
+    const sdk_mod = b.addModule("azure_sdk_container_registry", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .imports = &.{
@@ -38,4 +38,76 @@ pub fn build(b: *std.Build) void {
     });
     const test_step = b.step("test", "Run Container Registry SDK tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
+
+    const support_mod = b.createModule(.{
+        .root_source_file = b.path("examples/support.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "azure_core", .module = azure_core_mod },
+            .{ .name = "azure_sdk_container_registry", .module = sdk_mod },
+        },
+    });
+    const examples_step = b.step(
+        "examples",
+        "Compile all Container Registry examples",
+    );
+    const example_sources = [_]struct {
+        name: []const u8,
+        source: []const u8,
+    }{
+        .{
+            .name = "acr-list-repositories-tags",
+            .source = "examples/list_repositories_tags.zig",
+        },
+        .{
+            .name = "acr-anonymous-read",
+            .source = "examples/anonymous_read.zig",
+        },
+        .{
+            .name = "acr-oci-push-pull",
+            .source = "examples/oci_push_pull.zig",
+        },
+        .{
+            .name = "acr-delete-artifact",
+            .source = "examples/delete_artifact.zig",
+        },
+    };
+    for (example_sources) |example| {
+        const executable = b.addExecutable(.{
+            .name = example.name,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(example.source),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "azure_core", .module = azure_core_mod },
+                    .{
+                        .name = "azure_sdk_container_registry",
+                        .module = sdk_mod,
+                    },
+                    .{ .name = "acr_example_support", .module = support_mod },
+                },
+            }),
+        });
+        examples_step.dependOn(&executable.step);
+        test_step.dependOn(&executable.step);
+    }
+
+    const live_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("live_tests/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_core", .module = azure_core_mod },
+                .{ .name = "azure_sdk_container_registry", .module = sdk_mod },
+            },
+        }),
+    });
+    const live_test_step = b.step(
+        "live-test",
+        "Run destructive opt-in Container Registry live tests; unconfigured tests skip",
+    );
+    live_test_step.dependOn(&b.addRunArtifact(live_tests).step);
 }

--- a/sdk/container_registry/build.zig.zon
+++ b/sdk/container_registry/build.zig.zon
@@ -15,6 +15,8 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "examples",
+        "live_tests",
         "README.md",
     },
 }

--- a/sdk/container_registry/build.zig.zon
+++ b/sdk/container_registry/build.zig.zon
@@ -12,6 +12,7 @@
         },
     },
     .paths = .{
+        ".gitignore",
         "build.zig",
         "build.zig.zon",
         "src",

--- a/sdk/container_registry/examples/anonymous_read.zig
+++ b/sdk/container_registry/examples/anonymous_read.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const core = @import("azure_core");
+const acr = @import("azure_sdk_container_registry");
+const support = @import("acr_example_support");
+
+pub fn main(init: std.process.Init) !void {
+    const endpoint = try support.required(
+        init.environ_map,
+        support.endpoint_environment,
+    );
+    const repository = try support.required(
+        init.environ_map,
+        support.repository_environment,
+    );
+    const reference = try support.required(
+        init.environ_map,
+        "AZURE_CONTAINER_REGISTRY_MANIFEST_REFERENCE",
+    );
+
+    var transport = core.http.StdHttpTransport.init(init.gpa, init.io);
+    defer transport.deinit();
+    var content = try acr.ContainerRegistryContentClient.init(
+        init.gpa,
+        endpoint,
+        repository,
+        .{
+            .transport = transport.asTransport(),
+            .authentication = .anonymous,
+        },
+    );
+    defer content.deinit();
+
+    var manifest = try content.downloadManifest(reference);
+    defer manifest.deinit(init.gpa);
+    std.debug.print(
+        "anonymous manifest: digest={s} media-type={s} bytes={d}\n",
+        .{ manifest.digest, manifest.media_type, manifest.bytes.len },
+    );
+}

--- a/sdk/container_registry/examples/delete_artifact.zig
+++ b/sdk/container_registry/examples/delete_artifact.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const acr = @import("azure_sdk_container_registry");
+const support = @import("acr_example_support");
+
+pub fn main(init: std.process.Init) !void {
+    try support.requireOptIn(
+        init.environ_map,
+        "AZURE_CONTAINER_REGISTRY_ALLOW_DELETE",
+    );
+    const endpoint = try support.required(
+        init.environ_map,
+        support.endpoint_environment,
+    );
+    const repository = try support.required(
+        init.environ_map,
+        support.repository_environment,
+    );
+    const confirmation = try support.required(
+        init.environ_map,
+        "AZURE_CONTAINER_REGISTRY_CONFIRM_DELETE_REPOSITORY",
+    );
+    if (!std.mem.eql(u8, repository, confirmation))
+        return error.ContainerRegistryDeleteConfirmationMismatch;
+    const tag = init.environ_map.get("AZURE_CONTAINER_REGISTRY_DELETE_TAG");
+    const digest = init.environ_map.get("AZURE_CONTAINER_REGISTRY_DELETE_DIGEST");
+    const delete_repository = std.mem.eql(
+        u8,
+        init.environ_map.get("AZURE_CONTAINER_REGISTRY_DELETE_WHOLE_REPOSITORY") orelse "",
+        "1",
+    );
+    if (tag == null and digest == null and !delete_repository)
+        return error.ContainerRegistryDeleteTargetRequired;
+
+    const session = try support.AuthenticatedSession.create(
+        init.gpa,
+        init.io,
+        init.environ_map,
+    );
+    defer session.deinit();
+    var client = try acr.ContainerRegistryClient.init(
+        init.gpa,
+        endpoint,
+        session.clientOptions(),
+    );
+    defer client.deinit();
+
+    if (tag) |value| {
+        var result = try client.deleteTag(init.gpa, repository, value);
+        defer result.deinit();
+        _ = try support.expectDelete(&result);
+    }
+    if (digest) |value| {
+        var content = try acr.ContainerRegistryContentClient.init(
+            init.gpa,
+            endpoint,
+            repository,
+            session.clientOptions(),
+        );
+        defer content.deinit();
+        _ = try content.deleteManifest(value);
+    }
+    if (delete_repository) {
+        var result = try client.deleteRepository(init.gpa, repository);
+        defer result.deinit();
+        _ = try support.expectDelete(&result);
+    }
+}

--- a/sdk/container_registry/examples/list_repositories_tags.zig
+++ b/sdk/container_registry/examples/list_repositories_tags.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const acr = @import("azure_sdk_container_registry");
+const support = @import("acr_example_support");
+
+pub fn main(init: std.process.Init) !void {
+    const endpoint = try support.required(
+        init.environ_map,
+        support.endpoint_environment,
+    );
+    const repository = init.environ_map.get(support.repository_environment);
+    const session = try support.AuthenticatedSession.create(
+        init.gpa,
+        init.io,
+        init.environ_map,
+    );
+    defer session.deinit();
+
+    var client = try acr.ContainerRegistryClient.init(
+        init.gpa,
+        endpoint,
+        session.clientOptions(),
+    );
+    defer client.deinit();
+
+    var repositories = try client.listRepositories(init.gpa, .{});
+    defer repositories.deinit();
+    while (try repositories.next()) |page_value| {
+        var page = page_value;
+        defer page.deinit();
+        switch (page) {
+            .ok => |value| for (value.names) |name| {
+                std.debug.print("repository: {s}\n", .{name});
+            },
+            .err => |failure| {
+                std.log.err("{f}", .{failure});
+                return error.ContainerRegistryListRepositoriesFailed;
+            },
+        }
+    }
+
+    if (repository) |name| {
+        var tags = try client.listTagProperties(init.gpa, name, .{});
+        defer tags.deinit();
+        while (try tags.next()) |page_value| {
+            var page = page_value;
+            defer page.deinit();
+            switch (page) {
+                .ok => |value| for (value.items) |tag| {
+                    std.debug.print(
+                        "tag: {s}@{s}\n",
+                        .{ tag.name, tag.digest },
+                    );
+                },
+                .err => |failure| {
+                    std.log.err("{f}", .{failure});
+                    return error.ContainerRegistryListTagsFailed;
+                },
+            }
+        }
+    }
+}

--- a/sdk/container_registry/examples/oci_push_pull.zig
+++ b/sdk/container_registry/examples/oci_push_pull.zig
@@ -2,10 +2,11 @@ const std = @import("std");
 const acr = @import("azure_sdk_container_registry");
 const support = @import("acr_example_support");
 
-const config_bytes =
-    \\{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]},"config":{}}
-;
-const layer_bytes = "azure-sdk-for-zig minimal OCI layer\n";
+const config_bytes = "{}";
+const artifact_type = "application/vnd.azure.sdk-for-zig.example.v1";
+const layer_media_type =
+    "application/vnd.azure.sdk-for-zig.example.layer.v1";
+const layer_bytes = "azure-sdk-for-zig OCI artifact payload\n";
 
 pub fn main(init: std.process.Init) !void {
     try support.requireOptIn(
@@ -41,14 +42,34 @@ pub fn main(init: std.process.Init) !void {
     defer config.deinit();
     var layer = try content.uploadBlobBytes(layer_bytes, .{});
     defer layer.deinit();
+    const expected_config_digest = acr.computeSha256Digest(config_bytes);
+    const expected_layer_digest = acr.computeSha256Digest(layer_bytes);
+    if (config.size != config_bytes.len or
+        !try acr.sha256DigestsEqual(config.digest, &expected_config_digest))
+    {
+        return error.ContainerRegistryConfigDescriptorMismatch;
+    }
+    if (layer.size != layer_bytes.len or
+        !try acr.sha256DigestsEqual(layer.digest, &expected_layer_digest))
+    {
+        return error.ContainerRegistryLayerDescriptorMismatch;
+    }
     const manifest_bytes = try std.fmt.allocPrint(
         init.gpa,
         "{{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\"," ++
-            "\"config\":{{\"mediaType\":\"application/vnd.oci.image.config.v1+json\"," ++
+            "\"artifactType\":\"{s}\"," ++
+            "\"config\":{{\"mediaType\":\"application/vnd.oci.empty.v1+json\"," ++
             "\"digest\":\"{s}\",\"size\":{d}}},\"layers\":[{{\"mediaType\":" ++
-            "\"application/vnd.oci.image.layer.v1.tar\",\"digest\":\"{s}\"," ++
+            "\"{s}\",\"digest\":\"{s}\"," ++
             "\"size\":{d}}}]}}",
-        .{ config.digest, config.size, layer.digest, layer.size },
+        .{
+            artifact_type,
+            config.digest,
+            config.size,
+            layer_media_type,
+            layer.digest,
+            layer.size,
+        },
     );
     defer init.gpa.free(manifest_bytes);
 
@@ -61,6 +82,11 @@ pub fn main(init: std.process.Init) !void {
     defer downloaded.deinit(init.gpa);
     if (!std.mem.eql(u8, manifest_bytes, downloaded.bytes))
         return error.ContainerRegistryManifestRoundTripMismatch;
+    const expected_manifest_digest = acr.computeSha256Digest(manifest_bytes);
+    if (!try acr.sha256DigestsEqual(
+        uploaded.digest,
+        &expected_manifest_digest,
+    )) return error.ContainerRegistryManifestDescriptorMismatch;
 
     var blobs = try acr.BlobDownloadClient.init(
         init.gpa,
@@ -69,6 +95,12 @@ pub fn main(init: std.process.Init) !void {
         session.clientOptions(),
     );
     defer blobs.deinit();
+    var pulled_config = try blobs.downloadBlob(config.digest, .{
+        .max_size = 1024,
+    });
+    defer pulled_config.deinit();
+    if (!std.mem.eql(u8, config_bytes, pulled_config.bytes))
+        return error.ContainerRegistryConfigRoundTripMismatch;
     var pulled_layer = try blobs.downloadBlob(layer.digest, .{
         .max_size = 1024 * 1024,
     });

--- a/sdk/container_registry/examples/oci_push_pull.zig
+++ b/sdk/container_registry/examples/oci_push_pull.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const acr = @import("azure_sdk_container_registry");
+const support = @import("acr_example_support");
+
+const config_bytes =
+    \\{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]},"config":{}}
+;
+const layer_bytes = "azure-sdk-for-zig minimal OCI layer\n";
+
+pub fn main(init: std.process.Init) !void {
+    try support.requireOptIn(
+        init.environ_map,
+        "AZURE_CONTAINER_REGISTRY_ALLOW_WRITES",
+    );
+    const endpoint = try support.required(
+        init.environ_map,
+        support.endpoint_environment,
+    );
+    const repository = try support.required(
+        init.environ_map,
+        support.repository_environment,
+    );
+    const tag = init.environ_map.get("AZURE_CONTAINER_REGISTRY_TAG") orelse
+        "azure-sdk-for-zig-example";
+
+    const session = try support.AuthenticatedSession.create(
+        init.gpa,
+        init.io,
+        init.environ_map,
+    );
+    defer session.deinit();
+    var content = try acr.ContainerRegistryContentClient.init(
+        init.gpa,
+        endpoint,
+        repository,
+        session.clientOptions(),
+    );
+    defer content.deinit();
+
+    var config = try content.uploadBlobBytes(config_bytes, .{});
+    defer config.deinit();
+    var layer = try content.uploadBlobBytes(layer_bytes, .{});
+    defer layer.deinit();
+    const manifest_bytes = try std.fmt.allocPrint(
+        init.gpa,
+        "{{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\"," ++
+            "\"config\":{{\"mediaType\":\"application/vnd.oci.image.config.v1+json\"," ++
+            "\"digest\":\"{s}\",\"size\":{d}}},\"layers\":[{{\"mediaType\":" ++
+            "\"application/vnd.oci.image.layer.v1.tar\",\"digest\":\"{s}\"," ++
+            "\"size\":{d}}}]}}",
+        .{ config.digest, config.size, layer.digest, layer.size },
+    );
+    defer init.gpa.free(manifest_bytes);
+
+    var uploaded = try content.uploadManifest(manifest_bytes, .{
+        .reference = tag,
+        .media_type = .oci_image_manifest,
+    });
+    defer uploaded.deinit(init.gpa);
+    var downloaded = try content.downloadManifest(uploaded.digest);
+    defer downloaded.deinit(init.gpa);
+    if (!std.mem.eql(u8, manifest_bytes, downloaded.bytes))
+        return error.ContainerRegistryManifestRoundTripMismatch;
+
+    var blobs = try acr.BlobDownloadClient.init(
+        init.gpa,
+        endpoint,
+        repository,
+        session.clientOptions(),
+    );
+    defer blobs.deinit();
+    var pulled_layer = try blobs.downloadBlob(layer.digest, .{
+        .max_size = 1024 * 1024,
+    });
+    defer pulled_layer.deinit();
+    if (!std.mem.eql(u8, layer_bytes, pulled_layer.bytes))
+        return error.ContainerRegistryBlobRoundTripMismatch;
+
+    std.debug.print(
+        "pushed and pulled {s}:{s} ({s})\n",
+        .{ repository, tag, uploaded.digest },
+    );
+}

--- a/sdk/container_registry/examples/support.zig
+++ b/sdk/container_registry/examples/support.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const core = @import("azure_core");
+const acr = @import("azure_sdk_container_registry");
+
+pub const endpoint_environment = "AZURE_CONTAINER_REGISTRY_ENDPOINT";
+pub const repository_environment = "AZURE_CONTAINER_REGISTRY_REPOSITORY";
+
+pub const AuthenticatedSession = struct {
+    allocator: std.mem.Allocator,
+    transport: core.http.StdHttpTransport,
+    credential: core.identity.DefaultAzureCredential,
+
+    pub fn create(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        env: *const std.process.Environ.Map,
+    ) !*AuthenticatedSession {
+        const self = try allocator.create(AuthenticatedSession);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+        self.transport = core.http.StdHttpTransport.init(allocator, io);
+        errdefer self.transport.deinit();
+        self.credential = try core.identity.DefaultAzureCredential.init(
+            allocator,
+            io,
+            self.transport.asTransport(),
+            env,
+        );
+        return self;
+    }
+
+    pub fn clientOptions(
+        self: *AuthenticatedSession,
+    ) acr.ContainerRegistryClientOptions {
+        return .{
+            .transport = self.transport.asTransport(),
+            .authentication = .{ .credential = self.credential.asCredential() },
+        };
+    }
+
+    pub fn deinit(self: *AuthenticatedSession) void {
+        self.credential.deinit();
+        self.transport.deinit();
+        const allocator = self.allocator;
+        allocator.destroy(self);
+    }
+};
+
+pub fn required(
+    env: *const std.process.Environ.Map,
+    name: []const u8,
+) ![]const u8 {
+    const value = env.get(name) orelse {
+        std.debug.print("Missing required environment variable: {s}\n", .{name});
+        return error.ContainerRegistryExampleEnvironmentRequired;
+    };
+    if (value.len == 0) return error.ContainerRegistryExampleEnvironmentRequired;
+    return value;
+}
+
+pub fn requireOptIn(
+    env: *const std.process.Environ.Map,
+    name: []const u8,
+) !void {
+    const value = try required(env, name);
+    if (!std.mem.eql(u8, value, "1")) {
+        std.debug.print("{s} must be exactly 1\n", .{name});
+        return error.ContainerRegistryExampleOptInRequired;
+    }
+}
+
+pub fn expectDelete(result: *acr.DeleteResult) !acr.DeleteOutcome {
+    return switch (result.*) {
+        .ok => |outcome| outcome,
+        .err => |failure| {
+            std.log.err("{f}", .{failure});
+            return error.ContainerRegistryDeleteFailed;
+        },
+    };
+}

--- a/sdk/container_registry/live_tests/main.zig
+++ b/sdk/container_registry/live_tests/main.zig
@@ -121,9 +121,10 @@ test "live ACR metadata, transfers, non-seekable upload, range resume, redirects
     );
     defer downloads.deinit();
 
-    const config_bytes =
-        \\{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]},"config":{}}
-    ;
+    const config_bytes = "{}";
+    const artifact_type = "application/vnd.azure.sdk-for-zig.live-test.v1";
+    const layer_media_type =
+        "application/vnd.azure.sdk-for-zig.live-test.layer.v1";
     const layer_bytes = try allocator.alloc(u8, 96 * 1024);
     defer allocator.free(layer_bytes);
     for (layer_bytes, 0..) |*byte, index| byte.* = @truncate(index *% 31 +% 7);
@@ -142,13 +143,16 @@ test "live ACR metadata, transfers, non-seekable upload, range resume, redirects
     const manifest_bytes = try std.fmt.allocPrint(
         allocator,
         "{{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\"," ++
-            "\"config\":{{\"mediaType\":\"application/vnd.oci.image.config.v1+json\"," ++
+            "\"artifactType\":\"{s}\"," ++
+            "\"config\":{{\"mediaType\":\"application/vnd.oci.empty.v1+json\"," ++
             "\"digest\":\"{s}\",\"size\":{d}}},\"layers\":[{{\"mediaType\":" ++
-            "\"application/vnd.oci.image.layer.v1.tar\",\"digest\":\"{s}\"," ++
+            "\"{s}\",\"digest\":\"{s}\"," ++
             "\"size\":{d}}}]}}",
         .{
+            artifact_type,
             config_blob.digest,
             config_blob.size,
+            layer_media_type,
             layer_blob.digest,
             layer_blob.size,
         },
@@ -187,6 +191,8 @@ test "live ACR metadata, transfers, non-seekable upload, range resume, redirects
     try std.testing.expect(session.transport.redirect_count > 0);
 
     session.transport.inject_range_failure = true;
+    session.transport.range_failure_injected = false;
+    session.transport.range_request_count = 0;
     var ranged_output: std.Io.Writer.Allocating = .init(allocator);
     defer ranged_output.deinit();
     var ranged = try downloads.downloadBlobToWriter(
@@ -200,8 +206,16 @@ test "live ACR metadata, transfers, non-seekable upload, range resume, redirects
         layer_bytes,
         ranged_output.writer.buffered(),
     );
+    try std.testing.expect(session.transport.range_failure_injected);
     try std.testing.expect(session.transport.range_request_count >= 2);
-    try std.testing.expect(session.transport.sawResumedRange());
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        session.transport.range_starts[0],
+    );
+    try std.testing.expectEqual(
+        @as(u64, 8 * 1024),
+        session.transport.range_starts[1],
+    );
 
     var tag_delete = try metadata.deleteTag(allocator, repository, tag);
     defer tag_delete.deinit();
@@ -438,13 +452,6 @@ const ObservingTransport = struct {
         self.standard.deinit();
         self.allocator.free(self.endpoint);
         self.* = undefined;
-    }
-
-    fn sawResumedRange(self: *const ObservingTransport) bool {
-        for (self.range_starts[0..self.range_request_count]) |start| {
-            if (start > 0) return true;
-        }
-        return false;
     }
 
     fn send(

--- a/sdk/container_registry/live_tests/main.zig
+++ b/sdk/container_registry/live_tests/main.zig
@@ -1,0 +1,643 @@
+//! Destructive, explicit opt-in Azure Container Registry live coverage.
+const std = @import("std");
+const core = @import("azure_core");
+const acr = @import("azure_sdk_container_registry");
+
+const Config = struct {
+    endpoint: []const u8,
+    repository_prefix: []const u8,
+    run_id: []const u8,
+
+    fn fromEnvironment(env: *const std.process.Environ.Map) !?Config {
+        const enabled = nonEmpty(env.get("AZURE_CONTAINER_REGISTRY_LIVE_TESTS")) orelse
+            return null;
+        if (!std.mem.eql(u8, enabled, "1"))
+            return error.InvalidContainerRegistryLiveTestOptIn;
+        const endpoint = nonEmpty(env.get("AZURE_CONTAINER_REGISTRY_ENDPOINT")) orelse
+            return error.ContainerRegistryEndpointRequired;
+        if (!std.mem.startsWith(u8, endpoint, "https://") or
+            std.mem.endsWith(u8, endpoint, "/"))
+        {
+            return error.InvalidContainerRegistryEndpoint;
+        }
+        const run_id = nonEmpty(
+            env.get("AZURE_CONTAINER_REGISTRY_LIVE_TEST_RUN_ID"),
+        ) orelse return error.ContainerRegistryLiveTestRunIdRequired;
+        try validateNameComponent(run_id);
+        const prefix = nonEmpty(
+            env.get("AZURE_CONTAINER_REGISTRY_LIVE_TEST_REPOSITORY_PREFIX"),
+        ) orelse "azure-sdk-for-zig-live";
+        try validateRepositoryPrefix(prefix);
+        return .{
+            .endpoint = endpoint,
+            .repository_prefix = prefix,
+            .run_id = run_id,
+        };
+    }
+};
+
+const LiveSession = struct {
+    allocator: std.mem.Allocator,
+    transport: ObservingTransport,
+    credential: core.identity.DefaultAzureCredential,
+
+    fn create(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        env: *const std.process.Environ.Map,
+        endpoint: []const u8,
+    ) !*LiveSession {
+        const self = try allocator.create(LiveSession);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+        self.transport = try ObservingTransport.init(allocator, io, endpoint);
+        errdefer self.transport.deinit();
+        self.credential = try core.identity.DefaultAzureCredential.init(
+            allocator,
+            io,
+            self.transport.asTransport(),
+            env,
+        );
+        return self;
+    }
+
+    fn options(self: *LiveSession) acr.ContainerRegistryClientOptions {
+        return .{
+            .transport = self.transport.asTransport(),
+            .authentication = .{ .credential = self.credential.asCredential() },
+        };
+    }
+
+    fn deinit(self: *LiveSession) void {
+        self.credential.deinit();
+        self.transport.deinit();
+        const allocator = self.allocator;
+        allocator.destroy(self);
+    }
+};
+
+test "live ACR metadata, transfers, non-seekable upload, range resume, redirects, and cleanup" {
+    const allocator = std.testing.allocator;
+    var env = try std.process.Environ.createMap(std.testing.environ, allocator);
+    defer env.deinit();
+    const config = (try Config.fromEnvironment(&env)) orelse
+        return error.SkipZigTest;
+    const repository = try std.fmt.allocPrint(
+        allocator,
+        "{s}/azure-sdk-for-zig-live-issue-89-{s}",
+        .{ config.repository_prefix, config.run_id },
+    );
+    defer allocator.free(repository);
+    const tag = "live";
+
+    const session = try LiveSession.create(
+        allocator,
+        std.testing.io,
+        &env,
+        config.endpoint,
+    );
+    defer session.deinit();
+    var metadata = try acr.ContainerRegistryClient.init(
+        allocator,
+        config.endpoint,
+        session.options(),
+    );
+    defer metadata.deinit();
+    var cleanup_needed = true;
+    defer if (cleanup_needed) cleanupRepository(&metadata, allocator, repository);
+
+    var content = try acr.ContainerRegistryContentClient.init(
+        allocator,
+        config.endpoint,
+        repository,
+        session.options(),
+    );
+    defer content.deinit();
+    var downloads = try acr.BlobDownloadClient.init(
+        allocator,
+        config.endpoint,
+        repository,
+        session.options(),
+    );
+    defer downloads.deinit();
+
+    const config_bytes =
+        \\{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]},"config":{}}
+    ;
+    const layer_bytes = try allocator.alloc(u8, 96 * 1024);
+    defer allocator.free(layer_bytes);
+    for (layer_bytes, 0..) |*byte, index| byte.* = @truncate(index *% 31 +% 7);
+
+    var config_blob = try content.uploadBlobBytes(config_bytes, .{
+        .chunk_size = 8 * 1024,
+    });
+    defer config_blob.deinit();
+    var non_seekable = NonSeekableReader.init(layer_bytes, 3 * 1024);
+    var layer_blob = try content.uploadBlob(&non_seekable.interface, .{
+        .chunk_size = 16 * 1024,
+    });
+    defer layer_blob.deinit();
+    try std.testing.expectEqual(@as(u64, layer_bytes.len), layer_blob.size);
+
+    const manifest_bytes = try std.fmt.allocPrint(
+        allocator,
+        "{{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\"," ++
+            "\"config\":{{\"mediaType\":\"application/vnd.oci.image.config.v1+json\"," ++
+            "\"digest\":\"{s}\",\"size\":{d}}},\"layers\":[{{\"mediaType\":" ++
+            "\"application/vnd.oci.image.layer.v1.tar\",\"digest\":\"{s}\"," ++
+            "\"size\":{d}}}]}}",
+        .{
+            config_blob.digest,
+            config_blob.size,
+            layer_blob.digest,
+            layer_blob.size,
+        },
+    );
+    defer allocator.free(manifest_bytes);
+    var uploaded_manifest = try content.uploadManifest(manifest_bytes, .{
+        .reference = tag,
+    });
+    defer uploaded_manifest.deinit(allocator);
+
+    try expectRepositoryListed(&metadata, allocator, repository);
+    try expectTagListed(&metadata, allocator, repository, tag);
+    try expectMetadataProperties(
+        &metadata,
+        allocator,
+        repository,
+        tag,
+        uploaded_manifest.digest,
+    );
+
+    var downloaded_manifest = try content.downloadManifest(
+        uploaded_manifest.digest,
+    );
+    defer downloaded_manifest.deinit(allocator);
+    try std.testing.expectEqualStrings(
+        manifest_bytes,
+        downloaded_manifest.bytes,
+    );
+
+    session.transport.redirect_count = 0;
+    var downloaded_blob = try downloads.downloadBlob(layer_blob.digest, .{
+        .max_size = layer_bytes.len,
+    });
+    defer downloaded_blob.deinit();
+    try std.testing.expectEqualSlices(u8, layer_bytes, downloaded_blob.bytes);
+    try std.testing.expect(session.transport.redirect_count > 0);
+
+    session.transport.inject_range_failure = true;
+    var ranged_output: std.Io.Writer.Allocating = .init(allocator);
+    defer ranged_output.deinit();
+    var ranged = try downloads.downloadBlobToWriter(
+        layer_blob.digest,
+        &ranged_output.writer,
+        .{ .range_size = 32 * 1024, .max_retries = 3 },
+    );
+    defer ranged.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        layer_bytes,
+        ranged_output.writer.buffered(),
+    );
+    try std.testing.expect(session.transport.range_request_count >= 2);
+    try std.testing.expect(session.transport.sawResumedRange());
+
+    var tag_delete = try metadata.deleteTag(allocator, repository, tag);
+    defer tag_delete.deinit();
+    try expectDeleteAccepted(&tag_delete);
+    const manifest_delete = try content.deleteManifest(uploaded_manifest.digest);
+    try std.testing.expect(
+        manifest_delete == .accepted or manifest_delete == .not_found,
+    );
+    var repository_delete = try metadata.deleteRepository(allocator, repository);
+    defer repository_delete.deinit();
+    try expectDeleteAccepted(&repository_delete);
+    cleanup_needed = false;
+}
+
+fn expectRepositoryListed(
+    client: *acr.ContainerRegistryClient,
+    allocator: std.mem.Allocator,
+    repository: []const u8,
+) !void {
+    var pager = try client.listRepositories(allocator, .{ .max_results = 100 });
+    defer pager.deinit();
+    while (try pager.next()) |page_value| {
+        var page = page_value;
+        defer page.deinit();
+        switch (page) {
+            .ok => |value| for (value.names) |name| {
+                if (std.mem.eql(u8, name, repository)) return;
+            },
+            .err => return error.ContainerRegistryLiveMetadataFailed,
+        }
+    }
+    return error.ContainerRegistryLiveRepositoryNotListed;
+}
+
+fn expectTagListed(
+    client: *acr.ContainerRegistryClient,
+    allocator: std.mem.Allocator,
+    repository: []const u8,
+    tag: []const u8,
+) !void {
+    var pager = try client.listTagProperties(allocator, repository, .{});
+    defer pager.deinit();
+    while (try pager.next()) |page_value| {
+        var page = page_value;
+        defer page.deinit();
+        switch (page) {
+            .ok => |value| for (value.items) |item| {
+                if (std.mem.eql(u8, item.name, tag)) return;
+            },
+            .err => return error.ContainerRegistryLiveMetadataFailed,
+        }
+    }
+    return error.ContainerRegistryLiveTagNotListed;
+}
+
+fn expectMetadataProperties(
+    client: *acr.ContainerRegistryClient,
+    allocator: std.mem.Allocator,
+    repository: []const u8,
+    tag: []const u8,
+    digest: []const u8,
+) !void {
+    var repository_result = try client.getRepositoryProperties(
+        allocator,
+        repository,
+    );
+    defer repository_result.deinit();
+    switch (repository_result) {
+        .ok => |value| try std.testing.expectEqualStrings(repository, value.name),
+        .err => return error.ContainerRegistryLiveRepositoryPropertiesFailed,
+    }
+    var updated_repository = try client.updateRepositoryProperties(
+        allocator,
+        repository,
+        .{
+            .can_delete = true,
+            .can_write = true,
+            .can_list = true,
+            .can_read = true,
+        },
+    );
+    defer updated_repository.deinit();
+    switch (updated_repository) {
+        .ok => |value| try std.testing.expectEqual(true, value.can_read.?),
+        .err => return error.ContainerRegistryLiveRepositoryUpdateFailed,
+    }
+
+    var tag_result = try client.getTagProperties(allocator, repository, tag);
+    defer tag_result.deinit();
+    switch (tag_result) {
+        .ok => |value| try std.testing.expectEqualStrings(digest, value.digest),
+        .err => return error.ContainerRegistryLiveTagPropertiesFailed,
+    }
+    var updated_tag = try client.updateTagProperties(
+        allocator,
+        repository,
+        tag,
+        .{
+            .can_delete = true,
+            .can_write = true,
+            .can_list = true,
+            .can_read = true,
+        },
+    );
+    defer updated_tag.deinit();
+    switch (updated_tag) {
+        .ok => |value| try std.testing.expectEqual(true, value.can_read.?),
+        .err => return error.ContainerRegistryLiveTagUpdateFailed,
+    }
+
+    var manifest_result = try client.getManifestProperties(
+        allocator,
+        repository,
+        digest,
+    );
+    defer manifest_result.deinit();
+    switch (manifest_result) {
+        .ok => |value| try std.testing.expectEqualStrings(digest, value.digest),
+        .err => return error.ContainerRegistryLiveManifestPropertiesFailed,
+    }
+
+    var updated = try client.updateManifestProperties(
+        allocator,
+        repository,
+        digest,
+        .{
+            .can_delete = true,
+            .can_write = true,
+            .can_list = true,
+            .can_read = true,
+        },
+    );
+    defer updated.deinit();
+    switch (updated) {
+        .ok => |value| try std.testing.expectEqual(true, value.can_read.?),
+        .err => return error.ContainerRegistryLiveManifestUpdateFailed,
+    }
+}
+
+fn expectDeleteAccepted(result: *acr.DeleteResult) !void {
+    switch (result.*) {
+        .ok => |outcome| try std.testing.expect(
+            outcome == .accepted or outcome == .not_found,
+        ),
+        .err => return error.ContainerRegistryLiveDeleteFailed,
+    }
+}
+
+fn cleanupRepository(
+    client: *acr.ContainerRegistryClient,
+    allocator: std.mem.Allocator,
+    repository: []const u8,
+) void {
+    var result = client.deleteRepository(allocator, repository) catch |err| {
+        std.log.err("ACR live cleanup failed: {s}", .{@errorName(err)});
+        return;
+    };
+    switch (result) {
+        .ok => {},
+        .err => |failure| std.log.err(
+            "ACR live cleanup service failure: {f}",
+            .{failure},
+        ),
+    }
+    result.deinit();
+}
+
+const NonSeekableReader = struct {
+    interface: std.Io.Reader,
+    bytes: []const u8,
+    offset: usize = 0,
+    max_per_read: usize,
+
+    fn init(bytes: []const u8, max_per_read: usize) NonSeekableReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .bytes = bytes,
+            .max_per_read = max_per_read,
+        };
+    }
+
+    fn stream(
+        reader: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *NonSeekableReader =
+            @alignCast(@fieldParentPtr("interface", reader));
+        if (self.offset == self.bytes.len) return error.EndOfStream;
+        const count = @min(
+            self.bytes.len - self.offset,
+            @min(self.max_per_read, limit.minInt(std.math.maxInt(usize))),
+        );
+        try writer.writeAll(self.bytes[self.offset .. self.offset + count]);
+        self.offset += count;
+        return count;
+    }
+};
+
+const ObservingTransport = struct {
+    allocator: std.mem.Allocator,
+    endpoint: []u8,
+    standard: core.http.StdHttpTransport,
+    transport: core.http.HttpTransport,
+    redirect_count: usize = 0,
+    inject_range_failure: bool = false,
+    range_failure_injected: bool = false,
+    range_starts: [16]u64 = undefined,
+    range_request_count: usize = 0,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        endpoint: []const u8,
+    ) !ObservingTransport {
+        return .{
+            .allocator = allocator,
+            .endpoint = try allocator.dupe(u8, endpoint),
+            .standard = core.http.StdHttpTransport.init(allocator, io),
+            .transport = .{ .sendFn = &send, .openFn = &open },
+        };
+    }
+
+    fn asTransport(self: *ObservingTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn deinit(self: *ObservingTransport) void {
+        self.standard.deinit();
+        self.allocator.free(self.endpoint);
+        self.* = undefined;
+    }
+
+    fn sawResumedRange(self: *const ObservingTransport) bool {
+        for (self.range_starts[0..self.range_request_count]) |start| {
+            if (start > 0) return true;
+        }
+        return false;
+    }
+
+    fn send(
+        transport: *core.http.HttpTransport,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const self: *ObservingTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        const base = self.standard.asTransport();
+        return base.sendFn(base, request);
+    }
+
+    fn open(
+        transport: *core.http.HttpTransport,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *ObservingTransport =
+            @alignCast(@fieldParentPtr("transport", transport));
+        const range = request.getHeader("Range");
+        if (range != null and self.isRegistryUrl(request.url) and
+            self.range_request_count < self.range_starts.len)
+        {
+            self.range_starts[self.range_request_count] = try rangeStart(range.?);
+            self.range_request_count += 1;
+        }
+        const base = self.standard.asTransport();
+        const operation = try base.openFn.?(base, request, options);
+        if (operation.status_code == 307 and self.isRegistryUrl(request.url))
+            self.redirect_count += 1;
+        if (self.inject_range_failure and !self.range_failure_injected and
+            range != null and operation.status_code == 206)
+        {
+            self.range_failure_injected = true;
+            return FaultOperation.create(self.allocator, operation, 8 * 1024);
+        }
+        return operation;
+    }
+
+    fn isRegistryUrl(self: *const ObservingTransport, url: []const u8) bool {
+        return std.mem.startsWith(u8, url, self.endpoint) and
+            (url.len == self.endpoint.len or url[self.endpoint.len] == '/');
+    }
+};
+
+const FaultOperation = struct {
+    allocator: std.mem.Allocator,
+    operation: core.http.HttpOperation,
+    inner: *core.http.HttpOperation,
+    reader: FaultReader,
+
+    fn create(
+        allocator: std.mem.Allocator,
+        inner: *core.http.HttpOperation,
+        fail_after: usize,
+    ) !*core.http.HttpOperation {
+        const self = try allocator.create(FaultOperation);
+        self.* = .{
+            .allocator = allocator,
+            .operation = undefined,
+            .inner = inner,
+            .reader = FaultReader.init(inner.body_reader, fail_after),
+        };
+        self.operation = .{
+            .status_code = inner.status_code,
+            .headers = inner.headers,
+            .response_headers = inner.response_headers,
+            .body_reader = &self.reader.interface,
+            .finishFn = &finish,
+            .abortFn = &abort,
+            .cancelFn = &cancel,
+            .deinitFn = &deinit,
+            .bodyErrorFn = &bodyError,
+        };
+        inner.headers = std.StringHashMap([]const u8).init(allocator);
+        inner.response_headers = .{};
+        return &self.operation;
+    }
+
+    fn finish(operation: *core.http.HttpOperation) !void {
+        const self: *FaultOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        try self.inner.finish();
+    }
+
+    fn abort(operation: *core.http.HttpOperation) void {
+        const self: *FaultOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.inner.abort();
+    }
+
+    fn cancel(operation: *core.http.HttpOperation) void {
+        const self: *FaultOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.inner.cancel();
+    }
+
+    fn bodyError(operation: *const core.http.HttpOperation) ?anyerror {
+        const self: *const FaultOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        if (self.reader.failed) return error.ConnectionResetByPeer;
+        return self.inner.bodyError();
+    }
+
+    fn deinit(operation: *core.http.HttpOperation) void {
+        const self: *FaultOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.operation.response_headers.deinit();
+        var iterator = self.operation.headers.iterator();
+        while (iterator.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.operation.headers.deinit();
+        self.inner.deinit();
+        self.allocator.destroy(self);
+    }
+};
+
+const FaultReader = struct {
+    interface: std.Io.Reader,
+    source: *std.Io.Reader,
+    remaining: usize,
+    failed: bool = false,
+
+    fn init(source: *std.Io.Reader, fail_after: usize) FaultReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .source = source,
+            .remaining = fail_after,
+        };
+    }
+
+    fn stream(
+        reader: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *FaultReader =
+            @alignCast(@fieldParentPtr("interface", reader));
+        if (self.remaining == 0) {
+            self.failed = true;
+            return error.ReadFailed;
+        }
+        var buffer: [16 * 1024]u8 = undefined;
+        const count = self.source.readSliceShort(buffer[0..@min(
+            self.remaining,
+            limit.minInt(buffer.len),
+        )]) catch {
+            self.failed = true;
+            return error.ReadFailed;
+        };
+        if (count == 0) return error.EndOfStream;
+        try writer.writeAll(buffer[0..count]);
+        self.remaining -= count;
+        return count;
+    }
+};
+
+fn rangeStart(value: []const u8) !u64 {
+    if (!std.mem.startsWith(u8, value, "bytes="))
+        return error.InvalidLiveTestRange;
+    const dash = std.mem.indexOfScalar(u8, value, '-') orelse
+        return error.InvalidLiveTestRange;
+    return std.fmt.parseInt(u64, value["bytes=".len..dash], 10);
+}
+
+fn validateNameComponent(value: []const u8) !void {
+    if (value.len == 0 or value.len > 40) return error.InvalidLiveTestRunId;
+    for (value) |byte| {
+        if (!(std.ascii.isLower(byte) or std.ascii.isDigit(byte) or byte == '-'))
+            return error.InvalidLiveTestRunId;
+    }
+}
+
+fn validateRepositoryPrefix(value: []const u8) !void {
+    if (value.len == 0 or value.len > 120)
+        return error.InvalidLiveTestRepositoryPrefix;
+    for (value) |byte| {
+        if (!(std.ascii.isLower(byte) or std.ascii.isDigit(byte) or
+            byte == '-' or byte == '_' or byte == '.' or byte == '/'))
+        {
+            return error.InvalidLiveTestRepositoryPrefix;
+        }
+    }
+}
+
+fn nonEmpty(value: ?[]const u8) ?[]const u8 {
+    const present = value orelse return null;
+    return if (present.len == 0) null else present;
+}


### PR DESCRIPTION
Completes ACR release readiness with compiling examples, safe opt-in live coverage, ownership/media documentation, deterministic regeneration checks, tracked-only package staging, and repeatable two-stage orphan-branch publication tooling.

Closes #89
Closes #78