### PR TITLE
eng: publish convenience.zig + src for storage_blobs

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -249,6 +249,8 @@ pub const all = [_]Package{
             "build.zig.zon",
             "root.zig",
             "sas.zig",
+            "convenience.zig",
+            "src",
             "examples",
             "README.md",
             "LICENSE.txt",


### PR DESCRIPTION
`azure_sdk_storage_blobs` `publish_paths` in `eng/packages.zig` listed only the top-level hand-written sources (`root.zig`, `sas.zig`), but `root.zig` now also imports:
- **`convenience.zig`** — the convenience helpers merged in #147
- the generated **`src/`** tree (`clients.zig`, `models.zig`, `enums.zig`) merged in #123

A version-tag release would therefore publish a package that **cannot compile**, because those imports are absent from the published fileset. (This isn't caught by `package-check`, which only validates path well-formedness and the 4 required files, so nothing was red — but it is real release-time debt.)

This adds `"convenience.zig"` and `"src"` to the entry, matching the `src/`-based package convention (`arm_avs`, `keyvault_secrets`, `container_registry` all publish `"src"`).

## Validation
- `zig build package-check` → 22 packages valid
- `zig build package-history-check` → success
- `zig build test` (eng tooling) → pass
- `zig fmt --check eng/packages.zig` → clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 00901736-7ca2-408f-a032-512312458e50