### PR TITLE
data_tables: wrap generated protocol safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,23 @@ re-read `Data.Tables.Versions`, choose the newest stable member, and record an
 immutable upstream commit every time it is regenerated. A generic Storage
 `x-ms-version` is not a substitute for a Tables contract version.
 
-After the generated package is published, this SDK will pin it by immutable Git
-commit and Zig package hash and re-export its public root as `protocol`.
-`protocol` is reserved now so application imports do not change. Generated
-declarations must not absorb SDK policy, convenience, or ownership behavior.
+The SDK pins generated package commit
+`67d001426e73385a944a1bacde8d482b81dbf5ae` and Zig package hash
+`azure_rest_data_tables-0.1.0-CqXnR3B2AQBJhSOC2e17bpbGPj5hN9RjLcpQ01OfFGkf`,
+and re-exports its public root as `protocol`. Its provenance records upstream
+spec commit `0744f52a86919d243ba2225e55bdb9c87bf521a5`, generator commit
+`f5dde2c7aa95e7a5ac496793b5527c9a212d642c`, and stable API version
+`2019-02-02`.
+
+`ProtocolClient` is the shared validated bridge to generated calls. It
+normalizes endpoint paths while preserving SAS query bytes, maps metadata,
+request ID, server timeout, client timeout, and per-call policy options, and
+adapts generated values with allocator-owned raw response headers. Generated
+models remain the only wire models.
+
+The canonical TypeSpec does not model `$batch`; the generated provenance and
+operation inventory test prove that gap. This layer does not hand-write a
+replacement: the later transaction issue owns its documented implementation.
 
 ## Checked feature-parity contract
 

--- a/build.zig
+++ b/build.zig
@@ -16,12 +16,19 @@ pub fn build(b: *std.Build) void {
     });
     const serde_mod = serde_dep.module("serde");
 
+    const rest_dep = b.dependency("azure_rest_data_tables", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const rest_mod = rest_dep.module("azure_rest_data_tables");
+
     _ = b.addModule("azure_sdk_data_tables", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .imports = &.{
             .{ .name = "azure_sdk_core", .module = core_mod },
             .{ .name = "serde", .module = serde_mod },
+            .{ .name = "azure_rest_data_tables", .module = rest_mod },
         },
     });
 
@@ -33,6 +40,7 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{ .name = "azure_sdk_core", .module = core_mod },
                 .{ .name = "serde", .module = serde_mod },
+                .{ .name = "azure_rest_data_tables", .module = rest_mod },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,6 +12,10 @@
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
             .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
         },
+        .azure_rest_data_tables = .{
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#67d001426e73385a944a1bacde8d482b81dbf5ae",
+            .hash = "azure_rest_data_tables-0.1.0-CqXnR3B2AQBJhSOC2e17bpbGPj5hN9RjLcpQ01OfFGkf",
+        },
     },
     .paths = .{
         ".gitignore",
@@ -33,6 +37,7 @@
         "options.zig",
         "pager.zig",
         "pipeline.zig",
+        "protocol_client.zig",
         "request.zig",
         "responses.zig",
         "sas.zig",

--- a/options.zig
+++ b/options.zig
@@ -1,4 +1,37 @@
+const core = @import("azure_sdk_core");
+const protocol = @import("azure_rest_data_tables");
+
+pub const latest_api_version = "2019-02-02";
+pub const MetadataFormat = protocol.enums.OdataMetadataFormat;
+
+/// SDK settings shared by generated protocol calls.
+pub const ProtocolOptions = struct {
+    metadata: ?MetadataFormat = null,
+    client_request_id: ?[]const u8 = null,
+    /// Server-side timeout, in seconds.
+    timeout: ?i32 = null,
+    /// End-to-end client budget. A blocking in-flight send may exceed it.
+    operation_timeout_ms: ?u64 = null,
+    /// Per-call policies run before the client's configured pipeline.
+    policies: []const *core.pipeline.HttpPolicy = &.{},
+};
+
+pub const QueryEntitiesOptions = struct {
+    protocol: ProtocolOptions = .{},
+    top: ?i32 = null,
+    select: ?[]const u8 = null,
+    filter: ?[]const u8 = null,
+    next_partition_key: ?[]const u8 = null,
+    next_row_key: ?[]const u8 = null,
+};
+
+pub const QueryEntityOptions = struct {
+    protocol: ProtocolOptions = .{},
+    select: ?[]const u8 = null,
+    filter: ?[]const u8 = null,
+};
+
 /// Options accepted by the compatibility `TableClient.init` constructor.
 pub const TableClientOptions = struct {
-    api_version: []const u8 = "2019-02-02",
+    api_version: []const u8 = latest_api_version,
 };

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -2,3 +2,163 @@
 //!
 //! Owning clients will allocate pipeline state at a stable address. Derived
 //! clients borrow that state and may not outlive the owning service client.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const responses = @import("responses.zig");
+
+const HttpPolicy = core.pipeline.HttpPolicy;
+const HttpTransport = core.http.HttpTransport;
+const Request = core.http.Request;
+const Response = core.http.Response;
+
+pub const CallContext = struct {
+    allocator: std.mem.Allocator,
+    config_policy: *ConfigPolicy,
+    capture_policy: *CapturePolicy,
+    policy_ptrs: []*HttpPolicy,
+    pipeline: core.pipeline.HttpPipeline,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        base: core.pipeline.HttpPipeline,
+        raw_endpoint_query: ?[]const u8,
+        operation_timeout_ms: ?u64,
+        custom_policies: []const *HttpPolicy,
+    ) !CallContext {
+        const config = try allocator.create(ConfigPolicy);
+        errdefer allocator.destroy(config);
+        config.* = ConfigPolicy.init(raw_endpoint_query, operation_timeout_ms);
+        const capture = try allocator.create(CapturePolicy);
+        errdefer allocator.destroy(capture);
+        capture.* = CapturePolicy.init(allocator);
+
+        const policies = try allocator.alloc(
+            *HttpPolicy,
+            2 + custom_policies.len + base.policies.len,
+        );
+        errdefer allocator.free(policies);
+        policies[0] = config.asPolicy();
+        policies[1] = capture.asPolicy();
+        @memcpy(policies[2 .. 2 + custom_policies.len], custom_policies);
+        @memcpy(policies[2 + custom_policies.len ..], base.policies);
+        return .{
+            .allocator = allocator,
+            .config_policy = config,
+            .capture_policy = capture,
+            .policy_ptrs = policies,
+            .pipeline = .{ .policies = policies, .transport_impl = base.transport_impl },
+        };
+    }
+
+    pub fn takeResponse(self: *CallContext) !responses.ResponseMetadata {
+        const metadata = self.capture_policy.metadata orelse return error.MissingRawResponse;
+        self.capture_policy.metadata = null;
+        return metadata;
+    }
+
+    pub fn deinit(self: *CallContext) void {
+        self.capture_policy.deinit();
+        self.allocator.free(self.policy_ptrs);
+        self.allocator.destroy(self.capture_policy);
+        self.allocator.destroy(self.config_policy);
+        self.* = undefined;
+    }
+};
+
+const ConfigPolicy = struct {
+    raw_query: ?[]const u8,
+    operation_timeout_ms: ?u64,
+    policy: HttpPolicy,
+
+    fn init(raw_query: ?[]const u8, operation_timeout_ms: ?u64) ConfigPolicy {
+        return .{
+            .raw_query = raw_query,
+            .operation_timeout_ms = operation_timeout_ms,
+            .policy = .{ .processFn = &process },
+        };
+    }
+
+    fn asPolicy(self: *ConfigPolicy) *HttpPolicy {
+        return &self.policy;
+    }
+
+    fn process(
+        policy: *HttpPolicy,
+        request: *Request,
+        next: []*HttpPolicy,
+        transport: *HttpTransport,
+    ) anyerror!Response {
+        const self: *ConfigPolicy = @alignCast(@fieldParentPtr("policy", policy));
+        const old_timeout = request.operation_timeout_ms;
+        request.operation_timeout_ms = self.operation_timeout_ms;
+        defer request.operation_timeout_ms = old_timeout;
+
+        const old_url = request.url;
+        var owned_url: ?[]u8 = null;
+        defer if (owned_url) |url| request.allocator.free(url);
+        if (self.raw_query) |raw_query| {
+            const question = std.mem.indexOfScalar(u8, request.url, '?');
+            owned_url = if (question) |index|
+                try std.fmt.allocPrint(
+                    request.allocator,
+                    "{s}?{s}{s}{s}",
+                    .{
+                        request.url[0..index],
+                        raw_query,
+                        if (raw_query.len > 0 and index + 1 < request.url.len) "&" else "",
+                        request.url[index + 1 ..],
+                    },
+                )
+            else
+                try std.fmt.allocPrint(request.allocator, "{s}?{s}", .{ request.url, raw_query });
+            request.url = owned_url.?;
+        }
+        defer request.url = old_url;
+        return callNext(request, next, transport);
+    }
+};
+
+const CapturePolicy = struct {
+    allocator: std.mem.Allocator,
+    metadata: ?responses.ResponseMetadata = null,
+    policy: HttpPolicy,
+
+    fn init(allocator: std.mem.Allocator) CapturePolicy {
+        return .{
+            .allocator = allocator,
+            .policy = .{ .processFn = &process },
+        };
+    }
+
+    fn asPolicy(self: *CapturePolicy) *HttpPolicy {
+        return &self.policy;
+    }
+
+    fn process(
+        policy: *HttpPolicy,
+        request: *Request,
+        next: []*HttpPolicy,
+        transport: *HttpTransport,
+    ) anyerror!Response {
+        const self: *CapturePolicy = @alignCast(@fieldParentPtr("policy", policy));
+        var response = try callNext(request, next, transport);
+        errdefer response.deinit();
+        if (self.metadata) |*old| old.deinit();
+        self.metadata = try responses.ResponseMetadata.fromResponse(self.allocator, &response);
+        return response;
+    }
+
+    fn deinit(self: *CapturePolicy) void {
+        if (self.metadata) |*metadata| metadata.deinit();
+    }
+};
+
+fn callNext(
+    request: *Request,
+    next: []*HttpPolicy,
+    transport: *HttpTransport,
+) !Response {
+    if (next.len == 0) return transport.send(request);
+    return next[0].process(request, next[1..], transport);
+}

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -1,0 +1,252 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const protocol = @import("azure_rest_data_tables");
+const options = @import("options.zig");
+const pipeline_mod = @import("pipeline.zig");
+const request = @import("request.zig");
+const responses = @import("responses.zig");
+
+const ProtocolTable = @typeInfo(@TypeOf(protocol.TablesClient.table)).@"fn".return_type.?;
+
+/// Validated bridge from SDK options to the generated Tables protocol client.
+pub const ProtocolClient = struct {
+    allocator: std.mem.Allocator,
+    endpoint: request.NormalizedEndpoint,
+    api_version: []u8,
+    pipeline: core.pipeline.HttpPipeline,
+
+    pub const InitOptions = struct {
+        api_version: []const u8 = options.latest_api_version,
+    };
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        endpoint: []const u8,
+        http_pipeline: core.pipeline.HttpPipeline,
+        init_options: InitOptions,
+    ) !ProtocolClient {
+        try request.validateApiVersion(init_options.api_version);
+        var normalized = try request.NormalizedEndpoint.init(allocator, endpoint);
+        errdefer normalized.deinit();
+        return .{
+            .allocator = allocator,
+            .endpoint = normalized,
+            .api_version = try allocator.dupe(u8, init_options.api_version),
+            .pipeline = http_pipeline,
+        };
+    }
+
+    pub fn deinit(self: *ProtocolClient) void {
+        self.endpoint.deinit();
+        self.allocator.free(self.api_version);
+        self.* = undefined;
+    }
+
+    pub fn queryEntity(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        partition_key: []const u8,
+        row_key: []const u8,
+        query_options: options.QueryEntityOptions,
+    ) !responses.SdkResponse(ProtocolTable.QueryEntityWithPartitionAndRowKeyResult) {
+        try request.validateTableName(table_name);
+        try request.validateEntityKey(partition_key);
+        try request.validateEntityKey(row_key);
+        try request.validateProtocolOptions(query_options.protocol);
+
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        var call = try self.beginCall(arena_allocator, query_options.protocol);
+        defer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(
+            arena_allocator,
+            call.pipeline,
+            .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
+        );
+        var table = generated.table();
+        const value = try table.queryEntityWithPartitionAndRowKey(
+            arena_allocator,
+            query_options.protocol.client_request_id,
+            table_name,
+            query_options.protocol.timeout,
+            query_options.protocol.metadata,
+            query_options.select,
+            query_options.filter,
+            partition_key,
+            row_key,
+        );
+        const metadata = try call.takeResponse();
+        return .{
+            .value = value,
+            .status = metadata.status,
+            .headers = metadata.headers,
+            .arena = arena,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn queryEntities(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        query_options: options.QueryEntitiesOptions,
+    ) !responses.SdkResponse(ProtocolTable.QueryEntitiesResult) {
+        try request.validateTableName(table_name);
+        try request.validateProtocolOptions(query_options.protocol);
+        if (query_options.top) |top| {
+            if (top <= 0) return error.InvalidTop;
+        }
+
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        var call = try self.beginCall(arena_allocator, query_options.protocol);
+        defer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(
+            arena_allocator,
+            call.pipeline,
+            .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
+        );
+        var table = generated.table();
+        const value = try table.queryEntities(
+            arena_allocator,
+            query_options.protocol.client_request_id,
+            table_name,
+            query_options.protocol.metadata,
+            query_options.top,
+            query_options.select,
+            query_options.filter,
+            query_options.protocol.timeout,
+            query_options.next_partition_key,
+            query_options.next_row_key,
+        );
+        const metadata = try call.takeResponse();
+        return .{
+            .value = value,
+            .status = metadata.status,
+            .headers = metadata.headers,
+            .arena = arena,
+            .allocator = allocator,
+        };
+    }
+
+    fn beginCall(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        call_options: options.ProtocolOptions,
+    ) !pipeline_mod.CallContext {
+        return pipeline_mod.CallContext.init(
+            allocator,
+            self.pipeline,
+            if (self.endpoint.has_query) self.endpoint.raw_query else null,
+            call_options.operation_timeout_ms,
+            call_options.policies,
+        );
+    }
+};
+
+const HeaderPolicy = struct {
+    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+
+    fn process(
+        policy: *core.pipeline.HttpPolicy,
+        req: *core.http.Request,
+        next: []*core.pipeline.HttpPolicy,
+        transport: *core.http.HttpTransport,
+    ) anyerror!core.http.Response {
+        _ = policy;
+        try req.setHeader("x-test-policy", "applied");
+        if (next.len == 0) return transport.send(req);
+        return next[0].process(req, next[1..], transport);
+    }
+};
+
+test "generated query receives SDK options and preserves SAS bytes" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "ETag", .value = "etag-value" },
+        .{ .name = "x-ms-version", .value = "2020-test" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "x-extra", .value = "first" },
+        .{ .name = "x-extra", .value = "second" },
+    };
+    const base_pipeline: core.pipeline.HttpPipeline = .{
+        .policies = &.{},
+        .transport_impl = mock.asTransport(),
+    };
+    var client = try ProtocolClient.init(
+        allocator,
+        "https://account.table.core.windows.net/?sv=1%2F2&sig=a+b%3D&sp=r",
+        base_pipeline,
+        .{ .api_version = "2020-test" },
+    );
+    defer client.deinit();
+    var header_policy = HeaderPolicy{};
+    var response = try client.queryEntity(
+        allocator,
+        "Table123",
+        "O'Brien",
+        "雪 & row",
+        .{
+            .protocol = .{
+                .metadata = .full_metadata,
+                .client_request_id = "client-id",
+                .timeout = 30,
+                .operation_timeout_ms = 5000,
+                .policies = &.{&header_policy.policy},
+            },
+            .select = "Name,Price",
+        },
+    );
+    defer response.deinit();
+
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Table123(PartitionKey='O%27%27Brien',RowKey='%E9%9B%AA%20%26%20row')?sv=1%2F2&sig=a+b%3D&sp=r&timeout=30&$format=application%2Fjson%3Bodata%3Dfullmetadata&$select=Name%2CPrice",
+        mock.last_url.?,
+    );
+    try std.testing.expectEqualStrings("2020-test", mock.last_headers.get("x-ms-version").?);
+    try std.testing.expectEqualStrings("client-id", mock.last_headers.get("x-ms-client-request-id").?);
+    try std.testing.expectEqualStrings("applied", mock.last_headers.get("x-test-policy").?);
+    try std.testing.expectEqual(@as(?u64, 5000), mock.last_operation_timeout_ms);
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expectEqualStrings("etag-value", response.headers.getFirst("ETag").?);
+    try std.testing.expectEqual(@as(usize, 6), response.headers.entries.items.len);
+}
+
+test "invalid generated call inputs fail before transport" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+    const base_pipeline: core.pipeline.HttpPipeline = .{
+        .policies = &.{},
+        .transport_impl = mock.asTransport(),
+    };
+    var client = try ProtocolClient.init(
+        allocator,
+        "https://account.table.core.windows.net",
+        base_pipeline,
+        .{},
+    );
+    defer client.deinit();
+    try std.testing.expectEqualStrings(options.latest_api_version, client.api_version);
+    try std.testing.expectError(
+        error.InvalidTableName,
+        client.queryEntity(allocator, "bad-name", "pk", "rk", .{}),
+    );
+    try std.testing.expectError(
+        error.InvalidEntityKey,
+        client.queryEntity(allocator, "Table123", "bad/key", "rk", .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+}

--- a/request.zig
+++ b/request.zig
@@ -1,3 +1,146 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+pub const NormalizedEndpoint = struct {
+    base_url: []u8,
+    raw_query: []u8,
+    has_query: bool,
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, endpoint: []const u8) !NormalizedEndpoint {
+        if (endpoint.len == 0) return error.InvalidEndpoint;
+        for (endpoint) |byte| {
+            if (byte <= 0x20 or byte == 0x7f) return error.InvalidEndpoint;
+        }
+        if (std.mem.indexOfScalar(u8, endpoint, '#') != null) return error.InvalidEndpoint;
+
+        const query_index = std.mem.indexOfScalar(u8, endpoint, '?');
+        const base_input = if (query_index) |index| endpoint[0..index] else endpoint;
+        const raw_query = if (query_index) |index| endpoint[index + 1 ..] else "";
+
+        const uri = std.Uri.parse(base_input) catch return error.InvalidEndpoint;
+        if (!std.ascii.eqlIgnoreCase(uri.scheme, "https") and
+            !std.ascii.eqlIgnoreCase(uri.scheme, "http"))
+        {
+            return error.InvalidEndpointScheme;
+        }
+        if (uri.host == null or uri.user != null or uri.password != null or uri.fragment != null)
+            return error.InvalidEndpoint;
+        var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+        const host = uri.getHost(&host_buffer) catch return error.InvalidEndpoint;
+        if (host.bytes.len == 0) return error.InvalidEndpoint;
+
+        var end = base_input.len;
+        const authority_start = (std.mem.indexOf(u8, base_input, "://") orelse
+            return error.InvalidEndpoint) + 3;
+        const authority_end = std.mem.indexOfScalarPos(u8, base_input, authority_start, '/') orelse
+            base_input.len;
+        while (end > authority_end and base_input[end - 1] == '/') end -= 1;
+
+        const owned_base = try allocator.dupe(u8, base_input[0..end]);
+        errdefer allocator.free(owned_base);
+        return .{
+            .base_url = owned_base,
+            .raw_query = try allocator.dupe(u8, raw_query),
+            .has_query = query_index != null,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *NormalizedEndpoint) void {
+        self.allocator.free(self.base_url);
+        self.allocator.free(self.raw_query);
+        self.* = undefined;
+    }
+};
+
+pub fn validateTableName(name: []const u8) !void {
+    if (name.len < 3 or name.len > 63 or !std.ascii.isAlphabetic(name[0]))
+        return error.InvalidTableName;
+    for (name[1..]) |byte| {
+        if (!std.ascii.isAlphanumeric(byte)) return error.InvalidTableName;
+    }
+}
+
+pub fn validateEntityKey(key: []const u8) !void {
+    if (key.len == 0 or key.len > 1024 or !std.unicode.utf8ValidateSlice(key))
+        return error.InvalidEntityKey;
+    var index: usize = 0;
+    while (index < key.len) {
+        const sequence_len = std.unicode.utf8ByteSequenceLength(key[index]) catch
+            return error.InvalidEntityKey;
+        const codepoint = std.unicode.utf8Decode(key[index .. index + sequence_len]) catch
+            return error.InvalidEntityKey;
+        if (codepoint < 0x20 or (codepoint >= 0x7f and codepoint <= 0x9f) or
+            codepoint == '/' or codepoint == '\\' or codepoint == '#' or codepoint == '?')
+        {
+            return error.InvalidEntityKey;
+        }
+        index += sequence_len;
+    }
+}
+
+pub fn validateApiVersion(version: []const u8) !void {
+    if (version.len == 0) return error.InvalidApiVersion;
+    for (version) |byte| {
+        if (byte < 0x20 or byte == 0x7f) return error.InvalidApiVersion;
+    }
+}
+
+pub fn validateProtocolOptions(options: anytype) !void {
+    if (options.timeout) |timeout| {
+        if (timeout <= 0) return error.InvalidTimeout;
+    }
+    if (options.client_request_id) |request_id| {
+        if (request_id.len == 0) return error.InvalidClientRequestId;
+        for (request_id) |byte| {
+            if ((byte < 0x20 and byte != '\t') or byte == 0x7f)
+                return error.InvalidClientRequestId;
+        }
+    }
+}
+
+/// Doubles apostrophes for an OData literal, then encodes the raw bytes once.
+pub fn encodeODataStringLiteral(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    try validateEntityKey(value);
+    var escaped: std.ArrayList(u8) = .empty;
+    defer escaped.deinit(allocator);
+    for (value) |byte| {
+        try escaped.append(allocator, byte);
+        if (byte == '\'') try escaped.append(allocator, '\'');
+    }
+    return core.url.encodePathSegment(allocator, escaped.items);
+}
+
+pub fn buildEntityUrl(
+    allocator: std.mem.Allocator,
+    endpoint: []const u8,
+    table: []const u8,
+    partition_key: []const u8,
+    row_key: []const u8,
+) ![]u8 {
+    try validateTableName(table);
+    const encoded_partition = try encodeODataStringLiteral(allocator, partition_key);
+    defer allocator.free(encoded_partition);
+    const encoded_row = try encodeODataStringLiteral(allocator, row_key);
+    defer allocator.free(encoded_row);
+    var normalized = try NormalizedEndpoint.init(allocator, endpoint);
+    defer normalized.deinit();
+
+    return std.fmt.allocPrint(
+        allocator,
+        "{s}/{s}(PartitionKey='{s}',RowKey='{s}'){s}{s}",
+        .{
+            normalized.base_url,
+            table,
+            encoded_partition,
+            encoded_row,
+            if (normalized.has_query) "?" else "",
+            normalized.raw_query,
+        },
+    );
+}
+
 /// Writes a JSON-escaped string without surrounding quotes.
 pub fn writeJsonEscaped(writer: anytype, value: []const u8) !void {
     for (value) |c| {
@@ -19,4 +162,64 @@ pub fn writeJsonEscaped(writer: anytype, value: []const u8) !void {
             },
         }
     }
+}
+
+test "entity URL goldens encode OData literals exactly once" {
+    const allocator = std.testing.allocator;
+    const cases = [_]struct { key: []const u8, encoded: []const u8 }{
+        .{ .key = "O'Brien", .encoded = "O%27%27Brien" },
+        .{ .key = "two words", .encoded = "two%20words" },
+        .{ .key = "雪", .encoded = "%E9%9B%AA" },
+        .{ .key = "a&b=c", .encoded = "a%26b%3Dc" },
+        .{ .key = "already%20encoded", .encoded = "already%2520encoded" },
+    };
+    for (cases) |case| {
+        const url = try buildEntityUrl(
+            allocator,
+            "https://account.table.core.windows.net/",
+            "Table123",
+            case.key,
+            "row",
+        );
+        defer allocator.free(url);
+        const expected = try std.fmt.allocPrint(
+            allocator,
+            "https://account.table.core.windows.net/Table123(PartitionKey='{s}',RowKey='row')",
+            .{case.encoded},
+        );
+        defer allocator.free(expected);
+        try std.testing.expectEqualStrings(expected, url);
+    }
+}
+
+test "SAS endpoint query bytes and order are unchanged" {
+    const allocator = std.testing.allocator;
+    const url = try buildEntityUrl(
+        allocator,
+        "https://account.table.core.windows.net///?sv=1%2F2&sig=a+b%3D&sp=r",
+        "Table123",
+        "part",
+        "row",
+    );
+    defer allocator.free(url);
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Table123(PartitionKey='part',RowKey='row')?sv=1%2F2&sig=a+b%3D&sp=r",
+        url,
+    );
+}
+
+test "endpoint table key and property validation rejects invalid inputs" {
+    const entity = @import("entity.zig");
+    try std.testing.expectError(
+        error.InvalidEndpointScheme,
+        NormalizedEndpoint.init(std.testing.allocator, "ftp://example.com"),
+    );
+    try std.testing.expectError(
+        error.InvalidEndpoint,
+        NormalizedEndpoint.init(std.testing.allocator, "https:///missing-host"),
+    );
+    try std.testing.expectError(error.InvalidTableName, validateTableName("1table"));
+    try std.testing.expectError(error.InvalidEntityKey, validateEntityKey("bad/key"));
+    try std.testing.expectError(error.ReservedPropertyName, entity.validatePropertyName("PartitionKey"));
+    try std.testing.expectError(error.InvalidPropertyName, entity.validatePropertyName("bad/name"));
 }

--- a/responses.zig
+++ b/responses.zig
@@ -3,3 +3,93 @@
 //! Allocating responses will own an arena and expose one `deinit` operation.
 //! Response slices remain valid until that operation. HTTP failures are values
 //! in `*Result` variants; Zig errors are reserved for local failures.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// Allocator-owned raw headers, including duplicate values in wire order.
+pub const RawHeaders = struct {
+    entries: std.ArrayList(Header) = .empty,
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) RawHeaders {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn fromResponse(allocator: std.mem.Allocator, response: *const core.http.Response) !RawHeaders {
+        var result = init(allocator);
+        errdefer result.deinit();
+        if (response.response_headers.entries.items.len > 0) {
+            for (response.response_headers.entries.items) |header| {
+                try result.append(header.name, header.value);
+            }
+        } else {
+            var iterator = response.headers.iterator();
+            while (iterator.next()) |header| {
+                try result.append(header.key_ptr.*, header.value_ptr.*);
+            }
+        }
+        return result;
+    }
+
+    pub fn append(self: *RawHeaders, name: []const u8, value: []const u8) !void {
+        const owned_name = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned_name);
+        const owned_value = try self.allocator.dupe(u8, value);
+        errdefer self.allocator.free(owned_value);
+        try self.entries.append(self.allocator, .{ .name = owned_name, .value = owned_value });
+    }
+
+    pub fn getFirst(self: *const RawHeaders, name: []const u8) ?[]const u8 {
+        for (self.entries.items) |header| {
+            if (std.ascii.eqlIgnoreCase(name, header.name)) return header.value;
+        }
+        return null;
+    }
+
+    pub fn deinit(self: *RawHeaders) void {
+        for (self.entries.items) |header| {
+            self.allocator.free(header.name);
+            self.allocator.free(header.value);
+        }
+        self.entries.deinit(self.allocator);
+    }
+};
+
+pub const ResponseMetadata = struct {
+    status: u16,
+    headers: RawHeaders,
+
+    pub fn fromResponse(allocator: std.mem.Allocator, response: *const core.http.Response) !ResponseMetadata {
+        return .{
+            .status = response.status_code,
+            .headers = try RawHeaders.fromResponse(allocator, response),
+        };
+    }
+
+    pub fn deinit(self: *ResponseMetadata) void {
+        self.headers.deinit();
+    }
+};
+
+/// Owns generated response allocations and raw headers in one arena.
+pub fn SdkResponse(comptime T: type) type {
+    return struct {
+        value: T,
+        status: u16,
+        headers: RawHeaders,
+        arena: *std.heap.ArenaAllocator,
+        allocator: std.mem.Allocator,
+
+        pub fn deinit(self: *@This()) void {
+            self.arena.deinit();
+            self.allocator.destroy(self.arena);
+            self.* = undefined;
+        }
+    };
+}

--- a/root.zig
+++ b/root.zig
@@ -8,6 +8,7 @@ pub const errors = @import("errors.zig");
 pub const options = @import("options.zig");
 pub const pager = @import("pager.zig");
 pub const pipeline = @import("pipeline.zig");
+pub const protocol_client = @import("protocol_client.zig");
 pub const request = @import("request.zig");
 pub const responses = @import("responses.zig");
 pub const sas = @import("sas.zig");
@@ -15,9 +16,9 @@ pub const service_client = @import("service_client.zig");
 pub const service_models = @import("service_models.zig");
 pub const transaction = @import("transaction.zig");
 
-/// Generated Azure Tables wire declarations will be re-exported here after
-/// `azure_rest_data_tables` is generated and pinned.
-pub const protocol = struct {};
+/// Generated Azure Tables wire declarations pinned from `rest/data_tables`.
+pub const protocol = @import("azure_rest_data_tables");
+pub const ProtocolClient = protocol_client.ProtocolClient;
 
 // Compatibility exports for the original 0.1.0 package surface.
 pub const TableEntity = entity.TableEntity;
@@ -44,6 +45,7 @@ test {
     _ = options;
     _ = pager;
     _ = pipeline;
+    _ = protocol_client;
     _ = request;
     _ = responses;
     _ = sas;
@@ -51,6 +53,7 @@ test {
     _ = service_models;
     _ = transaction;
     _ = protocol;
+    _ = ProtocolClient;
     _ = TableEntity;
     _ = TableClient;
     _ = TableServiceClient;


### PR DESCRIPTION
Fixes #151
Parent: #148

## Summary
- pin and publicly re-export `azure_rest_data_tables`
- add validated endpoint/OData URL handling that preserves SAS query bytes
- flow metadata, request IDs, server/client timeout, and custom policies to generated calls
- adapt generated values with status and duplicate-preserving raw headers

## Immutable REST provenance
- package commit: `67d001426e73385a944a1bacde8d482b81dbf5ae`
- package hash: `azure_rest_data_tables-0.1.0-CqXnR3B2AQBJhSOC2e17bpbGPj5hN9RjLcpQ01OfFGkf`
- upstream spec commit: `0744f52a86919d243ba2225e55bdb9c87bf521a5`
- generated API version: `2019-02-02`

The canonical TypeSpec/provenance proves `$batch` is absent; this PR adds no hand-written protocol calls or duplicate wire models. Authentication, typed CRUD, paging, batches, and structured errors remain out of scope.

## Tests
- `git ls-files -z -- "*.zig" "build.zig.zon" | xargs -0 zig fmt --check`
- `zig build test --summary all` (13/13)