### PR TITLE
Add aggregate SDK package

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,12 +528,16 @@ The SDK uses only the Zig standard library plus two small Zig packages:
 
 ## Using as a Dependency
 
-Add to your `build.zig.zon`:
+Use a released aggregate package from the `sdk/aggregate` branch. The
+repository root is the non-published integration workspace and does not export
+consumer modules.
+
+Add the aggregate release commit to your `build.zig.zon`:
 
 ```zon
 .dependencies = .{
     .azure_sdk = .{
-        .url = "git+https://github.com/cataggar/azure-sdk-for-zig#<commit>",
+        .url = "git+https://github.com/cataggar/azure-sdk-for-zig#<aggregate-release-commit>",
         .hash = "...",
     },
 },
@@ -542,9 +546,15 @@ Add to your `build.zig.zon`:
 Then in `build.zig`:
 
 ```zig
-const azure = b.dependency("azure_sdk", .{});
+const azure = b.dependency("azure_sdk", .{
+    .target = target,
+    .optimize = optimize,
+});
 exe.root_module.addImport("azure_sdk_core", azure.module("azure_sdk_core"));
-exe.root_module.addImport("azure_identity", azure.module("azure_identity"));
+exe.root_module.addImport(
+    "azure_sdk_kusto_data",
+    azure.module("azure_sdk_kusto_data"),
+);
 ```
 
 ## Background

--- a/build.zig
+++ b/build.zig
@@ -5,274 +5,95 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // -- Dependencies --
-
-    const core_tracing_dep = b.dependency("azure_sdk_core_tracing", .{
+    const aggregate = b.dependency("azure_sdk", .{
         .target = target,
         .optimize = optimize,
     });
-    const core_tracing_mod = core_tracing_dep.module("azure_sdk_core_tracing");
+    const core_mod = aggregate.module("azure_sdk_core");
 
-    const core_perf_dep = b.dependency("azure_sdk_core_perf", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const core_perf_mod = core_perf_dep.module("azure_sdk_core_perf");
-
-    const core_amqp_dep = b.dependency("azure_sdk_core_amqp", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const core_amqp_mod = core_amqp_dep.module("azure_sdk_core_amqp");
-
-    const core_dep = b.dependency("azure_sdk_core", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const core_mod = core_dep.module("azure_sdk_core");
-
-    const core_testing_dep = b.dependency("azure_sdk_core_testing", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const core_testing_mod = core_testing_dep.module("azure_sdk_core_testing");
-
-    const uamqp_dep = b.dependency("uamqp", .{});
-    const uamqp_mod = b.createModule(.{
-        .root_source_file = uamqp_dep.path("src/zig/uamqp.zig"),
-        .target = target,
-    });
-
-    const serde_dep = b.dependency("serde", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const serde_mod = serde_dep.module("serde");
-
-    const arm_avs_dep = b.dependency("azure_rest_arm_avs", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const arm_avs_mod = arm_avs_dep.module("azure_rest_arm_avs");
-    arm_avs_mod.addImport("azure_sdk_core", core_mod);
-    arm_avs_mod.addImport("serde", serde_mod);
-
-    const keyvault_secrets_dep = b.dependency("azure_rest_keyvault_secrets", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const keyvault_secrets_mod = keyvault_secrets_dep.module("azure_rest_keyvault_secrets");
-    keyvault_secrets_mod.addImport("azure_sdk_core", core_mod);
-    keyvault_secrets_mod.addImport("serde", serde_mod);
-
-    const container_registry_protocol_dep = b.dependency("azure_rest_container_registry", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const container_registry_protocol_mod =
-        container_registry_protocol_dep.module("azure_rest_container_registry");
-    container_registry_protocol_mod.addImport("azure_sdk_core", core_mod);
-    container_registry_protocol_mod.addImport("serde", serde_mod);
-
-    const container_registry_sdk_dep = b.dependency("azure_sdk_container_registry", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const container_registry_sdk_mod =
-        container_registry_sdk_dep.module("azure_sdk_container_registry");
-    // Keep the SDK and generated protocol package on the workspace-owned
-    // Core module so the dependency diamond has one source owner.
-    container_registry_sdk_mod.addImport("azure_sdk_core", core_mod);
-    container_registry_sdk_mod.addImport(
-        "azure_rest_container_registry",
-        container_registry_protocol_mod,
+    const test_step = b.step("test", "Run all package and workspace tests");
+    const package_test_tail = addPackageTests(b);
+    const direct_consumer = addFixtureTest(
+        b,
+        "eng/fixtures/direct_package_consumer",
+        package_test_tail,
+    );
+    const aggregate_consumer = addFixtureTest(
+        b,
+        "eng/fixtures/aggregate_consumer",
+        &direct_consumer.step,
     );
 
-    const storage_common_dep = b.dependency("azure_sdk_storage_common", .{
+    const aggregate_export_fixture = b.dependency("aggregate_export_fixture", .{
         .target = target,
         .optimize = optimize,
     });
-    const storage_common_mod = storage_common_dep.module("azure_sdk_storage_common");
-    storage_common_mod.addImport("azure_sdk_core", core_mod);
-
-    const storage_blobs_dep = b.dependency("azure_sdk_storage_blobs", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const blobs_mod = storage_blobs_dep.module("azure_sdk_storage_blobs");
-    blobs_mod.addImport("azure_sdk_core", core_mod);
-    blobs_mod.addImport("azure_sdk_storage_common", storage_common_mod);
-    blobs_mod.addImport("serde", serde_mod);
-
-    const storage_queues_dep = b.dependency("azure_sdk_storage_queues", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const queues_mod = storage_queues_dep.module("azure_sdk_storage_queues");
-    queues_mod.addImport("azure_sdk_core", core_mod);
-    queues_mod.addImport("azure_sdk_storage_common", storage_common_mod);
-    queues_mod.addImport("serde", serde_mod);
-
-    const storage_files_shares_dep = b.dependency("azure_sdk_storage_files_shares", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const storage_files_shares_mod =
-        storage_files_shares_dep.module("azure_sdk_storage_files_shares");
-    storage_files_shares_mod.addImport("azure_sdk_core", core_mod);
-
-    const storage_files_datalake_dep = b.dependency("azure_sdk_storage_files_datalake", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const storage_files_datalake_mod =
-        storage_files_datalake_dep.module("azure_sdk_storage_files_datalake");
-    storage_files_datalake_mod.addImport("azure_sdk_core", core_mod);
-
-    const keyvault_dep = b.dependency("azure_sdk_keyvault", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const keyvault_mod = keyvault_dep.module("azure_sdk_keyvault");
-    keyvault_mod.addImport("azure_sdk_core", core_mod);
-    keyvault_mod.addImport("serde", serde_mod);
-
-    const data_tables_dep = b.dependency("azure_sdk_data_tables", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const data_tables_mod = data_tables_dep.module("azure_sdk_data_tables");
-    data_tables_mod.addImport("azure_sdk_core", core_mod);
-
-    const data_cosmos_dep = b.dependency("azure_sdk_data_cosmos", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const data_cosmos_mod = data_cosmos_dep.module("azure_sdk_data_cosmos");
-    data_cosmos_mod.addImport("azure_sdk_core", core_mod);
-    data_cosmos_mod.addImport("serde", serde_mod);
-
-    const data_appconfiguration_dep = b.dependency("azure_sdk_data_appconfiguration", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const data_appconfiguration_mod =
-        data_appconfiguration_dep.module("azure_sdk_data_appconfiguration");
-    data_appconfiguration_mod.addImport("azure_sdk_core", core_mod);
-    data_appconfiguration_mod.addImport("serde", serde_mod);
-
-    const attestation_dep = b.dependency("azure_sdk_attestation", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const attestation_mod = attestation_dep.module("azure_sdk_attestation");
-    attestation_mod.addImport("azure_sdk_core", core_mod);
-    attestation_mod.addImport("serde", serde_mod);
-
-    const messaging_common_dep = b.dependency("azure_sdk_messaging_common", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const messaging_common_mod =
-        messaging_common_dep.module("azure_sdk_messaging_common");
-
-    const eventhubs_dep = b.dependency("azure_sdk_eventhubs", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const eventhubs_mod = eventhubs_dep.module("azure_sdk_eventhubs");
-    eventhubs_mod.addImport("azure_sdk_core", core_mod);
-    eventhubs_mod.addImport("azure_sdk_messaging_common", messaging_common_mod);
-    eventhubs_mod.addImport("azure_sdk_storage_blobs", blobs_mod);
-    eventhubs_mod.addImport("uamqp", uamqp_mod);
-    eventhubs_mod.addImport("serde", serde_mod);
-
-    const servicebus_dep = b.dependency("azure_sdk_servicebus", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const servicebus_mod = servicebus_dep.module("azure_sdk_servicebus");
-    servicebus_mod.addImport("azure_sdk_core", core_mod);
-    servicebus_mod.addImport("azure_sdk_messaging_common", messaging_common_mod);
-    servicebus_mod.addImport("uamqp", uamqp_mod);
-    servicebus_mod.addImport("serde", serde_mod);
-
-    const kusto_common_dep = b.dependency("azure_sdk_kusto_common", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const kusto_common_mod = kusto_common_dep.module("azure_sdk_kusto_common");
-    kusto_common_mod.addImport("azure_sdk_core", core_mod);
-    kusto_common_mod.addImport("serde", serde_mod);
-
-    const kusto_data_dep = b.dependency("azure_sdk_kusto_data", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const kusto_data_mod = kusto_data_dep.module("azure_sdk_kusto_data");
-    kusto_data_mod.addImport("azure_sdk_core", core_mod);
-    kusto_data_mod.addImport("azure_sdk_kusto_common", kusto_common_mod);
-    kusto_data_mod.addImport("serde", serde_mod);
-
-    const kusto_ingest_dep = b.dependency("azure_sdk_kusto_ingest", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const kusto_ingest_mod = kusto_ingest_dep.module("azure_sdk_kusto_ingest");
-    kusto_ingest_mod.addImport("azure_sdk_core", core_mod);
-    kusto_ingest_mod.addImport("azure_sdk_kusto_common", kusto_common_mod);
-    kusto_ingest_mod.addImport("azure_sdk_kusto_data", kusto_data_mod);
-    kusto_ingest_mod.addImport("azure_sdk_storage_common", storage_common_mod);
-    kusto_ingest_mod.addImport("azure_sdk_storage_blobs", blobs_mod);
-    kusto_ingest_mod.addImport("azure_sdk_storage_queues", queues_mod);
-    kusto_ingest_mod.addImport("serde", serde_mod);
-
-    // -- Modules (libraries exposed to consumers) --
-
-    exportDependencyModule(b, "azure_sdk_core_tracing", core_tracing_mod);
-    exportDependencyModule(b, "azure_sdk_core_perf", core_perf_mod);
-    exportDependencyModule(b, "azure_sdk_core_amqp", core_amqp_mod);
-    exportDependencyModule(b, "azure_sdk_core", core_mod);
-    exportDependencyModule(b, "azure_sdk_core_testing", core_testing_mod);
-    exportDependencyModule(b, "azure_rest_arm_avs", arm_avs_mod);
-    exportDependencyModule(b, "azure_rest_keyvault_secrets", keyvault_secrets_mod);
-    exportDependencyModule(b, "azure_rest_container_registry", container_registry_protocol_mod);
-    exportDependencyModule(b, "azure_sdk_container_registry", container_registry_sdk_mod);
-    exportDependencyModule(b, "azure_sdk_storage_common", storage_common_mod);
-    exportDependencyModule(b, "azure_sdk_storage_blobs", blobs_mod);
-    exportDependencyModule(b, "azure_sdk_storage_queues", queues_mod);
-    exportDependencyModule(b, "azure_sdk_storage_files_shares", storage_files_shares_mod);
-    exportDependencyModule(b, "azure_sdk_storage_files_datalake", storage_files_datalake_mod);
-    exportDependencyModule(b, "azure_sdk_keyvault", keyvault_mod);
-    exportDependencyModule(b, "azure_sdk_data_tables", data_tables_mod);
-    exportDependencyModule(b, "azure_sdk_data_cosmos", data_cosmos_mod);
-    exportDependencyModule(b, "azure_sdk_data_appconfiguration", data_appconfiguration_mod);
-    exportDependencyModule(b, "azure_sdk_attestation", attestation_mod);
-    exportDependencyModule(b, "azure_sdk_messaging_common", messaging_common_mod);
-    exportDependencyModule(b, "azure_sdk_eventhubs", eventhubs_mod);
-    exportDependencyModule(b, "azure_sdk_servicebus", servicebus_mod);
-    exportDependencyModule(b, "azure_sdk_kusto_common", kusto_common_mod);
-    exportDependencyModule(b, "azure_sdk_kusto_data", kusto_data_mod);
-    exportDependencyModule(b, "azure_sdk_kusto_ingest", kusto_ingest_mod);
-
-    // -- Tests --
-
-    const storage_common_tests = b.addTest(.{
+    const aggregate_export_tests = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("sdk/storage/common/root.zig"),
+            .root_source_file = b.path("eng/fixtures/aggregate_export_consumer.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
-                .{ .name = "azure_sdk_core", .module = core_mod },
-                .{ .name = "serde", .module = serde_mod },
+                .{
+                    .name = "fixture_module",
+                    .module = aggregate_export_fixture.module("fixture_module"),
+                },
             },
         }),
     });
-    const run_storage_common_tests = b.addRunArtifact(storage_common_tests);
+    const run_aggregate_export_tests = b.addRunArtifact(aggregate_export_tests);
+    run_aggregate_export_tests.step.dependOn(&aggregate_consumer.step);
+    test_step.dependOn(&run_aggregate_export_tests.step);
 
-    const test_step = b.step("test", "Run all tests");
-    test_step.dependOn(&run_storage_common_tests.step);
+    addPackageToolSteps(b, test_step);
+    addExample(b, target, optimize, core_mod);
+    addCodegenSteps(b);
+}
 
+fn addPackageTests(b: *std.Build) *std.Build.Step {
+    const order = package_registry.topologicalOrder(
+        b.allocator,
+        &package_registry.all,
+    ) catch @panic("invalid package registry");
+    defer b.allocator.free(order);
+
+    var previous: ?*std.Build.Step = null;
+    for (order) |index| {
+        const package = package_registry.all[index];
+        if (package.state != .package or package.test_command == null) continue;
+
+        const package_tests = b.addSystemCommand(&.{
+            b.graph.zig_exe,
+            "build",
+            "test",
+            "--summary",
+            "all",
+        });
+        package_tests.setCwd(b.path(package.source_path));
+        if (previous) |step| package_tests.step.dependOn(step);
+        previous = &package_tests.step;
+    }
+    return previous orelse @panic("package registry has no tests");
+}
+
+fn addFixtureTest(
+    b: *std.Build,
+    path: []const u8,
+    dependency: *std.Build.Step,
+) *std.Build.Step.Run {
+    const fixture_tests = b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "build",
+        "test",
+        "--summary",
+        "all",
+    });
+    fixture_tests.setCwd(b.path(path));
+    fixture_tests.step.dependOn(dependency);
+    return fixture_tests;
+}
+
+fn addPackageToolSteps(b: *std.Build, test_step: *std.Build.Step) void {
     const package_tool_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("eng/package_tool_test.zig"),
@@ -294,6 +115,7 @@ pub fn build(b: *std.Build) void {
     package_check_run.addArg("check");
     package_check_run.setCwd(b.path("."));
     test_step.dependOn(&package_check_run.step);
+
     const package_check_step = b.step(
         "package-check",
         "Validate package metadata, documentation, licenses, and manifests",
@@ -330,41 +152,14 @@ pub fn build(b: *std.Build) void {
         "Synchronize package licenses and local manifest identities",
     );
     package_sync_step.dependOn(&package_sync_run.step);
+}
 
-    const aggregate_export_fixture = b.dependency("aggregate_export_fixture", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const aggregate_export_tests = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("eng/fixtures/aggregate_export_consumer.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{
-                    .name = "fixture_module",
-                    .module = aggregate_export_fixture.module("fixture_module"),
-                },
-            },
-        }),
-    });
-    test_step.dependOn(&b.addRunArtifact(aggregate_export_tests).step);
-
-    for (package_registry.all) |package| {
-        if (package.state != .package) continue;
-        const package_tests = b.addSystemCommand(&.{
-            b.graph.zig_exe,
-            "build",
-            "test",
-            "--summary",
-            "all",
-        });
-        package_tests.setCwd(b.path(package.source_path));
-        test_step.dependOn(&package_tests.step);
-    }
-
-    // -- Example executable --
-
+fn addExample(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    core_mod: *std.Build.Module,
+) void {
     const example = b.addExecutable(.{
         .name = "azure_example",
         .root_module = b.createModule(.{
@@ -376,104 +171,16 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-
     b.installArtifact(example);
 
     const run_example = b.addRunArtifact(example);
     run_example.step.dependOn(b.getInstallStep());
-    if (b.args) |args| {
-        run_example.addArgs(args);
-    }
-
+    if (b.args) |args| run_example.addArgs(args);
     const run_step = b.step("run", "Run the example");
     run_step.dependOn(&run_example.step);
+}
 
-    const acr_example_support_mod = b.createModule(.{
-        .root_source_file = b.path("sdk/container_registry/examples/support.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "azure_sdk_core", .module = core_mod },
-            .{
-                .name = "azure_sdk_container_registry",
-                .module = container_registry_sdk_mod,
-            },
-        },
-    });
-    const acr_examples_step = b.step(
-        "container-registry-examples",
-        "Compile all Container Registry examples",
-    );
-    const acr_example_sources = [_]struct {
-        name: []const u8,
-        source: []const u8,
-    }{
-        .{
-            .name = "acr-list-repositories-tags",
-            .source = "sdk/container_registry/examples/list_repositories_tags.zig",
-        },
-        .{
-            .name = "acr-anonymous-read",
-            .source = "sdk/container_registry/examples/anonymous_read.zig",
-        },
-        .{
-            .name = "acr-oci-push-pull",
-            .source = "sdk/container_registry/examples/oci_push_pull.zig",
-        },
-        .{
-            .name = "acr-delete-artifact",
-            .source = "sdk/container_registry/examples/delete_artifact.zig",
-        },
-    };
-    for (acr_example_sources) |acr_example| {
-        const executable = b.addExecutable(.{
-            .name = acr_example.name,
-            .root_module = b.createModule(.{
-                .root_source_file = b.path(acr_example.source),
-                .target = target,
-                .optimize = optimize,
-                .imports = &.{
-                    .{ .name = "azure_sdk_core", .module = core_mod },
-                    .{
-                        .name = "azure_sdk_container_registry",
-                        .module = container_registry_sdk_mod,
-                    },
-                    .{
-                        .name = "acr_example_support",
-                        .module = acr_example_support_mod,
-                    },
-                },
-            }),
-        });
-        acr_examples_step.dependOn(&executable.step);
-        test_step.dependOn(&executable.step);
-    }
-
-    const acr_live_tests = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("sdk/container_registry/live_tests/main.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "azure_sdk_core", .module = core_mod },
-                .{
-                    .name = "azure_sdk_container_registry",
-                    .module = container_registry_sdk_mod,
-                },
-            },
-        }),
-    });
-    const acr_live_test_step = b.step(
-        "container-registry-live-test",
-        "Run destructive opt-in Container Registry live tests; unconfigured tests skip",
-    );
-    acr_live_test_step.dependOn(&b.addRunArtifact(acr_live_tests).step);
-
-    // -- tspconfigs tool --
-    //
-    // Builds and exposes two steps that manage `codegen/tspconfigs.yaml`:
-    //   * tspconfigs-update  — reconcile entries against ../azure-rest-api-specs
-    //   * tspconfigs-resolve — fill in name/branch/zig_import from each tspconfig.yaml
+fn addCodegenSteps(b: *std.Build) void {
     const tspconfigs_exe = b.addExecutable(.{
         .name = "tspconfigs",
         .root_module = b.createModule(.{
@@ -502,16 +209,4 @@ pub fn build(b: *std.Build) void {
         "Fill in name/branch/zig_import by parsing each tspconfig.yaml",
     );
     tspconfigs_resolve_step.dependOn(&tspconfigs_resolve_run.step);
-}
-
-fn exportDependencyModule(
-    b: *std.Build,
-    name: []const u8,
-    module: *std.Build.Module,
-) void {
-    b.modules.put(
-        b.graph.arena,
-        b.dupe(name),
-        module,
-    ) catch @panic("OOM");
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,91 +4,11 @@
     .fingerprint = 0x96c2d79909d9671,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
-        .azure_sdk_core_tracing = .{
-            .path = "sdk/core/tracing",
-        },
-        .azure_sdk_core_perf = .{
-            .path = "sdk/core/perf",
-        },
-        .azure_sdk_core_amqp = .{
-            .path = "sdk/core/amqp",
-        },
-        .azure_sdk_core = .{
-            .path = "sdk/core",
-        },
-        .azure_sdk_core_testing = .{
-            .path = "sdk/core/testing",
-        },
-        .azure_rest_arm_avs = .{
-            .path = "rest/arm_avs",
-        },
-        .azure_rest_keyvault_secrets = .{
-            .path = "rest/keyvault_secrets",
-        },
-        .azure_rest_container_registry = .{
-            .path = "rest/container_registry",
-        },
-        .azure_sdk_container_registry = .{
-            .path = "sdk/container_registry",
-        },
-        .azure_sdk_storage_common = .{
-            .path = "sdk/storage/common",
-        },
-        .azure_sdk_storage_blobs = .{
-            .path = "sdk/storage/blobs",
-        },
-        .azure_sdk_storage_queues = .{
-            .path = "sdk/storage/queues",
-        },
-        .azure_sdk_storage_files_shares = .{
-            .path = "sdk/storage/files/shares",
-        },
-        .azure_sdk_storage_files_datalake = .{
-            .path = "sdk/storage/files/datalake",
-        },
-        .azure_sdk_keyvault = .{
-            .path = "sdk/keyvault",
-        },
-        .azure_sdk_data_tables = .{
-            .path = "sdk/data/tables",
-        },
-        .azure_sdk_data_cosmos = .{
-            .path = "sdk/data/cosmos",
-        },
-        .azure_sdk_data_appconfiguration = .{
-            .path = "sdk/data/appconfiguration",
-        },
-        .azure_sdk_attestation = .{
-            .path = "sdk/attestation",
-        },
-        .azure_sdk_messaging_common = .{
-            .path = "sdk/messaging/common",
-        },
-        .azure_sdk_eventhubs = .{
-            .path = "sdk/messaging/eventhubs",
-        },
-        .azure_sdk_servicebus = .{
-            .path = "sdk/messaging/servicebus",
-        },
-        .azure_sdk_kusto_common = .{
-            .path = "sdk/kusto/common",
-        },
-        .azure_sdk_kusto_data = .{
-            .path = "sdk/kusto/data",
-        },
-        .azure_sdk_kusto_ingest = .{
-            .path = "sdk/kusto/ingest",
+        .azure_sdk = .{
+            .path = "sdk/aggregate",
         },
         .aggregate_export_fixture = .{
             .path = "eng/fixtures/aggregate_export",
-        },
-        .uamqp = .{
-            .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",
-            .hash = "uamqp-0.1.0-lXMcafDqAQD3LSUZbUbyfrWhQfGG7OevKFUwhWxvGZDU",
-        },
-        .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
-            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
         },
     },
     .paths = .{

--- a/doc/package-catalog.md
+++ b/doc/package-catalog.md
@@ -4,9 +4,9 @@
 canonical packages start at `0.1.0`; package-scoped release tags use
 `<package>/v<version>`.
 
-`package` means a package-local build exists today. `monolithic` means the
-module is still built from the integration workspace and will be extracted in
-dependency order.
+Every entry has a package-local build and can be versioned independently. The
+root `azure_sdk_workspace` package is integration-only and is not part of this
+release catalog.
 
 | Package | Source documentation | Branch | State |
 | --- | --- | --- | --- |
@@ -35,4 +35,4 @@ dependency order.
 | `azure_sdk_kusto_common` | [Kusto Common](../sdk/kusto/common/README.md) | `sdk/kusto_common` | package |
 | `azure_sdk_kusto_data` | [Kusto Data](../sdk/kusto/data/README.md) | `sdk/kusto_data` | package |
 | `azure_sdk_kusto_ingest` | [Kusto Ingest](../sdk/kusto/ingest/README.md) | `sdk/kusto_ingest` | package |
-| `azure_sdk` | [Aggregate](../sdk/aggregate/README.md) | `sdk/aggregate` | monolithic |
+| `azure_sdk` | [Aggregate](../sdk/aggregate/README.md) | `sdk/aggregate` | package |

--- a/eng/fixtures/aggregate_consumer/.gitignore
+++ b/eng/fixtures/aggregate_consumer/.gitignore
@@ -1,0 +1,4 @@
+.zig-cache/
+zig-out/
+zig-pkg/
+

--- a/eng/fixtures/aggregate_consumer/build.zig
+++ b/eng/fixtures/aggregate_consumer/build.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+
+const canonical_module_names = [_][]const u8{
+    "azure_sdk_core_tracing",
+    "azure_sdk_core_perf",
+    "azure_sdk_core_amqp",
+    "azure_sdk_core",
+    "azure_sdk_core_testing",
+    "azure_rest_arm_avs",
+    "azure_rest_keyvault_secrets",
+    "azure_rest_container_registry",
+    "azure_sdk_container_registry",
+    "azure_sdk_storage_common",
+    "azure_sdk_storage_blobs",
+    "azure_sdk_storage_queues",
+    "azure_sdk_storage_files_shares",
+    "azure_sdk_storage_files_datalake",
+    "azure_sdk_keyvault",
+    "azure_sdk_data_tables",
+    "azure_sdk_data_cosmos",
+    "azure_sdk_data_appconfiguration",
+    "azure_sdk_attestation",
+    "azure_sdk_messaging_common",
+    "azure_sdk_eventhubs",
+    "azure_sdk_servicebus",
+    "azure_sdk_kusto_common",
+    "azure_sdk_kusto_data",
+    "azure_sdk_kusto_ingest",
+};
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const aggregate = b.dependency("azure_sdk", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    var imports: [canonical_module_names.len]std.Build.Module.Import = undefined;
+    for (canonical_module_names, 0..) |name, index| {
+        imports[index] = .{
+            .name = name,
+            .module = aggregate.module(name),
+        };
+    }
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/all_modules.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &imports,
+        }),
+    });
+    const test_step = b.step("test", "Compile an aggregate-only consumer");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}

--- a/eng/fixtures/aggregate_consumer/build.zig.zon
+++ b/eng/fixtures/aggregate_consumer/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .aggregate_consumer_fixture,
+    .version = "0.0.0",
+    .fingerprint = 0x0f793e70e34e35f5,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .azure_sdk = .{
+            .path = "../../../sdk/aggregate",
+        },
+    },
+    .paths = .{
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "test",
+    },
+}

--- a/eng/fixtures/aggregate_consumer/test/all_modules.zig
+++ b/eng/fixtures/aggregate_consumer/test/all_modules.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+
+const azure_sdk_core_tracing = @import("azure_sdk_core_tracing");
+const azure_sdk_core_perf = @import("azure_sdk_core_perf");
+const azure_sdk_core_amqp = @import("azure_sdk_core_amqp");
+const azure_sdk_core = @import("azure_sdk_core");
+const azure_sdk_core_testing = @import("azure_sdk_core_testing");
+const azure_rest_arm_avs = @import("azure_rest_arm_avs");
+const azure_rest_keyvault_secrets = @import("azure_rest_keyvault_secrets");
+const azure_rest_container_registry = @import("azure_rest_container_registry");
+const azure_sdk_container_registry = @import("azure_sdk_container_registry");
+const azure_sdk_storage_common = @import("azure_sdk_storage_common");
+const azure_sdk_storage_blobs = @import("azure_sdk_storage_blobs");
+const azure_sdk_storage_queues = @import("azure_sdk_storage_queues");
+const azure_sdk_storage_files_shares = @import("azure_sdk_storage_files_shares");
+const azure_sdk_storage_files_datalake = @import("azure_sdk_storage_files_datalake");
+const azure_sdk_keyvault = @import("azure_sdk_keyvault");
+const azure_sdk_data_tables = @import("azure_sdk_data_tables");
+const azure_sdk_data_cosmos = @import("azure_sdk_data_cosmos");
+const azure_sdk_data_appconfiguration = @import("azure_sdk_data_appconfiguration");
+const azure_sdk_attestation = @import("azure_sdk_attestation");
+const azure_sdk_messaging_common = @import("azure_sdk_messaging_common");
+const azure_sdk_eventhubs = @import("azure_sdk_eventhubs");
+const azure_sdk_servicebus = @import("azure_sdk_servicebus");
+const azure_sdk_kusto_common = @import("azure_sdk_kusto_common");
+const azure_sdk_kusto_data = @import("azure_sdk_kusto_data");
+const azure_sdk_kusto_ingest = @import("azure_sdk_kusto_ingest");
+
+test "aggregate-only consumer imports every canonical module" {
+    _ = azure_sdk_core_tracing;
+    _ = azure_sdk_core_perf;
+    _ = azure_sdk_core_amqp;
+    _ = azure_sdk_core;
+    _ = azure_sdk_core_testing;
+    _ = azure_rest_arm_avs;
+    _ = azure_rest_keyvault_secrets;
+    _ = azure_rest_container_registry;
+    _ = azure_sdk_container_registry;
+    _ = azure_sdk_storage_common;
+    _ = azure_sdk_storage_blobs;
+    _ = azure_sdk_storage_queues;
+    _ = azure_sdk_storage_files_shares;
+    _ = azure_sdk_storage_files_datalake;
+    _ = azure_sdk_keyvault;
+    _ = azure_sdk_data_tables;
+    _ = azure_sdk_data_cosmos;
+    _ = azure_sdk_data_appconfiguration;
+    _ = azure_sdk_attestation;
+    _ = azure_sdk_messaging_common;
+    _ = azure_sdk_eventhubs;
+    _ = azure_sdk_servicebus;
+    _ = azure_sdk_kusto_common;
+    _ = azure_sdk_kusto_data;
+    _ = azure_sdk_kusto_ingest;
+
+    try std.testing.expectEqualStrings("0.1.0", azure_sdk_core.version);
+    try std.testing.expect(@sizeOf(azure_sdk_kusto_ingest.StreamingIngestTarget) > 0);
+}

--- a/eng/fixtures/direct_package_consumer/.gitignore
+++ b/eng/fixtures/direct_package_consumer/.gitignore
@@ -1,0 +1,4 @@
+.zig-cache/
+zig-out/
+zig-pkg/
+

--- a/eng/fixtures/direct_package_consumer/build.zig
+++ b/eng/fixtures/direct_package_consumer/build.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const ingest_mod = b.dependency("azure_sdk_kusto_ingest", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_kusto_ingest");
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_kusto_ingest", .module = ingest_mod },
+            },
+        }),
+    });
+    const test_step = b.step("test", "Compile a direct-package consumer");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}

--- a/eng/fixtures/direct_package_consumer/build.zig.zon
+++ b/eng/fixtures/direct_package_consumer/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .direct_consumer_fixture,
+    .version = "0.0.0",
+    .fingerprint = 0x4b9baa28abcfb85d,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .azure_sdk_kusto_ingest = .{
+            .path = "../../../sdk/kusto/ingest",
+        },
+    },
+    .paths = .{
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "test",
+    },
+}

--- a/eng/fixtures/direct_package_consumer/test/main.zig
+++ b/eng/fixtures/direct_package_consumer/test/main.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+const ingest = @import("azure_sdk_kusto_ingest");
+
+test "direct package consumer compiles" {
+    try std.testing.expect(@sizeOf(ingest.StreamingIngestTarget) > 0);
+}

--- a/eng/package_tool_test.zig
+++ b/eng/package_tool_test.zig
@@ -4,6 +4,9 @@ const registry = @import("packages.zig");
 test "registry contains a valid twenty-six-package dependency graph" {
     try std.testing.expectEqual(@as(usize, 26), registry.all.len);
     try registry.validate(std.testing.allocator, &registry.all);
+    for (registry.all) |entry| {
+        try std.testing.expectEqual(registry.MigrationState.package, entry.state);
+    }
 }
 
 test "topological order places dependencies before dependents" {

--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -611,12 +611,22 @@ pub const all = [_]Package{
     },
     .{
         .kind = .aggregate,
+        .state = .package,
         .source_path = "sdk/aggregate",
-        .root_source_file = "src/root.zig",
+        .root_source_file = "test/all_modules.zig",
         .name = "azure_sdk",
         .module_name = "azure_sdk",
         .branch = "sdk/aggregate",
         .dependencies = all_implementation_packages,
+        .external_dependencies = &.{ "uamqp", "serde" },
+        .publish_paths = &.{
+            ".gitignore",
+            "build.zig",
+            "build.zig.zon",
+            "test",
+            "README.md",
+            "LICENSE.txt",
+        },
     },
 };
 

--- a/sdk/aggregate/.gitignore
+++ b/sdk/aggregate/.gitignore
@@ -1,0 +1,4 @@
+.zig-cache/
+zig-out/
+zig-pkg/
+

--- a/sdk/aggregate/README.md
+++ b/sdk/aggregate/README.md
@@ -1,17 +1,25 @@
-# azure_sdk aggregate
+# Azure SDK aggregate package
 
-`azure_sdk` is the convenience aggregate over all independently versioned
-Azure SDK for Zig packages.
+Package `azure_sdk` provides one dependency that exports every canonical Azure
+SDK for Zig module. Consumers still import modules by their canonical names,
+for example:
 
-The aggregate is released from `sdk/aggregate`, starts at `0.1.0`, and exposes
-only canonical module names such as `azure_sdk_core` and
-`azure_sdk_storage_blobs`. It does not expose old module aliases.
+```zig
+const core = @import("azure_sdk_core");
+const blobs = @import("azure_sdk_storage_blobs");
+```
 
-Consumers should choose either:
+Choose either this aggregate package or direct dependencies on the individual
+packages an application uses. Do not combine aggregate and direct instances of
+the same package in one build, because that can create duplicate Zig source
+owners.
 
-- direct package dependencies for the smallest dependency graph; or
-- this aggregate for one dependency containing every canonical module.
+The aggregate intentionally exposes no legacy module names. See the
+[package catalog](https://github.com/cataggar/azure-sdk-for-zig/blob/main/doc/package-catalog.md)
+for the complete canonical module list.
 
-Do not mix direct and aggregate instances of the same package in one build.
-The aggregate package-local build is introduced after all implementation
-packages have been extracted.
+## Development
+
+```bash
+zig build test --summary all
+```

--- a/sdk/aggregate/build.zig
+++ b/sdk/aggregate/build.zig
@@ -1,0 +1,339 @@
+const std = @import("std");
+
+const Modules = struct {
+    azure_sdk_core_tracing: *std.Build.Module,
+    azure_sdk_core_perf: *std.Build.Module,
+    azure_sdk_core_amqp: *std.Build.Module,
+    azure_sdk_core: *std.Build.Module,
+    azure_sdk_core_testing: *std.Build.Module,
+    azure_rest_arm_avs: *std.Build.Module,
+    azure_rest_keyvault_secrets: *std.Build.Module,
+    azure_rest_container_registry: *std.Build.Module,
+    azure_sdk_container_registry: *std.Build.Module,
+    azure_sdk_storage_common: *std.Build.Module,
+    azure_sdk_storage_blobs: *std.Build.Module,
+    azure_sdk_storage_queues: *std.Build.Module,
+    azure_sdk_storage_files_shares: *std.Build.Module,
+    azure_sdk_storage_files_datalake: *std.Build.Module,
+    azure_sdk_keyvault: *std.Build.Module,
+    azure_sdk_data_tables: *std.Build.Module,
+    azure_sdk_data_cosmos: *std.Build.Module,
+    azure_sdk_data_appconfiguration: *std.Build.Module,
+    azure_sdk_attestation: *std.Build.Module,
+    azure_sdk_messaging_common: *std.Build.Module,
+    azure_sdk_eventhubs: *std.Build.Module,
+    azure_sdk_servicebus: *std.Build.Module,
+    azure_sdk_kusto_common: *std.Build.Module,
+    azure_sdk_kusto_data: *std.Build.Module,
+    azure_sdk_kusto_ingest: *std.Build.Module,
+};
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const modules = loadModules(b, target, optimize);
+
+    exportDependencyModule(b, "azure_sdk_core_tracing", modules.azure_sdk_core_tracing);
+    exportDependencyModule(b, "azure_sdk_core_perf", modules.azure_sdk_core_perf);
+    exportDependencyModule(b, "azure_sdk_core_amqp", modules.azure_sdk_core_amqp);
+    exportDependencyModule(b, "azure_sdk_core", modules.azure_sdk_core);
+    exportDependencyModule(b, "azure_sdk_core_testing", modules.azure_sdk_core_testing);
+    exportDependencyModule(b, "azure_rest_arm_avs", modules.azure_rest_arm_avs);
+    exportDependencyModule(b, "azure_rest_keyvault_secrets", modules.azure_rest_keyvault_secrets);
+    exportDependencyModule(b, "azure_rest_container_registry", modules.azure_rest_container_registry);
+    exportDependencyModule(b, "azure_sdk_container_registry", modules.azure_sdk_container_registry);
+    exportDependencyModule(b, "azure_sdk_storage_common", modules.azure_sdk_storage_common);
+    exportDependencyModule(b, "azure_sdk_storage_blobs", modules.azure_sdk_storage_blobs);
+    exportDependencyModule(b, "azure_sdk_storage_queues", modules.azure_sdk_storage_queues);
+    exportDependencyModule(b, "azure_sdk_storage_files_shares", modules.azure_sdk_storage_files_shares);
+    exportDependencyModule(b, "azure_sdk_storage_files_datalake", modules.azure_sdk_storage_files_datalake);
+    exportDependencyModule(b, "azure_sdk_keyvault", modules.azure_sdk_keyvault);
+    exportDependencyModule(b, "azure_sdk_data_tables", modules.azure_sdk_data_tables);
+    exportDependencyModule(b, "azure_sdk_data_cosmos", modules.azure_sdk_data_cosmos);
+    exportDependencyModule(b, "azure_sdk_data_appconfiguration", modules.azure_sdk_data_appconfiguration);
+    exportDependencyModule(b, "azure_sdk_attestation", modules.azure_sdk_attestation);
+    exportDependencyModule(b, "azure_sdk_messaging_common", modules.azure_sdk_messaging_common);
+    exportDependencyModule(b, "azure_sdk_eventhubs", modules.azure_sdk_eventhubs);
+    exportDependencyModule(b, "azure_sdk_servicebus", modules.azure_sdk_servicebus);
+    exportDependencyModule(b, "azure_sdk_kusto_common", modules.azure_sdk_kusto_common);
+    exportDependencyModule(b, "azure_sdk_kusto_data", modules.azure_sdk_kusto_data);
+    exportDependencyModule(b, "azure_sdk_kusto_ingest", modules.azure_sdk_kusto_ingest);
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/all_modules.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &moduleImports(modules),
+        }),
+    });
+    const test_step = b.step("test", "Compile every canonical aggregate module");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}
+
+fn loadModules(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) Modules {
+    const core_tracing_mod = b.dependency("azure_sdk_core_tracing", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_core_tracing");
+    const core_perf_mod = b.dependency("azure_sdk_core_perf", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_core_perf");
+    const core_amqp_mod = b.dependency("azure_sdk_core_amqp", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_core_amqp");
+    const core_mod = b.dependency("azure_sdk_core", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_core");
+    const core_testing_mod = b.dependency("azure_sdk_core_testing", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_core_testing");
+
+    const uamqp_dep = b.dependency("uamqp", .{});
+    const uamqp_mod = b.createModule(.{
+        .root_source_file = uamqp_dep.path("src/zig/uamqp.zig"),
+        .target = target,
+    });
+    const serde_mod = b.dependency("serde", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("serde");
+
+    core_amqp_mod.addImport("uamqp", uamqp_mod);
+    core_mod.addImport("azure_sdk_core_tracing", core_tracing_mod);
+    core_mod.addImport("serde", serde_mod);
+    core_testing_mod.addImport("azure_sdk_core", core_mod);
+
+    const arm_avs_mod = b.dependency("azure_rest_arm_avs", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_rest_arm_avs");
+    arm_avs_mod.addImport("azure_sdk_core", core_mod);
+    arm_avs_mod.addImport("serde", serde_mod);
+
+    const keyvault_secrets_mod = b.dependency("azure_rest_keyvault_secrets", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_rest_keyvault_secrets");
+    keyvault_secrets_mod.addImport("azure_sdk_core", core_mod);
+    keyvault_secrets_mod.addImport("serde", serde_mod);
+
+    const container_registry_protocol_mod =
+        b.dependency("azure_rest_container_registry", .{
+            .target = target,
+            .optimize = optimize,
+        }).module("azure_rest_container_registry");
+    container_registry_protocol_mod.addImport("azure_sdk_core", core_mod);
+    container_registry_protocol_mod.addImport("serde", serde_mod);
+
+    const container_registry_sdk_mod =
+        b.dependency("azure_sdk_container_registry", .{
+            .target = target,
+            .optimize = optimize,
+        }).module("azure_sdk_container_registry");
+    container_registry_sdk_mod.addImport("azure_sdk_core", core_mod);
+    container_registry_sdk_mod.addImport(
+        "azure_rest_container_registry",
+        container_registry_protocol_mod,
+    );
+
+    const storage_common_mod = b.dependency("azure_sdk_storage_common", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_storage_common");
+    storage_common_mod.addImport("azure_sdk_core", core_mod);
+
+    const storage_blobs_mod = b.dependency("azure_sdk_storage_blobs", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_storage_blobs");
+    storage_blobs_mod.addImport("azure_sdk_core", core_mod);
+    storage_blobs_mod.addImport("azure_sdk_storage_common", storage_common_mod);
+    storage_blobs_mod.addImport("serde", serde_mod);
+
+    const storage_queues_mod = b.dependency("azure_sdk_storage_queues", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_storage_queues");
+    storage_queues_mod.addImport("azure_sdk_core", core_mod);
+    storage_queues_mod.addImport("azure_sdk_storage_common", storage_common_mod);
+    storage_queues_mod.addImport("serde", serde_mod);
+
+    const storage_files_shares_mod =
+        b.dependency("azure_sdk_storage_files_shares", .{
+            .target = target,
+            .optimize = optimize,
+        }).module("azure_sdk_storage_files_shares");
+    storage_files_shares_mod.addImport("azure_sdk_core", core_mod);
+
+    const storage_files_datalake_mod =
+        b.dependency("azure_sdk_storage_files_datalake", .{
+            .target = target,
+            .optimize = optimize,
+        }).module("azure_sdk_storage_files_datalake");
+    storage_files_datalake_mod.addImport("azure_sdk_core", core_mod);
+
+    const keyvault_mod = b.dependency("azure_sdk_keyvault", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_keyvault");
+    keyvault_mod.addImport("azure_sdk_core", core_mod);
+    keyvault_mod.addImport("serde", serde_mod);
+
+    const data_tables_mod = b.dependency("azure_sdk_data_tables", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_data_tables");
+    data_tables_mod.addImport("azure_sdk_core", core_mod);
+
+    const data_cosmos_mod = b.dependency("azure_sdk_data_cosmos", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_data_cosmos");
+    data_cosmos_mod.addImport("azure_sdk_core", core_mod);
+    data_cosmos_mod.addImport("serde", serde_mod);
+
+    const data_appconfiguration_mod =
+        b.dependency("azure_sdk_data_appconfiguration", .{
+            .target = target,
+            .optimize = optimize,
+        }).module("azure_sdk_data_appconfiguration");
+    data_appconfiguration_mod.addImport("azure_sdk_core", core_mod);
+    data_appconfiguration_mod.addImport("serde", serde_mod);
+
+    const attestation_mod = b.dependency("azure_sdk_attestation", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_attestation");
+    attestation_mod.addImport("azure_sdk_core", core_mod);
+    attestation_mod.addImport("serde", serde_mod);
+
+    const messaging_common_mod = b.dependency("azure_sdk_messaging_common", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_messaging_common");
+
+    const eventhubs_mod = b.dependency("azure_sdk_eventhubs", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_eventhubs");
+    eventhubs_mod.addImport("azure_sdk_core", core_mod);
+    eventhubs_mod.addImport("azure_sdk_messaging_common", messaging_common_mod);
+    eventhubs_mod.addImport("azure_sdk_storage_blobs", storage_blobs_mod);
+    eventhubs_mod.addImport("uamqp", uamqp_mod);
+    eventhubs_mod.addImport("serde", serde_mod);
+
+    const servicebus_mod = b.dependency("azure_sdk_servicebus", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_servicebus");
+    servicebus_mod.addImport("azure_sdk_core", core_mod);
+    servicebus_mod.addImport("azure_sdk_messaging_common", messaging_common_mod);
+    servicebus_mod.addImport("uamqp", uamqp_mod);
+    servicebus_mod.addImport("serde", serde_mod);
+
+    const kusto_common_mod = b.dependency("azure_sdk_kusto_common", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_kusto_common");
+    kusto_common_mod.addImport("azure_sdk_core", core_mod);
+    kusto_common_mod.addImport("serde", serde_mod);
+
+    const kusto_data_mod = b.dependency("azure_sdk_kusto_data", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_kusto_data");
+    kusto_data_mod.addImport("azure_sdk_core", core_mod);
+    kusto_data_mod.addImport("azure_sdk_kusto_common", kusto_common_mod);
+    kusto_data_mod.addImport("serde", serde_mod);
+
+    const kusto_ingest_mod = b.dependency("azure_sdk_kusto_ingest", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azure_sdk_kusto_ingest");
+    kusto_ingest_mod.addImport("azure_sdk_core", core_mod);
+    kusto_ingest_mod.addImport("azure_sdk_kusto_common", kusto_common_mod);
+    kusto_ingest_mod.addImport("azure_sdk_kusto_data", kusto_data_mod);
+    kusto_ingest_mod.addImport("azure_sdk_storage_common", storage_common_mod);
+    kusto_ingest_mod.addImport("azure_sdk_storage_blobs", storage_blobs_mod);
+    kusto_ingest_mod.addImport("azure_sdk_storage_queues", storage_queues_mod);
+    kusto_ingest_mod.addImport("serde", serde_mod);
+
+    return .{
+        .azure_sdk_core_tracing = core_tracing_mod,
+        .azure_sdk_core_perf = core_perf_mod,
+        .azure_sdk_core_amqp = core_amqp_mod,
+        .azure_sdk_core = core_mod,
+        .azure_sdk_core_testing = core_testing_mod,
+        .azure_rest_arm_avs = arm_avs_mod,
+        .azure_rest_keyvault_secrets = keyvault_secrets_mod,
+        .azure_rest_container_registry = container_registry_protocol_mod,
+        .azure_sdk_container_registry = container_registry_sdk_mod,
+        .azure_sdk_storage_common = storage_common_mod,
+        .azure_sdk_storage_blobs = storage_blobs_mod,
+        .azure_sdk_storage_queues = storage_queues_mod,
+        .azure_sdk_storage_files_shares = storage_files_shares_mod,
+        .azure_sdk_storage_files_datalake = storage_files_datalake_mod,
+        .azure_sdk_keyvault = keyvault_mod,
+        .azure_sdk_data_tables = data_tables_mod,
+        .azure_sdk_data_cosmos = data_cosmos_mod,
+        .azure_sdk_data_appconfiguration = data_appconfiguration_mod,
+        .azure_sdk_attestation = attestation_mod,
+        .azure_sdk_messaging_common = messaging_common_mod,
+        .azure_sdk_eventhubs = eventhubs_mod,
+        .azure_sdk_servicebus = servicebus_mod,
+        .azure_sdk_kusto_common = kusto_common_mod,
+        .azure_sdk_kusto_data = kusto_data_mod,
+        .azure_sdk_kusto_ingest = kusto_ingest_mod,
+    };
+}
+
+fn moduleImports(modules: Modules) [25]std.Build.Module.Import {
+    return .{
+        .{ .name = "azure_sdk_core_tracing", .module = modules.azure_sdk_core_tracing },
+        .{ .name = "azure_sdk_core_perf", .module = modules.azure_sdk_core_perf },
+        .{ .name = "azure_sdk_core_amqp", .module = modules.azure_sdk_core_amqp },
+        .{ .name = "azure_sdk_core", .module = modules.azure_sdk_core },
+        .{ .name = "azure_sdk_core_testing", .module = modules.azure_sdk_core_testing },
+        .{ .name = "azure_rest_arm_avs", .module = modules.azure_rest_arm_avs },
+        .{ .name = "azure_rest_keyvault_secrets", .module = modules.azure_rest_keyvault_secrets },
+        .{ .name = "azure_rest_container_registry", .module = modules.azure_rest_container_registry },
+        .{ .name = "azure_sdk_container_registry", .module = modules.azure_sdk_container_registry },
+        .{ .name = "azure_sdk_storage_common", .module = modules.azure_sdk_storage_common },
+        .{ .name = "azure_sdk_storage_blobs", .module = modules.azure_sdk_storage_blobs },
+        .{ .name = "azure_sdk_storage_queues", .module = modules.azure_sdk_storage_queues },
+        .{ .name = "azure_sdk_storage_files_shares", .module = modules.azure_sdk_storage_files_shares },
+        .{ .name = "azure_sdk_storage_files_datalake", .module = modules.azure_sdk_storage_files_datalake },
+        .{ .name = "azure_sdk_keyvault", .module = modules.azure_sdk_keyvault },
+        .{ .name = "azure_sdk_data_tables", .module = modules.azure_sdk_data_tables },
+        .{ .name = "azure_sdk_data_cosmos", .module = modules.azure_sdk_data_cosmos },
+        .{ .name = "azure_sdk_data_appconfiguration", .module = modules.azure_sdk_data_appconfiguration },
+        .{ .name = "azure_sdk_attestation", .module = modules.azure_sdk_attestation },
+        .{ .name = "azure_sdk_messaging_common", .module = modules.azure_sdk_messaging_common },
+        .{ .name = "azure_sdk_eventhubs", .module = modules.azure_sdk_eventhubs },
+        .{ .name = "azure_sdk_servicebus", .module = modules.azure_sdk_servicebus },
+        .{ .name = "azure_sdk_kusto_common", .module = modules.azure_sdk_kusto_common },
+        .{ .name = "azure_sdk_kusto_data", .module = modules.azure_sdk_kusto_data },
+        .{ .name = "azure_sdk_kusto_ingest", .module = modules.azure_sdk_kusto_ingest },
+    };
+}
+
+fn exportDependencyModule(
+    b: *std.Build,
+    name: []const u8,
+    module: *std.Build.Module,
+) void {
+    b.modules.put(
+        b.graph.arena,
+        b.dupe(name),
+        module,
+    ) catch @panic("OOM");
+}

--- a/sdk/aggregate/build.zig.zon
+++ b/sdk/aggregate/build.zig.zon
@@ -1,0 +1,99 @@
+.{
+    .name = .azure_sdk,
+    .version = "0.1.0",
+    .fingerprint = 0x27c178e4deac8d1f,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .azure_sdk_core_tracing = .{
+            .path = "../../sdk/core/tracing",
+        },
+        .azure_sdk_core_perf = .{
+            .path = "../../sdk/core/perf",
+        },
+        .azure_sdk_core_amqp = .{
+            .path = "../../sdk/core/amqp",
+        },
+        .azure_sdk_core = .{
+            .path = "../../sdk/core",
+        },
+        .azure_sdk_core_testing = .{
+            .path = "../../sdk/core/testing",
+        },
+        .azure_rest_arm_avs = .{
+            .path = "../../rest/arm_avs",
+        },
+        .azure_rest_keyvault_secrets = .{
+            .path = "../../rest/keyvault_secrets",
+        },
+        .azure_rest_container_registry = .{
+            .path = "../../rest/container_registry",
+        },
+        .azure_sdk_container_registry = .{
+            .path = "../../sdk/container_registry",
+        },
+        .azure_sdk_storage_common = .{
+            .path = "../../sdk/storage/common",
+        },
+        .azure_sdk_storage_blobs = .{
+            .path = "../../sdk/storage/blobs",
+        },
+        .azure_sdk_storage_queues = .{
+            .path = "../../sdk/storage/queues",
+        },
+        .azure_sdk_storage_files_shares = .{
+            .path = "../../sdk/storage/files/shares",
+        },
+        .azure_sdk_storage_files_datalake = .{
+            .path = "../../sdk/storage/files/datalake",
+        },
+        .azure_sdk_keyvault = .{
+            .path = "../../sdk/keyvault",
+        },
+        .azure_sdk_data_tables = .{
+            .path = "../../sdk/data/tables",
+        },
+        .azure_sdk_data_cosmos = .{
+            .path = "../../sdk/data/cosmos",
+        },
+        .azure_sdk_data_appconfiguration = .{
+            .path = "../../sdk/data/appconfiguration",
+        },
+        .azure_sdk_attestation = .{
+            .path = "../../sdk/attestation",
+        },
+        .azure_sdk_messaging_common = .{
+            .path = "../../sdk/messaging/common",
+        },
+        .azure_sdk_eventhubs = .{
+            .path = "../../sdk/messaging/eventhubs",
+        },
+        .azure_sdk_servicebus = .{
+            .path = "../../sdk/messaging/servicebus",
+        },
+        .azure_sdk_kusto_common = .{
+            .path = "../../sdk/kusto/common",
+        },
+        .azure_sdk_kusto_data = .{
+            .path = "../../sdk/kusto/data",
+        },
+        .azure_sdk_kusto_ingest = .{
+            .path = "../../sdk/kusto/ingest",
+        },
+        .uamqp = .{
+            .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",
+            .hash = "uamqp-0.1.0-lXMcafDqAQD3LSUZbUbyfrWhQfGG7OevKFUwhWxvGZDU",
+        },
+        .serde = .{
+            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
+            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+        },
+    },
+    .paths = .{
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "test",
+        "README.md",
+        "LICENSE.txt",
+    },
+}

--- a/sdk/aggregate/test/all_modules.zig
+++ b/sdk/aggregate/test/all_modules.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+
+const azure_sdk_core_tracing = @import("azure_sdk_core_tracing");
+const azure_sdk_core_perf = @import("azure_sdk_core_perf");
+const azure_sdk_core_amqp = @import("azure_sdk_core_amqp");
+const azure_sdk_core = @import("azure_sdk_core");
+const azure_sdk_core_testing = @import("azure_sdk_core_testing");
+const azure_rest_arm_avs = @import("azure_rest_arm_avs");
+const azure_rest_keyvault_secrets = @import("azure_rest_keyvault_secrets");
+const azure_rest_container_registry = @import("azure_rest_container_registry");
+const azure_sdk_container_registry = @import("azure_sdk_container_registry");
+const azure_sdk_storage_common = @import("azure_sdk_storage_common");
+const azure_sdk_storage_blobs = @import("azure_sdk_storage_blobs");
+const azure_sdk_storage_queues = @import("azure_sdk_storage_queues");
+const azure_sdk_storage_files_shares = @import("azure_sdk_storage_files_shares");
+const azure_sdk_storage_files_datalake = @import("azure_sdk_storage_files_datalake");
+const azure_sdk_keyvault = @import("azure_sdk_keyvault");
+const azure_sdk_data_tables = @import("azure_sdk_data_tables");
+const azure_sdk_data_cosmos = @import("azure_sdk_data_cosmos");
+const azure_sdk_data_appconfiguration = @import("azure_sdk_data_appconfiguration");
+const azure_sdk_attestation = @import("azure_sdk_attestation");
+const azure_sdk_messaging_common = @import("azure_sdk_messaging_common");
+const azure_sdk_eventhubs = @import("azure_sdk_eventhubs");
+const azure_sdk_servicebus = @import("azure_sdk_servicebus");
+const azure_sdk_kusto_common = @import("azure_sdk_kusto_common");
+const azure_sdk_kusto_data = @import("azure_sdk_kusto_data");
+const azure_sdk_kusto_ingest = @import("azure_sdk_kusto_ingest");
+
+test "aggregate exports every canonical module" {
+    _ = azure_sdk_core_tracing;
+    _ = azure_sdk_core_perf;
+    _ = azure_sdk_core_amqp;
+    _ = azure_sdk_core;
+    _ = azure_sdk_core_testing;
+    _ = azure_rest_arm_avs;
+    _ = azure_rest_keyvault_secrets;
+    _ = azure_rest_container_registry;
+    _ = azure_sdk_container_registry;
+    _ = azure_sdk_storage_common;
+    _ = azure_sdk_storage_blobs;
+    _ = azure_sdk_storage_queues;
+    _ = azure_sdk_storage_files_shares;
+    _ = azure_sdk_storage_files_datalake;
+    _ = azure_sdk_keyvault;
+    _ = azure_sdk_data_tables;
+    _ = azure_sdk_data_cosmos;
+    _ = azure_sdk_data_appconfiguration;
+    _ = azure_sdk_attestation;
+    _ = azure_sdk_messaging_common;
+    _ = azure_sdk_eventhubs;
+    _ = azure_sdk_servicebus;
+    _ = azure_sdk_kusto_common;
+    _ = azure_sdk_kusto_data;
+    _ = azure_sdk_kusto_ingest;
+
+    try std.testing.expectEqualStrings("0.1.0", azure_sdk_core.version);
+    try std.testing.expect(@sizeOf(azure_sdk_kusto_ingest.StreamingIngestTarget) > 0);
+}


### PR DESCRIPTION
## Summary
- add the `azure_sdk` aggregate package and export all 25 canonical modules
- normalize shared dependency module ownership and add direct/aggregate consumer fixtures
- make the root workspace orchestration-only with registry-ordered package tests
- mark all 26 release packages as independently buildable

## Validation
- aggregate and consumer fixture tests
- package registry and archive-boundary validation
- full registry-ordered workspace suite
- Windows cross-compilation of the aggregate-backed root example