### PR TITLE
sdk/data_tables: implement typed entity add, get, and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,17 @@ replacement: the later transaction issue owns its documented implementation.
 ## Entity CRUD
 
 `TableClient.addEntity` accepts either a comptime-validated caller struct or a
-`DynamicEntity`; `getEntity(T, ...)` decodes either form. The matching
+`DynamicEntity`; `getEntityAs(T, ...)` decodes either form. The matching
 `*Result` methods retain structured service failures, while simple methods map
 them to operation errors. `EntityResponse(T)` owns its decoded value, ETag,
 OData metadata, selected and raw headers in an arena; call `deinit`.
 
 `DeleteEntityOptions.if_match` defaults to `"*"` and accepts an ETag for a
-conditional delete. `getEntityRaw`, `createEntity`, and `deleteEntityRaw`
-retain access to the original raw-response operations during migration.
+conditional delete through `deleteEntityWithOptions`. The original
+`getEntity(allocator, pk, rk)`, `createEntity`, and
+`deleteEntity(allocator, pk, rk)` raw-response calls retain exact source
+compatibility; explicit `getEntityRaw` and `deleteEntityRaw` aliases are also
+available.
 
 ## Checked feature-parity contract
 
@@ -151,8 +154,8 @@ it does **not** claim that a later roadmap phase is already implemented.
 | [x] | Table client `Delete` convenience | `TableClient.deleteTable` / `deleteTableResult` |
 | [x] | `NewListTablesPager` with filter, select, top, format, and continuation | `TableServiceClient.listTables` returning `TablePager` |
 | [x] | `AddEntity` | generic `TableClient.addEntity` / `addEntityResult` |
-| [x] | `GetEntity` | generic `TableClient.getEntity` / `getEntityResult` |
-| [x] | `DeleteEntity` with `IfMatch` | `TableClient.deleteEntity` / `deleteEntityResult` |
+| [x] | `GetEntity` | generic `TableClient.getEntityAs` / `getEntityResult`; raw-compatible `getEntity` |
+| [x] | `DeleteEntity` with `IfMatch` | `TableClient.deleteEntityWithOptions` / `deleteEntityResult`; raw-compatible `deleteEntity` |
 | [x] | `UpdateEntity` merge and replace with ETags | `TableClient.updateEntity` / `updateEntityResult` plus `UpdateMode` |
 | [x] | `UpsertEntity` merge and replace | `TableClient.upsertEntity` / `upsertEntityResult` |
 | [x] | `NewListEntitiesPager` with filter, select, top, format, and two continuation keys | generic `TableClient.listEntities` returning `EntityPager(T)` |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ The canonical TypeSpec does not model `$batch`; the generated provenance and
 operation inventory test prove that gap. This layer does not hand-write a
 replacement: the later transaction issue owns its documented implementation.
 
+## Entity CRUD
+
+`TableClient.addEntity` accepts either a comptime-validated caller struct or a
+`DynamicEntity`; `getEntity(T, ...)` decodes either form. The matching
+`*Result` methods retain structured service failures, while simple methods map
+them to operation errors. `EntityResponse(T)` owns its decoded value, ETag,
+OData metadata, selected and raw headers in an arena; call `deinit`.
+
+`DeleteEntityOptions.if_match` defaults to `"*"` and accepts an ETag for a
+conditional delete. `getEntityRaw`, `createEntity`, and `deleteEntityRaw`
+retain access to the original raw-response operations during migration.
+
 ## Checked feature-parity contract
 
 `[x]` means the Go capability has been reviewed and assigned a Zig API owner;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,6 +32,7 @@
         "entity_codec_compile_fail_missing_keys.zig",
         "entity_codec_compile_fail_invalid_wire_name.zig",
         "entity_codec_compile_fail_reserved_wire_name.zig",
+        "entity_codec_compile_fail_too_many_properties.zig",
         "entity_codec_compile_fail_unsupported_type.zig",
         "errors.zig",
         "options.zig",

--- a/client.zig
+++ b/client.zig
@@ -3,6 +3,7 @@ const core = @import("azure_sdk_core");
 const auth = @import("auth.zig");
 const connection_string = @import("connection_string.zig");
 const entity = @import("entity.zig");
+const entity_codec = @import("entity_codec.zig");
 const options = @import("options.zig");
 const pipeline = @import("pipeline.zig");
 const protocol_client = @import("protocol_client.zig");
@@ -248,8 +249,156 @@ pub const TableClient = struct {
         );
     }
 
-    /// GET `{endpoint}/{tableName}(PartitionKey='{pk}',RowKey='{rk}')`.
+    /// Adds a typed or dynamic entity and returns the service echo.
+    pub fn addEntity(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        value: anytype,
+        add_options: options.AddEntityOptions,
+    ) !responses.EntityResponse(@TypeOf(value)) {
+        const result = try self.addEntityResult(allocator, value, add_options);
+        return switch (result) {
+            .success => |response| response,
+            .failure => |table_error| {
+                var owned_error = table_error;
+                owned_error.deinit();
+                return error.AddEntityFailed;
+            },
+        };
+    }
+
+    /// Result-preserving add operation. HTTP failures are values; malformed
+    /// success payloads, transport failures, and allocation failures are Zig
+    /// errors.
+    pub fn addEntityResult(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        value: anytype,
+        add_options: options.AddEntityOptions,
+    ) !responses.TableResult(responses.EntityResponse(@TypeOf(value))) {
+        const T = @TypeOf(value);
+        try validateEntityValue(T, value);
+        const json = if (T == entity.DynamicEntity)
+            try entity_codec.dynamicToJson(allocator, value)
+        else
+            try entity_codec.EntityCodec(T).toJson(allocator, value);
+        defer allocator.free(json);
+        if (json.len > 1024 * 1024) return error.EntityTooLarge;
+
+        const protocol_result = try self.protocol.insertEntityResult(
+            allocator,
+            self.table_name,
+            json,
+            add_options,
+        );
+        return switch (protocol_result) {
+            .failure => |table_error| .{ .failure = table_error },
+            .success => |raw_value| blk: {
+                var raw = raw_value;
+                errdefer raw.deinit();
+                break :blk .{ .success = try adaptEntityResponse(T, &raw) };
+            },
+        };
+    }
+
+    /// Retrieves and decodes one typed or dynamic entity.
     pub fn getEntity(
+        self: *TableClient,
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        partition_key: []const u8,
+        row_key: []const u8,
+        get_options: options.GetEntityOptions,
+    ) !responses.EntityResponse(T) {
+        const result = try self.getEntityResult(T, allocator, partition_key, row_key, get_options);
+        return switch (result) {
+            .success => |response| response,
+            .failure => |table_error| {
+                var owned_error = table_error;
+                owned_error.deinit();
+                return error.GetEntityFailed;
+            },
+        };
+    }
+
+    pub fn getEntityResult(
+        self: *TableClient,
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        partition_key: []const u8,
+        row_key: []const u8,
+        get_options: options.GetEntityOptions,
+    ) !responses.TableResult(responses.EntityResponse(T)) {
+        if (T != entity.DynamicEntity) _ = entity_codec.EntityCodec(T);
+        const protocol_result = try self.protocol.queryEntityResult(
+            allocator,
+            self.table_name,
+            partition_key,
+            row_key,
+            get_options,
+        );
+        return switch (protocol_result) {
+            .failure => |table_error| .{ .failure = table_error },
+            .success => |raw_value| blk: {
+                var raw = raw_value;
+                errdefer raw.deinit();
+                break :blk .{ .success = try adaptEntityResponse(T, &raw) };
+            },
+        };
+    }
+
+    /// Deletes an entity unconditionally (`if_match = "*"`) or conditionally
+    /// with a service ETag.
+    pub fn deleteEntity(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        partition_key: []const u8,
+        row_key: []const u8,
+        delete_options: options.DeleteEntityOptions,
+    ) !responses.DeleteEntityResponse {
+        const result = try self.deleteEntityResult(allocator, partition_key, row_key, delete_options);
+        return switch (result) {
+            .success => |response| response,
+            .failure => |table_error| {
+                var owned_error = table_error;
+                owned_error.deinit();
+                return error.DeleteEntityFailed;
+            },
+        };
+    }
+
+    pub fn deleteEntityResult(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        partition_key: []const u8,
+        row_key: []const u8,
+        delete_options: options.DeleteEntityOptions,
+    ) !responses.TableResult(responses.DeleteEntityResponse) {
+        const protocol_result = try self.protocol.deleteEntityResult(
+            allocator,
+            self.table_name,
+            partition_key,
+            row_key,
+            delete_options,
+        );
+        return switch (protocol_result) {
+            .failure => |table_error| .{ .failure = table_error },
+            .success => |raw_value| blk: {
+                var raw = raw_value;
+                const etag_headers = entityHeaders(&raw.headers);
+                break :blk .{ .success = .{
+                    .status = raw.status,
+                    .headers = etag_headers,
+                    .raw_headers = raw.headers,
+                    .arena = raw.arena,
+                    .allocator = raw.allocator,
+                } };
+            },
+        };
+    }
+
+    /// Compatibility escape hatch for the original raw GET operation.
+    pub fn getEntityRaw(
         self: *TableClient,
         allocator: std.mem.Allocator,
         partition_key: []const u8,
@@ -314,8 +463,8 @@ pub const TableClient = struct {
         return self.protocol.send(&req, .{});
     }
 
-    /// DELETE `{endpoint}/{tableName}(PartitionKey='{pk}',RowKey='{rk}')`.
-    pub fn deleteEntity(
+    /// Compatibility escape hatch for the original raw DELETE operation.
+    pub fn deleteEntityRaw(
         self: *TableClient,
         allocator: std.mem.Allocator,
         partition_key: []const u8,
@@ -439,6 +588,150 @@ fn queryHexDigit(byte: u8) ?u8 {
     return null;
 }
 
+fn validateEntityValue(comptime T: type, value: T) !void {
+    if (T == entity.DynamicEntity) {
+        try request.validateEntityKey(value.partition_key);
+        try request.validateEntityKey(value.row_key);
+        if (value.properties.count() > entity.max_custom_properties)
+            return error.TooManyProperties;
+        var iterator = value.properties.iterator();
+        while (iterator.next()) |entry| try entity.validatePropertyName(entry.key_ptr.*);
+        return;
+    }
+    _ = entity_codec.EntityCodec(T);
+    try request.validateEntityKey(@field(value, "partition_key"));
+    try request.validateEntityKey(@field(value, "row_key"));
+}
+
+fn adaptEntityResponse(comptime T: type, raw: anytype) !responses.EntityResponse(T) {
+    const arena_allocator = raw.arena.allocator();
+    const body = raw.body orelse return error.MissingRawResponseBody;
+    const decoded: T = if (T == entity.DynamicEntity)
+        try entity_codec.dynamicFromJson(arena_allocator, body)
+    else
+        try entity_codec.EntityCodec(T).deserialize(arena_allocator, body);
+    const etag = raw.headers.getFirst("ETag") orelse return error.MissingResponseHeader;
+    return .{
+        .value = decoded,
+        .etag = etag,
+        .status = raw.status,
+        .headers = entityHeaders(&raw.headers),
+        .metadata = try entityMetadata(arena_allocator, body),
+        .raw_headers = raw.headers,
+        .arena = raw.arena,
+        .allocator = raw.allocator,
+    };
+}
+
+fn entityHeaders(headers: *const responses.RawHeaders) responses.EntityHeaders {
+    return .{
+        .request_id = headers.getFirst("x-ms-request-id"),
+        .client_request_id = headers.getFirst("x-ms-client-request-id"),
+        .date = headers.getFirst("Date"),
+        .api_version = headers.getFirst("x-ms-version"),
+        .content_type = headers.getFirst("Content-Type"),
+        .preference_applied = headers.getFirst("Preference-Applied"),
+    };
+}
+
+fn entityMetadata(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !responses.EntityMetadata {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+    const object = switch (parsed.value) {
+        .object => |value| value,
+        else => return error.ExpectedObject,
+    };
+    return .{
+        .metadata = try copyJsonString(allocator, object.get("odata.metadata")),
+        .type_name = try copyJsonString(allocator, object.get("odata.type")),
+        .id = try copyJsonString(allocator, object.get("odata.id")),
+        .etag = try copyJsonString(allocator, object.get("odata.etag")),
+        .edit_link = try copyJsonString(allocator, object.get("odata.editLink")),
+    };
+}
+
+fn copyJsonString(allocator: std.mem.Allocator, value: ?std.json.Value) !?[]const u8 {
+    const item = value orelse return null;
+    return switch (item) {
+        .string => |string| try allocator.dupe(u8, string),
+        else => error.InvalidODataMetadata,
+    };
+}
+
+const AllocationSizeLimiter = struct {
+    child: std.mem.Allocator,
+    max_allocation: usize,
+    rejected_allocations: usize = 0,
+
+    fn allocator(self: *AllocationSizeLimiter) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    fn alloc(
+        context: *anyopaque,
+        len: usize,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *AllocationSizeLimiter = @ptrCast(@alignCast(context));
+        if (len > self.max_allocation) {
+            self.rejected_allocations += 1;
+            return null;
+        }
+        return self.child.rawAlloc(len, alignment, return_address);
+    }
+
+    fn resize(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) bool {
+        const self: *AllocationSizeLimiter = @ptrCast(@alignCast(context));
+        if (new_len > self.max_allocation) {
+            self.rejected_allocations += 1;
+            return false;
+        }
+        return self.child.rawResize(memory, alignment, new_len, return_address);
+    }
+
+    fn remap(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *AllocationSizeLimiter = @ptrCast(@alignCast(context));
+        if (new_len > self.max_allocation) {
+            self.rejected_allocations += 1;
+            return null;
+        }
+        return self.child.rawRemap(memory, alignment, new_len, return_address);
+    }
+
+    fn free(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) void {
+        const self: *AllocationSizeLimiter = @ptrCast(@alignCast(context));
+        self.child.rawFree(memory, alignment, return_address);
+    }
+};
+
 const TestCredential = struct {
     calls: usize = 0,
     credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
@@ -462,6 +755,255 @@ const TestCredential = struct {
 
 fn moveClient(client: TableClient) TableClient {
     return client;
+}
+
+const TestEntity = struct {
+    partition_key: []const u8,
+    row_key: []const u8,
+    name: []const u8,
+    active: bool,
+    count: edm.EdmInt64,
+    small_count: i32,
+    ratio: f64,
+    data: edm.EdmBinary,
+    created: edm.EdmDateTime,
+    id: edm.EdmGuid,
+    timestamp: ?edm.EdmDateTime = null,
+};
+
+const edm = @import("edm.zig");
+
+const entity_response_headers = &[_]core.http.MockTransport.HeaderPair{
+    .{ .name = "ETag", .value = "W/\"datetime'2026-07-26T00%3A00%3A00Z'\"" },
+    .{ .name = "x-ms-version", .value = "2019-02-02" },
+    .{ .name = "x-ms-request-id", .value = "request-id" },
+    .{ .name = "x-ms-client-request-id", .value = "client-id" },
+    .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+    .{ .name = "Content-Type", .value = "application/json" },
+    .{ .name = "Preference-Applied", .value = "return-content" },
+};
+
+const typed_entity_json =
+    \\{"odata.metadata":"https://account/$metadata#Table123/@Element","odata.type":"account.Table123","odata.id":"https://account/Table123(PartitionKey='p',RowKey='r')","odata.etag":"W/\"tag\"","odata.editLink":"Table123(PartitionKey='p',RowKey='r')","PartitionKey":"p","RowKey":"r","name":"widget","active":true,"count":"9223372036854775807","count@odata.type":"Edm.Int64","small_count":7,"ratio":1.5,"data":"aGk=","data@odata.type":"Edm.Binary","created":"2026-07-26T00:00:00Z","created@odata.type":"Edm.DateTime","id":"01234567-89ab-cdef-0123-456789abcdef","id@odata.type":"Edm.Guid","Timestamp":"2026-07-26T00:00:01Z"}
+;
+
+fn testEntityValue() !TestEntity {
+    return .{
+        .partition_key = "p",
+        .row_key = "r",
+        .name = "widget",
+        .active = true,
+        .count = .{ .value = std.math.maxInt(i64) },
+        .small_count = 7,
+        .ratio = 1.5,
+        .data = .{ .bytes = "hi" },
+        .created = try edm.EdmDateTime.init("2026-07-26T00:00:00Z"),
+        .id = try edm.EdmGuid.init("01234567-89ab-cdef-0123-456789abcdef"),
+    };
+}
+
+test "typed and dynamic add share EDM wire behavior and preserve metadata" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 201, typed_entity_json);
+    defer mock.deinit();
+    mock.response_headers_list = entity_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    var typed = try client.addEntity(allocator, try testEntityValue(), .{
+        .protocol = .{ .metadata = .full_metadata, .client_request_id = "client-id" },
+    });
+    defer typed.deinit();
+    try std.testing.expectEqual(@as(u16, 201), typed.status);
+    try std.testing.expectEqualStrings("widget", typed.value.name);
+    try std.testing.expectEqual(std.math.maxInt(i64), typed.value.count.value);
+    try std.testing.expectEqualStrings("hi", typed.value.data.bytes);
+    try std.testing.expectEqualStrings(entity_response_headers[0].value, typed.etag);
+    try std.testing.expectEqualStrings("account.Table123", typed.metadata.type_name.?);
+    try std.testing.expectEqualStrings("request-id", typed.headers.request_id.?);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"count@odata.type\":\"Edm.Int64\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "odata%3Dfullmetadata") != null);
+
+    var dynamic = try entity.DynamicEntity.init(allocator, "p", "r");
+    defer dynamic.deinit();
+    try dynamic.put("name", .{ .string = "widget" });
+    try dynamic.put("count", .{ .int64 = .{ .value = std.math.maxInt(i64) } });
+    mock.response_body = typed_entity_json;
+    var dynamic_response = try client.addEntity(allocator, dynamic, .{});
+    defer dynamic_response.deinit();
+    try std.testing.expectEqualStrings("widget", dynamic_response.value.properties.get("name").?.string);
+    try std.testing.expectEqual(std.math.maxInt(i64), dynamic_response.value.properties.get("count").?.int64.value);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"count@odata.type\":\"Edm.Int64\"") != null);
+}
+
+test "get supports full minimal and no metadata responses" {
+    const SimpleEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        name: []const u8,
+        timestamp: ?edm.EdmDateTime = null,
+    };
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\{"odata.metadata":"meta","odata.type":"type","PartitionKey":"p","RowKey":"r","name":"full"}
+    );
+    defer mock.deinit();
+    mock.response_headers_list = entity_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    var full = try client.getEntity(SimpleEntity, allocator, "p", "r", .{
+        .protocol = .{ .metadata = .full_metadata },
+    });
+    defer full.deinit();
+    try std.testing.expectEqualStrings("meta", full.metadata.metadata.?);
+    try std.testing.expectEqualStrings("type", full.metadata.type_name.?);
+
+    mock.response_body =
+        \\{"odata.metadata":"meta","PartitionKey":"p","RowKey":"r","name":"minimal"}
+    ;
+    var minimal = try client.getEntity(SimpleEntity, allocator, "p", "r", .{
+        .protocol = .{ .metadata = .minimal_metadata },
+    });
+    defer minimal.deinit();
+    try std.testing.expectEqualStrings("minimal", minimal.value.name);
+    try std.testing.expect(minimal.metadata.type_name == null);
+
+    mock.response_body =
+        \\{"PartitionKey":"p","RowKey":"r","name":"none"}
+    ;
+    var none = try client.getEntity(SimpleEntity, allocator, "p", "r", .{
+        .protocol = .{ .metadata = .no_metadata },
+    });
+    defer none.deinit();
+    try std.testing.expectEqualStrings("none", none.value.name);
+    try std.testing.expect(none.metadata.metadata == null);
+}
+
+test "conditional delete preserves service failure and wildcard success" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 412,
+        \\{"code":"UpdateConditionNotSatisfied","message":"etag mismatch"}
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "x-ms-request-id", .value = "condition-request" },
+    };
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    var failure = try client.deleteEntityResult(allocator, "p", "r", .{ .if_match = "W/\"old\"" });
+    defer failure.deinit(allocator);
+    switch (failure) {
+        .failure => |table_error| {
+            try std.testing.expectEqual(@as(u16, 412), table_error.status);
+            try std.testing.expectEqualStrings("UpdateConditionNotSatisfied", table_error.code);
+        },
+        .success => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqualStrings("W/\"old\"", mock.last_headers.get("If-Match").?);
+
+    mock.response_status = 204;
+    mock.response_body = "";
+    mock.response_headers_list = &.{
+        .{ .name = "x-ms-version", .value = "2019-02-02" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+    };
+    var success = try client.deleteEntity(allocator, "p", "r", .{});
+    defer success.deinit();
+    try std.testing.expectEqual(@as(u16, 204), success.status);
+    try std.testing.expectEqualStrings("*", mock.last_headers.get("If-Match").?);
+}
+
+test "entity constraints and malformed success fail locally" {
+    const SimpleEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        name: []const u8,
+    };
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{");
+    defer mock.deinit();
+    mock.response_headers_list = entity_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    try std.testing.expectError(
+        error.InvalidEntityKey,
+        client.addEntityResult(allocator, SimpleEntity{
+            .partition_key = "bad/key",
+            .row_key = "r",
+            .name = "invalid",
+        }, .{}),
+    );
+    try std.testing.expectError(
+        error.InvalidIfMatch,
+        client.deleteEntityResult(allocator, "p", "r", .{ .if_match = "" }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+
+    if (client.getEntityResult(SimpleEntity, allocator, "p", "r", .{})) |result| {
+        var unexpected = result;
+        unexpected.deinit(allocator);
+        return error.TestExpectedMalformedPayload;
+    } else |_| {}
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
+fn testEntityCrudAllocationFailures(allocator: std.mem.Allocator) !void {
+    const SimpleEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        name: []const u8,
+    };
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\{"PartitionKey":"p","RowKey":"r","name":"owned"}
+    );
+    defer mock.deinit();
+    mock.response_headers_list = entity_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=allocation-secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+    var response = try client.getEntity(SimpleEntity, allocator, "p", "r", .{});
+    response.deinit();
+}
+
+test "entity CRUD allocation failure paths are leak-free" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        testEntityCrudAllocationFailures,
+        .{},
+    );
 }
 
 test "token client survives moves and applies all client options" {
@@ -488,7 +1030,7 @@ test "token client survives moves and applies all client options" {
     table_client = moveClient(table_client);
     try std.testing.expect(table_client.pipeline_state == stable_address);
 
-    var response = try table_client.getEntity(allocator, "pk1", "rk1");
+    var response = try table_client.getEntityRaw(allocator, "pk1", "rk1");
     defer response.deinit();
     try std.testing.expectEqual(@as(u16, 200), response.status_code);
     try std.testing.expect(mock.last_headers.get("Authorization") != null);
@@ -598,7 +1140,7 @@ test "Shared Key and SAS constructors have isolated authentication behavior" {
         .{},
     );
     defer shared.deinit();
-    var shared_response = try shared.getEntity(allocator, "pk", "rk");
+    var shared_response = try shared.getEntityRaw(allocator, "pk", "rk");
     shared_response.deinit();
     try std.testing.expect(std.mem.startsWith(
         u8,
@@ -615,7 +1157,7 @@ test "Shared Key and SAS constructors have isolated authentication behavior" {
         .{},
     );
     defer sas.deinit();
-    var sas_response = try sas.getEntity(allocator, "pk", "rk");
+    var sas_response = try sas.getEntityRaw(allocator, "pk", "rk");
     sas_response.deinit();
     try std.testing.expect(mock.last_headers.get("Authorization") == null);
     try std.testing.expect(std.mem.indexOf(u8, mock.last_url.?, "sv=1%2F2&sig=a+b%3D&sp=r") != null);
@@ -632,7 +1174,7 @@ fn testSasOperationAllocationFailures(allocator: std.mem.Allocator) !void {
         .{},
     );
     defer sas.deinit();
-    var response = try sas.getEntity(allocator, "pk", "rk");
+    var response = try sas.getEntityRaw(allocator, "pk", "rk");
     response.deinit();
 }
 

--- a/client.zig
+++ b/client.zig
@@ -302,7 +302,7 @@ pub const TableClient = struct {
     }
 
     /// Retrieves and decodes one typed or dynamic entity.
-    pub fn getEntity(
+    pub fn getEntityAs(
         self: *TableClient,
         comptime T: type,
         allocator: std.mem.Allocator,
@@ -349,7 +349,7 @@ pub const TableClient = struct {
 
     /// Deletes an entity unconditionally (`if_match = "*"`) or conditionally
     /// with a service ETag.
-    pub fn deleteEntity(
+    pub fn deleteEntityWithOptions(
         self: *TableClient,
         allocator: std.mem.Allocator,
         partition_key: []const u8,
@@ -420,6 +420,16 @@ pub const TableClient = struct {
         return self.protocol.send(&req, .{});
     }
 
+    /// Original 0.1.0 raw-response GET retained with its exact signature.
+    pub fn getEntity(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        partition_key: []const u8,
+        row_key: []const u8,
+    ) !core.http.Response {
+        return self.getEntityRaw(allocator, partition_key, row_key);
+    }
+
     /// POST `{endpoint}/{tableName}` with JSON entity body.
     pub fn createEntity(
         self: *TableClient,
@@ -436,9 +446,9 @@ pub const TableClient = struct {
         );
         defer allocator.free(url);
 
-        var body_buf: std.ArrayList(u8) = .empty;
-        defer body_buf.deinit(allocator);
-        const writer = body_buf.writer(allocator);
+        var body_buf: std.Io.Writer.Allocating = .init(allocator);
+        defer body_buf.deinit();
+        const writer = &body_buf.writer;
         try writer.writeAll("{\"PartitionKey\":\"");
         try request.writeJsonEscaped(writer, table_entity.partition_key);
         try writer.writeAll("\",\"RowKey\":\"");
@@ -459,7 +469,7 @@ pub const TableClient = struct {
         try req.setHeader("Content-Type", "application/json");
         try req.setHeader("Accept", "application/json;odata=nometadata");
         try req.setHeader("x-ms-version", self.protocol.api_version);
-        req.body = body_buf.items;
+        req.body = body_buf.written();
         return self.protocol.send(&req, .{});
     }
 
@@ -484,6 +494,17 @@ pub const TableClient = struct {
         try req.setHeader("If-Match", "*");
         try req.setHeader("x-ms-version", self.protocol.api_version);
         return self.protocol.send(&req, .{});
+    }
+
+    /// Original 0.1.0 unconditional raw-response DELETE retained with its
+    /// exact signature.
+    pub fn deleteEntity(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        partition_key: []const u8,
+        row_key: []const u8,
+    ) !core.http.Response {
+        return self.deleteEntityRaw(allocator, partition_key, row_key);
     }
 };
 
@@ -864,7 +885,7 @@ test "get supports full minimal and no metadata responses" {
     );
     defer client.deinit();
 
-    var full = try client.getEntity(SimpleEntity, allocator, "p", "r", .{
+    var full = try client.getEntityAs(SimpleEntity, allocator, "p", "r", .{
         .protocol = .{ .metadata = .full_metadata },
     });
     defer full.deinit();
@@ -874,7 +895,7 @@ test "get supports full minimal and no metadata responses" {
     mock.response_body =
         \\{"odata.metadata":"meta","PartitionKey":"p","RowKey":"r","name":"minimal"}
     ;
-    var minimal = try client.getEntity(SimpleEntity, allocator, "p", "r", .{
+    var minimal = try client.getEntityAs(SimpleEntity, allocator, "p", "r", .{
         .protocol = .{ .metadata = .minimal_metadata },
     });
     defer minimal.deinit();
@@ -884,7 +905,7 @@ test "get supports full minimal and no metadata responses" {
     mock.response_body =
         \\{"PartitionKey":"p","RowKey":"r","name":"none"}
     ;
-    var none = try client.getEntity(SimpleEntity, allocator, "p", "r", .{
+    var none = try client.getEntityAs(SimpleEntity, allocator, "p", "r", .{
         .protocol = .{ .metadata = .no_metadata },
     });
     defer none.deinit();
@@ -928,7 +949,7 @@ test "conditional delete preserves service failure and wildcard success" {
         .{ .name = "x-ms-version", .value = "2019-02-02" },
         .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
     };
-    var success = try client.deleteEntity(allocator, "p", "r", .{});
+    var success = try client.deleteEntityWithOptions(allocator, "p", "r", .{});
     defer success.deinit();
     try std.testing.expectEqual(@as(u16, 204), success.status);
     try std.testing.expectEqualStrings("*", mock.last_headers.get("If-Match").?);
@@ -975,6 +996,74 @@ test "entity constraints and malformed success fail locally" {
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
 }
 
+test "dynamic entity enforces 252 custom properties regardless of timestamp" {
+    const allocator = std.testing.allocator;
+    var value = try entity.DynamicEntity.init(allocator, "p", "r");
+    defer value.deinit();
+    try value.setTimestamp(try edm.EdmDateTime.init("2026-07-26T00:00:00Z"));
+
+    var name_buffer: [32]u8 = undefined;
+    for (0..entity.max_custom_properties) |index| {
+        const name = try std.fmt.bufPrint(&name_buffer, "property_{d}", .{index});
+        try value.put(name, .null);
+    }
+    try validateEntityValue(entity.DynamicEntity, value);
+
+    try value.put("overflow_property", .null);
+    try std.testing.expectError(
+        error.TooManyProperties,
+        validateEntityValue(entity.DynamicEntity, value),
+    );
+}
+
+test "original raw entity method signatures remain source compatible" {
+    const RawKeyMethod = fn (
+        *TableClient,
+        std.mem.Allocator,
+        []const u8,
+        []const u8,
+    ) anyerror!core.http.Response;
+    const RawCreateMethod = fn (
+        *TableClient,
+        std.mem.Allocator,
+        entity.TableEntity,
+    ) anyerror!core.http.Response;
+    const get_fn: *const RawKeyMethod = &TableClient.getEntity;
+    const delete_fn: *const RawKeyMethod = &TableClient.deleteEntity;
+    const create_fn: *const RawCreateMethod = &TableClient.createEntity;
+
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=compatibility-secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    var get_response = try get_fn(&client, allocator, "p", "r");
+    get_response.deinit();
+    try std.testing.expectEqual(core.http.Method.GET, mock.last_method.?);
+
+    mock.response_status = 201;
+    var old_entity = entity.TableEntity.init(allocator, "p", "r");
+    defer old_entity.deinit();
+    try old_entity.put("Name", "old");
+    var create_response = try create_fn(&client, allocator, old_entity);
+    create_response.deinit();
+    try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"Name\":\"old\"") != null);
+
+    mock.response_status = 204;
+    var delete_response = try delete_fn(&client, allocator, "p", "r");
+    delete_response.deinit();
+    try std.testing.expectEqual(core.http.Method.DELETE, mock.last_method.?);
+    try std.testing.expectEqualStrings("*", mock.last_headers.get("If-Match").?);
+}
+
 fn testEntityCrudAllocationFailures(allocator: std.mem.Allocator) !void {
     const SimpleEntity = struct {
         partition_key: []const u8,
@@ -994,7 +1083,7 @@ fn testEntityCrudAllocationFailures(allocator: std.mem.Allocator) !void {
         .{},
     );
     defer client.deinit();
-    var response = try client.getEntity(SimpleEntity, allocator, "p", "r", .{});
+    var response = try client.getEntityAs(SimpleEntity, allocator, "p", "r", .{});
     response.deinit();
 }
 

--- a/client.zig
+++ b/client.zig
@@ -1064,6 +1064,80 @@ test "original raw entity method signatures remain source compatible" {
     try std.testing.expectEqualStrings("*", mock.last_headers.get("If-Match").?);
 }
 
+test "raw calls do not copy large response bodies while typed adapters capture" {
+    const SimpleEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        name: []const u8,
+    };
+    const allocator = std.testing.allocator;
+    const large_body = try allocator.alloc(u8, 512 * 1024);
+    defer allocator.free(large_body);
+    @memset(large_body, 'x');
+
+    var mock = core.http.MockTransport.init(allocator, 200, large_body);
+    defer mock.deinit();
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=no-copy-secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+    var limiter = AllocationSizeLimiter{
+        .child = allocator,
+        .max_allocation = 128 * 1024,
+    };
+    const limited = limiter.allocator();
+
+    var get_response = try client.getEntity(limited, "p", "r");
+    defer get_response.deinit();
+    try std.testing.expectEqual(@as(usize, large_body.len), get_response.body.len);
+    try std.testing.expectEqual(@as(usize, 0), limiter.rejected_allocations);
+
+    mock.response_status = 500;
+    var old_entity = entity.TableEntity.init(allocator, "p", "r");
+    defer old_entity.deinit();
+    var create_response = try client.createEntity(limited, old_entity);
+    defer create_response.deinit();
+    try std.testing.expectEqual(@as(u16, 500), create_response.status_code);
+    try std.testing.expectEqualSlices(u8, large_body, create_response.body);
+    try std.testing.expectEqual(@as(usize, 0), limiter.rejected_allocations);
+
+    var delete_response = try client.deleteEntity(limited, "p", "r");
+    defer delete_response.deinit();
+    try std.testing.expectEqual(@as(u16, 500), delete_response.status_code);
+    try std.testing.expectEqualSlices(u8, large_body, delete_response.body);
+    try std.testing.expectEqual(@as(usize, 0), limiter.rejected_allocations);
+
+    mock.response_status = 200;
+    mock.response_headers_list = entity_response_headers;
+    try std.testing.expectError(
+        error.OutOfMemory,
+        client.getEntityResult(SimpleEntity, limited, "p", "r", .{}),
+    );
+    try std.testing.expect(limiter.rejected_allocations > 0);
+
+    mock.response_status = 412;
+    mock.response_body =
+        \\{"code":"UpdateConditionNotSatisfied","message":"etag mismatch"}
+    ;
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "x-ms-request-id", .value = "captured-error" },
+    };
+    var result = try client.deleteEntityResult(limited, "p", "r", .{ .if_match = "W/\"old\"" });
+    defer result.deinit(limited);
+    switch (result) {
+        .failure => |table_error| {
+            try std.testing.expectEqualStrings("UpdateConditionNotSatisfied", table_error.code);
+            try std.testing.expectEqualStrings("captured-error", table_error.request_id.?);
+        },
+        .success => return error.TestUnexpectedResult,
+    }
+}
+
 fn testEntityCrudAllocationFailures(allocator: std.mem.Allocator) !void {
     const SimpleEntity = struct {
         partition_key: []const u8,

--- a/entity.zig
+++ b/entity.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 const edm = @import("edm.zig");
 
+/// Azure Tables permits 255 properties total. PartitionKey, RowKey, and the
+/// service Timestamp reserve three slots for every entity.
+pub const max_custom_properties = 252;
+
 /// A runtime-typed Table property. Dynamic entities own all values placed in
 /// their property map and release them through `DynamicEntity.deinit`.
 pub const EdmValue = union(enum) {

--- a/entity_codec.zig
+++ b/entity_codec.zig
@@ -147,16 +147,26 @@ pub fn dynamicFromJson(allocator: std.mem.Allocator, json: []const u8) !DynamicE
     while (it.next()) |entry| {
         const name = entry.key_ptr.*;
         if (std.mem.eql(u8, name, "PartitionKey") or std.mem.eql(u8, name, "RowKey") or
-            std.mem.eql(u8, name, "Timestamp") or std.mem.endsWith(u8, name, "@odata.type")) continue;
+            std.mem.eql(u8, name, "Timestamp") or std.mem.endsWith(u8, name, "@odata.type") or
+            isEntityMetadataAnnotation(name)) continue;
         const annotation = getAnnotation(object, name);
         const property = try decodeEdmValue(allocator, entry.value_ptr.*, annotation);
         defer {
             var owned_property = property;
             owned_property.deinit(allocator);
         }
+
         try result.put(name, property);
     }
     return result;
+}
+
+fn isEntityMetadataAnnotation(name: []const u8) bool {
+    return std.mem.eql(u8, name, "odata.metadata") or
+        std.mem.eql(u8, name, "odata.type") or
+        std.mem.eql(u8, name, "odata.id") or
+        std.mem.eql(u8, name, "odata.etag") or
+        std.mem.eql(u8, name, "odata.editLink");
 }
 
 fn validateEntity(comptime T: type) void {

--- a/entity_codec.zig
+++ b/entity_codec.zig
@@ -12,6 +12,7 @@ pub const DynamicEntity = entity.DynamicEntity;
 /// Returns a codec specialized for `T`. Instantiating this function validates
 /// the complete entity schema at compile time.
 pub fn EntityCodec(comptime T: type) type {
+    @setEvalBranchQuota(2_000_000);
     comptime validateEntity(T);
 
     return struct {
@@ -177,6 +178,10 @@ fn validateEntity(comptime T: type) void {
     if (!isString(partition_field.type)) @compileError("EntityCodec partition_key must be []const u8 or []u8");
     if (!isString(row_field.type)) @compileError("EntityCodec row_key must be []const u8 or []u8");
 
+    if (customPropertyCount(T) > entity.max_custom_properties) {
+        @compileError("EntityCodec supports at most 252 custom properties");
+    }
+
     inline for (fields) |field| {
         if (std.mem.eql(u8, field.name, "timestamp")) {
             if (field.type != ?edm.EdmDateTime) @compileError("EntityCodec timestamp must be ?EdmDateTime");
@@ -206,6 +211,20 @@ fn validateEntity(comptime T: type) void {
             }
         }
     }
+}
+
+fn customPropertyCount(comptime T: type) usize {
+    var count: usize = 0;
+    inline for (std.meta.fields(T)) |field| {
+        if (!isSystemField(field.name)) count += 1;
+    }
+    return count;
+}
+
+fn isSystemField(comptime name: []const u8) bool {
+    return std.mem.eql(u8, name, "partition_key") or
+        std.mem.eql(u8, name, "row_key") or
+        std.mem.eql(u8, name, "timestamp");
 }
 
 fn findField(comptime T: type, comptime name: []const u8) ?std.builtin.Type.StructField {
@@ -426,6 +445,49 @@ fn decodeEdmValue(allocator: std.mem.Allocator, value: std.json.Value, annotatio
         .string => |inner| .{ .string = try allocator.dupe(u8, inner) },
         else => error.InvalidPropertyType,
     };
+}
+
+fn propertyBoundaryEntity(
+    comptime custom_count: usize,
+    comptime include_timestamp: bool,
+) type {
+    const field_count = 2 + custom_count + @intFromBool(include_timestamp);
+    var names: [field_count][:0]const u8 = undefined;
+    var types: [field_count]type = undefined;
+    const attributes: [field_count]std.builtin.Type.StructField.Attributes = @splat(.{});
+    names[0] = "partition_key";
+    types[0] = []const u8;
+    names[1] = "row_key";
+    types[1] = []const u8;
+    inline for (0..custom_count) |index| {
+        names[2 + index] = std.fmt.comptimePrint("property_{d}", .{index});
+        types[2 + index] = ?bool;
+    }
+    if (include_timestamp) {
+        names[field_count - 1] = "timestamp";
+        types[field_count - 1] = ?edm.EdmDateTime;
+    }
+    return @Struct(.auto, null, &names, &types, &attributes);
+}
+
+test "typed entity permits exactly 252 custom optional properties" {
+    @setEvalBranchQuota(2_000_000);
+    _ = EntityCodec(propertyBoundaryEntity(entity.max_custom_properties, false));
+    _ = EntityCodec(propertyBoundaryEntity(entity.max_custom_properties, true));
+}
+
+test "typed custom property count is unchanged by rename and optional timestamp" {
+    const RenamedEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        optional_value: ?bool,
+        ordinary_value: i32,
+        timestamp: ?edm.EdmDateTime,
+
+        pub const table = .{ .rename = .{ .optional_value = "RenamedValue" } };
+    };
+    try std.testing.expectEqual(@as(usize, 2), comptime customPropertyCount(RenamedEntity));
+    _ = EntityCodec(RenamedEntity);
 }
 
 test "typed entity codec writes annotations and round trips owned values" {

--- a/entity_codec_compile_fail_too_many_properties.zig
+++ b/entity_codec_compile_fail_too_many_properties.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const codec = @import("entity_codec.zig");
+const edm = @import("edm.zig");
+
+fn boundaryEntity(comptime custom_count: usize) type {
+    const field_count = 3 + custom_count;
+    var names: [field_count][:0]const u8 = undefined;
+    var types: [field_count]type = undefined;
+    const attributes: [field_count]std.builtin.Type.StructField.Attributes = @splat(.{});
+    names[0] = "partition_key";
+    types[0] = []const u8;
+    names[1] = "row_key";
+    types[1] = []const u8;
+    inline for (0..custom_count) |index| {
+        names[2 + index] = std.fmt.comptimePrint("optional_property_{d}", .{index});
+        types[2 + index] = ?bool;
+    }
+    names[field_count - 1] = "timestamp";
+    types[field_count - 1] = ?edm.EdmDateTime;
+    return @Struct(.auto, null, &names, &types, &attributes);
+}
+
+comptime {
+    @setEvalBranchQuota(2_000_000);
+    _ = codec.EntityCodec(boundaryEntity(253));
+}

--- a/options.zig
+++ b/options.zig
@@ -49,6 +49,19 @@ pub const ListTablesOptions = struct {
     continuation_token: ?[]const u8 = null,
 };
 
+pub const AddEntityOptions = struct {
+    protocol: ProtocolOptions = .{},
+};
+
+pub const GetEntityOptions = QueryEntityOptions;
+
+pub const DeleteEntityOptions = struct {
+    protocol: ProtocolOptions = .{},
+    /// `"*"` performs an unconditional delete; an entity ETag makes it
+    /// conditional.
+    if_match: []const u8 = "*",
+};
+
 pub const RetryOptions = struct {
     max_retries: u32 = 3,
     initial_delay_ms: u64 = 800,

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -271,7 +271,7 @@ fn validateHeaderValue(value: ?[]const u8, comptime invalid_error: anyerror) !vo
 pub const CallContext = struct {
     allocator: std.mem.Allocator,
     config_policy: *ConfigPolicy,
-    capture_policy: *CapturePolicy,
+    capture_policy: ?*CapturePolicy,
     sas_policy: *SasAuthPolicy,
     policy_ptrs: []*HttpPolicy,
     pipeline: core.pipeline.HttpPipeline,
@@ -285,6 +285,70 @@ pub const CallContext = struct {
         server_timeout: ?i32,
         custom_policies: []const *HttpPolicy,
     ) !CallContext {
+        return initInternal(
+            allocator,
+            base,
+            raw_endpoint_query,
+            endpoint_query_is_sas,
+            operation_timeout_ms,
+            server_timeout,
+            custom_policies,
+            .failure_only,
+        );
+    }
+
+    pub fn initWithResponseBody(
+        allocator: std.mem.Allocator,
+        base: core.pipeline.HttpPipeline,
+        raw_endpoint_query: ?[]const u8,
+        endpoint_query_is_sas: bool,
+        operation_timeout_ms: ?u64,
+        server_timeout: ?i32,
+        custom_policies: []const *HttpPolicy,
+    ) !CallContext {
+        return initInternal(
+            allocator,
+            base,
+            raw_endpoint_query,
+            endpoint_query_is_sas,
+            operation_timeout_ms,
+            server_timeout,
+            custom_policies,
+            .all,
+        );
+    }
+
+    pub fn initNoCapture(
+        allocator: std.mem.Allocator,
+        base: core.pipeline.HttpPipeline,
+        raw_endpoint_query: ?[]const u8,
+        endpoint_query_is_sas: bool,
+        operation_timeout_ms: ?u64,
+        server_timeout: ?i32,
+        custom_policies: []const *HttpPolicy,
+    ) !CallContext {
+        return initInternal(
+            allocator,
+            base,
+            raw_endpoint_query,
+            endpoint_query_is_sas,
+            operation_timeout_ms,
+            server_timeout,
+            custom_policies,
+            .none,
+        );
+    }
+
+    fn initInternal(
+        allocator: std.mem.Allocator,
+        base: core.pipeline.HttpPipeline,
+        raw_endpoint_query: ?[]const u8,
+        endpoint_query_is_sas: bool,
+        operation_timeout_ms: ?u64,
+        server_timeout: ?i32,
+        custom_policies: []const *HttpPolicy,
+        capture_mode: CaptureMode,
+    ) !CallContext {
         const config = try allocator.create(ConfigPolicy);
         errdefer allocator.destroy(config);
         config.* = ConfigPolicy.init(
@@ -292,22 +356,30 @@ pub const CallContext = struct {
             operation_timeout_ms,
             server_timeout,
         );
-        const capture = try allocator.create(CapturePolicy);
-        errdefer allocator.destroy(capture);
-        capture.* = CapturePolicy.init(allocator);
+        const capture = if (capture_mode != .none)
+            try allocator.create(CapturePolicy)
+        else
+            null;
+        errdefer if (capture) |value| allocator.destroy(value);
+        if (capture) |value|
+            value.* = CapturePolicy.init(allocator, capture_mode == .all);
         const sas = try allocator.create(SasAuthPolicy);
         errdefer allocator.destroy(sas);
         sas.* = SasAuthPolicy.init(if (endpoint_query_is_sas) raw_endpoint_query else null);
 
         const policies = try allocator.alloc(
             *HttpPolicy,
-            3 + custom_policies.len + base.policies.len,
+            2 + @intFromBool(capture != null) + custom_policies.len + base.policies.len,
         );
         errdefer allocator.free(policies);
         policies[0] = config.asPolicy();
-        policies[1] = capture.asPolicy();
-        @memcpy(policies[2 .. 2 + base.policies.len], base.policies);
-        const custom_start = 2 + base.policies.len;
+        var base_start: usize = 1;
+        if (capture) |value| {
+            policies[1] = value.asPolicy();
+            base_start += 1;
+        }
+        @memcpy(policies[base_start .. base_start + base.policies.len], base.policies);
+        const custom_start = base_start + base.policies.len;
         @memcpy(policies[custom_start .. custom_start + custom_policies.len], custom_policies);
         policies[policies.len - 1] = sas.asPolicy();
         return .{
@@ -321,20 +393,25 @@ pub const CallContext = struct {
     }
 
     pub fn takeResponse(self: *CallContext) !responses.ResponseMetadata {
-        const metadata = self.capture_policy.metadata orelse return error.MissingRawResponse;
-        self.capture_policy.metadata = null;
+        const capture = self.capture_policy orelse return error.ResponseCaptureDisabled;
+        const metadata = capture.metadata orelse return error.MissingRawResponse;
+        capture.metadata = null;
         return metadata;
     }
 
     pub fn deinit(self: *CallContext) void {
-        self.capture_policy.deinit();
+        if (self.capture_policy) |capture| {
+            capture.deinit();
+            self.allocator.destroy(capture);
+        }
         self.allocator.free(self.policy_ptrs);
-        self.allocator.destroy(self.capture_policy);
         self.allocator.destroy(self.config_policy);
         self.allocator.destroy(self.sas_policy);
         self.* = undefined;
     }
 };
+
+const CaptureMode = enum { none, failure_only, all };
 
 const ConfigPolicy = struct {
     raw_query: ?[]const u8,
@@ -476,12 +553,14 @@ fn appendServerTimeout(
 
 const CapturePolicy = struct {
     allocator: std.mem.Allocator,
+    capture_success_body: bool,
     metadata: ?responses.ResponseMetadata = null,
     policy: HttpPolicy,
 
-    fn init(allocator: std.mem.Allocator) CapturePolicy {
+    fn init(allocator: std.mem.Allocator, capture_success_body: bool) CapturePolicy {
         return .{
             .allocator = allocator,
+            .capture_success_body = capture_success_body,
             .policy = .{ .processFn = &process },
         };
     }
@@ -505,7 +584,7 @@ const CapturePolicy = struct {
             self.metadata.?.deinit();
             self.metadata = null;
         }
-        if (response.status_code < 200 or response.status_code >= 300)
+        if (self.capture_success_body or response.status_code < 200 or response.status_code >= 300)
             self.metadata.?.body = try self.allocator.dupe(u8, response.body);
         return response;
     }

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -369,7 +369,7 @@ pub const CallContext = struct {
 
         const policies = try allocator.alloc(
             *HttpPolicy,
-            2 + @intFromBool(capture != null) + custom_policies.len + base.policies.len,
+            2 + @as(usize, @intFromBool(capture != null)) + custom_policies.len + base.policies.len,
         );
         errdefer allocator.free(policies);
         policies[0] = config.asPolicy();

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const core = @import("azure_sdk_core");
 const errors = @import("errors.zig");
 const protocol = @import("azure_rest_data_tables");
+const serde = @import("serde");
 const options = @import("options.zig");
 const pipeline_mod = @import("pipeline.zig");
 const request = @import("request.zig");
@@ -244,14 +245,238 @@ pub const ProtocolClient = struct {
         return .{ .success = .{ .value = value, .status = metadata.status, .headers = metadata.headers, .arena = arena, .allocator = allocator } };
     }
 
+    /// Adapts the generated insert operation into an SDK result without
+    /// discarding non-2xx response details.
+    pub fn insertEntityResult(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        entity_json: []const u8,
+        add_options: options.AddEntityOptions,
+    ) !responses.TableResult(responses.SdkResponse(ProtocolTable.InsertEntityResult)) {
+        try request.validateTableName(table_name);
+        try request.validateProtocolOptions(add_options.protocol);
+        if (entity_json.len == 0 or entity_json.len > 1024 * 1024)
+            return error.InvalidEntity;
+
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+        const properties = try serde.json.fromSlice(
+            std.json.ArrayHashMap(protocol.models.JsonValue),
+            arena_allocator,
+            entity_json,
+        );
+
+        const body_policy = try arena_allocator.create(BodyOverridePolicy);
+        body_policy.* = .{ .body = entity_json };
+        const call_policies = try arena_allocator.alloc(
+            *core.pipeline.HttpPolicy,
+            add_options.protocol.policies.len + 1,
+        );
+        @memcpy(call_policies[0..add_options.protocol.policies.len], add_options.protocol.policies);
+        call_policies[call_policies.len - 1] = &body_policy.policy;
+        var protocol_options = add_options.protocol;
+        protocol_options.policies = call_policies;
+        var call = try self.beginEntityCall(arena_allocator, protocol_options);
+        errdefer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(
+            arena_allocator,
+            call.pipeline,
+            .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
+        );
+        var table = generated.table();
+        const value = table.insertEntity(
+            arena_allocator,
+            table_name,
+            add_options.protocol.timeout,
+            add_options.protocol.metadata,
+            add_options.protocol.client_request_id,
+            .return_content,
+            properties,
+        ) catch |operation_error| {
+            if (operation_error != error.AzureRequestFailed) return operation_error;
+            var metadata = try call.takeResponse();
+            const table_error = try errorsFromMetadata(allocator, &metadata);
+            metadata.deinit();
+            call.deinit();
+            arena.deinit();
+            allocator.destroy(arena);
+            return .{ .failure = table_error };
+        };
+        const metadata = try call.takeResponse();
+        call.deinit();
+        return .{ .success = .{
+            .value = value,
+            .status = metadata.status,
+            .headers = metadata.headers,
+            .body = metadata.body,
+            .arena = arena,
+            .allocator = allocator,
+        } };
+    }
+
+    /// Result-preserving counterpart to `queryEntity`.
+    pub fn queryEntityResult(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        partition_key: []const u8,
+        row_key: []const u8,
+        query_options: options.QueryEntityOptions,
+    ) !responses.TableResult(responses.SdkResponse(ProtocolTable.QueryEntityWithPartitionAndRowKeyResult)) {
+        try request.validateTableName(table_name);
+        try request.validateEntityKey(partition_key);
+        try request.validateEntityKey(row_key);
+        try request.validateProtocolOptions(query_options.protocol);
+
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        var call = try self.beginEntityCall(arena_allocator, query_options.protocol);
+        errdefer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(
+            arena_allocator,
+            call.pipeline,
+            .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
+        );
+        var table = generated.table();
+        const value = table.queryEntityWithPartitionAndRowKey(
+            arena_allocator,
+            query_options.protocol.client_request_id,
+            table_name,
+            query_options.protocol.timeout,
+            query_options.protocol.metadata,
+            query_options.select,
+            query_options.filter,
+            partition_key,
+            row_key,
+        ) catch |operation_error| {
+            if (operation_error != error.AzureRequestFailed) return operation_error;
+            var metadata = try call.takeResponse();
+            const table_error = try errorsFromMetadata(allocator, &metadata);
+            metadata.deinit();
+            call.deinit();
+            arena.deinit();
+            allocator.destroy(arena);
+            return .{ .failure = table_error };
+        };
+        const metadata = try call.takeResponse();
+        call.deinit();
+        return .{ .success = .{
+            .value = value,
+            .status = metadata.status,
+            .headers = metadata.headers,
+            .body = metadata.body,
+            .arena = arena,
+            .allocator = allocator,
+        } };
+    }
+
+    /// Adapts the generated delete operation, including conditional failures.
+    pub fn deleteEntityResult(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        partition_key: []const u8,
+        row_key: []const u8,
+        delete_options: options.DeleteEntityOptions,
+    ) !responses.TableResult(responses.SdkResponse(ProtocolTable.DeleteEntityResult)) {
+        try request.validateTableName(table_name);
+        try request.validateEntityKey(partition_key);
+        try request.validateEntityKey(row_key);
+        try request.validateIfMatch(delete_options.if_match);
+        try request.validateProtocolOptions(delete_options.protocol);
+
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        var call = try self.beginEntityCall(arena_allocator, delete_options.protocol);
+        errdefer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(
+            arena_allocator,
+            call.pipeline,
+            .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
+        );
+        var table = generated.table();
+        const value = table.deleteEntity(
+            arena_allocator,
+            delete_options.protocol.client_request_id,
+            table_name,
+            delete_options.protocol.timeout,
+            delete_options.if_match,
+            partition_key,
+            row_key,
+        ) catch |operation_error| {
+            if (operation_error != error.AzureRequestFailed) return operation_error;
+            var metadata = try call.takeResponse();
+            const table_error = try errorsFromMetadata(allocator, &metadata);
+            metadata.deinit();
+            call.deinit();
+            arena.deinit();
+            allocator.destroy(arena);
+            return .{ .failure = table_error };
+        };
+        const metadata = try call.takeResponse();
+        call.deinit();
+        return .{ .success = .{
+            .value = value,
+            .status = metadata.status,
+            .headers = metadata.headers,
+            .body = metadata.body,
+            .arena = arena,
+            .allocator = allocator,
+        } };
+    }
+
+    fn beginEntityCall(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        call_options: options.ProtocolOptions,
+    ) !pipeline_mod.CallContext {
+        return pipeline_mod.CallContext.initWithResponseBody(
+            allocator,
+            self.pipeline,
+            if (self.endpoint.has_query) self.endpoint.raw_query else null,
+            self.endpoint_query_is_sas,
+            call_options.operation_timeout_ms,
+            call_options.timeout,
+            call_options.policies,
+        );
+    }
+
     pub fn send(
         self: *ProtocolClient,
         req: *core.http.Request,
         call_options: options.ProtocolOptions,
     ) !core.http.Response {
-        var call = try self.beginCall(req.allocator, call_options, null);
+        var call = try self.beginCallNoCapture(req.allocator, call_options);
         defer call.deinit();
         return call.pipeline.send(req);
+    }
+
+    fn beginCallNoCapture(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        call_options: options.ProtocolOptions,
+    ) !pipeline_mod.CallContext {
+        return pipeline_mod.CallContext.initNoCapture(
+            allocator,
+            self.pipeline,
+            if (self.endpoint.has_query) self.endpoint.raw_query else null,
+            self.endpoint_query_is_sas,
+            call_options.operation_timeout_ms,
+            call_options.timeout,
+            call_options.policies,
+        );
     }
 
     fn tableErrorFromGeneratedFailure(self: *ProtocolClient, allocator: std.mem.Allocator, call: *pipeline_mod.CallContext, generated_error: anyerror) !errors.TableError {
@@ -279,6 +504,41 @@ pub const ProtocolClient = struct {
         );
     }
 };
+
+const BodyOverridePolicy = struct {
+    body: []const u8,
+    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+
+    // The generated open JSON model cannot retain property annotations during
+    // serialization, so the SDK codec's validated bytes are authoritative.
+    fn process(
+        policy: *core.pipeline.HttpPolicy,
+        req: *core.http.Request,
+        next: []*core.pipeline.HttpPolicy,
+        transport: *core.http.HttpTransport,
+    ) anyerror!core.http.Response {
+        const self: *BodyOverridePolicy = @alignCast(@fieldParentPtr("policy", policy));
+        req.body = self.body;
+        if (next.len == 0) return transport.send(req);
+        return next[0].process(req, next[1..], transport);
+    }
+};
+
+fn errorsFromMetadata(
+    allocator: std.mem.Allocator,
+    metadata: *responses.ResponseMetadata,
+) !@import("errors.zig").TableError {
+    const content_type = metadata.headers.getFirst("Content-Type");
+    const request_id = metadata.headers.getFirst("x-ms-request-id");
+    return @import("errors.zig").TableError.fromResponse(
+        allocator,
+        metadata.status,
+        content_type,
+        request_id,
+        null,
+        metadata.body orelse "",
+    );
+}
 
 const HeaderPolicy = struct {
     policy: core.pipeline.HttpPolicy = .{ .processFn = &process },

--- a/request.zig
+++ b/request.zig
@@ -153,6 +153,13 @@ pub fn validateProtocolOptions(options: anytype) !void {
     }
 }
 
+pub fn validateIfMatch(value: []const u8) !void {
+    if (value.len == 0) return error.InvalidIfMatch;
+    for (value) |byte| {
+        if (byte < 0x20 or byte == 0x7f) return error.InvalidIfMatch;
+    }
+}
+
 /// Doubles apostrophes for an OData literal, then encodes the raw bytes once.
 pub fn encodeODataStringLiteral(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
     try validateEntityKey(value);

--- a/responses.zig
+++ b/responses.zig
@@ -86,6 +86,7 @@ pub fn SdkResponse(comptime T: type) type {
         value: T,
         status: u16,
         headers: RawHeaders,
+        body: ?[]const u8 = null,
         arena: *std.heap.ArenaAllocator,
         allocator: std.mem.Allocator,
 
@@ -96,6 +97,62 @@ pub fn SdkResponse(comptime T: type) type {
         }
     };
 }
+
+/// Frequently used Tables response headers. Slices are owned by the enclosing
+/// response and remain valid until its `deinit`.
+pub const EntityHeaders = struct {
+    request_id: ?[]const u8 = null,
+    client_request_id: ?[]const u8 = null,
+    date: ?[]const u8 = null,
+    api_version: ?[]const u8 = null,
+    content_type: ?[]const u8 = null,
+    preference_applied: ?[]const u8 = null,
+};
+
+/// OData entity annotations emitted by full and minimal metadata responses.
+/// No-metadata responses leave every field null.
+pub const EntityMetadata = struct {
+    metadata: ?[]const u8 = null,
+    type_name: ?[]const u8 = null,
+    id: ?[]const u8 = null,
+    etag: ?[]const u8 = null,
+    edit_link: ?[]const u8 = null,
+};
+
+/// An arena-owned decoded entity response.
+pub fn EntityResponse(comptime T: type) type {
+    return struct {
+        value: T,
+        etag: []const u8,
+        status: u16,
+        headers: EntityHeaders,
+        metadata: EntityMetadata,
+        raw_headers: RawHeaders,
+        arena: *std.heap.ArenaAllocator,
+        allocator: std.mem.Allocator,
+
+        pub fn deinit(self: *@This()) void {
+            self.arena.deinit();
+            self.allocator.destroy(self.arena);
+            self.* = undefined;
+        }
+    };
+}
+
+/// Arena-owned response from an entity deletion.
+pub const DeleteEntityResponse = struct {
+    status: u16,
+    headers: EntityHeaders,
+    raw_headers: RawHeaders,
+    arena: *std.heap.ArenaAllocator,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *DeleteEntityResponse) void {
+        self.arena.deinit();
+        self.allocator.destroy(self.arena);
+        self.* = undefined;
+    }
+};
 
 /// A typed operation outcome. Local failures remain in the outer Zig error
 /// union; non-successful HTTP responses are `failure` values.

--- a/root.zig
+++ b/root.zig
@@ -61,6 +61,11 @@ pub const TablePager = pager.TablePager;
 pub const ListTablesPage = pager.ListTablesPage;
 pub const CreateTableResponse = responses.SdkResponse(protocol_client.CreateTableResponse);
 pub const DeleteTableResponse = responses.SdkResponse(protocol_client.DeleteTableResponse);
+pub const EntityResponse = responses.EntityResponse;
+pub const DeleteEntityResponse = responses.DeleteEntityResponse;
+pub const AddEntityOptions = options.AddEntityOptions;
+pub const GetEntityOptions = options.GetEntityOptions;
+pub const DeleteEntityOptions = options.DeleteEntityOptions;
 pub const unwrapGetEntity = responses.unwrapGetEntity;
 pub const unwrapCreateEntity = responses.unwrapCreateEntity;
 
@@ -124,6 +129,11 @@ test {
     _ = ListTablesPage;
     _ = CreateTableResponse;
     _ = DeleteTableResponse;
+    _ = EntityResponse;
+    _ = DeleteEntityResponse;
+    _ = AddEntityOptions;
+    _ = GetEntityOptions;
+    _ = DeleteEntityOptions;
     _ = unwrapGetEntity;
     _ = unwrapCreateEntity;
 }

--- a/service_client.zig
+++ b/service_client.zig
@@ -301,13 +301,13 @@ test "derived clients share token cache and transport and borrow pipeline state"
 
     var first = try service.getTableClient("FirstTable");
     try std.testing.expect(first.pipeline_state == shared_state);
-    var first_response = try first.getEntityRaw(allocator, "pk", "rk");
+    var first_response = try first.getEntity(allocator, "pk", "rk");
     first_response.deinit();
     first.deinit();
 
     var second = try service.getTableClient("SecondTable");
     defer second.deinit();
-    var second_response = try second.getEntityRaw(allocator, "pk", "rk");
+    var second_response = try second.getEntity(allocator, "pk", "rk");
     second_response.deinit();
 
     try std.testing.expectEqual(@as(usize, 1), credential.calls);

--- a/service_client.zig
+++ b/service_client.zig
@@ -301,13 +301,13 @@ test "derived clients share token cache and transport and borrow pipeline state"
 
     var first = try service.getTableClient("FirstTable");
     try std.testing.expect(first.pipeline_state == shared_state);
-    var first_response = try first.getEntity(allocator, "pk", "rk");
+    var first_response = try first.getEntityRaw(allocator, "pk", "rk");
     first_response.deinit();
     first.deinit();
 
     var second = try service.getTableClient("SecondTable");
     defer second.deinit();
-    var second_response = try second.getEntity(allocator, "pk", "rk");
+    var second_response = try second.getEntityRaw(allocator, "pk", "rk");
     second_response.deinit();
 
     try std.testing.expectEqual(@as(usize, 1), credential.calls);


### PR DESCRIPTION
## Summary
- add typed and dynamic `addEntity`, `getEntity`, and conditional `deleteEntity` APIs with structured result variants
- adapt generated protocol successes and failures into arena-owned entity responses without losing headers, bodies, ETags, or OData metadata
- validate keys, entities, and conditions before transport while preserving raw compatibility methods and all authentication pipelines
- cover EDM wire parity, metadata formats, conditional failures, malformed payloads, invalid inputs, auth compatibility, and allocation failures

## Validation
- `zig fmt --check client.zig entity_codec.zig options.zig protocol_client.zig request.zig responses.zig root.zig service_client.zig`
- `zig build test` (51 tests)

Fixes #158

Part of #148