### PR TITLE
eng: publish container_client.zig for storage_blobs

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -250,6 +250,7 @@ pub const all = [_]Package{
             "root.zig",
             "sas.zig",
             "convenience.zig",
+            "container_client.zig",
             "src",
             "examples",
             "README.md",


### PR DESCRIPTION
## Summary

- Register `container_client.zig` in the `azure_sdk_storage_blobs` entry of `eng/packages.zig`.

`sdk/storage_blobs` gained `container_client.zig` in #211, which added it to the branch manifest's `.paths`. `eng/package_branch_tool.zig` asserts `expectExactSet(package.publish_paths, manifest.paths)`, so without this the branch check fails and a release would omit the file.

## Validation

```
zig fmt --check eng/packages.zig
zig build package-check --summary all   # package registry: 22 packages valid
zig build test --summary all
```

Part of #191