### PR TITLE
Generate Azure Tables REST package

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,0 +1,9 @@
+generator_commit=f5dde2c7aa95e7a5ac496793b5527c9a212d642c
+fixture=codegen/fixtures/data_tables.json
+source_repository=https://github.com/Azure/azure-rest-api-specs
+source_commit=0744f52a86919d243ba2225e55bdb9c87bf521a5
+source_path=specification/cosmos-db/data-plane/Tables/tspconfig.yaml
+stable_api_versions=2019-02-02
+selected_api_version=2019-02-02
+batch_operation=absent
+command=(cd codegen/cli && zig build -Ddata-tables-output=<package-output> -Dazure-sdk-core-commit=da55987aa3c90393a726fc1fa5e86ccd69d72271 -Dazure-sdk-core-hash=azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs generate-data-tables-package)

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -1,0 +1,37 @@
+name: Package CI
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  package-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    name: package-test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - name: Check formatting
+        shell: bash
+        run: git ls-files -z -- '*.zig' 'build.zig.zon' | xargs -0 zig fmt --check
+      - name: Run package tests
+        shell: bash
+        run: zig build test --summary all
+      - name: Build examples
+        shell: bash
+        run: echo "No examples configured"
+      - name: Compile live tests
+        shell: bash
+        run: echo "No live tests configured"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+zig-cache/
+zig-out/
+zig-pkg/
+.zig-cache/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Azure Tables REST for Zig
+
+`azure_rest_data_tables` is the generated Azure Tables protocol package for
+the stable **2019-02-02** TypeSpec contract. It is entirely
+generator-owned; update the fixture or emitter and regenerate instead of
+editing package files by hand.
+
+## Protocol surface
+
+The package exposes `TablesClient`, `Table`, and `Service`, covering all
+14 canonical operations, JSON and XML wire models, enum values, response
+headers, exact alternate statuses, and continuation headers. It preserves
+the TypeSpec's OData entity records and literal-query routes.
+
+The source contract is
+[`specification/cosmos-db/data-plane/Tables/tspconfig.yaml`](https://github.com/Azure/azure-rest-api-specs/tree/0744f52a86919d243ba2225e55bdb9c87bf521a5/specification/cosmos-db/data-plane/Tables).
+The directory is historical; this package has no Cosmos-specific runtime
+behavior. The selected TypeSpec has no `$batch` operation.
+
+## Build and regeneration
+
+```bash
+zig build test --summary all
+```
+
+The manifest pins `azure_sdk_core` by immutable release commit and Zig
+package hash. The `.azure-sdk-generator` provenance file records the
+generator revision and reproducible generation command.

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const azure_sdk_core_dep = b.dependency("azure_sdk_core", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const azure_sdk_core_mod = azure_sdk_core_dep.module("azure_sdk_core");
+
+    const serde_dep = b.dependency("serde", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const serde_mod = serde_dep.module("serde");
+
+    _ = b.addModule("azure_rest_data_tables", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "azure_sdk_core", .module = azure_sdk_core_mod },
+            .{ .name = "serde", .module = serde_mod },
+        },
+    });
+
+    const t = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = azure_sdk_core_mod },
+                .{ .name = "serde", .module = serde_mod },
+            },
+        }),
+    });
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&b.addRunArtifact(t).step);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,24 @@
+.{
+    .name = .azure_rest_data_tables,
+    .version = "0.1.0",
+    .fingerprint = 0x7750f6d647e7a50a,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .azure_sdk_core = .{
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#da55987aa3c90393a726fc1fa5e86ccd69d72271",
+            .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
+        },
+        .serde = .{
+            .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
+            .hash = "serde-1.0.1-1DszT1XhDACnteUU3yWahMMjLjkJqB34hwROPIfhZc7l",
+        },
+    },
+    .paths = .{
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+        "LICENSE.txt",
+    },
+}

--- a/src/clients.zig
+++ b/src/clients.zig
@@ -1,0 +1,1602 @@
+//! Generated service clients.
+
+const std = @import("std");
+const serde = @import("serde");
+const core = @import("azure_sdk_core");
+const models = @import("models.zig");
+const enums = @import("enums.zig");
+
+// Keep raw-body ownership behind one helper so the generated shape can
+// adopt the core streaming response API without changing status/header logic.
+fn bufferRawResponseBody(allocator: std.mem.Allocator, body: []const u8) ![]u8 {
+    return allocator.dupe(u8, body);
+}
+
+fn responseStatusExpected(status: u16, expected: []const u16) bool {
+    if (expected.len == 0) return status >= 200 and status < 300;
+    for (expected) |value| {
+        if (status == value) return true;
+    }
+    return false;
+}
+fn encodeODataStringLiteral(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    var escaped: std.ArrayList(u8) = .empty;
+    defer escaped.deinit(allocator);
+    for (value) |byte| {
+        try escaped.append(allocator, byte);
+        if (byte == '\'') try escaped.append(allocator, '\'');
+    }
+    return core.url.encodePathSegment(allocator, escaped.items);
+}
+const default_api_version = "2019-02-02";
+const auth_scopes: []const []const u8 = &.{"https://storage.azure.com/.default"};
+
+pub const TablesClient = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+    allocator: std.mem.Allocator,
+    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
+    policy_ptrs: []*core.pipeline.HttpPolicy,
+
+    pub const InitOptions = struct {
+        credential: *core.credentials.TokenCredential,
+        transport: *core.http.HttpTransport,
+        endpoint: []const u8,
+        api_version: []const u8 = default_api_version,
+    };
+
+    pub const PipelineOptions = struct {
+        endpoint: []const u8,
+        api_version: []const u8 = default_api_version,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !TablesClient {
+        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
+        errdefer allocator.destroy(auth_policy);
+        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
+            allocator,
+            options.credential,
+            auth_scopes,
+        );
+
+        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
+        errdefer allocator.free(policy_ptrs);
+        policy_ptrs[0] = auth_policy.asPolicy();
+
+        return .{
+            .allocator = allocator,
+            .endpoint = options.endpoint,
+            .api_version = options.api_version,
+            .auth_policy = auth_policy,
+            .policy_ptrs = policy_ptrs,
+            .pipeline = .{
+                .policies = policy_ptrs,
+                .transport_impl = options.transport,
+            },
+        };
+    }
+    pub fn initWithPipeline(
+        allocator: std.mem.Allocator,
+        pipeline: core.pipeline.HttpPipeline,
+        options: PipelineOptions,
+    ) TablesClient {
+        return .{
+            .allocator = allocator,
+            .endpoint = options.endpoint,
+            .api_version = options.api_version,
+            .auth_policy = null,
+            .policy_ptrs = &.{},
+            .pipeline = pipeline,
+        };
+    }
+
+    pub fn deinit(self: *@This()) void {
+        if (self.auth_policy) |auth_policy| {
+            auth_policy.deinit();
+            self.allocator.destroy(auth_policy);
+            self.allocator.free(self.policy_ptrs);
+        }
+    }
+
+    pub fn table(self: *@This()) Table {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+        };
+    }
+
+    pub fn service(self: *@This()) Service {
+        return .{
+            .endpoint = self.endpoint,
+            .api_version = self.api_version,
+            .pipeline = self.pipeline,
+        };
+    }
+};
+
+pub const Table = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+
+    pub const QueryResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                next_table_name: ?[]const u8 = null,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+                content_type: []const u8,
+            },
+            body: models.TableQueryResponse,
+        },
+    };
+
+    pub const CreateResult = union(enum) {
+        status_201: struct {
+            status: u16 = 201,
+            headers: struct {
+                preference_applied: ?[]const u8 = null,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+                content_type: []const u8,
+            },
+            body: models.TableResponse,
+        },
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                preference_applied: ?[]const u8 = null,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const DeleteResult = union(enum) {
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const QueryEntitiesResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                next_partition_key: ?[]const u8 = null,
+                next_row_key: ?[]const u8 = null,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+                content_type: []const u8,
+            },
+            body: models.TableEntityQueryResponse,
+        },
+    };
+
+    pub const QueryEntityWithPartitionAndRowKeyResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                e_tag: []const u8,
+                next_partition_key: ?[]const u8 = null,
+                next_row_key: ?[]const u8 = null,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+                content_type: []const u8,
+            },
+            body: std.json.ArrayHashMap(models.JsonValue),
+        },
+    };
+
+    pub const UpdateEntityResult = union(enum) {
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                e_tag: []const u8,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const MergeEntityResult = union(enum) {
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                e_tag: []const u8,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const DeleteEntityResult = union(enum) {
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const InsertEntityResult = union(enum) {
+        status_201: struct {
+            status: u16 = 201,
+            headers: struct {
+                preference_applied: ?[]const u8 = null,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+                e_tag: []const u8,
+                content_type: []const u8,
+            },
+            body: std.json.ArrayHashMap(models.JsonValue),
+        },
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                preference_applied: ?[]const u8 = null,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                date: []const u8,
+                e_tag: []const u8,
+            },
+            body: void,
+        },
+    };
+
+    pub const GetAccessPolicyResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                date: []const u8,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                content_type: []const u8,
+            },
+            body: models.SignedIdentifiers,
+        },
+    };
+
+    pub const SetAccessPolicyResult = union(enum) {
+        status_204: struct {
+            status: u16 = 204,
+            headers: struct {
+                date: []const u8,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+            },
+            body: void,
+        },
+    };
+    /// Queries tables under the given account.
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, @"$format": ?enums.OdataMetadataFormat, @"$top": ?i32, @"$select": ?[]const u8, @"$filter": ?[]const u8, next_table_name: ?[]const u8) !QueryResult {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/Tables", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (@"$format") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v.toWire());
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$format={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (@"$top") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}$top={d}", .{ sep, v });
+            has_query = true;
+        }
+        if (@"$select") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$select={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (@"$filter") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$filter={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (next_table_name) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}NextTableName={s}", .{ sep, enc });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Accept", "application/json;odata=minimalmetadata");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuation-NextTableName")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                const response_header_5 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_5);
+                const response_body = try serde.json.fromSlice(models.TableQueryResponse, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .next_table_name = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .date = response_header_4,
+                        .content_type = response_header_5,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.query", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Creates a new table under the given account.
+    pub fn create(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, @"$format": ?enums.OdataMetadataFormat, table_properties: models.TableProperties, prefer: ?enums.ResponseFormat) !CreateResult {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/Tables", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (@"$format") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v.toWire());
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$format={s}", .{ sep, enc });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        if (prefer) |value| try req.setHeader("Prefer", value.toWire());
+        try req.setHeader("Accept", "application/json;odata=minimalmetadata");
+        const body_json = try serde.json.toSlice(alloc, table_properties);
+        defer alloc.free(body_json);
+        req.body = body_json;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            201 => {
+                const response_header_0 = if (resp.getHeader("Preference-Applied")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                const response_header_5 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_5);
+                const response_body = try serde.json.fromSlice(models.TableResponse, alloc, resp.body);
+                return .{ .status_201 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .preference_applied = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .date = response_header_4,
+                        .content_type = response_header_5,
+                    },
+                    .body = response_body,
+                } };
+            },
+            204 => {
+                const response_header_0 = if (resp.getHeader("Preference-Applied")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .preference_applied = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .date = response_header_4,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.create", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Deletes an existing table.
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8) !DeleteResult {
+        const encoded_path_0 = try encodeODataStringLiteral(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/Tables('{s}')", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        const url = base_url;
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            204 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_1) |value| alloc.free(value);
+                const response_header_2 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_3);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .api_version = response_header_0,
+                        .request_id = response_header_1,
+                        .client_request_id = response_header_2,
+                        .date = response_header_3,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.delete", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Queries entities under the given table.
+    pub fn queryEntities(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8, @"$format": ?enums.OdataMetadataFormat, @"$top": ?i32, @"$select": ?[]const u8, @"$filter": ?[]const u8, timeout: ?i32, next_partition_key: ?[]const u8, next_row_key: ?[]const u8) !QueryEntitiesResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}()", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (@"$format") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v.toWire());
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$format={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (@"$top") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}$top={d}", .{ sep, v });
+            has_query = true;
+        }
+        if (@"$select") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$select={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (@"$filter") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$filter={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        if (next_partition_key) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}NextPartitionKey={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (next_row_key) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}NextRowKey={s}", .{ sep, enc });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Accept", "application/json;odata=minimalmetadata");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuation-NextPartitionKey")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_header_1 = if (resp.getHeader("x-ms-continuation-NextRowKey")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_1) |value| alloc.free(value);
+                const response_header_2 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_2);
+                const response_header_3 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_4) |value| alloc.free(value);
+                const response_header_5 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_5);
+                const response_header_6 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_6);
+                const response_body = try serde.json.fromSlice(models.TableEntityQueryResponse, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .next_partition_key = response_header_0,
+                        .next_row_key = response_header_1,
+                        .api_version = response_header_2,
+                        .request_id = response_header_3,
+                        .client_request_id = response_header_4,
+                        .date = response_header_5,
+                        .content_type = response_header_6,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.queryEntities", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Retrieve a single entity.
+    pub fn queryEntityWithPartitionAndRowKey(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8, timeout: ?i32, @"$format": ?enums.OdataMetadataFormat, @"$select": ?[]const u8, @"$filter": ?[]const u8, partition_key: []const u8, row_key: []const u8) !QueryEntityWithPartitionAndRowKeyResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try encodeODataStringLiteral(alloc, partition_key);
+        defer alloc.free(encoded_path_1);
+        const encoded_path_2 = try encodeODataStringLiteral(alloc, row_key);
+        defer alloc.free(encoded_path_2);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}(PartitionKey='{s}',RowKey='{s}')", .{ self.endpoint, encoded_path_0, encoded_path_1, encoded_path_2 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        if (@"$format") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v.toWire());
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$format={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (@"$select") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$select={s}", .{ sep, enc });
+            has_query = true;
+        }
+        if (@"$filter") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v);
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$filter={s}", .{ sep, enc });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Accept", "application/json;odata=minimalmetadata");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("ETag") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = if (resp.getHeader("x-ms-continuation-NextPartitionKey")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_1) |value| alloc.free(value);
+                const response_header_2 = if (resp.getHeader("x-ms-continuation-NextRowKey")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_3);
+                const response_header_4 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_4) |value| alloc.free(value);
+                const response_header_5 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_5) |value| alloc.free(value);
+                const response_header_6 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_6);
+                const response_header_7 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_7);
+                const response_body = try serde.json.fromSlice(std.json.ArrayHashMap(models.JsonValue), alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .e_tag = response_header_0,
+                        .next_partition_key = response_header_1,
+                        .next_row_key = response_header_2,
+                        .api_version = response_header_3,
+                        .request_id = response_header_4,
+                        .client_request_id = response_header_5,
+                        .date = response_header_6,
+                        .content_type = response_header_7,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.queryEntityWithPartitionAndRowKey", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Update entity in a table.
+    pub fn updateEntity(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8, timeout: ?i32, if_match: ?[]const u8, partition_key: []const u8, row_key: []const u8, table_entity_properties: ?std.json.ArrayHashMap(models.JsonValue)) !UpdateEntityResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try encodeODataStringLiteral(alloc, partition_key);
+        defer alloc.free(encoded_path_1);
+        const encoded_path_2 = try encodeODataStringLiteral(alloc, row_key);
+        defer alloc.free(encoded_path_2);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}(PartitionKey='{s}',RowKey='{s}')", .{ self.endpoint, encoded_path_0, encoded_path_1, encoded_path_2 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        if (if_match) |value| try req.setHeader("If-Match", value);
+        var body_json: ?[]u8 = null;
+        defer if (body_json) |bytes| alloc.free(bytes);
+        if (table_entity_properties) |body| {
+            const bytes = try serde.json.toSlice(alloc, body);
+            body_json = bytes;
+            req.body = bytes;
+        }
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            204 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("ETag") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .e_tag = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .date = response_header_4,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.updateEntity", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Merge entity in a table.
+    pub fn mergeEntity(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8, timeout: ?i32, if_match: ?[]const u8, partition_key: []const u8, row_key: []const u8, table_entity_properties: ?std.json.ArrayHashMap(models.JsonValue)) !MergeEntityResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try encodeODataStringLiteral(alloc, partition_key);
+        defer alloc.free(encoded_path_1);
+        const encoded_path_2 = try encodeODataStringLiteral(alloc, row_key);
+        defer alloc.free(encoded_path_2);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}(PartitionKey='{s}',RowKey='{s}')", .{ self.endpoint, encoded_path_0, encoded_path_1, encoded_path_2 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PATCH, url);
+        defer req.deinit();
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("Accept", "application/json");
+        if (if_match) |value| try req.setHeader("If-Match", value);
+        var body_json: ?[]u8 = null;
+        defer if (body_json) |bytes| alloc.free(bytes);
+        if (table_entity_properties) |body| {
+            const bytes = try serde.json.toSlice(alloc, body);
+            body_json = bytes;
+            req.body = bytes;
+        }
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            204 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("ETag") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .e_tag = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .date = response_header_4,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.mergeEntity", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Deletes the specified entity in a table.
+    pub fn deleteEntity(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8, timeout: ?i32, if_match: []const u8, partition_key: []const u8, row_key: []const u8) !DeleteEntityResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const encoded_path_1 = try encodeODataStringLiteral(alloc, partition_key);
+        defer alloc.free(encoded_path_1);
+        const encoded_path_2 = try encodeODataStringLiteral(alloc, row_key);
+        defer alloc.free(encoded_path_2);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}(PartitionKey='{s}',RowKey='{s}')", .{ self.endpoint, encoded_path_0, encoded_path_1, encoded_path_2 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .DELETE, url);
+        defer req.deinit();
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("If-Match", if_match);
+        try req.setHeader("Accept", "application/json");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            204 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_1) |value| alloc.free(value);
+                const response_header_2 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_3);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .api_version = response_header_0,
+                        .request_id = response_header_1,
+                        .client_request_id = response_header_2,
+                        .date = response_header_3,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.deleteEntity", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Insert entity in a table.
+    pub fn insertEntity(self: *@This(), alloc: std.mem.Allocator, table: []const u8, timeout: ?i32, @"$format": ?enums.OdataMetadataFormat, client_request_id: ?[]const u8, prefer: ?enums.ResponseFormat, table_entity_properties: ?std.json.ArrayHashMap(models.JsonValue)) !InsertEntityResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        if (@"$format") |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            const enc = try core.url.percentEncode(alloc, v.toWire());
+            defer alloc.free(enc);
+            try url_buf.print(alloc, "{s}$format={s}", .{ sep, enc });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .POST, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/json");
+        try req.setHeader("DataServiceVersion", "3.0");
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        if (prefer) |value| try req.setHeader("Prefer", value.toWire());
+        try req.setHeader("Accept", "application/json;odata=minimalmetadata");
+        var body_json: ?[]u8 = null;
+        defer if (body_json) |bytes| alloc.free(bytes);
+        if (table_entity_properties) |body| {
+            const bytes = try serde.json.toSlice(alloc, body);
+            body_json = bytes;
+            req.body = bytes;
+        }
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            201 => {
+                const response_header_0 = if (resp.getHeader("Preference-Applied")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                const response_header_5 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("ETag") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_5);
+                const response_header_6 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_6);
+                const response_body = try serde.json.fromSlice(std.json.ArrayHashMap(models.JsonValue), alloc, resp.body);
+                return .{ .status_201 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .preference_applied = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .date = response_header_4,
+                        .e_tag = response_header_5,
+                        .content_type = response_header_6,
+                    },
+                    .body = response_body,
+                } };
+            },
+            204 => {
+                const response_header_0 = if (resp.getHeader("Preference-Applied")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                const response_header_5 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("ETag") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_5);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .preference_applied = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .date = response_header_4,
+                        .e_tag = response_header_5,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.insertEntity", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Retrieves details about any stored access policies specified on the table that
+    /// may be used with Shared Access Signatures.
+    pub fn getAccessPolicy(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8, timeout: ?i32) !GetAccessPolicyResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}?comp=acl", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Accept", "application/xml");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                const response_body = try serde.xml.fromSlice(models.SignedIdentifiers, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .date = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .content_type = response_header_4,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.getAccessPolicy", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Sets stored access policies for the table that may be used with Shared Access
+    /// Signatures.
+    pub fn setAccessPolicy(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, table: []const u8, table_acl: models.SignedIdentifiers, timeout: ?i32) !SetAccessPolicyResult {
+        const encoded_path_0 = try core.url.encodePathSegment(alloc, table);
+        defer alloc.free(encoded_path_0);
+        const base_url = try std.fmt.allocPrint(alloc, "{s}/{s}?comp=acl", .{ self.endpoint, encoded_path_0 });
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Content-Type", "application/xml");
+        try req.setHeader("Accept", "application/xml");
+        const body_xml = try serde.xml.toSlice(alloc, table_acl);
+        defer alloc.free(body_xml);
+        req.body = body_xml;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            204 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                return .{ .status_204 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .date = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Table.setAccessPolicy", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+};
+
+pub const Service = struct {
+    endpoint: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+
+    pub const SetPropertiesResult = union(enum) {
+        status_202: struct {
+            status: u16 = 202,
+            headers: struct {
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+            },
+            body: void,
+        },
+    };
+
+    pub const GetPropertiesResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                content_type: []const u8,
+            },
+            body: models.TableServiceProperties,
+        },
+    };
+
+    pub const GetStatisticsResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                date: []const u8,
+                api_version: []const u8,
+                request_id: ?[]const u8 = null,
+                client_request_id: ?[]const u8 = null,
+                content_type: []const u8,
+            },
+            body: models.TableServiceStats,
+        },
+    };
+    /// Sets properties for an account's Table service endpoint, including properties
+    /// for Analytics and CORS (Cross-Origin Resource Sharing) rules.
+    pub fn setProperties(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, timeout: ?i32, table_service_properties: models.TableServiceProperties) !SetPropertiesResult {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}?restype=service&comp=properties", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Content-Type", "application/xml");
+        try req.setHeader("Accept", "application/xml");
+        const body_xml = try serde.xml.toSlice(alloc, table_service_properties);
+        defer alloc.free(body_xml);
+        req.body = body_xml;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            202 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_1) |value| alloc.free(value);
+                const response_header_2 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                return .{ .status_202 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .api_version = response_header_0,
+                        .request_id = response_header_1,
+                        .client_request_id = response_header_2,
+                    },
+                    .body = {},
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Service.setProperties", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Gets the properties of an account's Table service, including properties for
+    /// Analytics and CORS (Cross-Origin Resource Sharing) rules.
+    pub fn getProperties(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, timeout: ?i32) !GetPropertiesResult {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}?restype=service&comp=properties", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Accept", "application/xml");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_1) |value| alloc.free(value);
+                const response_header_2 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_3);
+                const response_body = try serde.xml.fromSlice(models.TableServiceProperties, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .api_version = response_header_0,
+                        .request_id = response_header_1,
+                        .client_request_id = response_header_2,
+                        .content_type = response_header_3,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Service.getProperties", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+    /// Retrieves statistics related to replication for the Table service. It is only
+    /// available on the secondary location endpoint when read-access geo-redundant
+    /// replication is enabled for the account.
+    pub fn getStatistics(self: *@This(), alloc: std.mem.Allocator, client_request_id: ?[]const u8, timeout: ?i32) !GetStatisticsResult {
+        const base_url = try std.fmt.allocPrint(alloc, "{s}?restype=service&comp=stats", .{self.endpoint});
+        defer alloc.free(base_url);
+        var url_buf: std.ArrayList(u8) = .empty;
+        defer url_buf.deinit(alloc);
+        try url_buf.appendSlice(alloc, base_url);
+        var has_query = std.mem.indexOfScalar(u8, base_url, '?') != null;
+        if (timeout) |v| {
+            const sep: []const u8 = if (has_query) "&" else "?";
+            try url_buf.print(alloc, "{s}timeout={d}", .{ sep, v });
+            has_query = true;
+        }
+        const url = try url_buf.toOwnedSlice(alloc);
+        defer alloc.free(url);
+        var req = core.http.Request.init(alloc, .GET, url);
+        defer req.deinit();
+        try req.setHeader("x-ms-version", self.api_version);
+        if (client_request_id) |value| try req.setHeader("x-ms-client-request-id", value);
+        try req.setHeader("Accept", "application/xml");
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Date") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_0);
+                const response_header_1 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("x-ms-version") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_1);
+                const response_header_2 = if (resp.getHeader("x-ms-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_2) |value| alloc.free(value);
+                const response_header_3 = if (resp.getHeader("x-ms-client-request-id")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_3) |value| alloc.free(value);
+                const response_header_4 = try alloc.dupe(
+                    u8,
+                    resp.getHeader("Content-Type") orelse return error.MissingResponseHeader,
+                );
+                errdefer alloc.free(response_header_4);
+                const response_body = try serde.xml.fromSlice(models.TableServiceStats, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .date = response_header_0,
+                        .api_version = response_header_1,
+                        .request_id = response_header_2,
+                        .client_request_id = response_header_3,
+                        .content_type = response_header_4,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Service.getStatistics", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
+        }
+    }
+};

--- a/src/clients_test.zig
+++ b/src/clients_test.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const clients = @import("clients.zig");
+const models = @import("models.zig");
+
+test "all fourteen stable Tables operations are directly accessible" {
+    try expectPublicMethods(clients.TablesClient, &.{ "table", "service" });
+    try expectPublicMethods(clients.Table, &.{
+        "query",
+        "create",
+        "delete",
+        "queryEntities",
+        "queryEntityWithPartitionAndRowKey",
+        "updateEntity",
+        "mergeEntity",
+        "deleteEntity",
+        "insertEntity",
+        "getAccessPolicy",
+        "setAccessPolicy",
+    });
+    try expectPublicMethods(clients.Service, &.{
+        "setProperties",
+        "getProperties",
+        "getStatistics",
+    });
+    try std.testing.expect(@hasDecl(models, "TableServiceProperties"));
+    try std.testing.expect(@hasDecl(models, "TableServiceStats"));
+}
+
+fn expectPublicMethods(comptime Client: type, comptime methods: []const []const u8) !void {
+    inline for (methods) |method| {
+        try std.testing.expect(@hasDecl(Client, method));
+    }
+}

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -1,0 +1,137 @@
+//! Generated enums.
+//!
+//! Azure data-plane enums are typically *extensible* — the wire
+//! contract may grow with new values that older clients still
+//! need to round-trip. Represented as a tagged union with a
+//! catch-all `unrecognized` variant.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+/// Specifies the level of metadata to be returned with the response.
+pub const OdataMetadataFormat = union(enum) {
+    no_metadata,
+    minimal_metadata,
+    full_metadata,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .no_metadata = "application/json;odata=nometadata",
+        .minimal_metadata = "application/json;odata=minimalmetadata",
+        .full_metadata = "application/json;odata=fullmetadata",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+/// Specifies whether the response should echo the created content.
+pub const ResponseFormat = union(enum) {
+    return_no_content,
+    return_content,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .return_no_content = "return-no-content",
+        .return_content = "return-content",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+/// The status of the secondary location.
+pub const GeoReplicationStatusType = union(enum) {
+    live,
+    bootstrap,
+    unavailable,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .live = "live",
+        .bootstrap = "bootstrap",
+        .unavailable = "unavailable",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+/// The Azure Tables service versions.
+pub const Versions = enum {
+    v2019_02_02,
+
+    pub fn toWire(self: @This()) []const u8 {
+        return switch (self) {
+            .v2019_02_02 => "2019-02-02",
+        };
+    }
+
+    pub fn fromWire(s: []const u8) ?@This() {
+        if (std.mem.eql(u8, s, "2019-02-02")) return .v2019_02_02;
+        return null;
+    }
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.fixed_enum.deserialize(T, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.fixed_enum.serialize(self, serializer);
+    }
+};

--- a/src/models.zig
+++ b/src/models.zig
@@ -1,0 +1,403 @@
+//! Generated data-transfer-object models.
+
+const std = @import("std");
+const enums = @import("enums.zig");
+
+pub const JsonValue = union(enum) {
+    null_value: void,
+    boolean: bool,
+    integer: i64,
+    float: f64,
+    string: []const u8,
+    array: []JsonValue,
+    object: std.StringArrayHashMapUnmanaged(JsonValue),
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        const saved = deserializer.*;
+        if (deserializer.deserializeVoid()) |_| {
+            return .{ .null_value = {} };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeBool()) |value| {
+            return .{ .boolean = value };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeInt(i64)) |value| {
+            return .{ .integer = value };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeFloat(f64)) |value| {
+            return .{ .float = value };
+        } else |_| deserializer.* = saved;
+        if (deserializer.deserializeString(allocator)) |value| {
+            return .{ .string = value };
+        } else |_| deserializer.* = saved;
+
+        if (deserializer.deserializeSeqAccess()) |sequence_value| {
+            var sequence = sequence_value;
+            var values: std.ArrayList(JsonValue) = .empty;
+            errdefer values.deinit(allocator);
+            while (try sequence.nextElement(JsonValue, allocator)) |value| {
+                values.append(allocator, value) catch
+                    return deserializer.raiseError(error.OutOfMemory);
+            }
+            return .{ .array = values.toOwnedSlice(allocator) catch
+                return deserializer.raiseError(error.OutOfMemory) };
+        } else |_| deserializer.* = saved;
+
+        var map = deserializer.deserializeStruct(T) catch
+            return deserializer.raiseError(error.UnexpectedToken);
+        var values: std.StringArrayHashMapUnmanaged(JsonValue) = .empty;
+        errdefer values.deinit(allocator);
+        while (try map.nextKey(allocator)) |key| {
+            const owned_key = allocator.dupe(u8, key) catch
+                return deserializer.raiseError(error.OutOfMemory);
+            const value = map.nextValue(JsonValue, allocator) catch |err| {
+                allocator.free(owned_key);
+                return err;
+            };
+            values.put(allocator, owned_key, value) catch {
+                allocator.free(owned_key);
+                return deserializer.raiseError(error.OutOfMemory);
+            };
+        }
+        return .{ .object = values };
+    }
+
+    pub fn zerdeSerialize(self: JsonValue, serializer: anytype) @TypeOf(serializer.*).Error!void {
+        switch (self) {
+            .null_value => return serializer.serializeNull(),
+            .boolean => |value| return serializer.serializeBool(value),
+            .integer => |value| return serializer.serializeInt(value),
+            .float => |value| return serializer.serializeFloat(value),
+            .string => |value| return serializer.serializeString(value),
+            .array => |values| {
+                var array = try serializer.beginArray();
+                for (values) |value| try value.zerdeSerialize(&array);
+                return array.end();
+            },
+            .object => |values| {
+                var object = try serializer.beginStruct();
+                var iterator = values.iterator();
+                while (iterator.next()) |entry| {
+                    try object.serializeEntry(entry.key_ptr.*, entry.value_ptr.*);
+                }
+                return object.end();
+            },
+        }
+    }
+};
+
+/// The properties for the table query response.
+pub const TableQueryResponse = struct {
+    /// The metadata response of the table.
+    odata_metadata: ?[]const u8 = null,
+    /// The requested list of tables.
+    value: ?[]const TableProperties = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .odata_metadata = "odata.metadata",
+        },
+    };
+};
+
+/// The properties for the table response.
+pub const TableProperties = struct {
+    /// The name of the table.
+    table_name: ?[]const u8 = null,
+    /// The odata type of the table.
+    odata_type: ?[]const u8 = null,
+    /// The id of the table.
+    odata_id: ?[]const u8 = null,
+    /// The edit link of the table.
+    odata_edit_link: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .table_name = "TableName",
+            .odata_type = "odata.type",
+            .odata_id = "odata.id",
+            .odata_edit_link = "odata.editLink",
+        },
+    };
+};
+
+/// Table JSON error.
+pub const TablesError = struct {
+    /// Content-Type header
+    content_type: []const u8,
+    /// The error code.
+    error_code: ?[]const u8 = null,
+    /// The error message.
+    message: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .message = "Message",
+        },
+    };
+};
+
+/// The table properties as returned in an echo response.
+pub const TableResponse = struct {
+    /// The name of the table.
+    table_name: ?[]const u8 = null,
+    /// The odata type of the table.
+    odata_type: ?[]const u8 = null,
+    /// The id of the table.
+    odata_id: ?[]const u8 = null,
+    /// The edit link of the table.
+    odata_edit_link: ?[]const u8 = null,
+    /// The metadata response of the table.
+    odata_metadata: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .table_name = "TableName",
+            .odata_type = "odata.type",
+            .odata_id = "odata.id",
+            .odata_edit_link = "odata.editLink",
+            .odata_metadata = "odata.metadata",
+        },
+    };
+};
+
+/// The properties for the table entity query response.
+pub const TableEntityQueryResponse = struct {
+    /// The metadata response of the table.
+    odata_metadata: ?[]const u8 = null,
+    /// List of table entities.
+    value: ?[]const std.json.ArrayHashMap(JsonValue) = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+        .rename = .{
+            .odata_metadata = "odata.metadata",
+        },
+    };
+};
+
+/// Table signed identifiers.
+pub const SignedIdentifiers = struct {
+    /// An array of signed identifiers
+    identifiers: []const SignedIdentifier,
+
+    pub const serde = .{
+        .xml_root = "SignedIdentifiers",
+        .rename = .{
+            .identifiers = "SignedIdentifier",
+        },
+    };
+};
+
+/// The signed identifier.
+pub const SignedIdentifier = struct {
+    /// The unique ID for the signed identifier.
+    id: []const u8,
+    /// The access policy for the signed identifier.
+    access_policy: AccessPolicy,
+
+    pub const serde = .{
+        .xml_root = "SignedIdentifier",
+        .rename = .{
+            .id = "Id",
+            .access_policy = "AccessPolicy",
+        },
+    };
+};
+
+/// An access policy.
+pub const AccessPolicy = struct {
+    /// The date-time the policy is active.
+    start: []const u8,
+    /// The date-time the policy expires.
+    expiry: []const u8,
+    /// The permissions for acl the policy.
+    permission: []const u8,
+
+    pub const serde = .{
+        .xml_root = "AccessPolicy",
+        .rename = .{
+            .start = "Start",
+            .expiry = "Expiry",
+            .permission = "Permission",
+        },
+    };
+};
+
+/// The Tables service XML error.
+pub const TablesServiceError = struct {
+    /// The error code.
+    error_code: ?[]const u8 = null,
+    /// The error code.
+    code: ?[]const u8 = null,
+    /// The error message.
+    message: ?[]const u8 = null,
+
+    pub const serde = .{
+        .xml_root = "TablesServiceError",
+        .rename = .{
+            .error_code = "errorCode",
+            .code = "Code",
+            .message = "Message",
+        },
+    };
+};
+
+/// The service properties.
+pub const TableServiceProperties = struct {
+    /// The logging properties.
+    logging: ?Logging = null,
+    /// The hour metrics properties.
+    hour_metrics: ?Metrics = null,
+    /// The minute metrics properties.
+    minute_metrics: ?Metrics = null,
+    /// The CORS properties.
+    cors: ?CorsXml = null,
+    pub const CorsXml = struct {
+        items: []const CorsRule = &.{},
+        pub const serde = .{ .rename = .{ .items = "CorsRule" } };
+    };
+
+    pub const serde = .{
+        .xml_root = "StorageServiceProperties",
+        .rename = .{
+            .logging = "Logging",
+            .hour_metrics = "HourMetrics",
+            .minute_metrics = "MinuteMetrics",
+            .cors = "Cors",
+        },
+    };
+};
+
+/// Azure Analytics Logging settings.
+pub const Logging = struct {
+    /// The version of the logging properties.
+    version: []const u8,
+    /// Whether delete operation is logged.
+    delete: bool,
+    /// Whether read operation is logged.
+    read: bool,
+    /// Whether write operation is logged.
+    write: bool,
+    /// The retention policy of the logs.
+    retention_policy: RetentionPolicy,
+
+    pub const serde = .{
+        .xml_root = "Logging",
+        .rename = .{
+            .version = "Version",
+            .delete = "Delete",
+            .read = "Read",
+            .write = "Write",
+            .retention_policy = "RetentionPolicy",
+        },
+    };
+};
+
+/// The retention policy.
+pub const RetentionPolicy = struct {
+    /// Whether to enable the retention policy.
+    enabled: bool,
+    /// Indicates the number of days that metrics or logging or soft-deleted data
+    /// should be retained. All data older than this value will be deleted.
+    days: ?i32 = null,
+
+    pub const serde = .{
+        .xml_root = "RetentionPolicy",
+        .rename = .{
+            .enabled = "Enabled",
+            .days = "Days",
+        },
+    };
+};
+
+/// The metrics properties.
+pub const Metrics = struct {
+    /// The version of the metrics properties.
+    version: ?[]const u8 = null,
+    /// Indicates whether metrics are enabled for the Table service.
+    enabled: bool,
+    /// Indicates whether metrics should generate summary statistics for called API
+    /// operations.
+    include_apis: ?bool = null,
+    /// The retention policy of the metrics.
+    retention_policy: ?RetentionPolicy = null,
+
+    pub const serde = .{
+        .xml_root = "Metrics",
+        .rename = .{
+            .version = "Version",
+            .enabled = "Enabled",
+            .include_apis = "IncludeAPIs",
+            .retention_policy = "RetentionPolicy",
+        },
+    };
+};
+
+/// CORS is an HTTP feature that enables a web application running under one domain to access resources in another domain. Web browsers implement a security restriction known as same-origin policy that prevents a web page from calling APIs in a different domain; CORS provides a secure way to allow one domain (the origin domain) to call APIs in another domain
+pub const CorsRule = struct {
+    /// The origin domains that are permitted to make a request against the service via
+    /// CORS. The origin domain is the domain from which the request originates. Note
+    /// that the origin must be an exact case-sensitive match with the origin that the
+    /// user age sends to the service. You can also use the wildcard character '*' to
+    /// allow all origin domains to make requests via CORS.
+    allowed_origins: []const u8,
+    /// The methods (HTTP request verbs) that the origin domain may use for a CORS
+    /// request.
+    allowed_methods: []const u8,
+    /// The request headers that the origin domain may specify on the CORS request.
+    allowed_headers: []const u8,
+    /// The response headers that may be sent in the response to the CORS request and
+    /// exposed by the browser to the request issuer.
+    exposed_headers: []const u8,
+    /// The maximum amount time that a browser should cache the preflight OPTIONS
+    /// request.
+    max_age_in_seconds: i32,
+
+    pub const serde = .{
+        .xml_root = "CorsRule",
+        .rename = .{
+            .allowed_origins = "AllowedOrigins",
+            .allowed_methods = "AllowedMethods",
+            .allowed_headers = "AllowedHeaders",
+            .exposed_headers = "ExposedHeaders",
+            .max_age_in_seconds = "MaxAgeInSeconds",
+        },
+    };
+};
+
+/// Stats for the table service.
+pub const TableServiceStats = struct {
+    /// Geo-Replication information for the Secondary Storage Service.
+    geo_replication: ?GeoReplication = null,
+
+    pub const serde = .{
+        .xml_root = "StorageServiceStats",
+        .rename = .{
+            .geo_replication = "GeoReplication",
+        },
+    };
+};
+
+/// Geo-Replication information for the Secondary Storage Service
+pub const GeoReplication = struct {
+    /// The status of the secondary location
+    status: ?enums.GeoReplicationStatusType = null,
+    /// A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads.
+    last_sync_time: ?[]const u8 = null,
+
+    pub const serde = .{
+        .xml_root = "GeoReplication",
+        .rename = .{
+            .status = "Status",
+            .last_sync_time = "LastSyncTime",
+        },
+    };
+};

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,0 +1,12 @@
+//! data-tables — generated from TypeSpec.
+//!
+//! Do not edit by hand. Regenerate with `codegen`.
+
+const clients = @import("clients.zig");
+pub const models = @import("models.zig");
+pub const enums = @import("enums.zig");
+pub const TablesClient = clients.TablesClient;
+
+test {
+    _ = @import("clients_test.zig");
+}


### PR DESCRIPTION
Fixes #155

Parent tracker: #148

## Summary
- add the fixture-emitted `azure_rest_data_tables` package on the new `rest/data_tables` branch
- expose all 14 canonical Tables operations across `TablesClient`, `Table`, and `Service`, including JSON/XML models, enums, options, response headers, exact status alternatives, continuations, and generated contract checks
- install standard package CI and `.azure-sdk-generator` regeneration provenance
- keep `$batch` excluded because it is absent from the selected TypeSpec; add no Cosmos runtime behavior

## Provenance
- generator: main `f5dde2c7aa95e7a5ac496793b5527c9a212d642c`
- fixture: `codegen/fixtures/data_tables.json`
- canonical TypeSpec: `Azure/azure-rest-api-specs` `0744f52a86919d243ba2225e55bdb9c87bf521a5`
- path: `specification/cosmos-db/data-plane/Tables/tspconfig.yaml`
- newest stable selected after implementation-time refresh: `2019-02-02`
- Core: released `azure_sdk_core/v0.1.2` at `da55987aa3c90393a726fc1fa5e86ccd69d72271`; Zig hash `azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs`

## Tests
- `zig fmt --check .`
- `zig build test --summary all` (2/2)
- `zig run eng/package_branch_tool.zig -- validate-tree azure_rest_data_tables <package-worktree>`
- `scripts/verify-data-tables-regeneration.sh --rest-package-root <package-worktree>`
- package CI covers Ubuntu, Windows, and macOS.