### PR TITLE
Re-pin azure_sdk_core to 0.1.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5c37f2997b0a9dcc2db91f83baf0a492342621a2",
-            .hash = "azure_sdk_core-0.1.0-eFY0EtlTBQDltjWjN0xVytGGsv4kqwm1JP_PY18iWFb3",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#da55987aa3c90393a726fc1fa5e86ccd69d72271",
+            .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
         },
         .azure_rest_container_registry = .{
             .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#70cf5bf1e8155fc9a5ae23206a6b092c2182d21b",


### PR DESCRIPTION
Bump azure_sdk_core 0.1.0 (5c37f299) → 0.1.2 (da55987a). Core-only re-pin; internal deps unchanged.