### PR TITLE
Move example index into documentation

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -28,7 +28,7 @@ jobs:
           version: 0.16.0
 
       - name: Format check
-        run: zig fmt --check sdk/core/ examples/ codegen/ eng/ build.zig
+        run: zig fmt --check sdk/core/ codegen/ eng/ build.zig
 
       - name: Build workspace
         run: zig build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ zig build
 zig build test --summary all
 zig build package-check --summary all
 zig build package-history-check --summary all
-zig fmt sdk/core/ examples/ codegen/ eng/ build.zig
-zig fmt --check sdk/core/ examples/ codegen/ eng/ build.zig
+zig fmt sdk/core/ codegen/ eng/ build.zig
+zig fmt --check sdk/core/ codegen/ eng/ build.zig
 ```
 
 ## Source ownership
@@ -22,10 +22,9 @@ zig fmt --check sdk/core/ examples/ codegen/ eng/ build.zig
 
 ## Repository structure
 
-- `sdk/core/` — Main-owned framework and credentials
+- `sdk/core/` — Main-owned framework, credentials, and Core examples
 - `eng/` — package registry, validation, history, and release tooling
 - `codegen/` — TypeSpec and fixture-based package generation
-- `examples/` — Main-owned examples
 
 Branch-owned source is available from the package branches documented in
 `doc/package-catalog.md`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ dependencies, and validation commands.
 ## Documentation
 
 - [Development](doc/development.md)
+- [Examples](doc/examples.md)
 - [Package branch model](doc/package-branch-model.md)
 - [Releasing packages](doc/releasing-packages.md)
 - [Package reset record](doc/package-reset-2026-07-24.md)

--- a/build.zig
+++ b/build.zig
@@ -185,7 +185,7 @@ fn addExample(
     const example = b.addExecutable(.{
         .name = "azure_example",
         .root_module = b.createModule(.{
-            .root_source_file = b.path("examples/hello.zig"),
+            .root_source_file = b.path("sdk/core/examples/hello.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,7 @@
 # Documentation
 
 - [Development](development.md)
+- [Examples](examples.md)
 - [Package catalog](package-catalog.md)
 - [Package branch model](package-branch-model.md)
 - [Releasing packages](releasing-packages.md)

--- a/doc/development.md
+++ b/doc/development.md
@@ -11,7 +11,7 @@ zig build
 zig build test --summary all
 zig build package-check --summary all
 zig build package-history-check --summary all
-zig fmt --check sdk/core/ examples/ codegen/ eng/ build.zig
+zig fmt --check sdk/core/ codegen/ eng/ build.zig
 ```
 
 Root package tests intentionally run only the five Main-owned Core packages.

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -4,12 +4,13 @@ Examples are owned by the package or package family they demonstrate. They use
 environment variables rather than embedded endpoints or credentials and avoid
 printing authorization headers, service-issued SAS URIs, or payloads.
 
+- [Core example](../sdk/core/examples/hello.zig)
 - [Kusto examples and live tests](https://github.com/cataggar/azure-sdk-for-zig/tree/example/kusto)
 - [Container Registry examples](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/container_registry#examples)
 - [ARM AVS generated examples](https://github.com/cataggar/azure-sdk-for-zig/tree/example/arm_avs)
 
 The current workspace example commands are documented in
-[`doc/development.md`](../doc/development.md).
+[`development.md`](development.md).
 
 The package reset moved the staged Kusto project to the standalone
 [`example/kusto`](https://github.com/cataggar/azure-sdk-for-zig/tree/example/kusto)

--- a/sdk/core/examples/hello.zig
+++ b/sdk/core/examples/hello.zig
@@ -1,3 +1,5 @@
+//! Main-owned Core SDK example.
+
 const std = @import("std");
 const core = @import("azure_sdk_core");
 


### PR DESCRIPTION
## Summary

- move the example index to `doc/examples.md`
- move the Core demo under `sdk/core/examples`
- remove the top-level `examples` directory and update build, CI, and documentation paths