### PR TITLE
codegen: XML client support — compile & deserialize live Azure XML

### DIFF
--- a/codegen/cli/build.zig.zon
+++ b/codegen/cli/build.zig.zon
@@ -8,8 +8,8 @@
             .path = "../../sdk/core",
         },
         .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
-            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+            .url = "git+https://github.com/cataggar/serde.zig#f0a50369cb4188961047a3922ad01e03ed928b45",
+            .hash = "serde-1.0.1-1DszT8jXDAB_pa3Zn5LX9v5L46vhXhQkbcF10yOuSkRu",
         },
     },
     .paths = .{

--- a/codegen/cli/build.zig.zon
+++ b/codegen/cli/build.zig.zon
@@ -8,8 +8,8 @@
             .path = "../../sdk/core",
         },
         .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#f0a50369cb4188961047a3922ad01e03ed928b45",
-            .hash = "serde-1.0.1-1DszT8jXDAB_pa3Zn5LX9v5L46vhXhQkbcF10yOuSkRu",
+            .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
+            .hash = "serde-1.0.1-1DszT1XhDACnteUU3yWahMMjLjkJqB34hwROPIfhZc7l",
         },
     },
     .paths = .{

--- a/codegen/cli/src/codemodel.zig
+++ b/codegen/cli/src/codemodel.zig
@@ -191,6 +191,12 @@ pub const Model = struct {
     /// Type accepted for undeclared JSON properties. Null means the
     /// model is closed.
     additional_properties: ?TypeRef = null,
+    /// True when any property carries XML serialization options; drives
+    /// whether the emitter renders an XML-flavored `serde` decl.
+    is_xml: bool = false,
+    /// Root XML element name (from `@xml.name`/`@encodedName`), used when
+    /// the model is the top-level element of a request/response body.
+    xml_name: ?[]const u8 = null,
 };
 
 pub const Field = struct {
@@ -202,6 +208,26 @@ pub const Field = struct {
     read_only: bool = false,
     flatten: bool = false,
     multipart: ?MultipartField = null,
+    /// XML serialization options for this property, when present.
+    xml: ?XmlField = null,
+};
+
+pub const XmlField = struct {
+    /// Element (or attribute) name.
+    name: []const u8,
+    /// True when the property is an XML attribute rather than a child element.
+    attribute: bool = false,
+    /// When false (the default for arrays), the property is a wrapper element
+    /// named `name` containing repeated `items_name` child elements.
+    unwrapped: bool = false,
+    /// Child element name for wrapped arrays.
+    items_name: ?[]const u8 = null,
+    ns: ?XmlNs = null,
+};
+
+pub const XmlNs = struct {
+    namespace: []const u8,
+    prefix: []const u8,
 };
 
 pub const MultipartField = struct {

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -878,7 +878,9 @@ fn renderUrlBuild(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method,
 
     for (m.query_parameters, 0..) |qp, index| {
         if (exclude_marker and std.mem.eql(u8, qp.wire_name, "marker")) continue;
-        if (qp.optional and qp.source.name != null) {
+        if (queryParamArrayElement(m, qp)) |elem| {
+            try renderArrayQueryAppend(allocator, w, qp, elem);
+        } else if (qp.optional and qp.source.name != null) {
             const user_id = try ids.quoteIfNeeded(allocator, qp.source.name.?);
             defer allocator.free(user_id);
             try renderOptionalAppendNoRequired(w, user_id, qp.wire_name, innerOptionKind(m, qp));
@@ -1039,6 +1041,99 @@ fn renderOptionalAppendNoRequired(
             \\        }}
             \\
         , .{ user_id, wire_name }),
+    }
+}
+
+/// If `qp` maps to a user parameter whose (optionally-unwrapped) type is an
+/// array, return the array element TypeRef; otherwise null. Array-valued query
+/// parameters (e.g. blob `include`) are serialized as a comma-joined list.
+fn queryParamArrayElement(m: cm.Method, qp: cm.WireParameter) ?cm.TypeRef {
+    if (!std.mem.eql(u8, qp.source.kind, "user")) return null;
+    const name = qp.source.name orelse return null;
+    for (m.user_parameters) |p| {
+        if (!std.mem.eql(u8, p.name, name)) continue;
+        var t = p.param_type;
+        if (t.isOption()) t = nestedTypeRef(t);
+        if (!t.isArray()) return null;
+        return nestedTypeRef(t);
+    }
+    return null;
+}
+
+/// Render a comma-joined, percent-encoded query parameter for an array-valued
+/// user parameter. Enum elements use `.toWire()`; scalar strings pass through;
+/// numeric/boolean elements are formatted inline.
+fn renderArrayQueryAppend(
+    allocator: std.mem.Allocator,
+    w: *std.Io.Writer,
+    qp: cm.WireParameter,
+    elem: cm.TypeRef,
+) !void {
+    const user_id = try ids.quoteIfNeeded(allocator, qp.source.name orelse "<missing>");
+    defer allocator.free(user_id);
+    const kind = classifyTypeRef(elem);
+    const item_expr: []const u8 = switch (kind) {
+        .enum_or_union => "item.toWire()",
+        .boolean => "if (item) \"true\" else \"false\"",
+        else => "item",
+    };
+
+    // Optional arrays are guarded with `if (list) |items|`; required arrays
+    // iterate the slice directly.
+    if (qp.optional) {
+        try w.print("        if ({s}) |items| {{\n", .{user_id});
+    } else {
+        try w.print("        {{\n            const items = {s};\n", .{user_id});
+    }
+
+    switch (kind) {
+        .numeric => try w.print(
+            \\            var list_buf: std.ArrayList(u8) = .empty;
+            \\            defer list_buf.deinit(alloc);
+            \\            for (items, 0..) |item, i| {{
+            \\                if (i != 0) try list_buf.append(alloc, ',');
+            \\                try list_buf.print(alloc, "{{d}}", .{{item}});
+            \\            }}
+            \\
+        , .{}),
+        else => try w.print(
+            \\            var list_buf: std.ArrayList(u8) = .empty;
+            \\            defer list_buf.deinit(alloc);
+            \\            for (items, 0..) |item, i| {{
+            \\                if (i != 0) try list_buf.append(alloc, ',');
+            \\                try list_buf.appendSlice(alloc, {s});
+            \\            }}
+            \\
+        , .{item_expr}),
+    }
+
+    try w.print(
+        \\            if (items.len != 0) {{
+        \\                const sep: []const u8 = if (has_query) "&" else "?";
+        \\                const enc = try core.url.percentEncode(alloc, list_buf.items);
+        \\                defer alloc.free(enc);
+        \\                try url_buf.print(alloc, "{{s}}{s}={{s}}", .{{ sep, enc }});
+        \\                has_query = true;
+        \\            }}
+        \\        }}
+        \\
+    , .{qp.wire_name});
+}
+
+/// Unwrap a single-nested TypeRef (`Option`/`Array`/`Map`) whose element type
+/// is stored as an object `{ kind, value }` in `.value`.
+fn nestedTypeRef(t: cm.TypeRef) cm.TypeRef {
+    switch (t.value) {
+        .object => |o| {
+            const kind_v = o.get("kind") orelse return t;
+            const kind = switch (kind_v) {
+                .string => |s| s,
+                else => return t,
+            };
+            const value_v = o.get("value") orelse std.json.Value{ .null = {} };
+            return .{ .kind = kind, .value = value_v };
+        },
+        else => return t,
     }
 }
 
@@ -1211,6 +1306,26 @@ fn renderRequestSetup(
             }
         } else if (std.mem.eql(u8, bp.serialization_kind, "multipart")) {
             try renderMultipartBody(allocator, w, model, bp, id);
+        } else if (std.mem.eql(u8, bp.serialization_kind, "xml")) {
+            if (bodyParameterIsOptional(m)) {
+                try w.print(
+                    \\        var body_xml: ?[]u8 = null;
+                    \\        defer if (body_xml) |bytes| alloc.free(bytes);
+                    \\        if ({s}) |body| {{
+                    \\            const bytes = try serde.xml.toSlice(alloc, body);
+                    \\            body_xml = bytes;
+                    \\            req.body = bytes;
+                    \\        }}
+                    \\
+                , .{id});
+            } else {
+                try w.print(
+                    \\        const body_xml = try serde.xml.toSlice(alloc, {s});
+                    \\        defer alloc.free(body_xml);
+                    \\        req.body = body_xml;
+                    \\
+                , .{id});
+            }
         } else {
             if (bodyParameterIsOptional(m)) {
                 try w.print(
@@ -1466,7 +1581,7 @@ fn renderProtocolBody(
         for (response.status_codes) |status| {
             const code = statusInteger(status) orelse continue;
             try w.print("            {d} => {{\n", .{code});
-            try renderProtocolVariantReturn(allocator, w, response, code);
+            try renderProtocolVariantReturn(allocator, w, model, response, code);
             try w.writeAll("            },\n");
         }
     }
@@ -1483,50 +1598,12 @@ fn renderProtocolBody(
 fn renderProtocolVariantReturn(
     allocator: std.mem.Allocator,
     w: *std.Io.Writer,
+    model: cm.CodeModel,
     response: cm.ResponseVariant,
     status: u16,
 ) !void {
     for (response.headers, 0..) |header, index| {
-        if (header.header_type.isScalar() and
-            std.mem.eql(u8, header.header_type.scalarName() orelse "", "int64"))
-        {
-            if (header.optional) {
-                try w.print(
-                    \\                const response_header_{d}: ?i64 = if (resp.getHeader("{s}")) |value|
-                    \\                    try std.fmt.parseInt(i64, value, 10)
-                    \\                else
-                    \\                    null;
-                    \\
-                , .{ index, header.wire_name });
-            } else {
-                try w.print(
-                    \\                const response_header_{d} = try std.fmt.parseInt(
-                    \\                    i64,
-                    \\                    resp.getHeader("{s}") orelse return error.MissingResponseHeader,
-                    \\                    10,
-                    \\                );
-                    \\
-                , .{ index, header.wire_name });
-            }
-        } else if (header.optional) {
-            try w.print(
-                \\                const response_header_{d} = if (resp.getHeader("{s}")) |value|
-                \\                    try alloc.dupe(u8, value)
-                \\                else
-                \\                    null;
-                \\                errdefer if (response_header_{d}) |value| alloc.free(value);
-                \\
-            , .{ index, header.wire_name, index });
-        } else {
-            try w.print(
-                \\                const response_header_{d} = try alloc.dupe(
-                \\                    u8,
-                \\                    resp.getHeader("{s}") orelse return error.MissingResponseHeader,
-                \\                );
-                \\                errdefer alloc.free(response_header_{d});
-                \\
-            , .{ index, header.wire_name, index });
-        }
+        try renderResponseHeaderExtract(allocator, w, model, header, index);
     }
 
     const emits_body = response.response_type != null and
@@ -1537,6 +1614,13 @@ fn renderProtocolVariantReturn(
             defer allocator.free(ty);
             try w.print(
                 \\                const response_body = try serde.json.fromSlice({s}, alloc, resp.body);
+                \\
+            , .{ty});
+        } else if (std.mem.eql(u8, response.body_kind, "xml")) {
+            const ty = try types.renderType(allocator, response.response_type.?, .clients);
+            defer allocator.free(ty);
+            try w.print(
+                \\                const response_body = try serde.xml.fromSlice({s}, alloc, resp.body);
                 \\
             , .{ty});
         } else {
@@ -1573,6 +1657,170 @@ fn renderProtocolVariantReturn(
         \\                } };
         \\
     );
+}
+
+/// Extract a single response header into a `response_header_{index}` local
+/// typed to match the generated struct field. Strings duplicate the raw
+/// value; integers/floats/booleans parse; enums use `fromWire` (open enums
+/// take the allocator to own an `unrecognized` value).
+fn renderResponseHeaderExtract(
+    allocator: std.mem.Allocator,
+    w: *std.Io.Writer,
+    model: cm.CodeModel,
+    header: cm.ResponseHeader,
+    index: usize,
+) !void {
+    var inner = header.header_type;
+    if (inner.isOption()) inner = unwrapOptionTypeRef(inner);
+    const optional = header.optional or header.header_type.isOption();
+    const zt = try types.renderType(allocator, inner, .clients);
+    defer allocator.free(zt);
+    const wire = header.wire_name;
+
+    // Enum header: parse the wire value into the enum via `fromWire`.
+    if (std.mem.startsWith(u8, zt, "enums.")) {
+        const extensible = enumIsExtensible(model, inner);
+        if (optional and extensible) {
+            try w.print(
+                \\                const response_header_{d}: ?{s} = if (resp.getHeader("{s}")) |value|
+                \\                    try {s}.fromWire(alloc, value)
+                \\                else
+                \\                    null;
+                \\
+            , .{ index, zt, wire, zt });
+        } else if (optional) {
+            try w.print(
+                \\                const response_header_{d}: ?{s} = if (resp.getHeader("{s}")) |value|
+                \\                    {s}.fromWire(value)
+                \\                else
+                \\                    null;
+                \\
+            , .{ index, zt, wire, zt });
+        } else if (extensible) {
+            try w.print(
+                \\                const response_header_{d} = try {s}.fromWire(
+                \\                    alloc,
+                \\                    resp.getHeader("{s}") orelse return error.MissingResponseHeader,
+                \\                );
+                \\
+            , .{ index, zt, wire });
+        } else {
+            try w.print(
+                \\                const response_header_{d} = {s}.fromWire(
+                \\                    resp.getHeader("{s}") orelse return error.MissingResponseHeader,
+                \\                ) orelse return error.UnexpectedResponseHeaderValue;
+                \\
+            , .{ index, zt, wire });
+        }
+        return;
+    }
+
+    // Boolean header.
+    if (std.mem.eql(u8, zt, "bool")) {
+        if (optional) {
+            try w.print(
+                \\                const response_header_{d}: ?bool = if (resp.getHeader("{s}")) |value|
+                \\                    std.mem.eql(u8, value, "true")
+                \\                else
+                \\                    null;
+                \\
+            , .{ index, wire });
+        } else {
+            try w.print(
+                \\                const response_header_{d} = std.mem.eql(u8, resp.getHeader("{s}") orelse return error.MissingResponseHeader, "true");
+                \\
+            , .{ index, wire });
+        }
+        return;
+    }
+
+    // Integer header.
+    if (isZigIntType(zt)) {
+        if (optional) {
+            try w.print(
+                \\                const response_header_{d}: ?{s} = if (resp.getHeader("{s}")) |value|
+                \\                    try std.fmt.parseInt({s}, value, 10)
+                \\                else
+                \\                    null;
+                \\
+            , .{ index, zt, wire, zt });
+        } else {
+            try w.print(
+                \\                const response_header_{d} = try std.fmt.parseInt(
+                \\                    {s},
+                \\                    resp.getHeader("{s}") orelse return error.MissingResponseHeader,
+                \\                    10,
+                \\                );
+                \\
+            , .{ index, zt, wire });
+        }
+        return;
+    }
+
+    // Float header.
+    if (std.mem.eql(u8, zt, "f32") or std.mem.eql(u8, zt, "f64")) {
+        if (optional) {
+            try w.print(
+                \\                const response_header_{d}: ?{s} = if (resp.getHeader("{s}")) |value|
+                \\                    try std.fmt.parseFloat({s}, value)
+                \\                else
+                \\                    null;
+                \\
+            , .{ index, zt, wire, zt });
+        } else {
+            try w.print(
+                \\                const response_header_{d} = try std.fmt.parseFloat(
+                \\                    {s},
+                \\                    resp.getHeader("{s}") orelse return error.MissingResponseHeader,
+                \\                );
+                \\
+            , .{ index, zt, wire });
+        }
+        return;
+    }
+
+    // String (and any other) header: duplicate the raw value.
+    if (optional) {
+        try w.print(
+            \\                const response_header_{d} = if (resp.getHeader("{s}")) |value|
+            \\                    try alloc.dupe(u8, value)
+            \\                else
+            \\                    null;
+            \\                errdefer if (response_header_{d}) |value| alloc.free(value);
+            \\
+        , .{ index, wire, index });
+    } else {
+        try w.print(
+            \\                const response_header_{d} = try alloc.dupe(
+            \\                    u8,
+            \\                    resp.getHeader("{s}") orelse return error.MissingResponseHeader,
+            \\                );
+            \\                errdefer alloc.free(response_header_{d});
+            \\
+        , .{ index, wire, index });
+    }
+}
+
+fn isZigIntType(s: []const u8) bool {
+    const ints = [_][]const u8{ "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64" };
+    for (ints) |i| {
+        if (std.mem.eql(u8, s, i)) return true;
+    }
+    return false;
+}
+
+fn enumIsExtensible(model: cm.CodeModel, t: cm.TypeRef) bool {
+    const name = t.namedTypeName() orelse return true;
+    for (model.enums) |e| {
+        if (std.mem.eql(u8, e.name, name)) return e.extensible;
+    }
+    return true;
+}
+
+/// Unwrap an `Option` TypeRef to its inner type.
+fn unwrapOptionTypeRef(t: cm.TypeRef) cm.TypeRef {
+    if (!t.isOption()) return t;
+    return nestedTypeRef(t);
 }
 
 fn renderExpectedStatuses(
@@ -1629,6 +1877,17 @@ pub fn renderModels(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
     for (model.models) |m| {
         if (m.doc) |d| try renderDocComment(w, d);
         try w.print("pub const {s} = struct {{\n", .{m.name});
+        // Azure services routinely omit nominally-required fields from
+        // response bodies (e.g. a blob listing omits `<Deleted>`/`<Snapshot>`
+        // for a normal blob). Match azure-sdk-for-rust, whose generated
+        // response models make every field optional, by treating fields of
+        // output-usage models as optional so deserialization tolerates the
+        // absence. Wrapped arrays already default to an empty collection.
+        // Restrict this to PURELY-output models: a model also used as a
+        // request body (`is_input`) keeps its declared optionality so
+        // request-side code (multipart bodies, header sources, serialization)
+        // can access required fields without unwrapping.
+        const force_optional = m.is_output and !m.is_input;
         for (m.fields) |f| {
             if (f.doc) |d| {
                 try w.writeAll("    ");
@@ -1648,9 +1907,10 @@ pub fn renderModels(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
                 }
                 continue;
             }
-            const ty = try renderFieldType(allocator, f.field_type, f.optional, .models);
+            const opt = f.optional or force_optional;
+            const ty = try renderFieldType(allocator, f.field_type, opt, .models);
             defer allocator.free(ty);
-            if (f.optional) {
+            if (opt) {
                 try w.print("    {s}: {s} = null,\n", .{ id, ty });
             } else {
                 try w.print("    {s}: {s},\n", .{ id, ty });
@@ -2048,12 +2308,15 @@ fn renderEnums(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
     errdefer aw.deinit();
     const w = &aw.writer;
 
-    var any_extensible = false;
+    var any_needs_core = false;
     for (model.enums) |e| {
         if (e.extensible) {
-            any_extensible = true;
+            any_needs_core = true;
             break;
         }
+        // Fixed enums with values now emit serde hooks that call
+        // `core.fixed_enum`, so they need the core import too.
+        if (e.values.len > 0) any_needs_core = true;
     }
 
     try w.writeAll(
@@ -2067,7 +2330,7 @@ fn renderEnums(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         \\const std = @import("std");
         \\
     );
-    if (any_extensible) {
+    if (any_needs_core) {
         try w.writeAll(
             \\const core = @import("azure_sdk_core");
             \\
@@ -2114,6 +2377,10 @@ fn renderEnums(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
                 \\    pub fn toWire(self: @This()) []const u8 {
                 \\        return core.open_enum.toWire(self, wire_names);
                 \\    }
+                \\
+                \\    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+                \\        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+                \\    }
                 \\};
                 \\
                 \\
@@ -2126,6 +2393,49 @@ fn renderEnums(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
                 const tag = try ids.quoteIfNeeded(allocator, snake);
                 defer allocator.free(tag);
                 try w.print("    {s},\n", .{tag});
+            }
+            if (e.values.len > 0) {
+                // toWire: map each variant to its fixed wire string.
+                try w.writeAll("\n    pub fn toWire(self: @This()) []const u8 {\n        return switch (self) {\n");
+                for (e.values) |v| {
+                    const snake = try naming.toSnakeCase(allocator, v.name);
+                    defer allocator.free(snake);
+                    const tag = try ids.quoteIfNeeded(allocator, snake);
+                    defer allocator.free(tag);
+                    const wire = wireNameForEnumValue(v);
+                    try w.print("            .{s} => \"{s}\",\n", .{ tag, wire });
+                }
+                try w.writeAll("        };\n    }\n\n");
+                // fromWire: parse a wire string into a variant, or null if unknown.
+                try w.writeAll("    pub fn fromWire(s: []const u8) ?@This() {\n");
+                for (e.values) |v| {
+                    const snake = try naming.toSnakeCase(allocator, v.name);
+                    defer allocator.free(snake);
+                    const tag = try ids.quoteIfNeeded(allocator, snake);
+                    defer allocator.free(tag);
+                    const wire = wireNameForEnumValue(v);
+                    try w.print("        if (std.mem.eql(u8, s, \"{s}\")) return .{s};\n", .{ wire, tag });
+                }
+                try w.writeAll("        return null;\n    }\n");
+                // serde hooks: route (de)serialization through the wire mapping
+                // (toWire/fromWire) instead of serde's default enum handling,
+                // which matches by the Zig variant identifier (snake_case) and
+                // would never match the PascalCase wire form.
+                try w.writeAll(
+                    \\
+                    \\    pub fn zerdeDeserialize(
+                    \\        comptime T: type,
+                    \\        allocator: std.mem.Allocator,
+                    \\        deserializer: anytype,
+                    \\    ) @TypeOf(deserializer.*).Error!T {
+                    \\        return core.fixed_enum.deserialize(T, allocator, deserializer);
+                    \\    }
+                    \\
+                    \\    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+                    \\        return core.fixed_enum.serialize(self, serializer);
+                    \\    }
+                    \\
+                );
             }
             try w.writeAll("};\n\n");
         }
@@ -2219,8 +2529,8 @@ fn renderBuildZigZon(
 
     const serde_entry =
         \\        .serde = .{
-        \\            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
-        \\            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+        \\            .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
+        \\            .hash = "serde-1.0.1-1DszT1XhDACnteUU3yWahMMjLjkJqB34hwROPIfhZc7l",
         \\        },
         \\
     ;

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -512,6 +512,30 @@ fn renderSubClientAccessor(w: *std.Io.Writer, parent: cm.Client, sc: cm.SubClien
 
 // ─── method bodies ────────────────────────────────────────────────────
 
+/// True when any success response of `m` is XML (content-type
+/// `application/xml`). Used to route XML list operations to `XmlPager`.
+fn responseIsXml(m: cm.Method) bool {
+    for (m.responses) |response| {
+        for (response.content_types) |ct| {
+            if (std.mem.indexOf(u8, ct, "xml") != null) return true;
+        }
+    }
+    return false;
+}
+
+/// The envelope model returned by an XML list operation's success response.
+/// The convenient `m.response` collapses a paging op to the item array, so
+/// the page envelope (e.g. `ListContainersResponse`) is read from the
+/// protocol response variants instead.
+fn xmlEnvelopeTypeRef(m: cm.Method) ?cm.TypeRef {
+    for (m.responses) |response| {
+        if (response.response_type) |t| {
+            if (t.isModel()) return t;
+        }
+    }
+    return null;
+}
+
 fn usesProtocolResult(m: cm.Method) bool {
     if (m.long_running != null or m.responses.len == 0) return false;
     for (m.responses) |response| {
@@ -629,7 +653,9 @@ fn responseBodyType(
     if (std.mem.eql(u8, response.body_kind, "none") or response.response_type == null) {
         return try allocator.dupe(u8, "void");
     }
-    if (std.mem.eql(u8, response.body_kind, "raw")) {
+    if (std.mem.eql(u8, response.body_kind, "raw") or
+        std.mem.eql(u8, response.body_kind, "multipart"))
+    {
         return try allocator.dupe(u8, "[]const u8");
     }
     return try types.renderType(allocator, response.response_type.?, .clients);
@@ -645,9 +671,11 @@ fn renderMethod(
     if (m.doc) |d| try renderDocComment(w, d);
 
     // Return type depends on method kind.
-    const ReturnKind = enum { void_op, value_op, list_op, lro_op, protocol_op };
+    const ReturnKind = enum { void_op, value_op, list_op, xml_list_op, lro_op, protocol_op };
     const ret_kind: ReturnKind = if (m.long_running != null)
         .lro_op
+    else if ((std.mem.eql(u8, m.kind, "paging") or std.mem.eql(u8, m.kind, "lropaging")) and responseIsXml(m))
+        .xml_list_op
     else if (usesProtocolResult(m))
         .protocol_op
     else if (std.mem.eql(u8, m.kind, "paging") or std.mem.eql(u8, m.kind, "lropaging"))
@@ -671,11 +699,13 @@ fn renderMethod(
     }
     try w.print(") !{s} {{\n", .{ret_str});
 
-    // URL build (path + query) — shared by every kind.
-    try renderUrlBuild(allocator, w, m);
+    // URL build (path + query) — shared by every kind. XML list pagers own
+    // the `marker` query pair, so it is excluded from the base URL here.
+    try renderUrlBuild(allocator, w, m, ret_kind == .xml_list_op);
 
     switch (ret_kind) {
         .list_op => try renderListBody(allocator, w, m),
+        .xml_list_op => try renderXmlListBody(allocator, w, m),
         .void_op => try renderVoidBody(allocator, w, model, c, m),
         .value_op => try renderValueBody(allocator, w, model, c, m),
         .lro_op => try renderLroBody(allocator, w, model, c, m),
@@ -717,6 +747,18 @@ fn renderReturnType(allocator: std.mem.Allocator, m: cm.Method, kind: anytype) !
             }
             break :blk try allocator.dupe(u8, "core.pager.PipelinePager(std.json.Value)");
         },
+        .xml_list_op => blk: {
+            // Each page is the whole XML envelope model (mirrors
+            // azure-sdk-for-rust's `Pager<ListContainersResponse, XmlFormat>`).
+            // The convenient `m.response` collapses to the item array, so the
+            // envelope comes from the protocol response variant.
+            if (xmlEnvelopeTypeRef(m)) |t| {
+                const ty = try types.renderType(allocator, t, .clients);
+                defer allocator.free(ty);
+                break :blk try std.fmt.allocPrint(allocator, "core.pager.XmlPager({s})", .{ty});
+            }
+            break :blk try allocator.dupe(u8, "core.pager.XmlPager(std.json.Value)");
+        },
         .lro_op => blk: {
             const final = if (m.long_running) |l| l.final_response_type else null;
             if (final) |t| {
@@ -741,7 +783,7 @@ fn renderReturnType(allocator: std.mem.Allocator, m: cm.Method, kind: anytype) !
 /// appended afterwards, each gated by `if (param) |v| { ... }`, with
 /// values percent-encoded via `core.url.percentEncode`. The final
 /// owned `[]u8` is exposed as `const url` and freed via `defer`.
-fn renderUrlBuild(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method) !void {
+fn renderUrlBuild(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method, exclude_marker: bool) !void {
     var fmt_buf: std.ArrayList(u8) = .empty;
     defer fmt_buf.deinit(allocator);
     var args_buf: std.ArrayList(u8) = .empty;
@@ -835,6 +877,7 @@ fn renderUrlBuild(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method)
     );
 
     for (m.query_parameters, 0..) |qp, index| {
+        if (exclude_marker and std.mem.eql(u8, qp.wire_name, "marker")) continue;
         if (qp.optional and qp.source.name != null) {
             const user_id = try ids.quoteIfNeeded(allocator, qp.source.name.?);
             defer allocator.free(user_id);
@@ -1042,6 +1085,39 @@ fn renderListBody(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method)
     , .{ item_ty, item_ty });
 }
 
+/// Body for an XML data-plane list operation. Returns a `core.pager.XmlPager`
+/// over the whole envelope model; the pager owns the `marker` query pair and
+/// the `x-ms-version` request header. The initial `marker` user parameter (if
+/// present) seeds the first page.
+fn renderXmlListBody(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method) !void {
+    const env_ty = if (xmlEnvelopeTypeRef(m)) |t|
+        try types.renderType(allocator, t, .clients)
+    else
+        try allocator.dupe(u8, "std.json.Value");
+    defer allocator.free(env_ty);
+
+    var has_marker = false;
+    var has_crid = false;
+    for (m.user_parameters) |p| {
+        if (std.mem.eql(u8, p.name, "marker")) has_marker = true;
+        if (std.mem.eql(u8, p.name, "client_request_id")) has_crid = true;
+    }
+    const marker_arg: []const u8 = if (has_marker) "marker" else "null";
+    const crid_arg: []const u8 = if (has_crid) "client_request_id" else "null";
+
+    try w.print(
+        \\        return core.pager.XmlPager({s}).init(
+        \\            self.pipeline,
+        \\            url,
+        \\            self.api_version,
+        \\            {s},
+        \\            {s},
+        \\            alloc,
+        \\        );
+        \\
+    , .{ env_ty, marker_arg, crid_arg });
+}
+
 fn renderRequestSetup(
     allocator: std.mem.Allocator,
     w: *std.Io.Writer,
@@ -1079,26 +1155,47 @@ fn renderRequestSetup(
                 try w.print("        try req.setHeader(\"{s}\", \"{s}\");\n", .{ hp.wire_name, hp.source.value orelse "" });
             }
         } else {
-            const source_name = hp.source.name orelse continue;
-            const source_id = try ids.quoteIfNeeded(allocator, source_name);
-            defer allocator.free(source_id);
+            if (hp.source.name == null) continue;
+            const value_expr = try sourceExpression(allocator, hp.source);
+            defer allocator.free(value_expr);
             const kind = sourceKind(m, hp.source);
             if (hp.optional) {
-                if (kind == .enum_or_union) {
-                    try w.print(
+                switch (kind) {
+                    .enum_or_union => try w.print(
                         \\        if ({s}) |value| try req.setHeader("{s}", value.toWire());
                         \\
-                    , .{ source_id, hp.wire_name });
-                } else {
-                    try w.print(
+                    , .{ value_expr, hp.wire_name }),
+                    .numeric => try w.print(
+                        \\        if ({s}) |value| {{
+                        \\            const header_val = try std.fmt.allocPrint(alloc, "{{d}}", .{{value}});
+                        \\            defer alloc.free(header_val);
+                        \\            try req.setHeader("{s}", header_val);
+                        \\        }}
+                        \\
+                    , .{ value_expr, hp.wire_name }),
+                    .boolean => try w.print(
+                        \\        if ({s}) |value| try req.setHeader("{s}", if (value) "true" else "false");
+                        \\
+                    , .{ value_expr, hp.wire_name }),
+                    .string_like => try w.print(
                         \\        if ({s}) |value| try req.setHeader("{s}", value);
                         \\
-                    , .{ source_id, hp.wire_name });
+                    , .{ value_expr, hp.wire_name }),
                 }
-            } else if (kind == .enum_or_union) {
-                try w.print("        try req.setHeader(\"{s}\", {s}.toWire());\n", .{ hp.wire_name, source_id });
             } else {
-                try w.print("        try req.setHeader(\"{s}\", {s});\n", .{ hp.wire_name, source_id });
+                switch (kind) {
+                    .enum_or_union => try w.print("        try req.setHeader(\"{s}\", {s}.toWire());\n", .{ hp.wire_name, value_expr }),
+                    .numeric => try w.print(
+                        \\        {{
+                        \\            const header_val = try std.fmt.allocPrint(alloc, "{{d}}", .{{{s}}});
+                        \\            defer alloc.free(header_val);
+                        \\            try req.setHeader("{s}", header_val);
+                        \\        }}
+                        \\
+                    , .{ value_expr, hp.wire_name }),
+                    .boolean => try w.print("        try req.setHeader(\"{s}\", if ({s}) \"true\" else \"false\");\n", .{ hp.wire_name, value_expr }),
+                    .string_like => try w.print("        try req.setHeader(\"{s}\", {s});\n", .{ hp.wire_name, value_expr }),
+                }
             }
         }
     }
@@ -1432,19 +1529,24 @@ fn renderProtocolVariantReturn(
         }
     }
 
-    if (std.mem.eql(u8, response.body_kind, "raw")) {
-        try w.writeAll(
-            \\                const response_body = try bufferRawResponseBody(alloc, resp.body);
-            \\                errdefer alloc.free(response_body);
-            \\
-        );
-    } else if (std.mem.eql(u8, response.body_kind, "json") and response.response_type != null) {
-        const ty = try types.renderType(allocator, response.response_type.?, .clients);
-        defer allocator.free(ty);
-        try w.print(
-            \\                const response_body = try serde.json.fromSlice({s}, alloc, resp.body);
-            \\
-        , .{ty});
+    const emits_body = response.response_type != null and
+        !std.mem.eql(u8, response.body_kind, "none");
+    if (emits_body) {
+        if (std.mem.eql(u8, response.body_kind, "json")) {
+            const ty = try types.renderType(allocator, response.response_type.?, .clients);
+            defer allocator.free(ty);
+            try w.print(
+                \\                const response_body = try serde.json.fromSlice({s}, alloc, resp.body);
+                \\
+            , .{ty});
+        } else {
+            // raw / multipart / other binary bodies are surfaced as bytes.
+            try w.writeAll(
+                \\                const response_body = try bufferRawResponseBody(alloc, resp.body);
+                \\                errdefer alloc.free(response_body);
+                \\
+            );
+        }
     }
 
     try w.print(
@@ -1532,10 +1634,22 @@ pub fn renderModels(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
                 try w.writeAll("    ");
                 try renderDocComment(w, d);
             }
-            const ty = try renderFieldType(allocator, f.field_type, f.optional, .models);
-            defer allocator.free(ty);
             const id = try ids.quoteIfNeeded(allocator, f.name);
             defer allocator.free(id);
+            if (xmlWrappedArray(f) != null) {
+                // Wrapped XML array (e.g. `<Containers><Container>…`): the
+                // property becomes a nested wrapper struct declared below.
+                const wt = try xmlWrapperTypeName(allocator, f);
+                defer allocator.free(wt);
+                if (f.optional) {
+                    try w.print("    {s}: ?{s} = null,\n", .{ id, wt });
+                } else {
+                    try w.print("    {s}: {s} = .{{}},\n", .{ id, wt });
+                }
+                continue;
+            }
+            const ty = try renderFieldType(allocator, f.field_type, f.optional, .models);
+            defer allocator.free(ty);
             if (f.optional) {
                 try w.print("    {s}: {s} = null,\n", .{ id, ty });
             } else {
@@ -1544,6 +1658,22 @@ pub fn renderModels(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         }
         if (m.additional_properties != null) {
             try w.writeAll("    additional_properties: std.StringArrayHashMapUnmanaged(JsonValue) = .empty,\n");
+        }
+
+        // Nested wrapper structs for wrapped XML arrays.
+        for (m.fields) |f| {
+            const x = xmlWrappedArray(f) orelse continue;
+            const wt = try xmlWrapperTypeName(allocator, f);
+            defer allocator.free(wt);
+            const elem_ty = try renderFieldType(allocator, f.field_type, false, .models);
+            defer allocator.free(elem_ty);
+            try w.print(
+                \\    pub const {s} = struct {{
+                \\        items: {s} = &.{{}},
+                \\        pub const serde = .{{ .rename = .{{ .items = "{s}" }} }};
+                \\    }};
+                \\
+            , .{ wt, elem_ty, x.items_name.? });
         }
 
         try renderModelSerdeOptions(allocator, w, m);
@@ -1705,6 +1835,10 @@ fn renderModelSerdeOptions(
     w: *std.Io.Writer,
     model: cm.Model,
 ) !void {
+    if (model.is_xml) {
+        try renderXmlModelSerdeOptions(allocator, w, model);
+        return;
+    }
     try w.writeAll("\n    pub const serde = .{\n        .rename_all = .camel_case,\n");
     var has_renames = false;
     for (model.fields) |field| {
@@ -1725,6 +1859,111 @@ fn renderModelSerdeOptions(
         try w.writeAll("        .skip = .{ .additional_properties = .always },\n");
     }
     try w.writeAll("    };\n");
+}
+
+/// True when `f` is a wrapped XML array — an array property whose items
+/// are nested under a wrapper element (`<Containers><Container>…`), i.e.
+/// `xml.unwrapped == false`. Such properties are emitted as a nested
+/// wrapper struct. Unwrapped arrays (repeated sibling elements) keep
+/// their slice type and are handled by serde.xml directly.
+fn xmlWrappedArray(f: cm.Field) ?cm.XmlField {
+    const x = f.xml orelse return null;
+    if (x.unwrapped) return null;
+    if (!f.field_type.isArray()) return null;
+    if (x.items_name == null) return null;
+    return x;
+}
+
+/// Nested wrapper-struct type name for a wrapped XML array property, e.g.
+/// `container_items` → `ContainerItemsXml`. Caller owns the returned slice.
+fn xmlWrapperTypeName(allocator: std.mem.Allocator, f: cm.Field) ![]u8 {
+    const pascal = try naming.toPascalCase(allocator, f.name);
+    defer allocator.free(pascal);
+    return std.fmt.allocPrint(allocator, "{s}Xml", .{pascal});
+}
+
+/// XML flavor of `renderModelSerdeOptions`. Emits `xml_root` (the element
+/// name for the model when it is a body root), `xml_attribute` for
+/// attribute properties, and an exact per-field `.rename` derived from the
+/// TCGC XML name (blob XML uses PascalCase with hyphens/acronyms that a
+/// `rename_all` convention cannot reproduce, e.g. `Last-Modified`, `Etag`).
+fn renderXmlModelSerdeOptions(
+    allocator: std.mem.Allocator,
+    w: *std.Io.Writer,
+    model: cm.Model,
+) !void {
+    try w.writeAll("\n    pub const serde = .{\n");
+    if (model.xml_name) |root| {
+        try w.print("        .xml_root = \"{s}\",\n", .{root});
+    }
+
+    // Attribute properties → `.xml_attribute = .{ .a, .b }`.
+    var has_attr = false;
+    for (model.fields) |f| {
+        const x = f.xml orelse continue;
+        if (!x.attribute) continue;
+        const id = try ids.quoteIfNeeded(allocator, f.name);
+        defer allocator.free(id);
+        if (!has_attr) {
+            try w.writeAll("        .xml_attribute = .{ ");
+            has_attr = true;
+        } else {
+            try w.writeAll(", ");
+        }
+        try w.print(".{s}", .{id});
+    }
+    if (has_attr) try w.writeAll(" },\n");
+
+    // Text-content property → `.xml_text = .field`. An `unwrapped` scalar
+    // (non-array, non-attribute) XML property carries the element's text
+    // content (e.g. `<Name Encoded=..>blob</Name>`), not a child element.
+    for (model.fields) |f| {
+        if (!xmlIsTextContent(f)) continue;
+        const id = try ids.quoteIfNeeded(allocator, f.name);
+        defer allocator.free(id);
+        try w.print("        .xml_text = .{s},\n", .{id});
+        break;
+    }
+
+    // Exact per-field element/attribute names. Wrapped-array properties
+    // carry the wrapper element name (`xml.name`); the item name lives on
+    // the nested wrapper struct's own `serde.rename`. Text-content fields
+    // are matched by field name via `xml_text`, so they are not renamed.
+    try w.writeAll("        .rename = .{\n");
+    for (model.fields) |f| {
+        if (xmlIsTextContent(f)) continue;
+        const id = try ids.quoteIfNeeded(allocator, f.name);
+        defer allocator.free(id);
+        const wire = if (f.xml) |x| x.name else f.serialized_name;
+        try w.print("            .{s} = \"{s}\",\n", .{ id, wire });
+    }
+    try w.writeAll("        },\n");
+    try w.writeAll("    };\n");
+}
+
+/// Returns true when the field is an `unwrapped` scalar XML property, i.e.
+/// it maps to the enclosing element's text content rather than a child
+/// element. Unwrapped *arrays* (sibling lists) are excluded.
+fn xmlIsTextContent(f: cm.Field) bool {
+    const x = f.xml orelse return false;
+    if (!x.unwrapped or x.attribute) return false;
+    return !xmlEffectiveIsArrayOrMap(f.field_type);
+}
+
+fn xmlEffectiveIsArrayOrMap(t: cm.TypeRef) bool {
+    if (t.isArray() or t.isMap()) return true;
+    if (t.isOption()) {
+        switch (t.value) {
+            .object => |o| {
+                if (o.get("kind")) |k| switch (k) {
+                    .string => |s| return std.mem.eql(u8, s, "Array") or std.mem.eql(u8, s, "Map"),
+                    else => {},
+                };
+            },
+            else => {},
+        }
+    }
+    return false;
 }
 
 fn renderOpenModelMethods(

--- a/codegen/cli/src/types.zig
+++ b/codegen/cli/src/types.zig
@@ -56,6 +56,11 @@ pub fn renderType(
         if (t.namedTypeName()) |n| return allocator.dupe(u8, n);
         return allocator.dupe(u8, "std.json.Value");
     }
+    if (std.mem.eql(u8, t.kind, "Constant")) {
+        // TypeSpec literal (e.g. a fixed `Content-Type` header). The adapter
+        // stringifies the value, so the Zig representation is a string.
+        return try renderScalar(allocator, "string", scope);
+    }
     if (t.isScalar()) {
         return try renderScalar(allocator, t.scalarName() orelse "unknown", scope);
     }

--- a/codegen/tcgc-component/scripts/build-component.mjs
+++ b/codegen/tcgc-component/scripts/build-component.mjs
@@ -44,6 +44,7 @@ const packages = [
   "@typespec/rest",
   "@typespec/versioning",
   "@typespec/openapi",
+  "@typespec/xml",
   "@azure-tools/typespec-azure-core",
   "@azure-tools/typespec-azure-resource-manager",
   "@azure-tools/typespec-client-generator-core",

--- a/codegen/tcgc-component/src/index.js
+++ b/codegen/tcgc-component/src/index.js
@@ -502,6 +502,14 @@ function serializationKind(options, contentTypes) {
   ) {
     return "json";
   }
+  if (
+    options?.xml ||
+    (contentTypes ?? []).some((c) =>
+      c.toLowerCase().includes("xml"),
+    )
+  ) {
+    return "xml";
+  }
   return "raw";
 }
 

--- a/codegen/tcgc-component/src/index.js
+++ b/codegen/tcgc-component/src/index.js
@@ -666,6 +666,7 @@ export function adaptModel(model) {
       read_only: !!p.readOnly,
       flatten: !!p.flatten,
       multipart: adaptMultipartField(p.serializationOptions?.multipart),
+      xml: adaptXmlField(p.serializationOptions?.xml),
     })),
     parents: model.baseModel ? [model.baseModel.name] : [],
     discriminator: model.discriminatorProperty?.name ?? null,
@@ -675,6 +676,29 @@ export function adaptModel(model) {
     additional_properties: model.additionalProperties
       ? adaptType(model.additionalProperties)
       : null,
+    // XML serialization: a model is "xml" when any property carries XML
+    // serialization options. `xml_name` is the root element name (from
+    // `@xml.name`/`@encodedName`), used when the model is the top-level
+    // element of a request/response body.
+    is_xml: props.some((p) => !!p.serializationOptions?.xml),
+    xml_name: model.serializationOptions?.xml?.name ?? null,
+  };
+}
+
+/**
+ * Adapt a property's XML serialization options into the code model.
+ * `name` is the element (or attribute) name; `items_name` is the child
+ * element name for wrapped arrays (`unwrapped: false`). Returns null
+ * when the property has no XML serialization options.
+ */
+function adaptXmlField(xml) {
+  if (!xml) return null;
+  return {
+    name: xml.name,
+    attribute: !!xml.attribute,
+    unwrapped: !!xml.unwrapped,
+    items_name: xml.itemsName ?? null,
+    ns: xml.ns ? { namespace: xml.ns.namespace, prefix: xml.ns.prefix } : null,
   };
 }
 

--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -116,6 +116,7 @@ pub const all = [_]Package{
             "errors.zig",
             "lro.zig",
             "open_enum.zig",
+            "fixed_enum.zig",
             "pager.zig",
             "response.zig",
             "safe_debug.zig",

--- a/sdk/core/build.zig.zon
+++ b/sdk/core/build.zig.zon
@@ -8,8 +8,8 @@
             .path = "tracing",
         },
         .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
-            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+            .url = "git+https://github.com/cataggar/serde.zig#f0a50369cb4188961047a3922ad01e03ed928b45",
+            .hash = "serde-1.0.1-1DszT8jXDAB_pa3Zn5LX9v5L46vhXhQkbcF10yOuSkRu",
         },
     },
     .paths = .{

--- a/sdk/core/build.zig.zon
+++ b/sdk/core/build.zig.zon
@@ -30,6 +30,7 @@
         "errors.zig",
         "lro.zig",
         "open_enum.zig",
+        "fixed_enum.zig",
         "pager.zig",
         "response.zig",
         "safe_debug.zig",

--- a/sdk/core/build.zig.zon
+++ b/sdk/core/build.zig.zon
@@ -8,8 +8,8 @@
             .path = "tracing",
         },
         .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#f0a50369cb4188961047a3922ad01e03ed928b45",
-            .hash = "serde-1.0.1-1DszT8jXDAB_pa3Zn5LX9v5L46vhXhQkbcF10yOuSkRu",
+            .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
+            .hash = "serde-1.0.1-1DszT1XhDACnteUU3yWahMMjLjkJqB34hwROPIfhZc7l",
         },
     },
     .paths = .{

--- a/sdk/core/fixed_enum.zig
+++ b/sdk/core/fixed_enum.zig
@@ -1,0 +1,93 @@
+//! Helpers for "fixed" (non-extensible) Azure string-valued enums.
+//!
+//! Fixed enums are generated as a plain Zig `enum` whose variant
+//! identifiers are snake_cased Zig names while the wire contract uses a
+//! different spelling (usually PascalCase), e.g.
+//!
+//!     pub const BlobType = enum {
+//!         block_blob,
+//!         page_blob,
+//!         append_blob,
+//!         pub fn toWire(self: @This()) []const u8 { ... }   // .block_blob => "BlockBlob"
+//!         pub fn fromWire(s: []const u8) ?@This() { ... }
+//!     };
+//!
+//! serde's built-in enum (de)serializer matches by the Zig variant
+//! identifier, so `"BlockBlob"` never matches `block_blob` and it
+//! fails with `error.UnexpectedToken`. The generated emitter therefore
+//! wires each fixed enum to the helpers below via `zerdeDeserialize` /
+//! `zerdeSerialize` hooks, which route through the enum's own
+//! `toWire` / `fromWire` wire mapping. This mirrors `open_enum` for the
+//! extensible case.
+
+const std = @import("std");
+
+/// Deserialize a fixed enum from a wire string via `T.fromWire`.
+/// Unknown wire values (not present in the enum) fail with
+/// `error.UnexpectedToken`, matching the strictness of a closed enum.
+pub fn deserialize(
+    comptime T: type,
+    allocator: std.mem.Allocator,
+    deserializer: anytype,
+) @TypeOf(deserializer.*).Error!T {
+    const s = try deserializer.deserializeString(allocator);
+    defer allocator.free(s);
+    return T.fromWire(s) orelse error.UnexpectedToken;
+}
+
+/// Serialize a fixed enum as its wire string via `value.toWire()`.
+pub fn serialize(value: anytype, serializer: anytype) !void {
+    return serializer.serializeString(value.toWire());
+}
+
+// ─────────────────────────── Tests ───────────────────────────
+
+const testing = std.testing;
+
+const Sample = enum {
+    block_blob,
+    page_blob,
+    append_blob,
+
+    pub fn toWire(self: @This()) []const u8 {
+        return switch (self) {
+            .block_blob => "BlockBlob",
+            .page_blob => "PageBlob",
+            .append_blob => "AppendBlob",
+        };
+    }
+
+    pub fn fromWire(s: []const u8) ?@This() {
+        if (std.mem.eql(u8, s, "BlockBlob")) return .block_blob;
+        if (std.mem.eql(u8, s, "PageBlob")) return .page_blob;
+        if (std.mem.eql(u8, s, "AppendBlob")) return .append_blob;
+        return null;
+    }
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return deserialize(T, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return serialize(self, serializer);
+    }
+};
+
+const serde = @import("serde");
+
+test "fixed_enum round-trips known wire value via JSON" {
+    const v = try serde.json.fromSlice(Sample, testing.allocator, "\"PageBlob\"");
+    try testing.expectEqual(Sample.page_blob, v);
+
+    const out = try serde.json.toSlice(testing.allocator, Sample.append_blob);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("\"AppendBlob\"", out);
+}
+
+test "fixed_enum rejects unknown wire value" {
+    try testing.expectError(error.UnexpectedToken, serde.json.fromSlice(Sample, testing.allocator, "\"NopeBlob\""));
+}

--- a/sdk/core/open_enum.zig
+++ b/sdk/core/open_enum.zig
@@ -87,6 +87,23 @@ pub fn toWire(value: anytype, comptime wire_names: anytype) []const u8 {
     unreachable;
 }
 
+/// Parse a wire string into an open-enum union value. Known values map to
+/// their void variant; unlisted values are captured in the `unrecognized`
+/// variant, whose backing string is duplicated with `allocator` so it
+/// outlives the borrowed input. The caller owns the returned value.
+pub fn fromWire(
+    comptime T: type,
+    comptime wire_names: anytype,
+    allocator: std.mem.Allocator,
+    s: []const u8,
+) std.mem.Allocator.Error!T {
+    inline for (comptime std.meta.fields(@TypeOf(wire_names))) |f| {
+        const wire: []const u8 = @field(wire_names, f.name);
+        if (std.mem.eql(u8, s, wire)) return @unionInit(T, f.name, {});
+    }
+    return @unionInit(T, "unrecognized", try allocator.dupe(u8, s));
+}
+
 // ─────────────────────────── Tests ───────────────────────────
 
 const testing = std.testing;
@@ -113,11 +130,32 @@ const Sample = union(enum) {
     pub fn toWire(self: @This()) []const u8 {
         return @import("open_enum.zig").toWire(self, wire_names);
     }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return @import("open_enum.zig").fromWire(@This(), wire_names, allocator, s);
+    }
 };
 
 test "open enum: toWire returns mapped wire name" {
     try testing.expectEqualStrings("One", Sample.toWire(.one));
     try testing.expectEqualStrings("Two", Sample.toWire(.two));
+}
+
+test "open enum: fromWire maps known wire name" {
+    try testing.expectEqual(Sample.one, try Sample.fromWire(testing.allocator, "One"));
+    try testing.expectEqual(Sample.two, try Sample.fromWire(testing.allocator, "Two"));
+}
+
+test "open enum: fromWire captures unrecognized wire value" {
+    const out = try Sample.fromWire(testing.allocator, "Floomp");
+    defer switch (out) {
+        .unrecognized => |s| testing.allocator.free(s),
+        else => {},
+    };
+    switch (out) {
+        .unrecognized => |s| try testing.expectEqualStrings("Floomp", s),
+        else => return error.ExpectedUnrecognized,
+    }
 }
 
 test "open enum: toWire returns inner string for unrecognized" {

--- a/sdk/core/pager.zig
+++ b/sdk/core/pager.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const serde = @import("serde");
 const pipeline_mod = @import("http/pipeline.zig");
 const transport = @import("http/transport.zig");
+const url_mod = @import("url.zig");
 
 /// Log a non-2xx HTTP response body so the developer sees the ARM/data-plane
 /// error message before the generic `PageFetchFailed` propagates upward.
@@ -140,6 +141,146 @@ pub fn PipelinePager(comptime T: type) type {
         fn deinitImpl(pager_ptr: *Pager(T)) void {
             const self: *Self = @alignCast(@fieldParentPtr("pager", pager_ptr));
             self.deinit();
+        }
+    };
+}
+
+// ─────────────────────────── XML marker pager ──────────────────────────────
+
+/// Pager for Azure XML data-plane list endpoints (Blob, Queue, …).
+///
+/// Unlike ARM's `{ value, nextLink }` JSON envelope, these APIs return an
+/// XML body whose `<NextMarker>` element carries the continuation token, and
+/// the next page is fetched by setting `?marker=<token>` on the *same* URL
+/// (not by following an absolute `nextLink`). Every request also needs the
+/// `x-ms-version` header. `T` is the whole per-page envelope model (e.g.
+/// `ListContainersResponse`), mirroring azure-sdk-for-rust's
+/// `Pager<ListContainersResponse, XmlFormat>`.
+///
+/// `T` must expose an optional `next_marker: ?[]const u8` field; when it is
+/// absent or empty the pager stops.
+///
+/// Each `next()` returns the deserialized envelope for one page, allocated
+/// from an internal arena that is reset on the following `next()` call — so a
+/// page is only valid until the next call or `deinit()`. Copy anything you
+/// need to retain.
+///
+/// Usage:
+/// ```
+/// var pager = try XmlPager(ListContainersResponse).init(
+///     pipeline, url, api_version, initial_marker, client_request_id, allocator);
+/// defer pager.deinit();
+/// while (try pager.next()) |page| {
+///     for (page.container_items.items) |container| { ... }
+/// }
+/// ```
+pub fn XmlPager(comptime T: type) type {
+    if (!@hasField(T, "next_marker"))
+        @compileError("XmlPager(" ++ @typeName(T) ++ ") requires a `next_marker` field");
+    return struct {
+        pipeline: pipeline_mod.HttpPipeline,
+        allocator: std.mem.Allocator,
+        arena: std.heap.ArenaAllocator,
+        /// Request URL without any `marker` query pair; the pager appends it.
+        base_url: []u8,
+        api_version: []const u8,
+        /// Optional `x-ms-client-request-id` correlation header, owned by
+        /// `allocator`, set on every page request when present.
+        client_request_id: ?[]u8,
+        /// Continuation (or initial) marker, owned by `allocator`. Null means
+        /// "no marker on the next request".
+        marker: ?[]u8,
+        /// False until the first page has been fetched, so that a null marker
+        /// on the first call means "start" rather than "done".
+        started: bool,
+
+        const Self = @This();
+
+        pub fn init(
+            pipeline: pipeline_mod.HttpPipeline,
+            initial_url: []const u8,
+            api_version: []const u8,
+            initial_marker: ?[]const u8,
+            client_request_id: ?[]const u8,
+            allocator: std.mem.Allocator,
+        ) !Self {
+            const base = try allocator.dupe(u8, initial_url);
+            errdefer allocator.free(base);
+            const marker: ?[]u8 = if (initial_marker) |m|
+                try allocator.dupe(u8, m)
+            else
+                null;
+            errdefer if (marker) |mk| allocator.free(mk);
+            const crid: ?[]u8 = if (client_request_id) |c|
+                try allocator.dupe(u8, c)
+            else
+                null;
+            return .{
+                .pipeline = pipeline,
+                .allocator = allocator,
+                .arena = std.heap.ArenaAllocator.init(allocator),
+                .base_url = base,
+                .api_version = api_version,
+                .client_request_id = crid,
+                .marker = marker,
+                .started = false,
+            };
+        }
+
+        /// Fetch the next page, or null when the listing is exhausted. The
+        /// returned value is valid until the next `next()` or `deinit()`.
+        pub fn next(self: *Self) !?T {
+            if (self.started and self.marker == null) return null;
+
+            const url = try self.buildUrl();
+            defer self.allocator.free(url);
+
+            var req = transport.Request.init(self.allocator, .GET, url);
+            defer req.deinit();
+            try req.setHeader("x-ms-version", self.api_version);
+            try req.setHeader("Accept", "application/xml");
+            if (self.client_request_id) |crid| try req.setHeader("x-ms-client-request-id", crid);
+
+            var resp = try self.pipeline.send(&req);
+            defer resp.deinit();
+            if (!resp.isSuccess()) {
+                logHttpError("XmlPager.next", resp.status_code, resp.body);
+                return error.PageFetchFailed;
+            }
+
+            _ = self.arena.reset(.retain_capacity);
+            const page = serde.xml.fromSlice(T, self.arena.allocator(), resp.body) catch |err| {
+                logHttpError("XmlPager.next parse failed", resp.status_code, resp.body);
+                return err;
+            };
+
+            // Advance the continuation marker. A missing/empty NextMarker
+            // ends the listing.
+            if (self.marker) |old| self.allocator.free(old);
+            self.marker = null;
+            if (page.next_marker) |nm| {
+                if (nm.len > 0) self.marker = try self.allocator.dupe(u8, nm);
+            }
+            self.started = true;
+            return page;
+        }
+
+        /// Free pager-owned state (URL, marker, and the page arena).
+        pub fn deinit(self: *Self) void {
+            self.arena.deinit();
+            self.allocator.free(self.base_url);
+            if (self.marker) |m| self.allocator.free(m);
+            self.marker = null;
+            if (self.client_request_id) |c| self.allocator.free(c);
+            self.client_request_id = null;
+        }
+
+        fn buildUrl(self: *Self) ![]u8 {
+            const marker = self.marker orelse return self.allocator.dupe(u8, self.base_url);
+            const enc = try url_mod.percentEncode(self.allocator, marker);
+            defer self.allocator.free(enc);
+            const sep: []const u8 = if (std.mem.indexOfScalar(u8, self.base_url, '?') != null) "&" else "?";
+            return std.fmt.allocPrint(self.allocator, "{s}{s}marker={s}", .{ self.base_url, sep, enc });
         }
     };
 }
@@ -307,6 +448,57 @@ test "PipelinePager error propagation" {
     try std.testing.expectError(error.PageFetchFailed, pip.next());
 }
 
+test "XmlPager paginates via NextMarker" {
+    const allocator = std.testing.allocator;
+    const Item = struct {
+        name: []const u8,
+        pub const serde = .{ .rename = .{ .name = "Name" } };
+    };
+    const Envelope = struct {
+        containers: ContainersXml = .{},
+        next_marker: ?[]const u8 = null,
+        pub const ContainersXml = struct {
+            items: []const Item = &.{},
+            pub const serde = .{ .rename = .{ .items = "Container" } };
+        };
+        pub const serde = .{
+            .xml_root = "EnumerationResults",
+            .rename = .{ .containers = "Containers", .next_marker = "NextMarker" },
+        };
+    };
+    const responses = [_]transport.SequenceMockTransport.CannedResponse{
+        .{ .status = 200, .body =
+        \\<EnumerationResults><Containers><Container><Name>a</Name></Container></Containers><NextMarker>m2</NextMarker></EnumerationResults>
+        },
+        .{ .status = 200, .body =
+        \\<EnumerationResults><Containers><Container><Name>b</Name></Container><Container><Name>c</Name></Container></Containers><NextMarker></NextMarker></EnumerationResults>
+        },
+    };
+    var seq = transport.SequenceMockTransport.init(allocator, &responses);
+
+    var pager = try XmlPager(Envelope).init(
+        .{ .policies = &.{}, .transport_impl = seq.asTransport() },
+        "https://example.com/?comp=list",
+        "2026-06-06",
+        null,
+        null,
+        allocator,
+    );
+    defer pager.deinit();
+
+    const p1 = (try pager.next()) orelse return error.ExpectedPage;
+    try std.testing.expectEqual(@as(usize, 1), p1.containers.items.len);
+    try std.testing.expectEqualStrings("a", p1.containers.items[0].name);
+
+    const p2 = (try pager.next()) orelse return error.ExpectedPage;
+    try std.testing.expectEqual(@as(usize, 2), p2.containers.items.len);
+    try std.testing.expectEqualStrings("b", p2.containers.items[0].name);
+    try std.testing.expectEqualStrings("c", p2.containers.items[1].name);
+
+    // Empty NextMarker ends the listing.
+    try std.testing.expect(try pager.next() == null);
+}
+
 test "Pager interface via asPager" {
     const allocator = std.testing.allocator;
     var mock = transport.MockTransport.init(allocator, 200,
@@ -340,7 +532,6 @@ test "Pager interface via asPager" {
 
 test "listPageParser handles standard envelope" {
     const allocator = std.testing.allocator;
-
     const Item = struct {
         name: []const u8,
 

--- a/sdk/core/pager.zig
+++ b/sdk/core/pager.zig
@@ -230,6 +230,11 @@ pub fn XmlPager(comptime T: type) type {
         /// Fetch the next page, or null when the listing is exhausted. The
         /// returned value is valid until the next `next()` or `deinit()`.
         pub fn next(self: *Self) !?T {
+            // Deserializing large service models (e.g. blob listings, whose
+            // element types carry dozens of fields) drives serde's comptime
+            // option-resolution past the default branch budget. Raise it here,
+            // at the sole call site of `serde.xml.fromSlice(T, ...)`.
+            @setEvalBranchQuota(1_000_000);
             if (self.started and self.marker == null) return null;
 
             const url = try self.buildUrl();

--- a/sdk/core/root.zig
+++ b/sdk/core/root.zig
@@ -33,6 +33,7 @@ pub const tracing = @import("azure_sdk_core_tracing");
 pub const dotenv = @import("dotenv.zig");
 pub const arm = @import("arm/resource.zig");
 pub const open_enum = @import("open_enum.zig");
+pub const fixed_enum = @import("fixed_enum.zig");
 pub const env_token = @import("credentials/env_token.zig");
 
 /// WASI HTTP transport for running the SDK inside a `wasi:http`-capable


### PR DESCRIPTION
## Summary

Makes the generic XML codegen path produce **fully-compiling, correctly-deserializing** Azure clients for XML services (Blob Storage), validated end-to-end against **real Azure** — without regressing existing JSON/ARM packages.

Builds on the generic XML groundwork (models, marker pager, `xml_text`) in the first commit, then fixes every emitter/adapter/serde defect surfaced by real Azure XML.

## Changes

**Emitter (`codegen/cli/src/emit.zig`, `types.zig`)**
- Fixed (non-extensible) enums emit `zerdeDeserialize`/`zerdeSerialize` hooks routing through new `core.fixed_enum`, so they (de)serialize by **wire value** (`BlockBlob`) not Zig field name (`block_blob`).
- Response models force `?T` on **purely-output** models (`is_output and !is_input`) to tolerate Azure omitting nominally-required fields — matching `azure-sdk-for-rust` — while request/round-trip bodies keep required fields for multipart/serialization access.
- Typed response-header extraction (enum `fromWire` / bool / int / float / string); `Constant` content_type → `[]const u8`.
- Array-of-enum query params (e.g. `include`) CSV-joined via element `toWire`.
- XML request bodies via `serde.xml.toSlice`; XML responses via `serde.xml.fromSlice`.
- Generated packages pin the serde fork commit carrying the XML fixes.

**TCGC adapter (`codegen/tcgc-component/src/index.js`)**
- Surfaces `is_input`/`is_output` usage flags and `serializationKind`/xml metadata.

**sdk/core**
- New `fixed_enum.zig` (fixed-enum wire (de)serialization; mirrors `open_enum.zig`), exported from `root.zig`.
- `open_enum.fromWire` for typed header/enum extraction.
- `pager.zig`: raise comptime eval branch quota for large XML models.
- Re-pin serde fork (`cataggar/serde.zig` @ `73d8727`) carrying XML self-closing / UTF-8 BOM fixes.

## Validation

- Codegen regression `zig build test` **16/16**
- sdk/core `zig build test` **149/149** (new `fixed_enum` tests)
- Generated blob client compiles (full `refAllDecls`) and **lists containers/blobs against real Azure** (resource group `vm17rg`)
- keyvault + arm_avs regen `ast-check` clean; XML paths inert (0 `serde.xml`/`XmlPager`), JSON `serde.json` path intact
- `zig fmt` clean

> Note: the `is_output` optionality change makes all purely-output response-model fields optional across every generated package (keyvault, arm_avs, …). This matches `azure-sdk-for-rust`'s generated models and is required for correct deserialization of real Azure responses.

> Depends on serde fork commit `cataggar/serde.zig@73d8727` (already pushed).