### PR TITLE
sdk/data_tables: add table lifecycle operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ Each page exposes the generated table wire response plus status and raw
 headers. Page values are borrowed from the pager until its next successful
 request or `deinit`. A pager owns an immutable protocol configuration copy,
 but borrows the service client's heap-stable pipeline state; deinitialize it
-before its parent service client.
+before its parent service client. `ListTablesOptions` strings and policy
+pointer-list storage are copied at pager creation, but the policy objects
+themselves are borrowed and must remain stable and outlive the pager.
 
 The pipeline policy order is request ID, telemetry, retry, then authentication.
 Putting authentication after retry ensures date-sensitive SharedKeyLite

--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ continues to borrow its keys and values.
   map bookkeeping is owned, but partition key, row key, property keys, and
   property values are borrowed. Call `deinit` to release the map.
 
+## Table lifecycle
+
+`TableServiceClient.createTable` and `deleteTable` operate on a supplied
+validated name; `TableClient` provides the same methods for its bound name.
+Their `*Result` variants retain non-2xx service failures as `TableError`.
+`listTables` returns a `TablePager`; configure `$filter`, `$select`, `$top`,
+metadata format, and an initial continuation through `ListTablesOptions`.
+Each page exposes the generated table wire response plus status and raw
+headers. Page values are borrowed from the pager until its next successful
+request or `deinit`.
+
 The pipeline policy order is request ID, telemetry, retry, then authentication.
 Putting authentication after retry ensures date-sensitive SharedKeyLite
 requests are signed on every attempt.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ Their `*Result` variants retain non-2xx service failures as `TableError`.
 metadata format, and an initial continuation through `ListTablesOptions`.
 Each page exposes the generated table wire response plus status and raw
 headers. Page values are borrowed from the pager until its next successful
-request or `deinit`.
+request or `deinit`. A pager owns an immutable protocol configuration copy,
+but borrows the service client's heap-stable pipeline state; deinitialize it
+before its parent service client.
 
 The pipeline policy order is request ID, telemetry, retry, then authentication.
 Putting authentication after retry ensures date-sensitive SharedKeyLite

--- a/client.zig
+++ b/client.zig
@@ -8,6 +8,7 @@ const pipeline = @import("pipeline.zig");
 const protocol_client = @import("protocol_client.zig");
 const request = @import("request.zig");
 const sas_types = @import("sas.zig");
+const responses = @import("responses.zig");
 
 /// Client for Azure Table Storage REST operations.
 ///
@@ -207,6 +208,44 @@ pub const TableClient = struct {
         );
         defer allocator.free(table_url);
         return parameters.appendToUrl(allocator, table_url);
+    }
+
+    pub fn createTableResult(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        create_options: options.CreateTableOptions,
+    ) !responses.TableResult(responses.SdkResponse(protocol_client.CreateTableResponse)) {
+        return self.protocol.createTable(allocator, self.table_name, create_options);
+    }
+
+    pub fn createTable(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        create_options: options.CreateTableOptions,
+    ) !responses.SdkResponse(protocol_client.CreateTableResponse) {
+        return responses.unwrapCreateTable(
+            responses.SdkResponse(protocol_client.CreateTableResponse),
+            try self.createTableResult(allocator, create_options),
+        );
+    }
+
+    pub fn deleteTableResult(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        delete_options: options.DeleteTableOptions,
+    ) !responses.TableResult(responses.SdkResponse(protocol_client.DeleteTableResponse)) {
+        return self.protocol.deleteTable(allocator, self.table_name, delete_options);
+    }
+
+    pub fn deleteTable(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        delete_options: options.DeleteTableOptions,
+    ) !responses.SdkResponse(protocol_client.DeleteTableResponse) {
+        return responses.unwrapDeleteTable(
+            responses.SdkResponse(protocol_client.DeleteTableResponse),
+            try self.deleteTableResult(allocator, delete_options),
+        );
     }
 
     /// GET `{endpoint}/{tableName}(PartitionKey='{pk}',RowKey='{rk}')`.

--- a/options.zig
+++ b/options.zig
@@ -31,6 +31,24 @@ pub const QueryEntityOptions = struct {
     filter: ?[]const u8 = null,
 };
 
+pub const CreateTableOptions = struct {
+    protocol: ProtocolOptions = .{},
+    prefer: ?protocol.enums.ResponseFormat = null,
+};
+
+pub const DeleteTableOptions = struct {
+    protocol: ProtocolOptions = .{},
+};
+
+pub const ListTablesOptions = struct {
+    protocol: ProtocolOptions = .{},
+    top: ?i32 = null,
+    select: ?[]const u8 = null,
+    filter: ?[]const u8 = null,
+    /// Opaque value from `x-ms-continuation-NextTableName`.
+    continuation_token: ?[]const u8 = null,
+};
+
 pub const RetryOptions = struct {
     max_retries: u32 = 3,
     initial_delay_ms: u64 = 800,

--- a/pager.zig
+++ b/pager.zig
@@ -16,6 +16,8 @@ pub const TablePager = struct {
     /// Owns immutable endpoint/version configuration while borrowing the
     /// parent client's heap-stable pipeline. The parent must outlive this pager.
     protocol: protocol_client.ProtocolClient,
+    /// Owns option strings and policy-pointer storage. Policy objects remain
+    /// borrowed and must outlive the pager.
     options: options.ListTablesOptions,
     continuation_token: ?[]u8,
     current: ?ListTablesPage = null,
@@ -31,20 +33,25 @@ pub const TablePager = struct {
         }
         var owned_protocol = try protocol.clone(allocator);
         errdefer owned_protocol.deinit();
+        var owned_options = try copyListOptions(allocator, list_options);
+        errdefer deinitListOptions(allocator, &owned_options);
+        const continuation_token = if (list_options.continuation_token) |token|
+            try allocator.dupe(u8, token)
+        else
+            null;
+        errdefer if (continuation_token) |token| allocator.free(token);
         return .{
             .allocator = allocator,
             .protocol = owned_protocol,
-            .options = list_options,
-            .continuation_token = if (list_options.continuation_token) |token|
-                try allocator.dupe(u8, token)
-            else
-                null,
+            .options = owned_options,
+            .continuation_token = continuation_token,
         };
     }
 
     pub fn deinit(self: *TablePager) void {
         if (self.current) |*page| page.deinit();
         if (self.continuation_token) |token| self.allocator.free(token);
+        deinitListOptions(self.allocator, &self.options);
         self.protocol.deinit();
         self.* = undefined;
     }
@@ -88,6 +95,53 @@ pub const TablePager = struct {
     }
 };
 
+fn copyListOptions(
+    allocator: std.mem.Allocator,
+    source: options.ListTablesOptions,
+) !options.ListTablesOptions {
+    var result = source;
+    result.select = null;
+    result.filter = null;
+    result.continuation_token = null;
+    result.protocol.client_request_id = null;
+    result.protocol.policies = &.{};
+    result.protocol.metadata = null;
+    errdefer deinitListOptions(allocator, &result);
+
+    if (source.select) |value| result.select = try allocator.dupe(u8, value);
+    if (source.filter) |value| result.filter = try allocator.dupe(u8, value);
+    if (source.protocol.client_request_id) |value|
+        result.protocol.client_request_id = try allocator.dupe(u8, value);
+    if (source.protocol.metadata) |metadata| {
+        result.protocol.metadata = switch (metadata) {
+            .unrecognized => |value| .{ .unrecognized = try allocator.dupe(u8, value) },
+            else => metadata,
+        };
+    }
+    if (source.protocol.policies.len > 0)
+        result.protocol.policies = try allocator.dupe(
+            *core.pipeline.HttpPolicy,
+            source.protocol.policies,
+        );
+    return result;
+}
+
+fn deinitListOptions(
+    allocator: std.mem.Allocator,
+    list_options: *options.ListTablesOptions,
+) void {
+    if (list_options.select) |value| allocator.free(value);
+    if (list_options.filter) |value| allocator.free(value);
+    if (list_options.protocol.client_request_id) |value| allocator.free(value);
+    if (list_options.protocol.metadata) |metadata| switch (metadata) {
+        .unrecognized => |value| allocator.free(value),
+        else => {},
+    };
+    if (list_options.protocol.policies.len > 0)
+        allocator.free(list_options.protocol.policies);
+    list_options.* = undefined;
+}
+
 fn continuationFromPage(
     allocator: std.mem.Allocator,
     page: *const ListTablesPage,
@@ -99,6 +153,29 @@ fn continuationFromPage(
             null,
     };
 }
+
+const OptionPolicy = struct {
+    calls: usize = 0,
+    expected_request_id: []const u8,
+    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+
+    fn process(
+        policy: *core.pipeline.HttpPolicy,
+        request: *core.http.Request,
+        next: []*core.pipeline.HttpPolicy,
+        transport: *core.http.HttpTransport,
+    ) anyerror!core.http.Response {
+        const self: *OptionPolicy = @alignCast(@fieldParentPtr("policy", policy));
+        if (!std.mem.eql(
+            u8,
+            self.expected_request_id,
+            request.getHeader("x-ms-client-request-id") orelse return error.MissingRequestId,
+        )) return error.UnexpectedRequestId;
+        self.calls += 1;
+        if (next.len == 0) return transport.send(request);
+        return next[0].process(request, next[1..], transport);
+    }
+};
 
 test "table pager carries options and exact continuation bytes across pages" {
     const allocator = std.testing.allocator;
@@ -219,6 +296,80 @@ test "table pager represents each OData metadata format" {
     }
 }
 
+test "table pager owns list option bytes and policy pointer storage" {
+    const allocator = std.testing.allocator;
+    const pages = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 200,
+            .body = "{\"value\":[{\"TableName\":\"First\"}]}",
+            .headers = &.{
+                .{ .name = "x-ms-version", .value = "2019-02-02" },
+                .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+                .{ .name = "Content-Type", .value = "application/json" },
+                .{ .name = "x-ms-continuation-NextTableName", .value = "Second" },
+            },
+        },
+        .{
+            .status = 200,
+            .body = "{\"value\":[{\"TableName\":\"Second\"}]}",
+            .headers = &.{
+                .{ .name = "x-ms-version", .value = "2019-02-02" },
+                .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+                .{ .name = "Content-Type", .value = "application/json" },
+            },
+        },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &pages);
+    const base_pipeline: core.pipeline.HttpPipeline = .{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    var protocol = try protocol_client.ProtocolClient.init(
+        allocator,
+        "https://account.table.core.windows.net",
+        base_pipeline,
+        .{},
+    );
+    defer protocol.deinit();
+
+    var select = [_]u8{ 'T', 'a', 'b', 'l', 'e', 'N', 'a', 'm', 'e' };
+    var filter = [_]u8{ 'T', 'a', 'b', 'l', 'e', 'N', 'a', 'm', 'e', ' ', 'e', 'q', ' ', '\'', 'O', 'r', 'i', 'g', 'i', 'n', 'a', 'l', '\'' };
+    var request_id = [_]u8{ 'o', 'r', 'i', 'g', '-', 'i', 'd' };
+    var metadata = [_]u8{ 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n', '/', 'j', 's', 'o', 'n', ';', 'o', 'd', 'a', 't', 'a', '=', 'c', 'u', 's', 't', 'o', 'm' };
+    var applied = OptionPolicy{ .expected_request_id = "orig-id" };
+    var replacement = OptionPolicy{ .expected_request_id = "orig-id" };
+    var policy_ptrs = [_]*core.pipeline.HttpPolicy{&applied.policy};
+    var table_pager = try TablePager.init(allocator, &protocol, .{
+        .select = &select,
+        .filter = &filter,
+        .protocol = .{
+            .metadata = .{ .unrecognized = &metadata },
+            .client_request_id = &request_id,
+            .policies = &policy_ptrs,
+        },
+    });
+    defer table_pager.deinit();
+
+    @memset(&select, 'x');
+    @memset(&filter, 'x');
+    @memset(&request_id, 'x');
+    @memset(&metadata, 'x');
+    policy_ptrs[0] = &replacement.policy;
+
+    try std.testing.expect((try table_pager.next()) != null);
+    try std.testing.expect((try table_pager.next()) != null);
+    try std.testing.expectEqual(@as(usize, 2), applied.calls);
+    try std.testing.expectEqual(@as(usize, 0), replacement.calls);
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dcustom&$select=TableName&$filter=TableName%20eq%20%27Original%27",
+        transport.captured_urls[0][0..transport.captured_url_lengths[0]],
+    );
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dcustom&$select=TableName&$filter=TableName%20eq%20%27Original%27&NextTableName=Second",
+        transport.captured_urls[1][0..transport.captured_url_lengths[1]],
+    );
+}
+
 fn testPagerAllocationFailures(allocator: std.mem.Allocator) !void {
     var transport = core.http.MockTransport.init(
         allocator,
@@ -243,7 +394,22 @@ fn testPagerAllocationFailures(allocator: std.mem.Allocator) !void {
         .{},
     );
     defer protocol.deinit();
-    var table_pager = try TablePager.init(allocator, &protocol, .{});
+    var select = [_]u8{ 'T', 'a', 'b', 'l', 'e', 'N', 'a', 'm', 'e' };
+    var filter = [_]u8{ 'T', 'a', 'b', 'l', 'e', 'N', 'a', 'm', 'e' };
+    var request_id = [_]u8{ 'a', 'l', 'l', 'o', 'c' };
+    var metadata = [_]u8{ 'c', 'u', 's', 't', 'o', 'm' };
+    var option_policy = OptionPolicy{ .expected_request_id = "alloc" };
+    var policy_ptrs = [_]*core.pipeline.HttpPolicy{&option_policy.policy};
+    var table_pager = try TablePager.init(allocator, &protocol, .{
+        .select = &select,
+        .filter = &filter,
+        .continuation_token = "Initial",
+        .protocol = .{
+            .metadata = .{ .unrecognized = &metadata },
+            .client_request_id = &request_id,
+            .policies = &policy_ptrs,
+        },
+    });
     defer table_pager.deinit();
     try std.testing.expect((try table_pager.next()) != null);
 }

--- a/pager.zig
+++ b/pager.zig
@@ -99,13 +99,19 @@ fn copyListOptions(
     allocator: std.mem.Allocator,
     source: options.ListTablesOptions,
 ) !options.ListTablesOptions {
-    var result = source;
-    result.select = null;
-    result.filter = null;
-    result.continuation_token = null;
-    result.protocol.client_request_id = null;
-    result.protocol.policies = &.{};
-    result.protocol.metadata = null;
+    var result: options.ListTablesOptions = .{
+        .protocol = .{
+            .metadata = null,
+            .client_request_id = null,
+            .timeout = source.protocol.timeout,
+            .operation_timeout_ms = source.protocol.operation_timeout_ms,
+            .policies = &.{},
+        },
+        .top = source.top,
+        .select = null,
+        .filter = null,
+        .continuation_token = null,
+    };
     errdefer deinitListOptions(allocator, &result);
 
     if (source.select) |value| result.select = try allocator.dupe(u8, value);

--- a/pager.zig
+++ b/pager.zig
@@ -57,7 +57,9 @@ pub const TablePager = struct {
         const result = try self.protocol.queryTables(self.allocator, query);
         switch (result) {
             .failure => |failure| return .{ .failure = failure },
-            .success => |page| {
+            .success => |fetched_page| {
+                var page = fetched_page;
+                errdefer page.deinit();
                 const next_token = try continuationFromPage(self.allocator, &page);
                 errdefer if (next_token) |token| self.allocator.free(token);
 
@@ -137,6 +139,7 @@ test "table pager carries options and exact continuation bytes across pages" {
         .protocol = .{
             .metadata = .full_metadata,
             .client_request_id = "list-request",
+            .timeout = 40,
         },
     });
     defer table_pager.deinit();
@@ -151,7 +154,7 @@ test "table pager carries options and exact continuation bytes across pages" {
         .status_200 => |value| value.body.value.?[0].table_name.?,
     });
     try std.testing.expectEqualStrings(
-        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata&$top=3&$select=TableName&$filter=TableName%20ge%20%27A%27&NextTableName=Initial%20table%2F%3F%3F",
+        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata&$top=3&$select=TableName&$filter=TableName%20ge%20%27A%27&NextTableName=Initial%20table%2F%3F%3F&timeout=40",
         transport.captured_urls[0][0..transport.captured_url_lengths[0]],
     );
 
@@ -161,7 +164,7 @@ test "table pager carries options and exact continuation bytes across pages" {
         .status_200 => |value| value.body.odata_metadata.?,
     });
     try std.testing.expectEqualStrings(
-        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata&$top=3&$select=TableName&$filter=TableName%20ge%20%27A%27&NextTableName=Second%20table%2F%3F",
+        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata&$top=3&$select=TableName&$filter=TableName%20ge%20%27A%27&NextTableName=Second%20table%2F%3F&timeout=40",
         transport.captured_urls[1][0..transport.captured_url_lengths[1]],
     );
     try std.testing.expect((try table_pager.next()) == null);
@@ -209,4 +212,41 @@ test "table pager represents each OData metadata format" {
         try std.testing.expect((try table_pager.next()) != null);
         try std.testing.expect(std.mem.indexOf(u8, transport.last_url.?, case.expected) != null);
     }
+}
+
+fn testPagerAllocationFailures(allocator: std.mem.Allocator) !void {
+    var transport = core.http.MockTransport.init(
+        allocator,
+        200,
+        "{\"value\":[{\"TableName\":\"Allocated\"}]}",
+    );
+    defer transport.deinit();
+    transport.response_headers_list = &.{
+        .{ .name = "x-ms-version", .value = "2019-02-02" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "x-ms-continuation-NextTableName", .value = "Continuation" },
+    };
+    const base_pipeline: core.pipeline.HttpPipeline = .{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    var protocol = try protocol_client.ProtocolClient.init(
+        allocator,
+        "https://account.table.core.windows.net",
+        base_pipeline,
+        .{},
+    );
+    defer protocol.deinit();
+    var table_pager = try TablePager.init(allocator, &protocol, .{});
+    defer table_pager.deinit();
+    try std.testing.expect((try table_pager.next()) != null);
+}
+
+test "table pager allocation failures release an unfetched page" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        testPagerAllocationFailures,
+        .{},
+    );
 }

--- a/pager.zig
+++ b/pager.zig
@@ -13,7 +13,9 @@ pub const ListTablesPage = responses.SdkResponse(protocol_client.QueryTablesResp
 
 pub const TablePager = struct {
     allocator: std.mem.Allocator,
-    protocol: *protocol_client.ProtocolClient,
+    /// Owns immutable endpoint/version configuration while borrowing the
+    /// parent client's heap-stable pipeline. The parent must outlive this pager.
+    protocol: protocol_client.ProtocolClient,
     options: options.ListTablesOptions,
     continuation_token: ?[]u8,
     current: ?ListTablesPage = null,
@@ -27,9 +29,11 @@ pub const TablePager = struct {
         if (list_options.top) |top| {
             if (top <= 0) return error.InvalidTop;
         }
+        var owned_protocol = try protocol.clone(allocator);
+        errdefer owned_protocol.deinit();
         return .{
             .allocator = allocator,
-            .protocol = protocol,
+            .protocol = owned_protocol,
             .options = list_options,
             .continuation_token = if (list_options.continuation_token) |token|
                 try allocator.dupe(u8, token)
@@ -41,6 +45,7 @@ pub const TablePager = struct {
     pub fn deinit(self: *TablePager) void {
         if (self.current) |*page| page.deinit();
         if (self.continuation_token) |token| self.allocator.free(token);
+        self.protocol.deinit();
         self.* = undefined;
     }
 

--- a/pager.zig
+++ b/pager.zig
@@ -2,3 +2,211 @@
 //!
 //! A page owns its values until the next page is requested or the pager is
 //! deinitialized, whichever occurs first.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const options = @import("options.zig");
+const protocol_client = @import("protocol_client.zig");
+const responses = @import("responses.zig");
+
+pub const ListTablesPage = responses.SdkResponse(protocol_client.QueryTablesResponse);
+
+pub const TablePager = struct {
+    allocator: std.mem.Allocator,
+    protocol: *protocol_client.ProtocolClient,
+    options: options.ListTablesOptions,
+    continuation_token: ?[]u8,
+    current: ?ListTablesPage = null,
+    done: bool = false,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        protocol: *protocol_client.ProtocolClient,
+        list_options: options.ListTablesOptions,
+    ) !TablePager {
+        if (list_options.top) |top| {
+            if (top <= 0) return error.InvalidTop;
+        }
+        return .{
+            .allocator = allocator,
+            .protocol = protocol,
+            .options = list_options,
+            .continuation_token = if (list_options.continuation_token) |token|
+                try allocator.dupe(u8, token)
+            else
+                null,
+        };
+    }
+
+    pub fn deinit(self: *TablePager) void {
+        if (self.current) |*page| page.deinit();
+        if (self.continuation_token) |token| self.allocator.free(token);
+        self.* = undefined;
+    }
+
+    /// Returns a page borrowed from this pager, or `null` after the final
+    /// continuation. The returned page stays valid until a later successful
+    /// call to `nextPage` or `deinit`.
+    pub fn nextPage(
+        self: *TablePager,
+    ) !responses.TableResult(?*const ListTablesPage) {
+        if (self.done) return .{ .success = null };
+
+        var query = self.options;
+        query.continuation_token = self.continuation_token;
+        const result = try self.protocol.queryTables(self.allocator, query);
+        switch (result) {
+            .failure => |failure| return .{ .failure = failure },
+            .success => |page| {
+                const next_token = try continuationFromPage(self.allocator, &page);
+                errdefer if (next_token) |token| self.allocator.free(token);
+
+                if (self.current) |*old_page| old_page.deinit();
+                self.current = page;
+                if (self.continuation_token) |old_token| self.allocator.free(old_token);
+                self.continuation_token = next_token;
+                self.done = next_token == null;
+                return .{ .success = &self.current.? };
+            },
+        }
+    }
+
+    pub fn next(
+        self: *TablePager,
+    ) !?*const ListTablesPage {
+        return responses.unwrapListTables(
+            ?*const ListTablesPage,
+            try self.nextPage(),
+        );
+    }
+};
+
+fn continuationFromPage(
+    allocator: std.mem.Allocator,
+    page: *const ListTablesPage,
+) !?[]u8 {
+    return switch (page.value) {
+        .status_200 => |response| if (response.headers.next_table_name) |token|
+            try allocator.dupe(u8, token)
+        else
+            null,
+    };
+}
+
+test "table pager carries options and exact continuation bytes across pages" {
+    const allocator = std.testing.allocator;
+    const responses_for_pages = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 200,
+            .body = "{\"odata.metadata\":\"first\",\"value\":[{\"TableName\":\"First\"}]}",
+            .headers = &.{
+                .{ .name = "x-ms-version", .value = "2019-02-02" },
+                .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+                .{ .name = "Content-Type", .value = "application/json" },
+                .{ .name = "x-ms-continuation-NextTableName", .value = "Second table/?" },
+            },
+        },
+        .{
+            .status = 200,
+            .body = "{\"odata.metadata\":\"second\",\"value\":[{\"TableName\":\"Second\"}]}",
+            .headers = &.{
+                .{ .name = "x-ms-version", .value = "2019-02-02" },
+                .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+                .{ .name = "Content-Type", .value = "application/json" },
+            },
+        },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &responses_for_pages);
+    const base_pipeline: core.pipeline.HttpPipeline = .{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    var protocol = try protocol_client.ProtocolClient.init(
+        allocator,
+        "https://account.table.core.windows.net",
+        base_pipeline,
+        .{},
+    );
+    defer protocol.deinit();
+
+    var table_pager = try TablePager.init(allocator, &protocol, .{
+        .top = 3,
+        .select = "TableName",
+        .filter = "TableName ge 'A'",
+        .continuation_token = "Initial table/??",
+        .protocol = .{
+            .metadata = .full_metadata,
+            .client_request_id = "list-request",
+        },
+    });
+    defer table_pager.deinit();
+
+    const first = try table_pager.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqual(@as(u16, 200), first.?.status);
+    try std.testing.expectEqualStrings("first", switch (first.?.value) {
+        .status_200 => |value| value.body.odata_metadata.?,
+    });
+    try std.testing.expectEqualStrings("First", switch (first.?.value) {
+        .status_200 => |value| value.body.value.?[0].table_name.?,
+    });
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata&$top=3&$select=TableName&$filter=TableName%20ge%20%27A%27&NextTableName=Initial%20table%2F%3F%3F",
+        transport.captured_urls[0][0..transport.captured_url_lengths[0]],
+    );
+
+    const second = try table_pager.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings("second", switch (second.?.value) {
+        .status_200 => |value| value.body.odata_metadata.?,
+    });
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata&$top=3&$select=TableName&$filter=TableName%20ge%20%27A%27&NextTableName=Second%20table%2F%3F",
+        transport.captured_urls[1][0..transport.captured_url_lengths[1]],
+    );
+    try std.testing.expect((try table_pager.next()) == null);
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+}
+
+test "table pager represents each OData metadata format" {
+    const allocator = std.testing.allocator;
+    const cases = [_]struct {
+        metadata: options.MetadataFormat,
+        expected: []const u8,
+    }{
+        .{ .metadata = .no_metadata, .expected = "odata%3Dnometadata" },
+        .{ .metadata = .minimal_metadata, .expected = "odata%3Dminimalmetadata" },
+        .{ .metadata = .full_metadata, .expected = "odata%3Dfullmetadata" },
+    };
+    for (cases) |case| {
+        var transport = core.http.MockTransport.init(
+            allocator,
+            200,
+            "{\"value\":[{\"TableName\":\"Metadata\"}]}",
+        );
+        defer transport.deinit();
+        transport.response_headers_list = &.{
+            .{ .name = "x-ms-version", .value = "2019-02-02" },
+            .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+            .{ .name = "Content-Type", .value = "application/json" },
+        };
+        const base_pipeline: core.pipeline.HttpPipeline = .{
+            .policies = &.{},
+            .transport_impl = transport.asTransport(),
+        };
+        var protocol = try protocol_client.ProtocolClient.init(
+            allocator,
+            "https://account.table.core.windows.net",
+            base_pipeline,
+            .{},
+        );
+        defer protocol.deinit();
+        var table_pager = try TablePager.init(allocator, &protocol, .{
+            .protocol = .{ .metadata = case.metadata },
+        });
+        defer table_pager.deinit();
+
+        try std.testing.expect((try table_pager.next()) != null);
+        try std.testing.expect(std.mem.indexOf(u8, transport.last_url.?, case.expected) != null);
+    }
+}

--- a/pager.zig
+++ b/pager.zig
@@ -119,10 +119,13 @@ fn copyListOptions(
     if (source.protocol.client_request_id) |value|
         result.protocol.client_request_id = try allocator.dupe(u8, value);
     if (source.protocol.metadata) |metadata| {
-        result.protocol.metadata = switch (metadata) {
-            .unrecognized => |value| .{ .unrecognized = try allocator.dupe(u8, value) },
-            else => metadata,
-        };
+        switch (metadata) {
+            .unrecognized => |value| {
+                const owned_value = try allocator.dupe(u8, value);
+                result.protocol.metadata = .{ .unrecognized = owned_value };
+            },
+            else => result.protocol.metadata = metadata,
+        }
     }
     if (source.protocol.policies.len > 0)
         result.protocol.policies = try allocator.dupe(

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -282,6 +282,7 @@ pub const CallContext = struct {
         raw_endpoint_query: ?[]const u8,
         endpoint_query_is_sas: bool,
         operation_timeout_ms: ?u64,
+        server_timeout: ?i32,
         custom_policies: []const *HttpPolicy,
     ) !CallContext {
         const config = try allocator.create(ConfigPolicy);
@@ -289,6 +290,7 @@ pub const CallContext = struct {
         config.* = ConfigPolicy.init(
             if (endpoint_query_is_sas) null else raw_endpoint_query,
             operation_timeout_ms,
+            server_timeout,
         );
         const capture = try allocator.create(CapturePolicy);
         errdefer allocator.destroy(capture);
@@ -337,12 +339,18 @@ pub const CallContext = struct {
 const ConfigPolicy = struct {
     raw_query: ?[]const u8,
     operation_timeout_ms: ?u64,
+    server_timeout: ?i32,
     policy: HttpPolicy,
 
-    fn init(raw_query: ?[]const u8, operation_timeout_ms: ?u64) ConfigPolicy {
+    fn init(
+        raw_query: ?[]const u8,
+        operation_timeout_ms: ?u64,
+        server_timeout: ?i32,
+    ) ConfigPolicy {
         return .{
             .raw_query = raw_query,
             .operation_timeout_ms = operation_timeout_ms,
+            .server_timeout = server_timeout,
             .policy = .{ .processFn = &process },
         };
     }
@@ -362,13 +370,27 @@ const ConfigPolicy = struct {
         request.operation_timeout_ms = self.operation_timeout_ms;
         defer request.operation_timeout_ms = old_timeout;
 
-        const raw_query = self.raw_query orelse return callNext(request, next, transport);
         const old_url = request.url;
-        const url = try appendEndpointQuery(request.allocator, request.url, raw_query);
-        request.url = url;
+        var url = old_url;
+        var owned_url: ?[]u8 = null;
+        errdefer if (owned_url) |value| request.allocator.free(value);
+        if (self.raw_query) |raw_query| {
+            owned_url = try appendEndpointQuery(request.allocator, url, raw_query);
+            url = owned_url.?;
+        }
+        if (self.server_timeout) |timeout| {
+            const timeout_url = try appendServerTimeout(request.allocator, url, timeout);
+            if (owned_url) |value| request.allocator.free(value);
+            owned_url = timeout_url;
+            url = timeout_url;
+        }
+        if (owned_url == null) return callNext(request, next, transport);
+        const final_url = owned_url.?;
+        owned_url = null;
+        request.url = final_url;
         defer {
             request.url = old_url;
-            request.allocator.free(url);
+            request.allocator.free(final_url);
         }
         return callNext(request, next, transport);
     }
@@ -438,6 +460,20 @@ fn appendEndpointQuery(
         std.fmt.allocPrint(allocator, "{s}?{s}", .{ url, raw_query });
 }
 
+/// Appends the validated decimal Azure Tables `timeout` query option without
+/// re-encoding generated query parameters or opaque endpoint query bytes.
+fn appendServerTimeout(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    timeout: i32,
+) ![]u8 {
+    const separator: []const u8 = if (std.mem.indexOfScalar(u8, url, '?')) |_| blk: {
+        if (url.len > 0 and (url[url.len - 1] == '?' or url[url.len - 1] == '&')) break :blk "";
+        break :blk "&";
+    } else "?";
+    return std.fmt.allocPrint(allocator, "{s}{s}timeout={d}", .{ url, separator, timeout });
+}
+
 const CapturePolicy = struct {
     allocator: std.mem.Allocator,
     metadata: ?responses.ResponseMetadata = null,
@@ -469,7 +505,8 @@ const CapturePolicy = struct {
             self.metadata.?.deinit();
             self.metadata = null;
         }
-        self.metadata.?.body = try self.allocator.dupe(u8, response.body);
+        if (response.status_code < 200 or response.status_code >= 300)
+            self.metadata.?.body = try self.allocator.dupe(u8, response.body);
         return response;
     }
 
@@ -477,6 +514,53 @@ const CapturePolicy = struct {
         if (self.metadata) |*metadata| metadata.deinit();
     }
 };
+
+fn testLargeSuccessCapture(allocator: std.mem.Allocator) !void {
+    var body: [64 * 1024]u8 = undefined;
+    @memset(&body, 'x');
+    var transport = core.http.MockTransport.init(allocator, 200, &body);
+    defer transport.deinit();
+    const base: core.pipeline.HttpPipeline = .{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    var call = try CallContext.init(allocator, base, null, false, null, null, &.{});
+    defer call.deinit();
+    var request = Request.init(allocator, .GET, "https://example.test/Tables");
+    defer request.deinit();
+    var response = try call.pipeline.send(&request);
+    defer response.deinit();
+    var metadata = try call.takeResponse();
+    defer metadata.deinit();
+    try std.testing.expect(metadata.body == null);
+}
+
+test "capture does not duplicate large successful response bodies" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        testLargeSuccessCapture,
+        .{},
+    );
+}
+
+test "capture retains a non-success body for structured error adaptation" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 409, "failure body");
+    defer transport.deinit();
+    const base: core.pipeline.HttpPipeline = .{
+        .policies = &.{},
+        .transport_impl = transport.asTransport(),
+    };
+    var call = try CallContext.init(allocator, base, null, false, null, null, &.{});
+    defer call.deinit();
+    var request = Request.init(allocator, .GET, "https://example.test/Tables");
+    defer request.deinit();
+    var response = try call.pipeline.send(&request);
+    defer response.deinit();
+    var metadata = try call.takeResponse();
+    defer metadata.deinit();
+    try std.testing.expectEqualStrings("failure body", metadata.body.?);
+}
 
 fn callNext(
     request: *Request,
@@ -620,6 +704,7 @@ test "stable policy order authenticates every retry and runs caller policies" {
         null,
         false,
         null,
+        null,
         &.{&per_call.policy},
     );
     defer call.deinit();
@@ -664,7 +749,7 @@ test "core logging and tracing never observe SAS while retries send exact opaque
     const clean_url = "https://account.table.core.windows.net/Table123?timeout=30&$filter=x%20y";
     const raw_sas = "sv=1%2F2&sig=opaque+SECRET%2Fbytes%3D&sp=r";
     const exact_sas_url = "https://account.table.core.windows.net/Table123?sv=1%2F2&sig=opaque+SECRET%2Fbytes%3D&sp=r&timeout=30&$filter=x%20y";
-    var call = try CallContext.init(allocator, state.pipeline, raw_sas, true, null, &.{});
+    var call = try CallContext.init(allocator, state.pipeline, raw_sas, true, null, null, &.{});
     defer call.deinit();
     var request = Request.init(allocator, .GET, clean_url);
     defer request.deinit();
@@ -711,6 +796,7 @@ test "SAS transport errors restore the credential-free URL and redirect policy" 
         "sig=transport-error-SECRET%3D&sv=1",
         true,
         null,
+        null,
         &.{},
     );
     defer call.deinit();
@@ -743,6 +829,7 @@ test "SAS URL allocation errors leave the request untouched" {
         base,
         "sig=allocation-SECRET&sv=1",
         true,
+        null,
         null,
         &.{},
     );
@@ -783,7 +870,7 @@ test "Shared Key core observability records no credential material in URLs" {
         .{ .policies = &.{ logging.asPolicy(), tracing.asPolicy() } },
     );
     defer state.deinit();
-    var call = try CallContext.init(allocator, state.pipeline, null, false, null, &.{});
+    var call = try CallContext.init(allocator, state.pipeline, null, false, null, null, &.{});
     defer call.deinit();
     const clean_url = "https://account.table.core.windows.net/Table123?comp=acl";
     var request = Request.init(allocator, .GET, clean_url);

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -465,6 +465,11 @@ const CapturePolicy = struct {
         errdefer response.deinit();
         if (self.metadata) |*old| old.deinit();
         self.metadata = try responses.ResponseMetadata.fromResponse(self.allocator, &response);
+        errdefer {
+            self.metadata.?.deinit();
+            self.metadata = null;
+        }
+        self.metadata.?.body = try self.allocator.dupe(u8, response.body);
         return response;
     }
 

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
+const errors = @import("errors.zig");
 const protocol = @import("azure_rest_data_tables");
 const options = @import("options.zig");
 const pipeline_mod = @import("pipeline.zig");
@@ -7,6 +8,10 @@ const request = @import("request.zig");
 const responses = @import("responses.zig");
 
 const ProtocolTable = @typeInfo(@TypeOf(protocol.TablesClient.table)).@"fn".return_type.?;
+
+pub const QueryTablesResponse = ProtocolTable.QueryResult;
+pub const CreateTableResponse = ProtocolTable.CreateResult;
+pub const DeleteTableResponse = ProtocolTable.DeleteResult;
 
 /// Validated bridge from SDK options to the generated Tables protocol client.
 pub const ProtocolClient = struct {
@@ -141,6 +146,78 @@ pub const ProtocolClient = struct {
         };
     }
 
+    pub fn queryTables(self: *ProtocolClient, allocator: std.mem.Allocator, query_options: options.ListTablesOptions) !responses.TableResult(responses.SdkResponse(QueryTablesResponse)) {
+        try request.validateProtocolOptions(query_options.protocol);
+        if (query_options.top) |top| if (top <= 0) return error.InvalidTop;
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+        var call = try self.beginCall(arena_allocator, query_options.protocol);
+        errdefer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var table = generated.table();
+        const value = table.query(arena_allocator, query_options.protocol.client_request_id, query_options.protocol.metadata, query_options.top, query_options.select, query_options.filter, query_options.continuation_token) catch |err| {
+            const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
+            call.deinit();
+            arena.deinit();
+            allocator.destroy(arena);
+            return .{ .failure = table_error };
+        };
+        const metadata = try call.takeResponse();
+        call.deinit();
+        return .{ .success = .{ .value = value, .status = metadata.status, .headers = metadata.headers, .arena = arena, .allocator = allocator } };
+    }
+
+    pub fn createTable(self: *ProtocolClient, allocator: std.mem.Allocator, table_name: []const u8, create_options: options.CreateTableOptions) !responses.TableResult(responses.SdkResponse(CreateTableResponse)) {
+        try request.validateTableName(table_name);
+        try request.validateProtocolOptions(create_options.protocol);
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+        var call = try self.beginCall(arena_allocator, create_options.protocol);
+        errdefer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var table = generated.table();
+        const value = table.create(arena_allocator, create_options.protocol.client_request_id, create_options.protocol.metadata, .{ .table_name = table_name }, create_options.prefer) catch |err| {
+            const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
+            call.deinit();
+            arena.deinit();
+            allocator.destroy(arena);
+            return .{ .failure = table_error };
+        };
+        const metadata = try call.takeResponse();
+        call.deinit();
+        return .{ .success = .{ .value = value, .status = metadata.status, .headers = metadata.headers, .arena = arena, .allocator = allocator } };
+    }
+
+    pub fn deleteTable(self: *ProtocolClient, allocator: std.mem.Allocator, table_name: []const u8, delete_options: options.DeleteTableOptions) !responses.TableResult(responses.SdkResponse(DeleteTableResponse)) {
+        try request.validateTableName(table_name);
+        try request.validateProtocolOptions(delete_options.protocol);
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+        var call = try self.beginCall(arena_allocator, delete_options.protocol);
+        errdefer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var table = generated.table();
+        const value = table.delete(arena_allocator, delete_options.protocol.client_request_id, table_name) catch |err| {
+            const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
+            call.deinit();
+            arena.deinit();
+            allocator.destroy(arena);
+            return .{ .failure = table_error };
+        };
+        const metadata = try call.takeResponse();
+        call.deinit();
+        return .{ .success = .{ .value = value, .status = metadata.status, .headers = metadata.headers, .arena = arena, .allocator = allocator } };
+    }
+
     pub fn send(
         self: *ProtocolClient,
         req: *core.http.Request,
@@ -149,6 +226,14 @@ pub const ProtocolClient = struct {
         var call = try self.beginCall(req.allocator, call_options);
         defer call.deinit();
         return call.pipeline.send(req);
+    }
+
+    fn tableErrorFromGeneratedFailure(self: *ProtocolClient, allocator: std.mem.Allocator, call: *pipeline_mod.CallContext, generated_error: anyerror) !errors.TableError {
+        _ = self;
+        if (generated_error != error.AzureRequestFailed) return generated_error;
+        var metadata = call.takeResponse() catch return generated_error;
+        defer metadata.deinit();
+        return errors.TableError.fromResponse(allocator, metadata.status, metadata.headers.getFirst("Content-Type"), metadata.headers.getFirst("x-ms-request-id"), null, metadata.body orelse "");
     }
 
     fn beginCall(

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -69,7 +69,7 @@ pub const ProtocolClient = struct {
         errdefer arena.deinit();
         const arena_allocator = arena.allocator();
 
-        var call = try self.beginCall(arena_allocator, query_options.protocol);
+        var call = try self.beginCall(arena_allocator, query_options.protocol, null);
         defer call.deinit();
         var generated = protocol.TablesClient.initWithPipeline(
             arena_allocator,
@@ -116,7 +116,7 @@ pub const ProtocolClient = struct {
         errdefer arena.deinit();
         const arena_allocator = arena.allocator();
 
-        var call = try self.beginCall(arena_allocator, query_options.protocol);
+        var call = try self.beginCall(arena_allocator, query_options.protocol, null);
         defer call.deinit();
         var generated = protocol.TablesClient.initWithPipeline(
             arena_allocator,
@@ -154,7 +154,11 @@ pub const ProtocolClient = struct {
         arena.* = .init(allocator);
         errdefer arena.deinit();
         const arena_allocator = arena.allocator();
-        var call = try self.beginCall(arena_allocator, query_options.protocol);
+        var call = try self.beginCall(
+            arena_allocator,
+            query_options.protocol,
+            query_options.protocol.timeout,
+        );
         errdefer call.deinit();
         var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
@@ -178,7 +182,7 @@ pub const ProtocolClient = struct {
         arena.* = .init(allocator);
         errdefer arena.deinit();
         const arena_allocator = arena.allocator();
-        var call = try self.beginCall(arena_allocator, create_options.protocol);
+        var call = try self.beginCall(arena_allocator, create_options.protocol, create_options.protocol.timeout);
         errdefer call.deinit();
         var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
@@ -202,7 +206,7 @@ pub const ProtocolClient = struct {
         arena.* = .init(allocator);
         errdefer arena.deinit();
         const arena_allocator = arena.allocator();
-        var call = try self.beginCall(arena_allocator, delete_options.protocol);
+        var call = try self.beginCall(arena_allocator, delete_options.protocol, delete_options.protocol.timeout);
         errdefer call.deinit();
         var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
@@ -223,7 +227,7 @@ pub const ProtocolClient = struct {
         req: *core.http.Request,
         call_options: options.ProtocolOptions,
     ) !core.http.Response {
-        var call = try self.beginCall(req.allocator, call_options);
+        var call = try self.beginCall(req.allocator, call_options, null);
         defer call.deinit();
         return call.pipeline.send(req);
     }
@@ -240,6 +244,7 @@ pub const ProtocolClient = struct {
         self: *ProtocolClient,
         allocator: std.mem.Allocator,
         call_options: options.ProtocolOptions,
+        server_timeout: ?i32,
     ) !pipeline_mod.CallContext {
         return pipeline_mod.CallContext.init(
             allocator,
@@ -247,6 +252,7 @@ pub const ProtocolClient = struct {
             if (self.endpoint.has_query) self.endpoint.raw_query else null,
             self.endpoint_query_is_sas,
             call_options.operation_timeout_ms,
+            server_timeout,
             call_options.policies,
         );
     }

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -50,6 +50,28 @@ pub const ProtocolClient = struct {
         self.* = undefined;
     }
 
+    /// Clones immutable request configuration while retaining the same
+    /// heap-stable pipeline. The source client and its pipeline owner must
+    /// outlive the clone.
+    pub fn clone(self: *const ProtocolClient, allocator: std.mem.Allocator) !ProtocolClient {
+        if (self.endpoint.has_query) {
+            const endpoint = try std.fmt.allocPrint(
+                allocator,
+                "{s}?{s}",
+                .{ self.endpoint.base_url, self.endpoint.raw_query },
+            );
+            defer allocator.free(endpoint);
+            return init(allocator, endpoint, self.pipeline, .{
+                .api_version = self.api_version,
+                .endpoint_query_is_sas = self.endpoint_query_is_sas,
+            });
+        }
+        return init(allocator, self.endpoint.base_url, self.pipeline, .{
+            .api_version = self.api_version,
+            .endpoint_query_is_sas = self.endpoint_query_is_sas,
+        });
+    }
+
     pub fn queryEntity(
         self: *ProtocolClient,
         allocator: std.mem.Allocator,

--- a/responses.zig
+++ b/responses.zig
@@ -65,6 +65,7 @@ pub const RawHeaders = struct {
 pub const ResponseMetadata = struct {
     status: u16,
     headers: RawHeaders,
+    body: ?[]const u8 = null,
 
     pub fn fromResponse(allocator: std.mem.Allocator, response: *const core.http.Response) !ResponseMetadata {
         return .{
@@ -75,6 +76,7 @@ pub const ResponseMetadata = struct {
 
     pub fn deinit(self: *ResponseMetadata) void {
         self.headers.deinit();
+        if (self.body) |body| self.headers.allocator.free(body);
     }
 };
 
@@ -172,6 +174,39 @@ pub fn unwrapCreateEntity(comptime T: type, result: TableResult(T)) error{Create
             var owned_error = table_error;
             owned_error.deinit();
             return error.CreateEntityFailed;
+        },
+    };
+}
+
+pub fn unwrapCreateTable(comptime T: type, result: TableResult(T)) error{CreateTableFailed}!T {
+    return switch (result) {
+        .success => |value| value,
+        .failure => |table_error| {
+            var owned_error = table_error;
+            owned_error.deinit();
+            return error.CreateTableFailed;
+        },
+    };
+}
+
+pub fn unwrapDeleteTable(comptime T: type, result: TableResult(T)) error{DeleteTableFailed}!T {
+    return switch (result) {
+        .success => |value| value,
+        .failure => |table_error| {
+            var owned_error = table_error;
+            owned_error.deinit();
+            return error.DeleteTableFailed;
+        },
+    };
+}
+
+pub fn unwrapListTables(comptime T: type, result: TableResult(T)) error{ListTablesFailed}!T {
+    return switch (result) {
+        .success => |value| value,
+        .failure => |table_error| {
+            var owned_error = table_error;
+            owned_error.deinit();
+            return error.ListTablesFailed;
         },
     };
 }

--- a/root.zig
+++ b/root.zig
@@ -54,6 +54,13 @@ pub const dynamicFromJson = entity_codec.dynamicFromJson;
 pub const TableError = errors.TableError;
 pub const TableErrorCode = errors.TableErrorCode;
 pub const TableResult = responses.TableResult;
+pub const CreateTableOptions = options.CreateTableOptions;
+pub const DeleteTableOptions = options.DeleteTableOptions;
+pub const ListTablesOptions = options.ListTablesOptions;
+pub const TablePager = pager.TablePager;
+pub const ListTablesPage = pager.ListTablesPage;
+pub const CreateTableResponse = responses.SdkResponse(protocol_client.CreateTableResponse);
+pub const DeleteTableResponse = responses.SdkResponse(protocol_client.DeleteTableResponse);
 pub const unwrapGetEntity = responses.unwrapGetEntity;
 pub const unwrapCreateEntity = responses.unwrapCreateEntity;
 
@@ -110,6 +117,13 @@ test {
     _ = TableError;
     _ = TableErrorCode;
     _ = TableResult;
+    _ = CreateTableOptions;
+    _ = DeleteTableOptions;
+    _ = ListTablesOptions;
+    _ = TablePager;
+    _ = ListTablesPage;
+    _ = CreateTableResponse;
+    _ = DeleteTableResponse;
     _ = unwrapGetEntity;
     _ = unwrapCreateEntity;
 }

--- a/service_client.zig
+++ b/service_client.zig
@@ -269,6 +269,20 @@ const CountingCredential = struct {
     }
 };
 
+const MovedServicePager = struct {
+    service: TableServiceClient,
+    table_pager: pager.TablePager,
+};
+
+fn moveServiceWithPager(
+    service: TableServiceClient,
+    allocator: std.mem.Allocator,
+) !MovedServicePager {
+    var relocated = service;
+    const table_pager = try relocated.listTables(allocator, .{});
+    return .{ .service = relocated, .table_pager = table_pager };
+}
+
 test "derived clients share token cache and transport and borrow pipeline state" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
@@ -298,6 +312,57 @@ test "derived clients share token cache and transport and borrow pipeline state"
 
     try std.testing.expectEqual(@as(usize, 1), credential.calls);
     try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+}
+
+test "table pager survives a service client move across continuation pages" {
+    const allocator = std.testing.allocator;
+    const pages = [_]core.http.SequenceMockTransport.CannedResponse{
+        .{
+            .status = 200,
+            .body = "{\"value\":[{\"TableName\":\"First\"}]}",
+            .headers = &.{
+                .{ .name = "x-ms-version", .value = "2019-02-02" },
+                .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+                .{ .name = "Content-Type", .value = "application/json" },
+                .{ .name = "x-ms-continuation-NextTableName", .value = "Second" },
+            },
+        },
+        .{
+            .status = 200,
+            .body = "{\"value\":[{\"TableName\":\"Second\"}]}",
+            .headers = &.{
+                .{ .name = "x-ms-version", .value = "2019-02-02" },
+                .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+                .{ .name = "Content-Type", .value = "application/json" },
+            },
+        },
+    };
+    var transport = core.http.SequenceMockTransport.init(allocator, &pages);
+    var credential = CountingCredential{};
+    var source = try TableServiceClient.initWithToken(
+        allocator,
+        "https://account.table.core.windows.net",
+        credential.asCredential(),
+        transport.asTransport(),
+        .{},
+    );
+    var moved = try moveServiceWithPager(source, allocator);
+    source = undefined;
+    defer moved.service.deinit();
+    defer moved.table_pager.deinit();
+
+    const first = try moved.table_pager.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("First", switch (first.?.value) {
+        .status_200 => |value| value.body.value.?[0].table_name.?,
+    });
+    const second = try moved.table_pager.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings("Second", switch (second.?.value) {
+        .status_200 => |value| value.body.value.?[0].table_name.?,
+    });
+    try std.testing.expectEqual(@as(usize, 2), transport.call_count);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
 }
 
 test "token service client rejects HTTP before credential and transport use" {

--- a/service_client.zig
+++ b/service_client.zig
@@ -517,14 +517,14 @@ test "table lifecycle uses Shared Key and SAS pipeline authentication" {
         "SharedKeyLite account:",
     ));
 
-    var sas = try TableServiceClient.initWithSasUrl(
+    var sas_client = try TableServiceClient.initWithSasUrl(
         allocator,
         "https://account.table.core.windows.net?sv=1%2F2&sig=secret%3D&sp=r",
         transport.asTransport(),
         .{},
     );
-    defer sas.deinit();
-    var deleted = try sas.deleteTable(allocator, "Table123", .{});
+    defer sas_client.deinit();
+    var deleted = try sas_client.deleteTable(allocator, "Table123", .{});
     deleted.deinit();
     try std.testing.expect(transport.last_headers.get("Authorization") == null);
     try std.testing.expect(std.mem.indexOf(

--- a/service_client.zig
+++ b/service_client.zig
@@ -8,6 +8,8 @@ const pipeline = @import("pipeline.zig");
 const protocol_client = @import("protocol_client.zig");
 const request = @import("request.zig");
 const sas = @import("sas.zig");
+const pager = @import("pager.zig");
+const responses = @import("responses.zig");
 
 /// Client for Azure Table Service operations (list/create/delete tables).
 ///
@@ -190,6 +192,55 @@ pub const TableServiceClient = struct {
         defer allocator.free(service_url);
         return parameters.appendToUrl(allocator, service_url);
     }
+    pub fn createTableResult(
+        self: *TableServiceClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        create_options: options.CreateTableOptions,
+    ) !responses.TableResult(responses.SdkResponse(protocol_client.CreateTableResponse)) {
+        return self.protocol.createTable(allocator, table_name, create_options);
+    }
+
+    pub fn createTable(
+        self: *TableServiceClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        create_options: options.CreateTableOptions,
+    ) !responses.SdkResponse(protocol_client.CreateTableResponse) {
+        return responses.unwrapCreateTable(
+            responses.SdkResponse(protocol_client.CreateTableResponse),
+            try self.createTableResult(allocator, table_name, create_options),
+        );
+    }
+
+    pub fn deleteTableResult(
+        self: *TableServiceClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        delete_options: options.DeleteTableOptions,
+    ) !responses.TableResult(responses.SdkResponse(protocol_client.DeleteTableResponse)) {
+        return self.protocol.deleteTable(allocator, table_name, delete_options);
+    }
+
+    pub fn deleteTable(
+        self: *TableServiceClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        delete_options: options.DeleteTableOptions,
+    ) !responses.SdkResponse(protocol_client.DeleteTableResponse) {
+        return responses.unwrapDeleteTable(
+            responses.SdkResponse(protocol_client.DeleteTableResponse),
+            try self.deleteTableResult(allocator, table_name, delete_options),
+        );
+    }
+
+    pub fn listTables(
+        self: *TableServiceClient,
+        allocator: std.mem.Allocator,
+        list_options: options.ListTablesOptions,
+    ) !pager.TablePager {
+        return pager.TablePager.init(allocator, &self.protocol, list_options);
+    }
 };
 
 const CountingCredential = struct {
@@ -346,4 +397,214 @@ test "account SAS URL is exact and works with a credential-free service client" 
     const signed_query = sas_url[(std.mem.indexOfScalar(u8, sas_url, '?').? + 1)..];
     const sent_query = transport.last_url.?[(std.mem.indexOfScalar(u8, transport.last_url.?, '?').? + 1)..];
     try std.testing.expectEqualStrings(signed_query, sent_query);
+}
+
+test "table lifecycle result variants preserve generated responses and service errors" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 204, "");
+    defer transport.deinit();
+    transport.response_headers_list = &.{
+        .{ .name = "x-ms-version", .value = "2019-02-02" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+        .{ .name = "x-ms-request-id", .value = "create-id" },
+    };
+    var credential = CountingCredential{};
+    var service = try TableServiceClient.initWithToken(
+        allocator,
+        "https://account.table.core.windows.net",
+        credential.asCredential(),
+        transport.asTransport(),
+        .{ .client_request_id = "lifecycle-request" },
+    );
+    defer service.deinit();
+
+    var created = try service.createTable(allocator, "Table123", .{
+        .protocol = .{ .metadata = .full_metadata, .timeout = 13 },
+    });
+    defer created.deinit();
+    try std.testing.expectEqual(@as(u16, 204), created.status);
+    try std.testing.expectEqualStrings("create-id", created.headers.getFirst("x-ms-request-id").?);
+    try std.testing.expect(std.mem.startsWith(u8, transport.last_headers.get("Authorization").?, "Bearer "));
+    try std.testing.expectEqualStrings("lifecycle-request", transport.last_headers.get("x-ms-client-request-id").?);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata&timeout=13",
+        transport.last_url.?,
+    );
+
+    transport.response_status = 409;
+    transport.response_body = "{\"odata.error\":{\"code\":\"TableAlreadyExists\",\"message\":{\"value\":\"exists\"}}}";
+    transport.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "x-ms-request-id", .value = "already-exists" },
+    };
+    var duplicate = try service.createTableResult(allocator, "Table123", .{});
+    defer duplicate.deinit(allocator);
+    switch (duplicate) {
+        .failure => |failure| {
+            try std.testing.expectEqualStrings("TableAlreadyExists", failure.code);
+            try std.testing.expectEqual(@as(u16, 409), failure.status);
+            try std.testing.expectEqualStrings("already-exists", failure.request_id.?);
+        },
+        .success => return error.TestUnexpectedResult,
+    }
+}
+
+test "table lifecycle validates names before transport and table clients are convenient" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 204, "");
+    defer transport.deinit();
+    transport.response_headers_list = &.{
+        .{ .name = "x-ms-version", .value = "2019-02-02" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+    };
+    var credential = CountingCredential{};
+    var service = try TableServiceClient.initWithToken(
+        allocator,
+        "https://account.table.core.windows.net",
+        credential.asCredential(),
+        transport.asTransport(),
+        .{},
+    );
+    defer service.deinit();
+
+    try std.testing.expectError(
+        error.InvalidTableName,
+        service.deleteTableResult(allocator, "not-valid", .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+
+    var table_client = try service.getTableClient("Table123");
+    defer table_client.deinit();
+    var deleted = try table_client.deleteTable(allocator, .{
+        .protocol = .{ .timeout = 11 },
+    });
+    defer deleted.deinit();
+    try std.testing.expectEqual(@as(u16, 204), deleted.status);
+    try std.testing.expectEqualStrings(
+        "https://account.table.core.windows.net/Tables('Table123')?timeout=11",
+        transport.last_url.?,
+    );
+}
+
+test "table lifecycle uses Shared Key and SAS pipeline authentication" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 204, "");
+    defer transport.deinit();
+    transport.response_headers_list = &.{
+        .{ .name = "x-ms-version", .value = "2019-02-02" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+    };
+    var shared_credential = try auth.SharedKeyCredential.init(
+        allocator,
+        "account",
+        "YWNjb3VudC1rZXk=",
+    );
+    defer shared_credential.deinit();
+    var shared = try TableServiceClient.initWithSharedKey(
+        allocator,
+        "https://account.table.core.windows.net",
+        &shared_credential,
+        transport.asTransport(),
+        .{},
+    );
+    defer shared.deinit();
+    var created = try shared.createTable(allocator, "Table123", .{});
+    created.deinit();
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        transport.last_headers.get("Authorization").?,
+        "SharedKeyLite account:",
+    ));
+
+    var sas = try TableServiceClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1%2F2&sig=secret%3D&sp=r",
+        transport.asTransport(),
+        .{},
+    );
+    defer sas.deinit();
+    var deleted = try sas.deleteTable(allocator, "Table123", .{});
+    deleted.deinit();
+    try std.testing.expect(transport.last_headers.get("Authorization") == null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        transport.last_url.?,
+        "sv=1%2F2&sig=secret%3D&sp=r",
+    ) != null);
+}
+
+test "table lifecycle retains all documented table service failure codes" {
+    const allocator = std.testing.allocator;
+    const cases = [_]struct { status: u16, code: []const u8 }{
+        .{ .status = 409, .code = "TableAlreadyExists" },
+        .{ .status = 409, .code = "TableBeingDeleted" },
+        .{ .status = 404, .code = "TableNotFound" },
+    };
+    for (cases) |case| {
+        var transport = core.http.MockTransport.init(
+            allocator,
+            case.status,
+            "{\"odata.error\":{\"code\":\"TablePlaceholder\",\"message\":{\"value\":\"failed\"}}}",
+        );
+        defer transport.deinit();
+        transport.response_body = try std.fmt.allocPrint(
+            allocator,
+            "{{\"odata.error\":{{\"code\":\"{s}\",\"message\":{{\"value\":\"failed\"}}}}}}",
+            .{case.code},
+        );
+        defer allocator.free(transport.response_body);
+        transport.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "application/json" },
+            .{ .name = "x-ms-request-id", .value = "failure-id" },
+        };
+        var credential = CountingCredential{};
+        var service = try TableServiceClient.initWithToken(
+            allocator,
+            "https://account.table.core.windows.net",
+            credential.asCredential(),
+            transport.asTransport(),
+            .{},
+        );
+        defer service.deinit();
+
+        var result = try service.createTableResult(allocator, "Table123", .{});
+        defer result.deinit(allocator);
+        switch (result) {
+            .failure => |failure| {
+                try std.testing.expectEqualStrings(case.code, failure.code);
+                try std.testing.expectEqual(case.status, failure.status);
+                try std.testing.expectEqualStrings("failure-id", failure.request_id.?);
+            },
+            .success => return error.TestUnexpectedResult,
+        }
+    }
+}
+
+fn testLifecycleAllocationFailures(allocator: std.mem.Allocator) !void {
+    var transport = core.http.MockTransport.init(allocator, 204, "");
+    defer transport.deinit();
+    transport.response_headers_list = &.{
+        .{ .name = "x-ms-version", .value = "2019-02-02" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+    };
+    var credential = CountingCredential{};
+    var service = try TableServiceClient.initWithToken(
+        allocator,
+        "https://account.table.core.windows.net",
+        credential.asCredential(),
+        transport.asTransport(),
+        .{},
+    );
+    defer service.deinit();
+    var result = try service.createTableResult(allocator, "Table123", .{});
+    result.deinit(allocator);
+}
+
+test "table lifecycle result allocation failures are leak-free" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        testLifecycleAllocationFailures,
+        .{},
+    );
 }


### PR DESCRIPTION
## Summary
- add generated-protocol-backed create/delete table result APIs and bound table-client conveniences
- add configured, header-continuation table pager with structured HTTP failures
- cover paging, metadata formats, auth modes, validation, allocation failures, and error codes

## Validation
- `zig build test --summary all`

Fixes #162
Parent #148