### PR TITLE
codegen: preserve Azure Tables wire shapes

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -79,6 +79,11 @@ contains 14 operations. It has no `$batch` route; transactions remain outside
 the generated REST contract unless a future upstream fixture records that
 operation as present.
 
+`cd codegen/cli && zig build test` renders and compiles this fixture as
+`azure_rest_data_tables`. Its focused assertions cover open OData records and
+dotted names, headers and status alternatives, XML serde metadata, literal
+query routes, and quoted OData path escaping.
+
 Regenerate the tracked, entirely generator-owned ACR protocol package
 from that fixture into a checkout of its package branch:
 

--- a/codegen/cli/build.zig
+++ b/codegen/cli/build.zig
@@ -79,10 +79,25 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     data_tables_test_mod.addImport("codemodel", codemodel_mod);
+    data_tables_test_mod.addImport("emit", emit_mod);
     const data_tables_test = b.addTest(.{
         .root_module = data_tables_test_mod,
     });
     test_step.dependOn(&b.addRunArtifact(data_tables_test).step);
+
+    const data_tables_generator_mod = b.createModule(.{
+        .root_source_file = b.path("../fixtures/generate_data_tables_package.zig"),
+        .target = host_target,
+        .optimize = optimize,
+    });
+    data_tables_generator_mod.addImport("emit", emit_mod);
+    const data_tables_generator = b.addExecutable(.{
+        .name = "generate-data-tables-package",
+        .root_module = data_tables_generator_mod,
+    });
+    const generate_data_tables_fixture = b.addRunArtifact(data_tables_generator);
+    const generated_data_tables_dir =
+        generate_data_tables_fixture.addOutputDirectoryArg("data-tables-package");
 
     const fixture_generator_mod = b.createModule(.{
         .root_source_file = b.path("../fixtures/generate_container_registry_package.zig"),
@@ -167,6 +182,19 @@ pub fn build(b: *std.Build) void {
         .target = host_target,
         .optimize = optimize,
     });
+    const generated_data_tables_mod = b.createModule(.{
+        .root_source_file = generated_data_tables_dir.path(b, "src/root.zig"),
+        .target = host_target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "azure_sdk_core", .module = azure_sdk_core_dep.module("azure_sdk_core") },
+            .{ .name = "serde", .module = serde_dep.module("serde") },
+        },
+    });
+    const generated_data_tables_test = b.addTest(.{
+        .root_module = generated_data_tables_mod,
+    });
+    test_step.dependOn(&b.addRunArtifact(generated_data_tables_test).step);
     const generated_fixture_mod = b.createModule(.{
         .root_source_file = generated_fixture_dir.path(b, "src/root.zig"),
         .target = host_target,

--- a/codegen/cli/src/codemodel.zig
+++ b/codegen/cli/src/codemodel.zig
@@ -111,7 +111,7 @@ pub const WireParameter = struct {
     style: ?[]const u8 = null,
     explode: ?bool = null,
     allow_reserved: ?bool = null,
-    /// "segment" | "repository" | "greedy" for path parameters.
+    /// "segment" | "repository" | "greedy" | "odata-string".
     path_encoding: ?[]const u8 = null,
 };
 

--- a/codegen/cli/src/emit.zig
+++ b/codegen/cli/src/emit.zig
@@ -255,6 +255,20 @@ pub fn renderClients(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         \\}
         \\
     );
+    if (hasODataStringPathParameter(model)) {
+        try w.writeAll(
+            \\fn encodeODataStringLiteral(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+            \\    var escaped: std.ArrayList(u8) = .empty;
+            \\    defer escaped.deinit(allocator);
+            \\    for (value) |byte| {
+            \\        try escaped.append(allocator, byte);
+            \\        if (byte == '\'') try escaped.append(allocator, '\'');
+            \\    }
+            \\    return core.url.encodePathSegment(allocator, escaped.items);
+            \\}
+            \\
+        );
+    }
 
     // Per-family constants (endpoint default, api-version default, auth
     // scopes) emitted next to the root client so callers can override
@@ -269,6 +283,19 @@ pub fn renderClients(allocator: std.mem.Allocator, model: cm.CodeModel) ![]u8 {
         try w.writeAll("\n");
     }
     return try aw.toOwnedSlice();
+}
+
+fn hasODataStringPathParameter(model: cm.CodeModel) bool {
+    for (model.clients) |client| {
+        for (client.methods) |method| {
+            for (method.path_parameters) |parameter| {
+                if (std.mem.eql(u8, parameter.path_encoding orelse "", "odata-string")) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
 }
 
 fn renderRootConstants(w: *std.Io.Writer, c: cm.Client) !void {
@@ -805,6 +832,12 @@ fn renderUrlBuild(allocator: std.mem.Allocator, w: *std.Io.Writer, m: cm.Method,
         } else if (std.mem.eql(u8, encoding, "repository")) {
             try w.print(
                 \\        const encoded_path_{d} = try core.url.encodeRepositoryName(alloc, {s});
+                \\        defer alloc.free(encoded_path_{d});
+                \\
+            , .{ index, source, index });
+        } else if (std.mem.eql(u8, encoding, "odata-string")) {
+            try w.print(
+                \\        const encoded_path_{d} = try encodeODataStringLiteral(alloc, {s});
                 \\        defer alloc.free(encoded_path_{d});
                 \\
             , .{ index, source, index });

--- a/codegen/fixtures/data_tables.json
+++ b/codegen/fixtures/data_tables.json
@@ -728,7 +728,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             }
           ],
           "query_parameters": [],
@@ -1354,7 +1354,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             },
             {
               "wire_name": "rowKey",
@@ -1366,7 +1366,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             }
           ],
           "query_parameters": [
@@ -1718,7 +1718,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             },
             {
               "wire_name": "rowKey",
@@ -1730,7 +1730,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             }
           ],
           "query_parameters": [
@@ -2043,7 +2043,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             },
             {
               "wire_name": "rowKey",
@@ -2055,7 +2055,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             }
           ],
           "query_parameters": [
@@ -2355,7 +2355,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             },
             {
               "wire_name": "rowKey",
@@ -2367,7 +2367,7 @@
               "style": "simple",
               "explode": false,
               "allow_reserved": false,
-              "path_encoding": "segment"
+              "path_encoding": "odata-string"
             }
           ],
           "query_parameters": [

--- a/codegen/fixtures/data_tables_test.zig
+++ b/codegen/fixtures/data_tables_test.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const cm = @import("codemodel");
+const emitter = @import("emit");
 
 const ProvenanceDocument = struct {
     provenance: struct {
@@ -74,6 +75,10 @@ fn expectMethodSet(methods: []const cm.Method, expected: []const []const u8) !vo
 fn expectStatus(status: std.json.Value, expected: i64) !void {
     try std.testing.expect(status == .integer);
     try std.testing.expectEqual(expected, status.integer);
+}
+
+fn expectContains(haystack: []const u8, needle: []const u8) !void {
+    try std.testing.expect(std.mem.indexOf(u8, haystack, needle) != null);
 }
 
 test "Tables fixture pins canonical provenance and newest stable version" {
@@ -281,6 +286,21 @@ test "Tables fixture preserves statuses headers routes and continuations" {
     for (route_expectations) |item| {
         try testing.expectEqualStrings(item.path, findMethod(model, item.name).?.path);
     }
+
+    try testing.expectEqualStrings(
+        "odata-string",
+        findMethod(model, "delete").?.path_parameters[0].path_encoding.?,
+    );
+    for ([_][]const u8{
+        "query_entity_with_partition_and_row_key",
+        "update_entity",
+        "merge_entity",
+        "delete_entity",
+    }) |name| {
+        const method = findMethod(model, name).?;
+        try testing.expectEqualStrings("odata-string", method.path_parameters[1].path_encoding.?);
+        try testing.expectEqualStrings("odata-string", method.path_parameters[2].path_encoding.?);
+    }
 }
 
 test "Tables fixture preserves JSON open records OData XML and customizations" {
@@ -409,4 +429,140 @@ test "Tables fixture preserves JSON open records OData XML and customizations" {
         "IncludeAPIs",
         findField(findModel(model, "Metrics").?, "include_apis").?.xml.?.name,
     );
+}
+
+test "Tables emitter preserves open records and dotted OData names" {
+    const testing = std.testing;
+    var parsed = try std.json.parseFromSlice(
+        cm.CodeModel,
+        testing.allocator,
+        @embedFile("data_tables.json"),
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
+
+    const models = try emitter.renderModels(testing.allocator, parsed.value);
+    defer testing.allocator.free(models);
+    const clients = try emitter.renderClients(testing.allocator, parsed.value);
+    defer testing.allocator.free(clients);
+
+    try expectContains(models, "value: ?[]const std.json.ArrayHashMap(JsonValue) = null");
+    try expectContains(clients, "body: std.json.ArrayHashMap(models.JsonValue)");
+    try expectContains(models, ".odata_type = \"odata.type\"");
+    try expectContains(models, ".odata_id = \"odata.id\"");
+    try expectContains(models, ".odata_edit_link = \"odata.editLink\"");
+    try expectContains(models, ".odata_metadata = \"odata.metadata\"");
+}
+
+test "Tables emitter preserves request and response headers and exact alternatives" {
+    const testing = std.testing;
+    var parsed = try std.json.parseFromSlice(
+        cm.CodeModel,
+        testing.allocator,
+        @embedFile("data_tables.json"),
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
+
+    const clients = try emitter.renderClients(testing.allocator, parsed.value);
+    defer testing.allocator.free(clients);
+
+    for (parsed.value.clients) |client| {
+        for (client.methods) |method| {
+            for (method.header_parameters) |header| {
+                const needle = try std.fmt.allocPrint(
+                    testing.allocator,
+                    "setHeader(\"{s}\"",
+                    .{header.wire_name},
+                );
+                defer testing.allocator.free(needle);
+                try expectContains(clients, needle);
+            }
+            for (method.responses) |response| {
+                for (response.headers) |header| {
+                    const needle = try std.fmt.allocPrint(
+                        testing.allocator,
+                        "getHeader(\"{s}\")",
+                        .{header.wire_name},
+                    );
+                    defer testing.allocator.free(needle);
+                    try expectContains(clients, needle);
+                }
+            }
+        }
+    }
+
+    try expectContains(clients, "try req.setHeader(\"DataServiceVersion\", \"3.0\")");
+    try expectContains(clients, "try req.setHeader(\"x-ms-version\", self.api_version)");
+    try expectContains(clients, "try req.setHeader(\"x-ms-client-request-id\", value)");
+    try expectContains(clients, "try req.setHeader(\"Prefer\", value.toWire())");
+    try expectContains(clients, "try req.setHeader(\"If-Match\", value)");
+    try expectContains(clients, "application/json;odata=minimalmetadata");
+    for ([_][]const u8{
+        "resp.getHeader(\"ETag\")",
+        "resp.getHeader(\"x-ms-request-id\")",
+        "resp.getHeader(\"x-ms-client-request-id\")",
+        "resp.getHeader(\"Preference-Applied\")",
+        "resp.getHeader(\"x-ms-continuation-NextTableName\")",
+        "resp.getHeader(\"x-ms-continuation-NextPartitionKey\")",
+        "resp.getHeader(\"x-ms-continuation-NextRowKey\")",
+    }) |header| {
+        try expectContains(clients, header);
+    }
+    try expectContains(clients, "pub const CreateResult = union(enum)");
+    try expectContains(clients, "status_201: struct");
+    try expectContains(clients, "body: models.TableResponse");
+    try expectContains(clients, "status_204: struct");
+    try expectContains(clients, "body: void");
+}
+
+test "Tables emitter preserves XML metadata and literal query routes" {
+    const testing = std.testing;
+    var parsed = try std.json.parseFromSlice(
+        cm.CodeModel,
+        testing.allocator,
+        @embedFile("data_tables.json"),
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
+
+    const models = try emitter.renderModels(testing.allocator, parsed.value);
+    defer testing.allocator.free(models);
+    const clients = try emitter.renderClients(testing.allocator, parsed.value);
+    defer testing.allocator.free(clients);
+
+    try expectContains(models, ".xml_root = \"SignedIdentifiers\"");
+    try expectContains(models, ".xml_root = \"StorageServiceProperties\"");
+    try expectContains(models, ".xml_root = \"StorageServiceStats\"");
+    try expectContains(models, ".include_apis = \"IncludeAPIs\"");
+    try expectContains(models, ".identifiers = \"SignedIdentifier\"");
+    try expectContains(clients, "serde.xml.toSlice(alloc, table_acl)");
+    try expectContains(clients, "serde.xml.toSlice(alloc, table_service_properties)");
+    try expectContains(clients, "serde.xml.fromSlice(models.SignedIdentifiers");
+    try expectContains(clients, "serde.xml.fromSlice(models.TableServiceProperties");
+    try expectContains(clients, "serde.xml.fromSlice(models.TableServiceStats");
+    try expectContains(clients, "{s}?restype=service&comp=properties");
+    try expectContains(clients, "{s}?restype=service&comp=stats");
+    try expectContains(clients, "var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null");
+}
+
+test "Tables emitter safely escapes quoted OData path values" {
+    const testing = std.testing;
+    var parsed = try std.json.parseFromSlice(
+        cm.CodeModel,
+        testing.allocator,
+        @embedFile("data_tables.json"),
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
+
+    const clients = try emitter.renderClients(testing.allocator, parsed.value);
+    defer testing.allocator.free(clients);
+
+    try expectContains(clients, "fn encodeODataStringLiteral");
+    try expectContains(clients, "if (byte == '\\'') try escaped.append(allocator, '\\'')");
+    try expectContains(clients, "return core.url.encodePathSegment(allocator, escaped.items)");
+    try expectContains(clients, "encodeODataStringLiteral(alloc, partition_key)");
+    try expectContains(clients, "encodeODataStringLiteral(alloc, row_key)");
+    try expectContains(clients, "encodeODataStringLiteral(alloc, table)");
 }

--- a/codegen/fixtures/generate_data_tables_package.zig
+++ b/codegen/fixtures/generate_data_tables_package.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const emitter = @import("emit");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+
+    var args = init.minimal.args.iterate();
+    _ = args.skip();
+    const output_path = args.next() orelse return error.MissingOutputPath;
+
+    var parsed = try std.json.parseFromSlice(
+        emitter.CodeModel,
+        allocator,
+        @embedFile("data_tables.json"),
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
+
+    const parent_path = std.fs.path.dirname(output_path) orelse ".";
+    const directory_name = std.fs.path.basename(output_path);
+    var parent = if (std.fs.path.isAbsolute(output_path))
+        try std.Io.Dir.openDirAbsolute(io, parent_path, .{})
+    else
+        try std.Io.Dir.cwd().createDirPathOpen(io, parent_path, .{});
+    defer parent.close(io);
+    if (std.mem.eql(u8, directory_name, ".") or
+        std.mem.eql(u8, directory_name, ".."))
+    {
+        return error.InvalidOutputPath;
+    }
+    try parent.deleteTree(io, directory_name);
+    var output = try parent.createDirPathOpen(io, directory_name, .{});
+    defer output.close(io);
+
+    try emitter.emit(allocator, io, output, parsed.value, .{
+        .package_name = "azure_rest_data_tables",
+        .display_name = "data-tables",
+        .azure_sdk_core_path = "../../sdk/core",
+    });
+    try output.writeFile(io, .{
+        .sub_path = "src/clients_test.zig",
+        .data =
+        \\const std = @import("std");
+        \\const clients = @import("clients.zig");
+        \\const models = @import("models.zig");
+        \\
+        \\test "generated Tables declarations compile" {
+        \\    try std.testing.expect(@hasDecl(clients, "Table"));
+        \\    try std.testing.expect(@hasDecl(models, "TableServiceProperties"));
+        \\}
+        \\
+        ,
+    });
+}

--- a/codegen/tcgc-component/src/index.js
+++ b/codegen/tcgc-component/src/index.js
@@ -476,6 +476,7 @@ function normalizeStatusCodes(statusCodes) {
 function pathEncoding(path, parameter) {
   if (parameter.allowReserved) return "greedy";
   const wireName = parameter.serializedName ?? parameter.name;
+  if (path.includes(`'{${wireName}}'`)) return "odata-string";
   if (
     wireName === "name" &&
     (path.startsWith("/v2/") || path.startsWith("/acr/v1/"))

--- a/codegen/tcgc-component/src/index.test.js
+++ b/codegen/tcgc-component/src/index.test.js
@@ -147,6 +147,52 @@ test("path adapter selects ACR repository and segment encoding", () => {
   assert.deepEqual(method.response.status_codes, [200, 206]);
 });
 
+test("path adapter identifies quoted OData string parameters", () => {
+  const partitionKey = {
+    kind: "method",
+    name: "partitionKey",
+    type: stringType,
+    optional: false,
+  };
+  const rowKey = {
+    kind: "method",
+    name: "rowKey",
+    type: stringType,
+    optional: false,
+  };
+  const method = adaptMethod(
+    {
+      name: "getEntity",
+      kind: "basic",
+      parameters: [partitionKey, rowKey],
+      operation: {
+        verb: "GET",
+        path: "/items(PartitionKey='{partitionKey}',RowKey='{rowKey}')",
+        parameters: [
+          {
+            ...partitionKey,
+            kind: "path",
+            serializedName: "partitionKey",
+            methodParameterSegments: [[partitionKey]],
+          },
+          {
+            ...rowKey,
+            kind: "path",
+            serializedName: "rowKey",
+            methodParameterSegments: [[rowKey]],
+          },
+        ],
+        responses: [{ statusCodes: 200 }],
+      },
+      response: {},
+    },
+    new Set(),
+  );
+
+  assert.equal(method.path_parameters[0].path_encoding, "odata-string");
+  assert.equal(method.path_parameters[1].path_encoding, "odata-string");
+});
+
 test("model adapter preserves multipart fields and open records", () => {
   const multipart = adaptModel({
     name: "MultipartBodyParameter",


### PR DESCRIPTION
Fixes #154

Parent tracker: #148

## Gaps fixed
- render open entity records as JSON maps and retain dotted OData wire names
- emit every modeled request/response header, including API/service versions, ETags, request IDs, metadata/Prefer, and continuation tokens
- retain exact alternate success statuses with status-specific optional bodies
- emit XML request/response serde metadata for ACL, service properties, and statistics models
- preserve literal-query x-ms-path routes while appending optional query parameters correctly
- classify quoted OData placeholders generically, double embedded apostrophes, then percent-encode the complete path value
- render and compile the deterministic Tables fixture during codegen tests

## Tests
- `cd codegen/cli && zig build test --summary all` (26/26)
- `cd codegen/tcgc-component && npm test` (6/6)
- `zig build test package-check package-history-check --summary all`
- `zig fmt --check codegen/ eng/ build.zig`