### PR TITLE
Handle worktree metadata in Tables regeneration checks

### DIFF
--- a/scripts/verify-data-tables-regeneration.sh
+++ b/scripts/verify-data-tables-regeneration.sh
@@ -40,6 +40,7 @@ snapshot_tree() {
   (
     cd "$path"
     find . -type f \
+      ! -path './.git' \
       ! -path './.git/*' \
       ! -path './.github/*' \
       ! -path './.gitattributes' \


### PR DESCRIPTION
Refs #155

Parent tracker: #148

Exclude the `.git` file used by linked worktrees from regeneration snapshots, so a package worktree compares only generator-owned package files.

## Tests
- `bash -n scripts/verify-data-tables-regeneration.sh`
- full deterministic package verification follows after merge.