### PR TITLE
Curate SDK package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,11 @@
 
 Azure service clients implemented in pure Zig without C dependencies.
 
-## Packages
+## SDK Packages
 
 | Package | Documentation |
 | --- | --- |
-| [`azure_sdk_core_tracing`](sdk/core/tracing/README.md) | Core tracing |
-| [`azure_sdk_core_perf`](sdk/core/perf/README.md) | Core performance helpers |
-| [`azure_sdk_core_amqp`](sdk/core/amqp/README.md) | AMQP core integration |
-| [`azure_sdk_core`](sdk/core/README.md) | HTTP pipeline, identity, and shared primitives |
-| [`azure_sdk_core_testing`](sdk/core/testing/README.md) | Core test support |
-| [`azure_rest_arm_avs`](rest/arm_avs/README.md) | ARM AVS generated protocol |
-| [`azure_rest_keyvault_secrets`](rest/keyvault_secrets/README.md) | Key Vault Secrets generated protocol |
-| [`azure_rest_container_registry`](rest/container_registry/README.md) | Container Registry generated protocol |
 | [`azure_sdk_container_registry`](sdk/container_registry/README.md) | Container Registry client |
-| [`azure_sdk_storage_common`](sdk/storage/common/README.md) | Storage shared primitives |
 | [`azure_sdk_storage_blobs`](sdk/storage/blobs/README.md) | Blob Storage |
 | [`azure_sdk_storage_queues`](sdk/storage/queues/README.md) | Queue Storage |
 | [`azure_sdk_storage_files_shares`](sdk/storage/files/shares/README.md) | Azure Files shares |
@@ -28,10 +19,8 @@ Azure service clients implemented in pure Zig without C dependencies.
 | [`azure_sdk_data_cosmos`](sdk/data/cosmos/README.md) | Cosmos DB |
 | [`azure_sdk_data_appconfiguration`](sdk/data/appconfiguration/README.md) | App Configuration |
 | [`azure_sdk_attestation`](sdk/attestation/README.md) | Attestation |
-| [`azure_sdk_messaging_common`](sdk/messaging/common/README.md) | Messaging shared primitives |
 | [`azure_sdk_eventhubs`](sdk/messaging/eventhubs/README.md) | Event Hubs and Blob checkpoint store |
 | [`azure_sdk_servicebus`](sdk/messaging/servicebus/README.md) | Service Bus |
-| [`azure_sdk_kusto_common`](sdk/kusto/common/README.md) | Kusto shared primitives |
 | [`azure_sdk_kusto_data`](sdk/kusto/data/README.md) | Kusto queries and management |
 | [`azure_sdk_kusto_ingest`](sdk/kusto/ingest/README.md) | Kusto ingestion |
 

--- a/doc/package-catalog.md
+++ b/doc/package-catalog.md
@@ -6,7 +6,10 @@ canonical packages start at `0.1.0`; package-scoped release tags use
 
 Every entry has a package-local build and can be versioned independently. The
 root `azure_sdk_workspace` package is integration-only and is not part of this
-release catalog.
+release catalog. The root README presents only service-facing SDKs; this
+catalog includes every independently versioned SDK and REST package.
+
+## SDK Packages
 
 | Package | Source documentation | Branch | State |
 | --- | --- | --- | --- |
@@ -15,9 +18,6 @@ release catalog.
 | `azure_sdk_core_amqp` | [Core AMQP](../sdk/core/amqp/README.md) | `sdk/core_amqp` | package |
 | `azure_sdk_core` | [Core](../sdk/core/README.md) | `sdk/core` | package |
 | `azure_sdk_core_testing` | [Core Testing](../sdk/core/testing/README.md) | `sdk/core_testing` | package |
-| `azure_rest_arm_avs` | [ARM AVS REST](../rest/arm_avs/README.md) | `rest/arm_avs` | package |
-| `azure_rest_keyvault_secrets` | [Key Vault Secrets REST](../rest/keyvault_secrets/README.md) | `rest/keyvault_secrets` | package |
-| `azure_rest_container_registry` | [Container Registry REST](../rest/container_registry/README.md) | `rest/container_registry` | package |
 | `azure_sdk_container_registry` | [Container Registry SDK](../sdk/container_registry/README.md) | `sdk/container_registry` | package |
 | `azure_sdk_storage_common` | [Storage Common](../sdk/storage/common/README.md) | `sdk/storage_common` | package |
 | `azure_sdk_storage_blobs` | [Storage Blobs](../sdk/storage/blobs/README.md) | `sdk/storage_blobs` | package |
@@ -35,3 +35,11 @@ release catalog.
 | `azure_sdk_kusto_common` | [Kusto Common](../sdk/kusto/common/README.md) | `sdk/kusto_common` | package |
 | `azure_sdk_kusto_data` | [Kusto Data](../sdk/kusto/data/README.md) | `sdk/kusto_data` | package |
 | `azure_sdk_kusto_ingest` | [Kusto Ingest](../sdk/kusto/ingest/README.md) | `sdk/kusto_ingest` | package |
+
+## REST Packages
+
+| Package | Source documentation | Branch | State |
+| --- | --- | --- | --- |
+| `azure_rest_arm_avs` | [ARM AVS REST](../rest/arm_avs/README.md) | `rest/arm_avs` | package |
+| `azure_rest_keyvault_secrets` | [Key Vault Secrets REST](../rest/keyvault_secrets/README.md) | `rest/keyvault_secrets` | package |
+| `azure_rest_container_registry` | [Container Registry REST](../rest/container_registry/README.md) | `rest/container_registry` | package |

--- a/eng/package_tool.zig
+++ b/eng/package_tool.zig
@@ -70,14 +70,6 @@ fn check(allocator: std.mem.Allocator, io: std.Io) !void {
         if (std.mem.indexOf(u8, catalog, entry.name) == null) {
             return error.PackageMissingFromCatalog;
         }
-        const root_index_link = try std.fmt.allocPrint(
-            allocator,
-            "[`{s}`]({s}/README.md)",
-            .{ entry.name, entry.source_path },
-        );
-        if (std.mem.indexOf(u8, root_readme, root_index_link) == null) {
-            return error.PackageMissingFromRootIndex;
-        }
 
         if (entry.state == .package) {
             const build_path = try std.fs.path.join(
@@ -101,7 +93,7 @@ fn checkRootReadme(readme: []const u8) !void {
         return error.InvalidRootReadmeTitle;
     }
     const expected = [_][]const u8{
-        "## Packages",
+        "## SDK Packages",
         "## Documentation",
         "## License",
     };


### PR DESCRIPTION
## Summary
- list only service-facing SDK packages in the root README
- split the complete package catalog into SDK and REST sections
- keep catalog completeness validation while allowing a curated root index

## Validation
- `zig build package-check --summary all`
- `zig build docs-check --summary all`
- `zig build test --summary all`
- `zig fmt --check eng/package_tool.zig`
- `git diff --check`