### PR TITLE
Make Tables regeneration verification portable

### DIFF
--- a/scripts/verify-data-tables-regeneration.sh
+++ b/scripts/verify-data-tables-regeneration.sh
@@ -52,7 +52,11 @@ snapshot_tree() {
       -print |
       LC_ALL=C sort |
       while IFS= read -r file; do
-        shasum -a 256 "${file#./}"
+        if command -v shasum >/dev/null 2>&1; then
+          shasum -a 256 "${file#./}"
+        else
+          sha256sum "${file#./}"
+        fi
       done
   ) >"$output"
 }


### PR DESCRIPTION
Refs #155

Parent tracker: #148

Use the available SHA-256 utility (`shasum` on macOS or `sha256sum` on Linux) so deterministic Azure Tables package regeneration verification runs on supported tooling.

## Tests
- `bash -n scripts/verify-data-tables-regeneration.sh`
- deterministic regeneration verification follows after this prerequisite merges.