### PR TITLE
sdk/amqp: enforce eol=lf (fix Windows fmt-check)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Add `.gitattributes` (`* text=auto eol=lf`) so Windows checkout keeps LF and `zig fmt --check` passes, matching the other branch-owned packages.