### PR TITLE
sdk/data_tables: implement entity update and upsert modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ conditional delete through `deleteEntityWithOptions`. The original
 compatibility; explicit `getEntityRaw` and `deleteEntityRaw` aliases are also
 available.
 
+`UpdateMode` is a closed `merge`/`replace` enum shared by `updateEntity` and
+`upsertEntity` (and their result-preserving variants). Merge uses the generated
+PATCH operation and preserves omitted properties; replace uses generated PUT
+and removes them. Updates default to wildcard `If-Match` and accept an explicit
+ETag, while upserts omit `If-Match` so a missing entity is created. Mutation
+responses own the returned ETag, status, selected headers, and raw headers.
+Explicit-ETag updates retry only failures before transport entry; a transport
+failure after entry is `error.MutationOutcomeUnknown`. Wildcard updates and
+upserts use normal retries because repeating the same payload is safe, but an
+exhausted transport failure is still classified as outcome-unknown.
+
 ## Checked feature-parity contract
 
 `[x]` means the Go capability has been reviewed and assigned a Zig API owner;

--- a/README.md
+++ b/README.md
@@ -133,9 +133,12 @@ and removes them. Updates default to wildcard `If-Match` and accept an explicit
 ETag, while upserts omit `If-Match` so a missing entity is created. Mutation
 responses own the returned ETag, status, selected headers, and raw headers.
 Explicit-ETag updates retry only failures before transport entry; a transport
-failure after entry is `error.MutationOutcomeUnknown`. Wildcard updates and
-upserts use normal retries because repeating the same payload is safe, but an
-exhausted transport failure is still classified as outcome-unknown.
+failure after entry is `error.MutationOutcomeUnknown`. Their pre-transport
+retries use the configured retry limit and exponential jittered backoff while
+checking the effective operation deadline before every attempt and delay.
+Wildcard updates and upserts use normal retries because repeating the same
+payload is safe, but an exhausted transport failure is still classified as
+outcome-unknown.
 
 ## Checked feature-parity contract
 
@@ -209,7 +212,9 @@ strings and binary data and must be released with `Codec.deinit`.
 
 For runtime schemas, `DynamicEntity.init` and `put` copy keys and values.
 Release it with `DynamicEntity.deinit`; use `dynamicToJson` and
-`dynamicFromJson` for its OData JSON representation. The original
+`dynamicFromJson` for its OData JSON representation. `Timestamp` is retained
+when decoding service responses but omitted by both typed and dynamic
+serialization because the service owns that field. The original
 string-only `TableEntity` remains available as a compatibility export and
 continues to borrow its keys and values.
 

--- a/client.zig
+++ b/client.zig
@@ -157,7 +157,8 @@ pub const TableClient = struct {
             .{
                 .api_version = api_version,
                 .endpoint_query_is_sas = state.usesSas(),
-                .mutation_max_retries = state.retry.max_retries,
+                .mutation_retry = state.retryOptions(),
+                .default_operation_timeout_ms = state.operationTimeoutMs(),
             },
         );
         errdefer protocol.deinit();
@@ -928,6 +929,24 @@ const PreTransportOncePolicy = struct {
     }
 };
 
+const AlwaysFailPreTransportPolicy = struct {
+    calls: usize = 0,
+    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+
+    fn process(
+        policy: *core.pipeline.HttpPolicy,
+        _: *core.http.Request,
+        _: []*core.pipeline.HttpPolicy,
+        _: *core.http.HttpTransport,
+    ) anyerror!core.http.Response {
+        const self: *AlwaysFailPreTransportPolicy = @alignCast(
+            @fieldParentPtr("policy", policy),
+        );
+        self.calls += 1;
+        return error.InjectedPreTransportFailure;
+    }
+};
+
 const FailingMutationTransport = struct {
     calls: usize = 0,
     transport: core.http.HttpTransport = .{ .sendFn = &send },
@@ -1043,6 +1062,97 @@ test "typed and dynamic add share EDM wire behavior and preserve metadata" {
     try std.testing.expectEqualStrings("widget", dynamic_response.value.properties.get("name").?.string);
     try std.testing.expectEqual(std.math.maxInt(i64), dynamic_response.value.properties.get("count").?.int64.value);
     try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"count@odata.type\":\"Edm.Int64\"") != null);
+}
+
+test "typed and dynamic add update and upsert payloads omit Timestamp exactly" {
+    const ParityEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        name: []const u8,
+        timestamp: ?edm.EdmDateTime = null,
+    };
+    const allocator = std.testing.allocator;
+    const expected = "{\"PartitionKey\":\"p\",\"RowKey\":\"r\",\"name\":\"widget\"}";
+    var mock = core.http.MockTransport.init(allocator, 201, expected);
+    defer mock.deinit();
+    mock.response_headers_list = entity_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+    const timestamp = try edm.EdmDateTime.init("2026-07-26T00:00:00Z");
+    const typed = ParityEntity{
+        .partition_key = "p",
+        .row_key = "r",
+        .name = "widget",
+        .timestamp = timestamp,
+    };
+    var dynamic = try entity.DynamicEntity.init(allocator, "p", "r");
+    defer dynamic.deinit();
+    try dynamic.put("name", .{ .string = "widget" });
+    try dynamic.setTimestamp(timestamp);
+
+    var typed_add = try client.addEntity(allocator, typed, .{});
+    typed_add.deinit();
+    try std.testing.expectEqualStrings(expected, mock.last_body.?);
+    var dynamic_add = try client.addEntity(allocator, dynamic, .{});
+    dynamic_add.deinit();
+    try std.testing.expectEqualStrings(expected, mock.last_body.?);
+
+    mock.response_status = 204;
+    mock.response_body = "";
+    mock.response_headers_list = mutation_response_headers;
+    var typed_update = try client.updateEntity(allocator, typed, .{});
+    typed_update.deinit();
+    try std.testing.expectEqualStrings(expected, mock.last_body.?);
+    var dynamic_update = try client.updateEntity(allocator, dynamic, .{});
+    dynamic_update.deinit();
+    try std.testing.expectEqualStrings(expected, mock.last_body.?);
+
+    var typed_upsert = try client.upsertEntity(allocator, typed, .{});
+    typed_upsert.deinit();
+    try std.testing.expectEqualStrings(expected, mock.last_body.?);
+    var dynamic_upsert = try client.upsertEntity(allocator, dynamic, .{});
+    dynamic_upsert.deinit();
+    try std.testing.expectEqualStrings(expected, mock.last_body.?);
+}
+
+test "dynamic read retains Timestamp but read-then-update omits it" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\{"PartitionKey":"p","RowKey":"r","name":"server","Timestamp":"2026-07-26T00:00:00Z"}
+    );
+    defer mock.deinit();
+    mock.response_headers_list = entity_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    var read = try client.getEntityAs(entity.DynamicEntity, allocator, "p", "r", .{});
+    defer read.deinit();
+    try std.testing.expectEqualStrings(
+        "2026-07-26T00:00:00Z",
+        read.value.timestamp.?.value,
+    );
+
+    mock.response_status = 204;
+    mock.response_body = "";
+    mock.response_headers_list = mutation_response_headers;
+    var updated = try client.updateEntity(allocator, read.value, .{});
+    updated.deinit();
+    try std.testing.expectEqualStrings(
+        "{\"PartitionKey\":\"p\",\"RowKey\":\"r\",\"name\":\"server\"}",
+        mock.last_body.?,
+    );
 }
 
 test "get supports full minimal and no metadata responses" {
@@ -1318,6 +1428,60 @@ test "conditional mutation retries before transport and classifies ambiguity aft
     response.deinit();
     try std.testing.expectEqual(@as(usize, 2), before_transport.calls);
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+
+    var exhausted = AlwaysFailPreTransportPolicy{};
+    try std.testing.expectError(
+        error.InjectedPreTransportFailure,
+        client.updateEntityResult(allocator, value, .{
+            .if_match = "W/\"exact\"",
+            .protocol = .{ .policies = &.{&exhausted.policy} },
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 3), exhausted.calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+
+    var expired = PreTransportOncePolicy{};
+    try std.testing.expectError(
+        error.OperationTimedOut,
+        client.updateEntityResult(allocator, value, .{
+            .if_match = "W/\"exact\"",
+            .protocol = .{
+                .operation_timeout_ms = 0,
+                .policies = &.{&expired.policy},
+            },
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), expired.calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+
+    var tight_mock = core.http.MockTransport.init(allocator, 204, "");
+    defer tight_mock.deinit();
+    tight_mock.response_headers_list = mutation_response_headers;
+    var tight_client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        tight_mock.asTransport(),
+        .{
+            .operation_timeout_ms = 1,
+            .retry = .{
+                .max_retries = 2,
+                .initial_delay_ms = 100,
+                .max_delay_ms = 100,
+            },
+        },
+    );
+    defer tight_client.deinit();
+    var tight = AlwaysFailPreTransportPolicy{};
+    try std.testing.expectError(
+        error.OperationTimedOut,
+        tight_client.updateEntityResult(allocator, value, .{
+            .if_match = "W/\"exact\"",
+            .protocol = .{ .policies = &.{&tight.policy} },
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), tight.calls);
+    try std.testing.expectEqual(@as(usize, 0), tight_mock.call_count);
 
     var failing = FailingMutationTransport{};
     var conditional_client = try TableClient.initWithSasUrl(

--- a/client.zig
+++ b/client.zig
@@ -157,6 +157,7 @@ pub const TableClient = struct {
             .{
                 .api_version = api_version,
                 .endpoint_query_is_sas = state.usesSas(),
+                .mutation_max_retries = state.retry.max_retries,
             },
         );
         errdefer protocol.deinit();
@@ -407,6 +408,123 @@ pub const TableClient = struct {
                 break :blk .{ .success = .{
                     .status = raw.status,
                     .headers = etag_headers,
+                    .raw_headers = raw.headers,
+                    .arena = raw.arena,
+                    .allocator = raw.allocator,
+                } };
+            },
+        };
+    }
+
+    /// Updates an existing typed or dynamic entity. Merge preserves omitted
+    /// properties; replace removes them.
+    pub fn updateEntity(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        value: anytype,
+        update_options: options.UpdateEntityOptions,
+    ) !responses.MutationEntityResponse {
+        const result = try self.updateEntityResult(allocator, value, update_options);
+        return switch (result) {
+            .success => |response| response,
+            .failure => |table_error| {
+                var owned_error = table_error;
+                owned_error.deinit();
+                return error.UpdateEntityFailed;
+            },
+        };
+    }
+
+    pub fn updateEntityResult(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        value: anytype,
+        update_options: options.UpdateEntityOptions,
+    ) !responses.TableResult(responses.MutationEntityResponse) {
+        try request.validateIfMatch(update_options.if_match);
+        return self.mutateEntityResult(
+            allocator,
+            value,
+            update_options.mode,
+            update_options.if_match,
+            update_options.protocol,
+        );
+    }
+
+    /// Inserts a missing entity or updates an existing one using the selected
+    /// merge/replace semantics.
+    pub fn upsertEntity(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        value: anytype,
+        upsert_options: options.UpsertEntityOptions,
+    ) !responses.MutationEntityResponse {
+        const result = try self.upsertEntityResult(allocator, value, upsert_options);
+        return switch (result) {
+            .success => |response| response,
+            .failure => |table_error| {
+                var owned_error = table_error;
+                owned_error.deinit();
+                return error.UpsertEntityFailed;
+            },
+        };
+    }
+
+    pub fn upsertEntityResult(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        value: anytype,
+        upsert_options: options.UpsertEntityOptions,
+    ) !responses.TableResult(responses.MutationEntityResponse) {
+        return self.mutateEntityResult(
+            allocator,
+            value,
+            upsert_options.mode,
+            null,
+            upsert_options.protocol,
+        );
+    }
+
+    fn mutateEntityResult(
+        self: *TableClient,
+        allocator: std.mem.Allocator,
+        value: anytype,
+        mode: options.UpdateMode,
+        if_match: ?[]const u8,
+        protocol_options: options.ProtocolOptions,
+    ) !responses.TableResult(responses.MutationEntityResponse) {
+        const T = @TypeOf(value);
+        try validateEntityValue(T, value);
+        const json = if (T == entity.DynamicEntity)
+            try entity_codec.dynamicToJson(allocator, value)
+        else
+            try entity_codec.EntityCodec(T).toJson(allocator, value);
+        defer allocator.free(json);
+        if (json.len > 1024 * 1024) return error.EntityTooLarge;
+
+        const partition_key = @field(value, "partition_key");
+        const row_key = @field(value, "row_key");
+        const protocol_result = try self.protocol.mutateEntityResult(
+            allocator,
+            self.table_name,
+            partition_key,
+            row_key,
+            json,
+            mode,
+            if_match,
+            protocol_options,
+        );
+        return switch (protocol_result) {
+            .failure => |table_error| .{ .failure = table_error },
+            .success => |raw_value| blk: {
+                var raw = raw_value;
+                errdefer raw.deinit();
+                const etag = raw.headers.getFirst("ETag") orelse
+                    return error.MissingResponseHeader;
+                break :blk .{ .success = .{
+                    .etag = etag,
+                    .status = raw.status,
+                    .headers = entityHeaders(&raw.headers),
                     .raw_headers = raw.headers,
                     .arena = raw.arena,
                     .allocator = raw.allocator,
@@ -792,6 +910,44 @@ const TestCredential = struct {
     }
 };
 
+const PreTransportOncePolicy = struct {
+    calls: usize = 0,
+    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+
+    fn process(
+        policy: *core.pipeline.HttpPolicy,
+        req: *core.http.Request,
+        next: []*core.pipeline.HttpPolicy,
+        transport: *core.http.HttpTransport,
+    ) anyerror!core.http.Response {
+        const self: *PreTransportOncePolicy = @alignCast(@fieldParentPtr("policy", policy));
+        self.calls += 1;
+        if (self.calls == 1) return error.InjectedPreTransportFailure;
+        if (next.len == 0) return transport.send(req);
+        return next[0].process(req, next[1..], transport);
+    }
+};
+
+const FailingMutationTransport = struct {
+    calls: usize = 0,
+    transport: core.http.HttpTransport = .{ .sendFn = &send },
+
+    fn asTransport(self: *FailingMutationTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn send(
+        transport: *core.http.HttpTransport,
+        _: *core.http.Request,
+    ) anyerror!core.http.Response {
+        const self: *FailingMutationTransport = @alignCast(
+            @fieldParentPtr("transport", transport),
+        );
+        self.calls += 1;
+        return error.InjectedTransportFailure;
+    }
+};
+
 fn moveClient(client: TableClient) TableClient {
     return client;
 }
@@ -820,6 +976,14 @@ const entity_response_headers = &[_]core.http.MockTransport.HeaderPair{
     .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
     .{ .name = "Content-Type", .value = "application/json" },
     .{ .name = "Preference-Applied", .value = "return-content" },
+};
+
+const mutation_response_headers = &[_]core.http.MockTransport.HeaderPair{
+    .{ .name = "ETag", .value = "W/\"updated\"" },
+    .{ .name = "x-ms-version", .value = "2019-02-02" },
+    .{ .name = "x-ms-request-id", .value = "mutation-request" },
+    .{ .name = "x-ms-client-request-id", .value = "mutation-client" },
+    .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
 };
 
 const typed_entity_json =
@@ -973,6 +1137,229 @@ test "conditional delete preserves service failure and wildcard success" {
     try std.testing.expectEqualStrings("*", mock.last_headers.get("If-Match").?);
 }
 
+test "typed and dynamic update and upsert use generated merge and replace operations" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 204, "");
+    defer mock.deinit();
+    mock.response_headers_list = mutation_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    var typed = try client.updateEntity(allocator, try testEntityValue(), .{
+        .mode = .merge,
+        .if_match = "W/\"current\"",
+        .protocol = .{ .client_request_id = "mutation-client" },
+    });
+    defer typed.deinit();
+    try std.testing.expectEqual(@as(u16, 204), typed.status);
+    try std.testing.expectEqualStrings("W/\"updated\"", typed.etag);
+    try std.testing.expectEqualStrings("mutation-request", typed.headers.request_id.?);
+    try std.testing.expectEqual(core.http.Method.PATCH, mock.last_method.?);
+    try std.testing.expectEqualStrings("W/\"current\"", mock.last_headers.get("If-Match").?);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"count@odata.type\":\"Edm.Int64\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"data@odata.type\":\"Edm.Binary\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"created@odata.type\":\"Edm.DateTime\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"id@odata.type\":\"Edm.Guid\"") != null);
+
+    var dynamic = try entity.DynamicEntity.init(allocator, "p", "r");
+    defer dynamic.deinit();
+    try dynamic.put("name", .{ .string = "widget" });
+    try dynamic.put("active", .{ .boolean = true });
+    try dynamic.put("count", .{ .int64 = .{ .value = std.math.maxInt(i64) } });
+    try dynamic.put("small_count", .{ .int32 = 7 });
+    try dynamic.put("ratio", .{ .float64 = 1.5 });
+    try dynamic.put("data", .{ .binary = .{ .bytes = "hi" } });
+    try dynamic.put("created", .{ .datetime = try edm.EdmDateTime.init("2026-07-26T00:00:00Z") });
+    try dynamic.put("id", .{ .guid = try edm.EdmGuid.init("01234567-89ab-cdef-0123-456789abcdef") });
+    try dynamic.put("nullable", .null);
+    var upserted = try client.upsertEntity(allocator, dynamic, .{ .mode = .replace });
+    defer upserted.deinit();
+    try std.testing.expectEqual(core.http.Method.PUT, mock.last_method.?);
+    try std.testing.expect(mock.last_headers.get("If-Match") == null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"count@odata.type\":\"Edm.Int64\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"data@odata.type\":\"Edm.Binary\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"created@odata.type\":\"Edm.DateTime\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "\"id@odata.type\":\"Edm.Guid\"") != null);
+}
+
+test "update existence and ETag failures remain structured while upsert creates" {
+    const PartialEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        changed: []const u8,
+    };
+    const value = PartialEntity{ .partition_key = "p", .row_key = "r", .changed = "new" };
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 404,
+        \\{"code":"ResourceNotFound","message":"missing"}
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "x-ms-request-id", .value = "missing-request" },
+    };
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+
+    var missing = try client.updateEntityResult(allocator, value, .{});
+    defer missing.deinit(allocator);
+    switch (missing) {
+        .failure => |table_error| {
+            try std.testing.expectEqual(@as(u16, 404), table_error.status);
+            try std.testing.expectEqualStrings("ResourceNotFound", table_error.code);
+        },
+        .success => return error.TestUnexpectedResult,
+    }
+
+    mock.response_status = 412;
+    mock.response_body =
+        \\{"code":"UpdateConditionNotSatisfied","message":"stale"}
+    ;
+    var stale = try client.updateEntityResult(allocator, value, .{
+        .if_match = "W/\"stale\"",
+    });
+    defer stale.deinit(allocator);
+    switch (stale) {
+        .failure => |table_error| {
+            try std.testing.expectEqual(@as(u16, 412), table_error.status);
+            try std.testing.expectEqualStrings("UpdateConditionNotSatisfied", table_error.code);
+        },
+        .success => return error.TestUnexpectedResult,
+    }
+
+    mock.response_status = 204;
+    mock.response_body = "";
+    mock.response_headers_list = mutation_response_headers;
+    var matching = try client.updateEntity(allocator, value, .{
+        .mode = .replace,
+        .if_match = "W/\"matching\"",
+    });
+    matching.deinit();
+    try std.testing.expectEqualStrings("W/\"matching\"", mock.last_headers.get("If-Match").?);
+
+    var created = try client.upsertEntity(allocator, value, .{ .mode = .merge });
+    created.deinit();
+    try std.testing.expectEqual(core.http.Method.PATCH, mock.last_method.?);
+    try std.testing.expect(mock.last_headers.get("If-Match") == null);
+}
+
+test "merge preserves omitted properties and replace removes them by wire operation" {
+    const PartialEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        changed: []const u8,
+    };
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 204, "");
+    defer mock.deinit();
+    mock.response_headers_list = mutation_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+    const partial = PartialEntity{ .partition_key = "p", .row_key = "r", .changed = "new" };
+
+    var merged = try client.upsertEntity(allocator, partial, .{ .mode = .merge });
+    merged.deinit();
+    try std.testing.expectEqual(core.http.Method.PATCH, mock.last_method.?);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "preserved") == null);
+
+    var replaced = try client.upsertEntity(allocator, partial, .{ .mode = .replace });
+    replaced.deinit();
+    try std.testing.expectEqual(core.http.Method.PUT, mock.last_method.?);
+    try std.testing.expect(std.mem.indexOf(u8, mock.last_body.?, "preserved") == null);
+}
+
+test "conditional mutation retries before transport and classifies ambiguity after entry" {
+    const SimpleEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        name: []const u8,
+    };
+    const value = SimpleEntity{ .partition_key = "p", .row_key = "r", .name = "updated" };
+    const allocator = std.testing.allocator;
+
+    var mock = core.http.MockTransport.init(allocator, 204, "");
+    defer mock.deinit();
+    mock.response_headers_list = mutation_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        mock.asTransport(),
+        .{ .retry = .{
+            .max_retries = 2,
+            .initial_delay_ms = 0,
+            .max_delay_ms = 0,
+        } },
+    );
+    defer client.deinit();
+    var before_transport = PreTransportOncePolicy{};
+    var response = try client.updateEntity(allocator, value, .{
+        .if_match = "W/\"exact\"",
+        .protocol = .{ .policies = &.{&before_transport.policy} },
+    });
+    response.deinit();
+    try std.testing.expectEqual(@as(usize, 2), before_transport.calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+
+    var failing = FailingMutationTransport{};
+    var conditional_client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        failing.asTransport(),
+        .{ .retry = .{
+            .max_retries = 2,
+            .initial_delay_ms = 0,
+            .max_delay_ms = 0,
+        } },
+    );
+    defer conditional_client.deinit();
+    try std.testing.expectError(
+        error.MutationOutcomeUnknown,
+        conditional_client.updateEntityResult(allocator, value, .{
+            .if_match = "W/\"exact\"",
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), failing.calls);
+
+    var safe_failing = FailingMutationTransport{};
+    var safe_client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=secret",
+        "Table123",
+        safe_failing.asTransport(),
+        .{ .retry = .{
+            .max_retries = 2,
+            .initial_delay_ms = 0,
+            .max_delay_ms = 0,
+        } },
+    );
+    defer safe_client.deinit();
+    try std.testing.expectError(
+        error.MutationOutcomeUnknown,
+        safe_client.upsertEntityResult(allocator, value, .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 3), safe_failing.calls);
+}
+
 test "entity constraints and malformed success fail locally" {
     const SimpleEntity = struct {
         partition_key: []const u8,
@@ -1004,6 +1391,22 @@ test "entity constraints and malformed success fail locally" {
         error.InvalidIfMatch,
         client.deleteEntityResult(allocator, "p", "r", .{ .if_match = "" }),
     );
+    try std.testing.expectError(
+        error.InvalidEntityKey,
+        client.updateEntityResult(allocator, SimpleEntity{
+            .partition_key = "bad/key",
+            .row_key = "r",
+            .name = "invalid",
+        }, .{}),
+    );
+    try std.testing.expectError(
+        error.InvalidIfMatch,
+        client.updateEntityResult(allocator, SimpleEntity{
+            .partition_key = "p",
+            .row_key = "r",
+            .name = "invalid",
+        }, .{ .if_match = "" }),
+    );
     try std.testing.expectEqual(@as(usize, 0), mock.call_count);
 
     if (client.getEntityResult(SimpleEntity, allocator, "p", "r", .{})) |result| {
@@ -1012,6 +1415,21 @@ test "entity constraints and malformed success fail locally" {
         return error.TestExpectedMalformedPayload;
     } else |_| {}
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+
+    mock.response_status = 204;
+    mock.response_body = "";
+    mock.response_headers_list = &.{
+        .{ .name = "x-ms-version", .value = "2019-02-02" },
+        .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
+    };
+    try std.testing.expectError(
+        error.MissingResponseHeader,
+        client.upsertEntityResult(allocator, SimpleEntity{
+            .partition_key = "p",
+            .row_key = "r",
+            .name = "malformed",
+        }, .{}),
+    );
 }
 
 test "entity query pager survives moving its source client" {
@@ -1214,6 +1632,44 @@ test "entity CRUD allocation failure paths are leak-free" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         testEntityCrudAllocationFailures,
+        .{},
+    );
+}
+
+fn testEntityMutationAllocationFailures(allocator: std.mem.Allocator) !void {
+    const SimpleEntity = struct {
+        partition_key: []const u8,
+        row_key: []const u8,
+        name: []const u8,
+    };
+    var mock = core.http.MockTransport.init(allocator, 204, "");
+    defer mock.deinit();
+    mock.response_headers_list = mutation_response_headers;
+    var client = try TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=allocation-secret",
+        "Table123",
+        mock.asTransport(),
+        .{},
+    );
+    defer client.deinit();
+    var response = client.upsertEntity(allocator, SimpleEntity{
+        .partition_key = "p",
+        .row_key = "r",
+        .name = "owned",
+    }, .{ .mode = .replace }) catch |err| {
+        // The failing allocator can trip the mock after transport entry; the
+        // production API correctly reports that outcome as ambiguous.
+        if (err == error.MutationOutcomeUnknown) return error.OutOfMemory;
+        return err;
+    };
+    response.deinit();
+}
+
+test "entity mutation allocation failure paths are leak-free" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        testEntityMutationAllocationFailures,
         .{},
     );
 }

--- a/entity_codec.zig
+++ b/entity_codec.zig
@@ -39,7 +39,10 @@ pub fn EntityCodec(comptime T: type) type {
         pub fn toJson(allocator: std.mem.Allocator, value: T) ![]u8 {
             var output: std.Io.Writer.Allocating = .init(allocator);
             errdefer output.deinit();
-            try Self.serialize(value, &output.writer);
+            Self.serialize(value, &output.writer) catch |err| {
+                if (err == error.WriteFailed) return error.OutOfMemory;
+                return err;
+            };
             return output.toOwnedSlice();
         }
 
@@ -96,7 +99,14 @@ pub fn EntityCodec(comptime T: type) type {
 pub fn dynamicToJson(allocator: std.mem.Allocator, value: DynamicEntity) ![]u8 {
     var output: std.Io.Writer.Allocating = .init(allocator);
     errdefer output.deinit();
-    const writer = &output.writer;
+    serializeDynamic(value, &output.writer) catch |err| {
+        if (err == error.WriteFailed) return error.OutOfMemory;
+        return err;
+    };
+    return output.toOwnedSlice();
+}
+
+fn serializeDynamic(value: DynamicEntity, writer: anytype) !void {
     var first = true;
     try writer.writeByte('{');
     try writePropertyPrefix(writer, &first, "PartitionKey");
@@ -120,7 +130,6 @@ pub fn dynamicToJson(allocator: std.mem.Allocator, value: DynamicEntity) ![]u8 {
         try writeJsonString(writer, timestamp.value);
     }
     try writer.writeByte('}');
-    return output.toOwnedSlice();
 }
 
 /// Decodes a runtime-schema entity. The returned entity owns its keys and

--- a/entity_codec.zig
+++ b/entity_codec.zig
@@ -125,10 +125,8 @@ fn serializeDynamic(value: DynamicEntity, writer: anytype) !void {
             try writeJsonString(writer, annotation);
         }
     }
-    if (value.timestamp) |timestamp| {
-        try writePropertyPrefix(writer, &first, "Timestamp");
-        try writeJsonString(writer, timestamp.value);
-    }
+    // Timestamp is decoded for response metadata but is managed by the
+    // service and must never be sent in entity mutation bodies.
     try writer.writeByte('}');
 }
 
@@ -545,9 +543,11 @@ test "dynamic entity codec preserves annotations and ownership" {
     defer value.deinit();
     try value.put("Blob", .{ .binary = .{ .bytes = "hello" } });
     try value.put("Id", .{ .guid = try edm.EdmGuid.init("01234567-89ab-cdef-0123-456789abcdef") });
+    try value.setTimestamp(try edm.EdmDateTime.init("2026-07-26T00:00:00Z"));
     const json = try dynamicToJson(allocator, value);
     defer allocator.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"Blob@odata.type\":\"Edm.Binary\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"Timestamp\"") == null);
     var decoded = try dynamicFromJson(allocator, json);
     defer decoded.deinit();
     try std.testing.expectEqualStrings("hello", decoded.properties.get("Blob").?.binary.bytes);

--- a/options.zig
+++ b/options.zig
@@ -62,6 +62,27 @@ pub const DeleteEntityOptions = struct {
     if_match: []const u8 = "*",
 };
 
+/// Selects the service's closed set of entity mutation semantics.
+pub const UpdateMode = enum {
+    /// Preserve properties omitted from the request body.
+    merge,
+    /// Remove properties omitted from the request body.
+    replace,
+};
+
+pub const UpdateEntityOptions = struct {
+    protocol: ProtocolOptions = .{},
+    mode: UpdateMode = .merge,
+    /// `"*"` updates the current entity unconditionally; an entity ETag makes
+    /// the update conditional.
+    if_match: []const u8 = "*",
+};
+
+pub const UpsertEntityOptions = struct {
+    protocol: ProtocolOptions = .{},
+    mode: UpdateMode = .merge,
+};
+
 pub const RetryOptions = struct {
     max_retries: u32 = 3,
     initial_delay_ms: u64 = 800,

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -14,6 +14,22 @@ const HttpTransport = core.http.HttpTransport;
 const Request = core.http.Request;
 const Response = core.http.Response;
 
+fn nanoTimestamp() i128 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    return std.Io.Timestamp.now(threaded.io(), .real).toNanoseconds();
+}
+
+fn monotonicNanoTimestamp() i128 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    return std.Io.Timestamp.now(threaded.io(), .awake).toNanoseconds();
+}
+
+fn sleepMs(ms: u64) void {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const nanoseconds = @as(i96, ms) * std.time.ns_per_ms;
+    threaded.io().sleep(.fromNanoseconds(nanoseconds), .awake) catch {};
+}
+
 pub const user_agent = "azsdk-zig-data-tables/0.1.0";
 
 /// Heap-owned policy storage shared by an owning client and its derived
@@ -169,6 +185,18 @@ pub const PipelineState = struct {
             .shared_key => |*policy| policy.credential,
             else => null,
         };
+    }
+
+    pub fn retryOptions(self: *const PipelineState) options.RetryOptions {
+        return .{
+            .max_retries = self.retry.max_retries,
+            .initial_delay_ms = self.retry.initial_delay_ms,
+            .max_delay_ms = self.retry.max_delay_ms,
+        };
+    }
+
+    pub fn operationTimeoutMs(self: *const PipelineState) ?u64 {
+        return self.request_options.operation_timeout_ms;
     }
 };
 
@@ -353,7 +381,7 @@ pub const CallContext = struct {
         operation_timeout_ms: ?u64,
         server_timeout: ?i32,
         custom_policies: []const *HttpPolicy,
-        max_pre_transport_retries: u32,
+        retry_options: options.RetryOptions,
         conditional: bool,
     ) !CallContext {
         return initInternal(
@@ -366,7 +394,7 @@ pub const CallContext = struct {
             custom_policies,
             .failure_only,
             .{
-                .max_pre_transport_retries = max_pre_transport_retries,
+                .options = retry_options,
                 .conditional = conditional,
             },
         );
@@ -449,7 +477,7 @@ pub const CallContext = struct {
 const CaptureMode = enum { none, failure_only, all };
 
 const MutationRetry = struct {
-    max_pre_transport_retries: u32,
+    options: options.RetryOptions,
     conditional: bool,
 };
 
@@ -534,22 +562,92 @@ const ConfigPolicy = struct {
         const old_retryable = request.retryable;
         request.retryable = false;
         defer request.retryable = old_retryable;
-        var retry_count: u32 = 0;
+        const deadline_ns: ?i128 = if (request.operation_timeout_ms) |timeout_ms|
+            std.math.add(
+                i128,
+                monotonicNanoTimestamp(),
+                @as(i128, timeout_ms) * std.time.ns_per_ms,
+            ) catch std.math.maxInt(i128)
+        else
+            null;
+        var attempt: u32 = 0;
+        var prng = std.Random.DefaultPrng.init(
+            @truncate(@as(u128, @bitCast(nanoTimestamp()))),
+        );
         while (true) {
+            if (deadlineExpired(deadline_ns)) return error.OperationTimedOut;
             request.transport_started = false;
-            return callNext(request, next, transport) catch |err| {
+            const result = callNext(request, next, transport);
+            if (result) |response| return response else |err| {
                 if (request.transport_started) return error.MutationOutcomeUnknown;
                 if (!isRetryablePreTransportError(err) or
-                    retry_count >= mutation.max_pre_transport_retries)
+                    attempt >= mutation.options.max_retries)
                 {
                     return err;
                 }
-                retry_count += 1;
-                continue;
-            };
+                attempt += 1;
+                const delay = retryDelay(mutation.options, &prng, attempt);
+                if (!sleepWithinBudget(delay, deadline_ns))
+                    return error.OperationTimedOut;
+            }
         }
     }
 };
+
+fn retryDelay(
+    retry_options: options.RetryOptions,
+    prng: *std.Random.DefaultPrng,
+    attempt: u32,
+) u64 {
+    const base_delay = exponentialDelayMs(
+        retry_options.initial_delay_ms,
+        retry_options.max_delay_ms,
+        attempt,
+    );
+    const jitter = prng.random().uintLessThan(u64, @max(base_delay, 1));
+    return base_delay / 2 + jitter / 2;
+}
+
+fn deadlineExpired(deadline_ns: ?i128) bool {
+    const deadline = deadline_ns orelse return false;
+    return monotonicNanoTimestamp() >= deadline;
+}
+
+fn sleepWithinBudget(delay_ms: u64, deadline_ns: ?i128) bool {
+    const deadline = deadline_ns orelse {
+        sleepMs(delay_ms);
+        return true;
+    };
+    const now = monotonicNanoTimestamp();
+    if (now >= deadline) return false;
+
+    const remaining_ns = deadline - now;
+    const delay_ns = @as(i128, delay_ms) * std.time.ns_per_ms;
+    if (delay_ns >= remaining_ns) {
+        var threaded: std.Io.Threaded = .init_single_threaded;
+        threaded.io().sleep(
+            .fromNanoseconds(@intCast(remaining_ns)),
+            .awake,
+        ) catch {};
+        return false;
+    }
+    sleepMs(delay_ms);
+    return true;
+}
+
+fn exponentialDelayMs(
+    initial_delay_ms: u64,
+    max_delay_ms: u64,
+    attempt: u32,
+) u64 {
+    if (initial_delay_ms == 0 or max_delay_ms == 0) return 0;
+    const shift = attempt -| 1;
+    if (shift >= 64) return max_delay_ms;
+    const multiplier = @as(u64, 1) << @intCast(shift);
+    const scaled = std.math.mul(u64, initial_delay_ms, multiplier) catch
+        std.math.maxInt(u64);
+    return @min(scaled, max_delay_ms);
+}
 
 fn isRetryablePreTransportError(failure: anyerror) bool {
     return switch (failure) {

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -294,6 +294,7 @@ pub const CallContext = struct {
             server_timeout,
             custom_policies,
             .failure_only,
+            null,
         );
     }
 
@@ -315,6 +316,7 @@ pub const CallContext = struct {
             server_timeout,
             custom_policies,
             .all,
+            null,
         );
     }
 
@@ -336,6 +338,37 @@ pub const CallContext = struct {
             server_timeout,
             custom_policies,
             .none,
+            null,
+        );
+    }
+
+    /// Entity mutations with an explicit ETag retry only failures known to
+    /// have happened before transport entry. Wildcard updates and upserts use
+    /// the standard retry policy because repeating their payload is safe.
+    pub fn initMutation(
+        allocator: std.mem.Allocator,
+        base: core.pipeline.HttpPipeline,
+        raw_endpoint_query: ?[]const u8,
+        endpoint_query_is_sas: bool,
+        operation_timeout_ms: ?u64,
+        server_timeout: ?i32,
+        custom_policies: []const *HttpPolicy,
+        max_pre_transport_retries: u32,
+        conditional: bool,
+    ) !CallContext {
+        return initInternal(
+            allocator,
+            base,
+            raw_endpoint_query,
+            endpoint_query_is_sas,
+            operation_timeout_ms,
+            server_timeout,
+            custom_policies,
+            .failure_only,
+            .{
+                .max_pre_transport_retries = max_pre_transport_retries,
+                .conditional = conditional,
+            },
         );
     }
 
@@ -348,6 +381,7 @@ pub const CallContext = struct {
         server_timeout: ?i32,
         custom_policies: []const *HttpPolicy,
         capture_mode: CaptureMode,
+        mutation_retry: ?MutationRetry,
     ) !CallContext {
         const config = try allocator.create(ConfigPolicy);
         errdefer allocator.destroy(config);
@@ -355,6 +389,7 @@ pub const CallContext = struct {
             if (endpoint_query_is_sas) null else raw_endpoint_query,
             operation_timeout_ms,
             server_timeout,
+            mutation_retry,
         );
         const capture = if (capture_mode != .none)
             try allocator.create(CapturePolicy)
@@ -413,21 +448,29 @@ pub const CallContext = struct {
 
 const CaptureMode = enum { none, failure_only, all };
 
+const MutationRetry = struct {
+    max_pre_transport_retries: u32,
+    conditional: bool,
+};
+
 const ConfigPolicy = struct {
     raw_query: ?[]const u8,
     operation_timeout_ms: ?u64,
     server_timeout: ?i32,
+    mutation_retry: ?MutationRetry,
     policy: HttpPolicy,
 
     fn init(
         raw_query: ?[]const u8,
         operation_timeout_ms: ?u64,
         server_timeout: ?i32,
+        mutation_retry: ?MutationRetry,
     ) ConfigPolicy {
         return .{
             .raw_query = raw_query,
             .operation_timeout_ms = operation_timeout_ms,
             .server_timeout = server_timeout,
+            .mutation_retry = mutation_retry,
             .policy = .{ .processFn = &process },
         };
     }
@@ -461,7 +504,7 @@ const ConfigPolicy = struct {
             owned_url = timeout_url;
             url = timeout_url;
         }
-        if (owned_url == null) return callNext(request, next, transport);
+        if (owned_url == null) return self.send(request, next, transport);
         const final_url = owned_url.?;
         owned_url = null;
         request.url = final_url;
@@ -469,9 +512,57 @@ const ConfigPolicy = struct {
             request.url = old_url;
             request.allocator.free(final_url);
         }
-        return callNext(request, next, transport);
+        return self.send(request, next, transport);
+    }
+
+    fn send(
+        self: *ConfigPolicy,
+        request: *Request,
+        next: []*HttpPolicy,
+        transport: *HttpTransport,
+    ) !Response {
+        const mutation = self.mutation_retry orelse
+            return callNext(request, next, transport);
+
+        if (!mutation.conditional) {
+            return callNext(request, next, transport) catch |err| {
+                if (request.transport_started) return error.MutationOutcomeUnknown;
+                return err;
+            };
+        }
+
+        const old_retryable = request.retryable;
+        request.retryable = false;
+        defer request.retryable = old_retryable;
+        var retry_count: u32 = 0;
+        while (true) {
+            request.transport_started = false;
+            return callNext(request, next, transport) catch |err| {
+                if (request.transport_started) return error.MutationOutcomeUnknown;
+                if (!isRetryablePreTransportError(err) or
+                    retry_count >= mutation.max_pre_transport_retries)
+                {
+                    return err;
+                }
+                retry_count += 1;
+                continue;
+            };
+        }
     }
 };
+
+fn isRetryablePreTransportError(failure: anyerror) bool {
+    return switch (failure) {
+        error.OutOfMemory,
+        error.OperationTimedOut,
+        error.OperationCancelled,
+        error.InvalidHttpHeaderName,
+        error.InvalidHttpHeaderValue,
+        error.InvalidUrl,
+        => false,
+        else => true,
+    };
+}
 
 /// Appends an opaque SAS query only for the transport call. It is always the
 /// final policy, inside retry, so caller observability sees a credential-free

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -21,11 +21,13 @@ pub const ProtocolClient = struct {
     endpoint: request.NormalizedEndpoint,
     endpoint_query_is_sas: bool,
     api_version: []u8,
+    mutation_max_retries: u32,
     pipeline: core.pipeline.HttpPipeline,
 
     pub const InitOptions = struct {
         api_version: []const u8 = options.latest_api_version,
         endpoint_query_is_sas: bool = false,
+        mutation_max_retries: u32 = 3,
     };
 
     pub fn init(
@@ -42,6 +44,7 @@ pub const ProtocolClient = struct {
             .endpoint = normalized,
             .endpoint_query_is_sas = init_options.endpoint_query_is_sas,
             .api_version = try allocator.dupe(u8, init_options.api_version),
+            .mutation_max_retries = init_options.mutation_max_retries,
             .pipeline = http_pipeline,
         };
     }
@@ -66,11 +69,13 @@ pub const ProtocolClient = struct {
             return init(allocator, endpoint, self.pipeline, .{
                 .api_version = self.api_version,
                 .endpoint_query_is_sas = self.endpoint_query_is_sas,
+                .mutation_max_retries = self.mutation_max_retries,
             });
         }
         return init(allocator, self.endpoint.base_url, self.pipeline, .{
             .api_version = self.api_version,
             .endpoint_query_is_sas = self.endpoint_query_is_sas,
+            .mutation_max_retries = self.mutation_max_retries,
         });
     }
 
@@ -497,6 +502,140 @@ pub const ProtocolClient = struct {
             .arena = arena,
             .allocator = allocator,
         } };
+    }
+
+    /// Uses the generated PUT/PATCH operations for both update and upsert.
+    /// Supplying `if_match` selects update semantics; null selects the
+    /// generated insert-or-replace/insert-or-merge semantics.
+    pub fn mutateEntityResult(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        table_name: []const u8,
+        partition_key: []const u8,
+        row_key: []const u8,
+        entity_json: []const u8,
+        mode: options.UpdateMode,
+        if_match: ?[]const u8,
+        protocol_options_input: options.ProtocolOptions,
+    ) !responses.TableResult(responses.SdkResponse(void)) {
+        try request.validateTableName(table_name);
+        try request.validateEntityKey(partition_key);
+        try request.validateEntityKey(row_key);
+        if (if_match) |value| try request.validateIfMatch(value);
+        try request.validateProtocolOptions(protocol_options_input);
+        if (entity_json.len == 0 or entity_json.len > 1024 * 1024)
+            return error.InvalidEntity;
+
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+        const arena_allocator = arena.allocator();
+        const properties = try serde.json.fromSlice(
+            std.json.ArrayHashMap(protocol.models.JsonValue),
+            arena_allocator,
+            entity_json,
+        );
+
+        const body_policy = try arena_allocator.create(BodyOverridePolicy);
+        body_policy.* = .{ .body = entity_json };
+        const call_policies = try arena_allocator.alloc(
+            *core.pipeline.HttpPolicy,
+            protocol_options_input.policies.len + 1,
+        );
+        @memcpy(
+            call_policies[0..protocol_options_input.policies.len],
+            protocol_options_input.policies,
+        );
+        call_policies[call_policies.len - 1] = &body_policy.policy;
+        var protocol_options = protocol_options_input;
+        protocol_options.policies = call_policies;
+        var call = try self.beginMutationCall(
+            arena_allocator,
+            protocol_options,
+            if_match != null and !std.mem.eql(u8, if_match.?, "*"),
+        );
+        errdefer call.deinit();
+        var generated = protocol.TablesClient.initWithPipeline(
+            arena_allocator,
+            call.pipeline,
+            .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
+        );
+        var table = generated.table();
+        switch (mode) {
+            .replace => _ = table.updateEntity(
+                arena_allocator,
+                protocol_options_input.client_request_id,
+                table_name,
+                protocol_options_input.timeout,
+                if_match,
+                partition_key,
+                row_key,
+                properties,
+            ) catch |operation_error| {
+                if (operation_error != error.AzureRequestFailed) return operation_error;
+                return self.mutationFailure(allocator, arena, &call);
+            },
+            .merge => _ = table.mergeEntity(
+                arena_allocator,
+                protocol_options_input.client_request_id,
+                table_name,
+                protocol_options_input.timeout,
+                if_match,
+                partition_key,
+                row_key,
+                properties,
+            ) catch |operation_error| {
+                if (operation_error != error.AzureRequestFailed) return operation_error;
+                return self.mutationFailure(allocator, arena, &call);
+            },
+        }
+        const metadata = try call.takeResponse();
+        call.deinit();
+        return .{ .success = .{
+            .value = {},
+            .status = metadata.status,
+            .headers = metadata.headers,
+            .body = metadata.body,
+            .arena = arena,
+            .allocator = allocator,
+        } };
+    }
+
+    fn mutationFailure(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        arena: *std.heap.ArenaAllocator,
+        call: *pipeline_mod.CallContext,
+    ) !responses.TableResult(responses.SdkResponse(void)) {
+        _ = self;
+        var metadata = try call.takeResponse();
+        errdefer metadata.deinit();
+        const table_error = try errorsFromMetadata(allocator, &metadata);
+        metadata.deinit();
+        call.deinit();
+        arena.deinit();
+        allocator.destroy(arena);
+        return .{ .failure = table_error };
+    }
+
+    fn beginMutationCall(
+        self: *ProtocolClient,
+        allocator: std.mem.Allocator,
+        call_options: options.ProtocolOptions,
+        conditional: bool,
+    ) !pipeline_mod.CallContext {
+        return pipeline_mod.CallContext.initMutation(
+            allocator,
+            self.pipeline,
+            if (self.endpoint.has_query) self.endpoint.raw_query else null,
+            self.endpoint_query_is_sas,
+            call_options.operation_timeout_ms,
+            call_options.timeout,
+            call_options.policies,
+            self.mutation_max_retries,
+            conditional,
+        );
     }
 
     fn beginEntityCall(

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -21,13 +21,15 @@ pub const ProtocolClient = struct {
     endpoint: request.NormalizedEndpoint,
     endpoint_query_is_sas: bool,
     api_version: []u8,
-    mutation_max_retries: u32,
+    mutation_retry: options.RetryOptions,
+    default_operation_timeout_ms: ?u64,
     pipeline: core.pipeline.HttpPipeline,
 
     pub const InitOptions = struct {
         api_version: []const u8 = options.latest_api_version,
         endpoint_query_is_sas: bool = false,
-        mutation_max_retries: u32 = 3,
+        mutation_retry: options.RetryOptions = .{},
+        default_operation_timeout_ms: ?u64 = null,
     };
 
     pub fn init(
@@ -44,7 +46,8 @@ pub const ProtocolClient = struct {
             .endpoint = normalized,
             .endpoint_query_is_sas = init_options.endpoint_query_is_sas,
             .api_version = try allocator.dupe(u8, init_options.api_version),
-            .mutation_max_retries = init_options.mutation_max_retries,
+            .mutation_retry = init_options.mutation_retry,
+            .default_operation_timeout_ms = init_options.default_operation_timeout_ms,
             .pipeline = http_pipeline,
         };
     }
@@ -69,13 +72,15 @@ pub const ProtocolClient = struct {
             return init(allocator, endpoint, self.pipeline, .{
                 .api_version = self.api_version,
                 .endpoint_query_is_sas = self.endpoint_query_is_sas,
-                .mutation_max_retries = self.mutation_max_retries,
+                .mutation_retry = self.mutation_retry,
+                .default_operation_timeout_ms = self.default_operation_timeout_ms,
             });
         }
         return init(allocator, self.endpoint.base_url, self.pipeline, .{
             .api_version = self.api_version,
             .endpoint_query_is_sas = self.endpoint_query_is_sas,
-            .mutation_max_retries = self.mutation_max_retries,
+            .mutation_retry = self.mutation_retry,
+            .default_operation_timeout_ms = self.default_operation_timeout_ms,
         });
     }
 
@@ -364,6 +369,7 @@ pub const ProtocolClient = struct {
             .return_content,
             properties,
         ) catch |operation_error| {
+            if (operation_error == error.WriteFailed) return error.OutOfMemory;
             if (operation_error != error.AzureRequestFailed) return operation_error;
             var metadata = try call.takeResponse();
             const table_error = try errorsFromMetadata(allocator, &metadata);
@@ -573,6 +579,7 @@ pub const ProtocolClient = struct {
                 row_key,
                 properties,
             ) catch |operation_error| {
+                if (operation_error == error.WriteFailed) return error.OutOfMemory;
                 if (operation_error != error.AzureRequestFailed) return operation_error;
                 return self.mutationFailure(allocator, arena, &call);
             },
@@ -586,6 +593,7 @@ pub const ProtocolClient = struct {
                 row_key,
                 properties,
             ) catch |operation_error| {
+                if (operation_error == error.WriteFailed) return error.OutOfMemory;
                 if (operation_error != error.AzureRequestFailed) return operation_error;
                 return self.mutationFailure(allocator, arena, &call);
             },
@@ -630,10 +638,10 @@ pub const ProtocolClient = struct {
             self.pipeline,
             if (self.endpoint.has_query) self.endpoint.raw_query else null,
             self.endpoint_query_is_sas,
-            call_options.operation_timeout_ms,
+            call_options.operation_timeout_ms orelse self.default_operation_timeout_ms,
             call_options.timeout,
             call_options.policies,
-            self.mutation_max_retries,
+            self.mutation_retry,
             conditional,
         );
     }

--- a/responses.zig
+++ b/responses.zig
@@ -154,6 +154,22 @@ pub const DeleteEntityResponse = struct {
     }
 };
 
+/// Arena-owned response from an entity update or upsert.
+pub const MutationEntityResponse = struct {
+    etag: []const u8,
+    status: u16,
+    headers: EntityHeaders,
+    raw_headers: RawHeaders,
+    arena: *std.heap.ArenaAllocator,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *MutationEntityResponse) void {
+        self.arena.deinit();
+        self.allocator.destroy(self.arena);
+        self.* = undefined;
+    }
+};
+
 /// A typed operation outcome. Local failures remain in the outer Zig error
 /// union; non-successful HTTP responses are `failure` values.
 pub fn TableResult(comptime T: type) type {

--- a/root.zig
+++ b/root.zig
@@ -66,9 +66,13 @@ pub const CreateTableResponse = responses.SdkResponse(protocol_client.CreateTabl
 pub const DeleteTableResponse = responses.SdkResponse(protocol_client.DeleteTableResponse);
 pub const EntityResponse = responses.EntityResponse;
 pub const DeleteEntityResponse = responses.DeleteEntityResponse;
+pub const MutationEntityResponse = responses.MutationEntityResponse;
 pub const AddEntityOptions = options.AddEntityOptions;
 pub const GetEntityOptions = options.GetEntityOptions;
 pub const DeleteEntityOptions = options.DeleteEntityOptions;
+pub const UpdateMode = options.UpdateMode;
+pub const UpdateEntityOptions = options.UpdateEntityOptions;
+pub const UpsertEntityOptions = options.UpsertEntityOptions;
 pub const unwrapGetEntity = responses.unwrapGetEntity;
 pub const unwrapCreateEntity = responses.unwrapCreateEntity;
 
@@ -137,9 +141,13 @@ test {
     _ = DeleteTableResponse;
     _ = EntityResponse;
     _ = DeleteEntityResponse;
+    _ = MutationEntityResponse;
     _ = AddEntityOptions;
     _ = GetEntityOptions;
     _ = DeleteEntityOptions;
+    _ = UpdateMode;
+    _ = UpdateEntityOptions;
+    _ = UpsertEntityOptions;
     _ = unwrapGetEntity;
     _ = unwrapCreateEntity;
 }


### PR DESCRIPTION
## Summary
- add closed merge/replace `UpdateMode` plus typed and dynamic update/upsert APIs and result variants
- route mutations through generated PATCH/PUT operations with shared codecs, conditional ETags, owned response metadata, and structured Table errors
- preserve merge/replace and update/upsert existence semantics while validating inputs before transport
- give explicit-ETag retries one effective deadline with configured limits and jittered backoff, retrying only pre-transport failures and classifying post-entry ambiguity
- omit service-managed `Timestamp` from typed and dynamic add/update/upsert payloads while retaining it on decoded responses
- cover exact wire parity, read-then-update, existence/ETags, deadline budgets, malformed responses, OOM, and leaks

## Validation
- `zig fmt --check *.zig`
- `zig build test`
- rebased onto current `sdk/data_tables` (`a7d186025`)

Fixes #159

Part of #148