### PR TITLE
sdk/eventhubs: store checkpoints and ownership in blob metadata

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -71,7 +71,6 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{ .name = "azure_sdk_core", .module = core_mod },
                 .{ .name = "azure_sdk_storage_blobs", .module = blobs_mod },
-                .{ .name = "serde", .module = serde_mod },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,24 +5,24 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#da55987aa3c90393a726fc1fa5e86ccd69d72271",
-            .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
+            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
         },
         .azure_sdk_messaging_common = .{
             .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#51c5ec8e181abd59a0f8180fc4c37b9ddc8a2bcb",
             .hash = "azure_sdk_messaging_common-0.1.0-YklmSnoYAACqhTFKLjL7ZX1jSngsgJRYKAhYkgx4J_RU",
         },
         .azure_sdk_storage_blobs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#4f1e3c0e3ed14df68956af442cd401ac2974b362",
-            .hash = "azure_sdk_storage_blobs-0.1.0-I5lGdgoKAQCviVvGY2BIs_0Guj5BQj1OpWy_m3VLkKpH",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#547a1f88972a9a245f4af15479f592a0e1f8344b",
+            .hash = "azure_sdk_storage_blobs-0.1.0-I5lGdlJ7CgCiJaJDvHH7ukhtln4baXBvqfvrDGCOhiVD",
         },
         .uamqp = .{
             .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",
             .hash = "uamqp-0.1.0-lXMcafDqAQD3LSUZbUbyfrWhQfGG7OevKFUwhWxvGZDU",
         },
         .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
-            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+            .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
+            .hash = "serde-1.0.1-1DszT1XhDACnteUU3yWahMMjLjkJqB34hwROPIfhZc7l",
         },
     },
     .paths = .{

--- a/checkpoint.zig
+++ b/checkpoint.zig
@@ -1,13 +1,28 @@
 const std = @import("std");
 
 /// Tracks consumer progress for a partition.
+///
+/// `offset` is an opaque service-defined token, not a number. Event Hubs
+/// returns non-numeric offsets under geo-disaster-recovery, and the Go and
+/// Rust SDKs both model it as a string, so it is kept as one here for wire
+/// compatibility.
 pub const Checkpoint = struct {
     fully_qualified_namespace: []const u8,
     event_hub_name: []const u8,
     consumer_group: []const u8,
     partition_id: []const u8,
-    offset: ?i64 = null,
+    offset: ?[]const u8 = null,
     sequence_number: ?i64 = null,
+
+    /// Free a checkpoint returned by a `CheckpointStore`. Values the caller
+    /// constructed itself do not need this.
+    pub fn deinit(self: Checkpoint, allocator: std.mem.Allocator) void {
+        allocator.free(self.fully_qualified_namespace);
+        allocator.free(self.event_hub_name);
+        allocator.free(self.consumer_group);
+        allocator.free(self.partition_id);
+        if (self.offset) |offset| allocator.free(offset);
+    }
 };
 
 /// Tracks partition ownership for load balancing.
@@ -16,18 +31,53 @@ pub const PartitionOwnership = struct {
     event_hub_name: []const u8,
     consumer_group: []const u8,
     partition_id: []const u8,
+    /// Identifier of the owning processor. An empty string means a previous
+    /// owner relinquished the partition, which is how Go and Rust signal that
+    /// the partition is free to claim.
     owner_id: []const u8,
+    /// Blob `Last-Modified`, in Unix seconds. Load balancing uses it to expire
+    /// ownership that a processor stopped renewing.
     last_modified_time: ?i64 = null,
     etag: ?[]const u8 = null,
+
+    pub fn isRelinquished(self: PartitionOwnership) bool {
+        return self.owner_id.len == 0;
+    }
+
+    /// Free ownership returned by a `CheckpointStore`. Values the caller
+    /// constructed itself do not need this.
+    pub fn deinit(self: PartitionOwnership, allocator: std.mem.Allocator) void {
+        allocator.free(self.fully_qualified_namespace);
+        allocator.free(self.event_hub_name);
+        allocator.free(self.consumer_group);
+        allocator.free(self.partition_id);
+        allocator.free(self.owner_id);
+        if (self.etag) |etag| allocator.free(etag);
+    }
 };
 
+pub fn freeCheckpoints(allocator: std.mem.Allocator, checkpoints: []const Checkpoint) void {
+    for (checkpoints) |checkpoint| checkpoint.deinit(allocator);
+    allocator.free(checkpoints);
+}
+
+pub fn freeOwnerships(allocator: std.mem.Allocator, ownerships: []const PartitionOwnership) void {
+    for (ownerships) |ownership| ownership.deinit(allocator);
+    allocator.free(ownerships);
+}
+
 /// Storage abstraction used by Event Hubs processors.
+///
+/// Every slice returned by these methods is allocator-owned; free it with
+/// `freeCheckpoints` or `freeOwnerships`.
 pub const CheckpointStore = struct {
     claimOwnershipFn: *const fn (self: *CheckpointStore, allocator: std.mem.Allocator, ownership: []const PartitionOwnership) anyerror![]PartitionOwnership,
     listOwnershipFn: *const fn (self: *CheckpointStore, allocator: std.mem.Allocator, fqns: []const u8, hub_name: []const u8, consumer_group: []const u8) anyerror![]PartitionOwnership,
     updateCheckpointFn: *const fn (self: *CheckpointStore, allocator: std.mem.Allocator, checkpoint: Checkpoint) anyerror!void,
     listCheckpointsFn: *const fn (self: *CheckpointStore, allocator: std.mem.Allocator, fqns: []const u8, hub_name: []const u8, consumer_group: []const u8) anyerror![]Checkpoint,
 
+    /// Attempt to claim each partition. Partitions lost to another processor
+    /// are omitted from the result rather than reported as an error.
     pub fn claimOwnership(self: *CheckpointStore, allocator: std.mem.Allocator, ownership: []const PartitionOwnership) ![]PartitionOwnership {
         return self.claimOwnershipFn(self, allocator, ownership);
     }
@@ -44,3 +94,18 @@ pub const CheckpointStore = struct {
         return self.listCheckpointsFn(self, allocator, fqns, hub_name, consumer_group);
     }
 };
+
+test "relinquished ownership is signalled by an empty owner id" {
+    const relinquished = PartitionOwnership{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .owner_id = "",
+    };
+    try std.testing.expect(relinquished.isRelinquished());
+
+    var owned = relinquished;
+    owned.owner_id = "processor-1";
+    try std.testing.expect(!owned.isRelinquished());
+}

--- a/checkpoint_store.zig
+++ b/checkpoint_store.zig
@@ -1,18 +1,29 @@
-///! Blob-based checkpoint store for Azure Event Hubs.
-///!
-///! Persists consumer progress and partition ownership in Azure Blob Storage,
-///! enabling distributed event processing with load balancing.
+//! Blob-based checkpoint store for Azure Event Hubs.
+//!
+//! State lives in blob **metadata**, not in the blob body, matching the Go and
+//! Rust Event Hubs SDKs so processors written in different languages can share
+//! one container:
+//!
+//! - Checkpoints: `{namespace}/{hub}/{group}/checkpoint/{partition}` with
+//!   `sequencenumber` and `offset` metadata.
+//! - Ownership: `{namespace}/{hub}/{group}/ownership/{partition}` with
+//!   `ownerid` metadata, plus the blob's own ETag and Last-Modified.
+//!
+//! Blob bodies are always empty.
+
 const std = @import("std");
 const core = @import("azure_sdk_core");
-const serde = @import("serde");
 const blobs = @import("azure_sdk_storage_blobs");
 const eventhubs = @import("checkpoint.zig");
 
+/// Metadata key holding the checkpoint sequence number.
+pub const sequence_number_key = "sequencenumber";
+/// Metadata key holding the opaque checkpoint offset.
+pub const offset_key = "offset";
+/// Metadata key holding the owning processor's identifier.
+pub const owner_id_key = "ownerid";
+
 /// Checkpoint store backed by Azure Blob Storage.
-///
-/// Stores checkpoints and ownership as JSON blobs:
-/// - Checkpoints: `{namespace}/{hubName}/{consumerGroup}/checkpoint/{partitionId}`
-/// - Ownership:   `{namespace}/{hubName}/{consumerGroup}/ownership/{partitionId}`
 pub const BlobCheckpointStore = struct {
     container_client: *blobs.BlobContainerClient,
     store: eventhubs.CheckpointStore,
@@ -33,124 +44,217 @@ pub const BlobCheckpointStore = struct {
         return &self.store;
     }
 
-    fn claimOwnershipImpl(store: *eventhubs.CheckpointStore, allocator: std.mem.Allocator, ownership: []const eventhubs.PartitionOwnership) anyerror![]eventhubs.PartitionOwnership {
+    /// Claims each partition with a compare-and-swap on the ownership blob.
+    ///
+    /// A processor holding an ETag renews with `If-Match`; a processor claiming
+    /// an unowned partition creates the blob with `If-None-Match: *`. Losing
+    /// the race is normal, so those partitions are dropped from the result
+    /// instead of failing the batch.
+    fn claimOwnershipImpl(
+        store: *eventhubs.CheckpointStore,
+        allocator: std.mem.Allocator,
+        ownership: []const eventhubs.PartitionOwnership,
+    ) anyerror![]eventhubs.PartitionOwnership {
         const self: *BlobCheckpointStore = @fieldParentPtr("store", store);
-        var claimed = std.ArrayList(eventhubs.PartitionOwnership).empty;
-        errdefer claimed.deinit(allocator);
+
+        var claimed: std.ArrayList(eventhubs.PartitionOwnership) = .empty;
+        errdefer {
+            for (claimed.items) |item| item.deinit(allocator);
+            claimed.deinit(allocator);
+        }
 
         for (ownership) |own| {
             const blob_path = try buildOwnershipPath(allocator, own);
             defer allocator.free(blob_path);
 
             var blob_client = self.container_client.getBlobClient(blob_path);
-            const body = try serializeOwnership(allocator, own);
-            defer allocator.free(body);
-
-            const result = blob_client.uploadConditional(allocator, body, .{
-                .content_type = "application/json",
-                .if_match = own.etag,
-                .if_none_match = if (own.etag == null) @as(?[]const u8, "*") else null,
-            }) catch {
-                continue; // Another processor won the claim
+            const metadata = [_]blobs.MetadataEntry{
+                .{ .name = owner_id_key, .value = own.owner_id },
             };
 
-            try claimed.append(allocator, .{
-                .fully_qualified_namespace = own.fully_qualified_namespace,
-                .event_hub_name = own.event_hub_name,
-                .consumer_group = own.consumer_group,
-                .partition_id = own.partition_id,
-                .owner_id = own.owner_id,
-                .etag = result.etag,
-            });
+            var result = if (own.etag) |etag|
+                try blob_client.setMetadataResult(allocator, &metadata, .{ .if_match = etag })
+            else
+                try blob_client.uploadConditionalResult(allocator, "", .{
+                    .metadata = &metadata,
+                    .if_none_match = "*",
+                });
+            defer result.deinit(allocator);
+
+            const written = switch (result) {
+                .ok => |value| value,
+                .err => |azure_error| {
+                    if (isClaimConflict(azure_error.status_code)) continue;
+                    return error.ClaimOwnershipFailed;
+                },
+            };
+
+            var entry = try cloneOwnership(allocator, own);
+            errdefer entry.deinit(allocator);
+            if (written.etag) |etag| entry.etag = try allocator.dupe(u8, etag);
+            entry.last_modified_time = if (written.last_modified) |value|
+                parseRfc1123(value)
+            else
+                null;
+
+            try claimed.append(allocator, entry);
         }
 
         return claimed.toOwnedSlice(allocator);
     }
 
-    fn listOwnershipImpl(store: *eventhubs.CheckpointStore, allocator: std.mem.Allocator, fqns: []const u8, hub_name: []const u8, consumer_group: []const u8) anyerror![]eventhubs.PartitionOwnership {
+    fn listOwnershipImpl(
+        store: *eventhubs.CheckpointStore,
+        allocator: std.mem.Allocator,
+        fqns: []const u8,
+        hub_name: []const u8,
+        consumer_group: []const u8,
+    ) anyerror![]eventhubs.PartitionOwnership {
         const self: *BlobCheckpointStore = @fieldParentPtr("store", store);
-        const prefix = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}/ownership/", .{ fqns, hub_name, consumer_group });
+
+        const prefix = try std.fmt.allocPrint(
+            allocator,
+            "{s}/{s}/{s}/ownership/",
+            .{ fqns, hub_name, consumer_group },
+        );
         defer allocator.free(prefix);
 
-        const blob_list = try self.container_client.listBlobs(allocator);
-        defer {
-            for (blob_list) |b| {
-                if (b.name.len > 0) allocator.free(b.name);
-                if (b.properties.content_type) |ct| allocator.free(ct);
-            }
-            allocator.free(blob_list);
+        const blob_list = try self.container_client.listBlobsWithOptions(allocator, .{
+            .prefix = prefix,
+            .include_metadata = true,
+        });
+        defer blobs.freeBlobItems(allocator, blob_list);
+
+        var result: std.ArrayList(eventhubs.PartitionOwnership) = .empty;
+        errdefer {
+            for (result.items) |item| item.deinit(allocator);
+            result.deinit(allocator);
         }
 
-        var result = std.ArrayList(eventhubs.PartitionOwnership).empty;
-        errdefer result.deinit(allocator);
-
         for (blob_list) |blob| {
-            if (!std.mem.startsWith(u8, blob.name, prefix)) continue;
+            const partition_id = partitionIdOf(blob.name) orelse continue;
 
-            const partition_id = blob.name[prefix.len..];
-            var blob_client = self.container_client.getBlobClient(blob.name);
-            const body = blob_client.download(allocator) catch continue;
-            defer allocator.free(body);
+            var entry = eventhubs.PartitionOwnership{
+                .fully_qualified_namespace = try allocator.dupe(u8, fqns),
+                .event_hub_name = undefined,
+                .consumer_group = undefined,
+                .partition_id = undefined,
+                // A missing `ownerid` means the partition was relinquished;
+                // the service omits metadata keys whose value is empty.
+                .owner_id = undefined,
+            };
+            errdefer entry.deinit(allocator);
+            entry.event_hub_name = try allocator.dupe(u8, hub_name);
+            entry.consumer_group = try allocator.dupe(u8, consumer_group);
+            entry.partition_id = try allocator.dupe(u8, partition_id);
+            entry.owner_id = try allocator.dupe(u8, blob.properties.metadata.get(owner_id_key) orelse "");
 
-            const owner_id = parseOwnerField(allocator, body) orelse continue;
+            if (blob.properties.etag) |etag| entry.etag = try allocator.dupe(u8, etag);
+            if (blob.properties.last_modified) |value| {
+                entry.last_modified_time = parseRfc1123(value);
+            }
 
-            try result.append(allocator, .{
-                .fully_qualified_namespace = fqns,
-                .event_hub_name = hub_name,
-                .consumer_group = consumer_group,
-                .partition_id = partition_id,
-                .owner_id = owner_id,
-            });
+            try result.append(allocator, entry);
         }
 
         return result.toOwnedSlice(allocator);
     }
 
-    fn updateCheckpointImpl(store: *eventhubs.CheckpointStore, allocator: std.mem.Allocator, checkpoint: eventhubs.Checkpoint) anyerror!void {
+    /// Writes the checkpoint into blob metadata, creating the blob if it does
+    /// not exist yet. Ownership is assumed, so no precondition is applied.
+    fn updateCheckpointImpl(
+        store: *eventhubs.CheckpointStore,
+        allocator: std.mem.Allocator,
+        checkpoint: eventhubs.Checkpoint,
+    ) anyerror!void {
         const self: *BlobCheckpointStore = @fieldParentPtr("store", store);
+
         const blob_path = try buildCheckpointPath(allocator, checkpoint);
         defer allocator.free(blob_path);
 
-        var blob_client = self.container_client.getBlobClient(blob_path);
-        const body = try serializeCheckpoint(allocator, checkpoint);
-        defer allocator.free(body);
-
-        try blob_client.upload(allocator, body, "application/json");
-    }
-
-    fn listCheckpointsImpl(store: *eventhubs.CheckpointStore, allocator: std.mem.Allocator, fqns: []const u8, hub_name: []const u8, consumer_group: []const u8) anyerror![]eventhubs.Checkpoint {
-        const self: *BlobCheckpointStore = @fieldParentPtr("store", store);
-        const prefix = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}/checkpoint/", .{ fqns, hub_name, consumer_group });
-        defer allocator.free(prefix);
-
-        const blob_list = try self.container_client.listBlobs(allocator);
-        defer {
-            for (blob_list) |b| {
-                if (b.name.len > 0) allocator.free(b.name);
-                if (b.properties.content_type) |ct| allocator.free(ct);
-            }
-            allocator.free(blob_list);
+        var sequence_buffer: [24]u8 = undefined;
+        var metadata: [2]blobs.MetadataEntry = undefined;
+        var count: usize = 0;
+        if (checkpoint.sequence_number) |sequence_number| {
+            metadata[count] = .{
+                .name = sequence_number_key,
+                .value = try std.fmt.bufPrint(&sequence_buffer, "{d}", .{sequence_number}),
+            };
+            count += 1;
+        }
+        if (checkpoint.offset) |offset| {
+            metadata[count] = .{ .name = offset_key, .value = offset };
+            count += 1;
         }
 
-        var result = std.ArrayList(eventhubs.Checkpoint).empty;
-        errdefer result.deinit(allocator);
+        var blob_client = self.container_client.getBlobClient(blob_path);
+
+        var set_result = try blob_client.setMetadataResult(allocator, metadata[0..count], .{});
+        defer set_result.deinit(allocator);
+        switch (set_result) {
+            .ok => return,
+            .err => |azure_error| {
+                if (azure_error.status_code != 404) return error.UpdateCheckpointFailed;
+            },
+        }
+
+        var upload_result = try blob_client.uploadConditionalResult(allocator, "", .{
+            .metadata = metadata[0..count],
+        });
+        defer upload_result.deinit(allocator);
+        if (upload_result == .err) return error.UpdateCheckpointFailed;
+    }
+
+    fn listCheckpointsImpl(
+        store: *eventhubs.CheckpointStore,
+        allocator: std.mem.Allocator,
+        fqns: []const u8,
+        hub_name: []const u8,
+        consumer_group: []const u8,
+    ) anyerror![]eventhubs.Checkpoint {
+        const self: *BlobCheckpointStore = @fieldParentPtr("store", store);
+
+        const prefix = try std.fmt.allocPrint(
+            allocator,
+            "{s}/{s}/{s}/checkpoint/",
+            .{ fqns, hub_name, consumer_group },
+        );
+        defer allocator.free(prefix);
+
+        const blob_list = try self.container_client.listBlobsWithOptions(allocator, .{
+            .prefix = prefix,
+            .include_metadata = true,
+        });
+        defer blobs.freeBlobItems(allocator, blob_list);
+
+        var result: std.ArrayList(eventhubs.Checkpoint) = .empty;
+        errdefer {
+            for (result.items) |item| item.deinit(allocator);
+            result.deinit(allocator);
+        }
 
         for (blob_list) |blob| {
-            if (!std.mem.startsWith(u8, blob.name, prefix)) continue;
+            const partition_id = partitionIdOf(blob.name) orelse continue;
 
-            const partition_id = blob.name[prefix.len..];
-            var blob_client = self.container_client.getBlobClient(blob.name);
-            const body = blob_client.download(allocator) catch continue;
-            defer allocator.free(body);
-
-            var cp = eventhubs.Checkpoint{
-                .fully_qualified_namespace = fqns,
-                .event_hub_name = hub_name,
-                .consumer_group = consumer_group,
-                .partition_id = partition_id,
+            var entry = eventhubs.Checkpoint{
+                .fully_qualified_namespace = try allocator.dupe(u8, fqns),
+                .event_hub_name = undefined,
+                .consumer_group = undefined,
+                .partition_id = undefined,
             };
-            parseCheckpointFields(allocator, body, &cp);
-            try result.append(allocator, cp);
+            errdefer entry.deinit(allocator);
+            entry.event_hub_name = try allocator.dupe(u8, hub_name);
+            entry.consumer_group = try allocator.dupe(u8, consumer_group);
+            entry.partition_id = try allocator.dupe(u8, partition_id);
+
+            if (blob.properties.metadata.get(offset_key)) |offset| {
+                entry.offset = try allocator.dupe(u8, offset);
+            }
+            if (blob.properties.metadata.get(sequence_number_key)) |value| {
+                entry.sequence_number = std.fmt.parseInt(i64, value, 10) catch null;
+            }
+
+            try result.append(allocator, entry);
         }
 
         return result.toOwnedSlice(allocator);
@@ -158,6 +262,39 @@ pub const BlobCheckpointStore = struct {
 };
 
 // ─────────────────────── Helpers ───────────────────────
+
+/// A claim lost to another processor. 412 is a failed precondition on renewal,
+/// 409 is another processor having created the blob first.
+fn isClaimConflict(status_code: u16) bool {
+    return status_code == 412 or status_code == 409;
+}
+
+fn cloneOwnership(
+    allocator: std.mem.Allocator,
+    own: eventhubs.PartitionOwnership,
+) !eventhubs.PartitionOwnership {
+    var entry = eventhubs.PartitionOwnership{
+        .fully_qualified_namespace = try allocator.dupe(u8, own.fully_qualified_namespace),
+        .event_hub_name = undefined,
+        .consumer_group = undefined,
+        .partition_id = undefined,
+        .owner_id = undefined,
+    };
+    errdefer entry.deinit(allocator);
+    entry.event_hub_name = try allocator.dupe(u8, own.event_hub_name);
+    entry.consumer_group = try allocator.dupe(u8, own.consumer_group);
+    entry.partition_id = try allocator.dupe(u8, own.partition_id);
+    entry.owner_id = try allocator.dupe(u8, own.owner_id);
+    return entry;
+}
+
+/// The partition id is the final path segment of a checkpoint or ownership
+/// blob name, matching Go's `[^/]+?$`.
+fn partitionIdOf(blob_name: []const u8) ?[]const u8 {
+    const slash = std.mem.lastIndexOfScalar(u8, blob_name, '/') orelse return null;
+    const partition_id = blob_name[slash + 1 ..];
+    return if (partition_id.len == 0) null else partition_id;
+}
 
 pub fn buildCheckpointPath(allocator: std.mem.Allocator, cp: eventhubs.Checkpoint) ![]u8 {
     return std.fmt.allocPrint(allocator, "{s}/{s}/{s}/checkpoint/{s}", .{
@@ -177,48 +314,80 @@ pub fn buildOwnershipPath(allocator: std.mem.Allocator, own: eventhubs.Partition
     });
 }
 
-pub fn serializeCheckpoint(allocator: std.mem.Allocator, cp: eventhubs.Checkpoint) ![]u8 {
-    if (cp.offset != null and cp.sequence_number != null) {
-        return std.fmt.allocPrint(allocator, "{{\"offset\":{d},\"sequenceNumber\":{d}}}", .{ cp.offset.?, cp.sequence_number.? });
-    } else if (cp.offset) |offset| {
-        return std.fmt.allocPrint(allocator, "{{\"offset\":{d}}}", .{offset});
-    } else if (cp.sequence_number) |seq| {
-        return std.fmt.allocPrint(allocator, "{{\"sequenceNumber\":{d}}}", .{seq});
+const month_names = [_][]const u8{
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+};
+
+/// Parse an HTTP-date such as `Mon, 27 Jul 2026 12:34:56 GMT` into Unix
+/// seconds. Blob `Last-Modified` always uses this format, and load balancing
+/// needs it as a number to expire stale ownership.
+pub fn parseRfc1123(value: []const u8) ?i64 {
+    const comma = std.mem.indexOfScalar(u8, value, ',') orelse return null;
+    const rest = std.mem.trim(u8, value[comma + 1 ..], " ");
+    if (rest.len < 20) return null;
+
+    var fields = std.mem.tokenizeScalar(u8, rest, ' ');
+    const day = std.fmt.parseInt(u8, fields.next() orelse return null, 10) catch return null;
+    const month_name = fields.next() orelse return null;
+    const year = std.fmt.parseInt(u16, fields.next() orelse return null, 10) catch return null;
+    const time = fields.next() orelse return null;
+
+    var month: u8 = 0;
+    for (month_names, 0..) |name, index| {
+        if (std.mem.eql(u8, name, month_name)) {
+            month = @intCast(index + 1);
+            break;
+        }
     }
-    return allocator.dupe(u8, "{}");
+    if (month == 0) return null;
+    if (day < 1 or day > 31) return null;
+
+    var time_fields = std.mem.splitScalar(u8, time, ':');
+    const hour = std.fmt.parseInt(u8, time_fields.next() orelse return null, 10) catch return null;
+    const minute = std.fmt.parseInt(u8, time_fields.next() orelse return null, 10) catch return null;
+    const second = std.fmt.parseInt(u8, time_fields.next() orelse return null, 10) catch return null;
+    if (hour > 23 or minute > 59 or second > 60) return null;
+
+    const days = daysFromCivil(year, month, day);
+    return days * std.time.s_per_day +
+        @as(i64, hour) * 3600 + @as(i64, minute) * 60 + @as(i64, second);
 }
 
-pub fn serializeOwnership(allocator: std.mem.Allocator, own: eventhubs.PartitionOwnership) ![]u8 {
-    return std.fmt.allocPrint(allocator, "{{\"ownerId\":\"{s}\"}}", .{own.owner_id});
-}
-
-/// Extract "ownerId" value from a JSON body like {"ownerId":"xyz"}.
-fn parseOwnerField(allocator: std.mem.Allocator, body: []const u8) ?[]const u8 {
-    const Schema = struct { ownerId: ?[]const u8 = null };
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-    const parsed = serde.json.fromSlice(Schema, arena.allocator(), body) catch return null;
-    const id = parsed.ownerId orelse return null;
-    return allocator.dupe(u8, id) catch null;
-}
-
-/// Parse offset and sequenceNumber from checkpoint JSON into the struct.
-fn parseCheckpointFields(allocator: std.mem.Allocator, body: []const u8, cp: *eventhubs.Checkpoint) void {
-    const Schema = struct {
-        offset: ?i64 = null,
-        sequenceNumber: ?i64 = null,
-    };
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-    const parsed = serde.json.fromSlice(Schema, arena.allocator(), body) catch return;
-    cp.offset = parsed.offset;
-    cp.sequence_number = parsed.sequenceNumber;
+/// Days since 1970-01-01 for a proleptic Gregorian date (Howard Hinnant's
+/// `days_from_civil`).
+fn daysFromCivil(year: u16, month: u8, day: u8) i64 {
+    var y: i64 = year;
+    const m: i64 = month;
+    const d: i64 = day;
+    y -= if (m <= 2) 1 else 0;
+    const era = @divFloor(y, 400);
+    const yoe = y - era * 400;
+    const doy = @divFloor(153 * (m + (if (m > 2) @as(i64, -3) else 9)) + 2, 5) + d - 1;
+    const doe = yoe * 365 + @divFloor(yoe, 4) - @divFloor(yoe, 100) + doy;
+    return era * 146097 + doe - 719468;
 }
 
 // ─────────────────────── Tests ───────────────────────
 
+const testing = std.testing;
+
+test {
+    _ = @import("checkpoint.zig");
+}
+
+fn testContainer(transport: *core.http.HttpTransport) blobs.BlobContainerClient {
+    return blobs.BlobContainerClient.initWithPipeline(
+        .{ .policies = &.{}, .transport_impl = transport },
+        .{
+            .endpoint = "https://myaccount.blob.core.windows.net",
+            .container_name = "checkpoints",
+        },
+    );
+}
+
 test "buildCheckpointPath" {
-    const allocator = std.testing.allocator;
+    const allocator = testing.allocator;
     const path = try buildCheckpointPath(allocator, .{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "hub",
@@ -226,11 +395,11 @@ test "buildCheckpointPath" {
         .partition_id = "0",
     });
     defer allocator.free(path);
-    try std.testing.expectEqualStrings("ns.servicebus.windows.net/hub/$Default/checkpoint/0", path);
+    try testing.expectEqualStrings("ns.servicebus.windows.net/hub/$Default/checkpoint/0", path);
 }
 
 test "buildOwnershipPath" {
-    const allocator = std.testing.allocator;
+    const allocator = testing.allocator;
     const path = try buildOwnershipPath(allocator, .{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "hub",
@@ -239,84 +408,408 @@ test "buildOwnershipPath" {
         .owner_id = "proc-1",
     });
     defer allocator.free(path);
-    try std.testing.expectEqualStrings("ns.servicebus.windows.net/hub/$Default/ownership/1", path);
+    try testing.expectEqualStrings("ns.servicebus.windows.net/hub/$Default/ownership/1", path);
 }
 
-test "serializeCheckpoint both fields" {
-    const allocator = std.testing.allocator;
-    const json = try serializeCheckpoint(allocator, .{
-        .fully_qualified_namespace = "ns",
-        .event_hub_name = "hub",
-        .consumer_group = "cg",
-        .partition_id = "0",
-        .offset = 100,
-        .sequence_number = 42,
-    });
-    defer allocator.free(json);
-    try std.testing.expectEqualStrings("{\"offset\":100,\"sequenceNumber\":42}", json);
+test "partitionIdOf takes the final path segment" {
+    try testing.expectEqualStrings("0", partitionIdOf("ns/hub/$Default/checkpoint/0").?);
+    try testing.expectEqualStrings("12", partitionIdOf("ns/hub/cg/ownership/12").?);
+    try testing.expect(partitionIdOf("ns/hub/cg/ownership/") == null);
+    try testing.expect(partitionIdOf("nopath") == null);
 }
 
-test "serializeOwnership" {
-    const allocator = std.testing.allocator;
-    const json = try serializeOwnership(allocator, .{
-        .fully_qualified_namespace = "ns",
-        .event_hub_name = "hub",
-        .consumer_group = "cg",
-        .partition_id = "0",
-        .owner_id = "processor-1",
-    });
-    defer allocator.free(json);
-    try std.testing.expectEqualStrings("{\"ownerId\":\"processor-1\"}", json);
+test "parseRfc1123 converts an HTTP-date to Unix seconds" {
+    try testing.expectEqual(@as(i64, 0), parseRfc1123("Thu, 01 Jan 1970 00:00:00 GMT").?);
+    try testing.expectEqual(@as(i64, 1000000000), parseRfc1123("Sun, 09 Sep 2001 01:46:40 GMT").?);
+    // A leap day, to exercise the civil-date conversion.
+    try testing.expectEqual(@as(i64, 1582934400), parseRfc1123("Sat, 29 Feb 2020 00:00:00 GMT").?);
+    try testing.expect(parseRfc1123("not a date") == null);
+    try testing.expect(parseRfc1123("Mon, 27 Xxx 2026 00:00:00 GMT") == null);
 }
 
-test "parseOwnerField" {
-    const owner = parseOwnerField(std.testing.allocator, "{\"ownerId\":\"proc-1\"}");
-    defer if (owner) |o| std.testing.allocator.free(o);
-    try std.testing.expectEqualStrings("proc-1", owner.?);
-}
-
-test "parseCheckpointFields" {
-    var cp = eventhubs.Checkpoint{
-        .fully_qualified_namespace = "ns",
-        .event_hub_name = "hub",
-        .consumer_group = "cg",
-        .partition_id = "0",
-    };
-    parseCheckpointFields(std.testing.allocator, "{\"offset\":100,\"sequenceNumber\":42}", &cp);
-    try std.testing.expectEqual(@as(i64, 100), cp.offset.?);
-    try std.testing.expectEqual(@as(i64, 42), cp.sequence_number.?);
-}
-
-test "BlobCheckpointStore updateCheckpoint" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 201, "");
+test "updateCheckpoint writes sequencenumber and offset metadata" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "");
     defer mock.deinit();
 
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-
-    var container = blobs.BlobContainerClient.init(
-        "https://myaccount.blob.core.windows.net",
-        "checkpoints",
-        cred.asCredential(),
-        mock.asTransport(),
-        .{},
-    );
-
+    var container = testContainer(mock.asTransport());
     var store = BlobCheckpointStore.init(&container);
+
     try store.asCheckpointStore().updateCheckpoint(allocator, .{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "hub",
         .consumer_group = "$Default",
         .partition_id = "0",
-        .offset = 100,
+        .offset = "100",
         .sequence_number = 42,
     });
 
-    // Verify the upload went to the correct path.
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "ns.servicebus.windows.net/hub/$Default/checkpoint/0") != null);
+    try testing.expectEqualStrings("42", mock.last_headers.get("x-ms-meta-sequencenumber").?);
+    try testing.expectEqualStrings("100", mock.last_headers.get("x-ms-meta-offset").?);
+    try testing.expect(std.mem.endsWith(
+        u8,
+        mock.last_url.?,
+        "/ns.servicebus.windows.net/hub/%24Default/checkpoint/0?comp=metadata",
+    ));
+    // The body stays empty; state lives entirely in metadata.
+    try testing.expect(mock.last_body == null or mock.last_body.?.len == 0);
 }
+
+test "updateCheckpoint keeps a non-numeric offset intact" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "");
+    defer mock.deinit();
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    try store.asCheckpointStore().updateCheckpoint(allocator, .{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .offset = "3298423984:2:9",
+        .sequence_number = 1,
+    });
+
+    try testing.expectEqualStrings("3298423984:2:9", mock.last_headers.get("x-ms-meta-offset").?);
+}
+
+test "updateCheckpoint creates the blob when setMetadata reports it is missing" {
+    const allocator = testing.allocator;
+    var scripted = ScriptedTransport.init(allocator, &.{
+        .{ .status = 404, .body = "" },
+        .{ .status = 201, .body = "" },
+    });
+    defer scripted.deinit();
+
+    var container = testContainer(scripted.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    try store.asCheckpointStore().updateCheckpoint(allocator, .{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .offset = "100",
+        .sequence_number = 42,
+    });
+
+    try testing.expectEqual(@as(usize, 2), scripted.requests.items.len);
+    try testing.expect(std.mem.endsWith(u8, scripted.requests.items[0].url, "?comp=metadata"));
+    // The fallback is a plain PUT of an empty block blob carrying the metadata.
+    try testing.expect(!std.mem.endsWith(u8, scripted.requests.items[1].url, "?comp=metadata"));
+    try testing.expectEqualStrings("BlockBlob", scripted.requests.items[1].headers.get("x-ms-blob-type").?);
+    try testing.expectEqualStrings("42", scripted.requests.items[1].headers.get("x-ms-meta-sequencenumber").?);
+}
+
+test "updateCheckpoint surfaces a non-404 failure" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 403, "");
+    defer mock.deinit();
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    try testing.expectError(error.UpdateCheckpointFailed, store.asCheckpointStore().updateCheckpoint(allocator, .{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .sequence_number = 1,
+    }));
+}
+
+test "listCheckpoints reads state from metadata" {
+    const allocator = testing.allocator;
+    const body =
+        \\<EnumerationResults><Blobs>
+        \\<Blob><Name>ns/hub/$Default/checkpoint/0</Name><Metadata><sequencenumber>42</sequencenumber><offset>100</offset></Metadata></Blob>
+        \\<Blob><Name>ns/hub/$Default/checkpoint/1</Name><Metadata><sequencenumber>7</sequencenumber><offset>3298423984:2:9</offset></Metadata></Blob>
+        \\</Blobs></EnumerationResults>
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    const checkpoints = try store.asCheckpointStore().listCheckpoints(
+        allocator,
+        "ns",
+        "hub",
+        "$Default",
+    );
+    defer eventhubs.freeCheckpoints(allocator, checkpoints);
+
+    try testing.expect(std.mem.indexOf(u8, mock.last_url.?, "include=metadata") != null);
+
+    try testing.expectEqual(@as(usize, 2), checkpoints.len);
+    try testing.expectEqualStrings("0", checkpoints[0].partition_id);
+    try testing.expectEqualStrings("100", checkpoints[0].offset.?);
+    try testing.expectEqual(@as(i64, 42), checkpoints[0].sequence_number.?);
+    try testing.expectEqualStrings("1", checkpoints[1].partition_id);
+    try testing.expectEqualStrings("3298423984:2:9", checkpoints[1].offset.?);
+    try testing.expectEqual(@as(i64, 7), checkpoints[1].sequence_number.?);
+    try testing.expectEqualStrings("ns", checkpoints[0].fully_qualified_namespace);
+    try testing.expectEqualStrings("hub", checkpoints[0].event_hub_name);
+    try testing.expectEqualStrings("$Default", checkpoints[0].consumer_group);
+}
+
+test "listOwnership returns etag and last modified for expiry and CAS" {
+    const allocator = testing.allocator;
+    const body =
+        \\<EnumerationResults><Blobs>
+        \\<Blob><Name>ns/hub/$Default/ownership/0</Name><Properties><Etag>"0x1"</Etag><Last-Modified>Sun, 09 Sep 2001 01:46:40 GMT</Last-Modified></Properties><Metadata><ownerid>processor-1</ownerid></Metadata></Blob>
+        \\<Blob><Name>ns/hub/$Default/ownership/1</Name><Properties><Etag>"0x2"</Etag><Last-Modified>Sun, 09 Sep 2001 01:46:40 GMT</Last-Modified></Properties><Metadata></Metadata></Blob>
+        \\</Blobs></EnumerationResults>
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    const ownerships = try store.asCheckpointStore().listOwnership(allocator, "ns", "hub", "$Default");
+    defer eventhubs.freeOwnerships(allocator, ownerships);
+
+    try testing.expectEqual(@as(usize, 2), ownerships.len);
+    try testing.expectEqualStrings("processor-1", ownerships[0].owner_id);
+    try testing.expectEqualStrings("\"0x1\"", ownerships[0].etag.?);
+    try testing.expectEqual(@as(i64, 1000000000), ownerships[0].last_modified_time.?);
+    try testing.expect(!ownerships[0].isRelinquished());
+
+    // A blob with no `ownerid` was relinquished by its previous owner.
+    try testing.expectEqualStrings("", ownerships[1].owner_id);
+    try testing.expect(ownerships[1].isRelinquished());
+    try testing.expectEqualStrings("\"0x2\"", ownerships[1].etag.?);
+}
+
+test "claimOwnership creates an unowned blob with If-None-Match" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 201, "");
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "ETag", .value = "\"0x1\"" },
+        .{ .name = "Last-Modified", .value = "Sun, 09 Sep 2001 01:46:40 GMT" },
+    };
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    const claimed = try store.asCheckpointStore().claimOwnership(allocator, &.{.{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .owner_id = "processor-1",
+    }});
+    defer eventhubs.freeOwnerships(allocator, claimed);
+
+    try testing.expectEqualStrings("*", mock.last_headers.get("If-None-Match").?);
+    try testing.expect(mock.last_headers.get("If-Match") == null);
+    try testing.expectEqualStrings("processor-1", mock.last_headers.get("x-ms-meta-ownerid").?);
+
+    try testing.expectEqual(@as(usize, 1), claimed.len);
+    try testing.expectEqualStrings("\"0x1\"", claimed[0].etag.?);
+    try testing.expectEqual(@as(i64, 1000000000), claimed[0].last_modified_time.?);
+}
+
+test "claimOwnership renews an existing claim with If-Match" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "");
+    defer mock.deinit();
+    mock.response_headers_list = &.{.{ .name = "ETag", .value = "\"0x2\"" }};
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    const claimed = try store.asCheckpointStore().claimOwnership(allocator, &.{.{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .owner_id = "processor-1",
+        .etag = "\"0x1\"",
+    }});
+    defer eventhubs.freeOwnerships(allocator, claimed);
+
+    try testing.expectEqualStrings("\"0x1\"", mock.last_headers.get("If-Match").?);
+    try testing.expect(mock.last_headers.get("If-None-Match") == null);
+    try testing.expect(std.mem.endsWith(u8, mock.last_url.?, "?comp=metadata"));
+    try testing.expectEqualStrings("\"0x2\"", claimed[0].etag.?);
+}
+
+test "claimOwnership drops partitions lost to another processor" {
+    const allocator = testing.allocator;
+    var scripted = ScriptedTransport.init(allocator, &.{
+        .{ .status = 412, .body = "" },
+        .{ .status = 200, .body = "", .etag = "\"0x9\"" },
+    });
+    defer scripted.deinit();
+
+    var container = testContainer(scripted.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    const claimed = try store.asCheckpointStore().claimOwnership(allocator, &.{
+        .{
+            .fully_qualified_namespace = "ns",
+            .event_hub_name = "hub",
+            .consumer_group = "$Default",
+            .partition_id = "0",
+            .owner_id = "processor-1",
+            .etag = "\"stale\"",
+        },
+        .{
+            .fully_qualified_namespace = "ns",
+            .event_hub_name = "hub",
+            .consumer_group = "$Default",
+            .partition_id = "1",
+            .owner_id = "processor-1",
+            .etag = "\"fresh\"",
+        },
+    });
+    defer eventhubs.freeOwnerships(allocator, claimed);
+
+    // Losing a claim is expected, not an error.
+    try testing.expectEqual(@as(usize, 1), claimed.len);
+    try testing.expectEqualStrings("1", claimed[0].partition_id);
+    try testing.expectEqualStrings("\"0x9\"", claimed[0].etag.?);
+}
+
+test "claimOwnership treats a lost creation race as a conflict" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 409, "");
+    defer mock.deinit();
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    const claimed = try store.asCheckpointStore().claimOwnership(allocator, &.{.{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .owner_id = "processor-1",
+    }});
+    defer eventhubs.freeOwnerships(allocator, claimed);
+
+    try testing.expectEqual(@as(usize, 0), claimed.len);
+}
+
+test "claimOwnership reports a genuine failure" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 403, "");
+    defer mock.deinit();
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    try testing.expectError(error.ClaimOwnershipFailed, store.asCheckpointStore().claimOwnership(allocator, &.{.{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .owner_id = "processor-1",
+    }}));
+}
+
+test "claimOwnership relinquishes a partition with an empty owner id" {
+    const allocator = testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "");
+    defer mock.deinit();
+
+    var container = testContainer(mock.asTransport());
+    var store = BlobCheckpointStore.init(&container);
+
+    const claimed = try store.asCheckpointStore().claimOwnership(allocator, &.{.{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .owner_id = "",
+        .etag = "\"0x1\"",
+    }});
+    defer eventhubs.freeOwnerships(allocator, claimed);
+
+    try testing.expectEqualStrings("", mock.last_headers.get("x-ms-meta-ownerid").?);
+    try testing.expect(claimed[0].isRelinquished());
+}
+
+/// Transport that replays a scripted sequence of responses and records each
+/// request, so multi-request flows can be asserted on.
+const ScriptedTransport = struct {
+    const Reply = struct {
+        status: u16,
+        body: []const u8,
+        etag: ?[]const u8 = null,
+    };
+
+    const Captured = struct {
+        url: []u8,
+        headers: std.StringHashMap([]const u8),
+
+        fn deinit(self: *Captured, allocator: std.mem.Allocator) void {
+            allocator.free(self.url);
+            var iterator = self.headers.iterator();
+            while (iterator.next()) |entry| {
+                allocator.free(entry.key_ptr.*);
+                allocator.free(entry.value_ptr.*);
+            }
+            self.headers.deinit();
+        }
+    };
+
+    allocator: std.mem.Allocator,
+    replies: []const Reply,
+    index: usize = 0,
+    requests: std.ArrayList(Captured) = .empty,
+    transport: core.http.HttpTransport = .{ .sendFn = &sendImpl },
+
+    fn init(allocator: std.mem.Allocator, replies: []const Reply) ScriptedTransport {
+        return .{ .allocator = allocator, .replies = replies };
+    }
+
+    fn deinit(self: *ScriptedTransport) void {
+        for (self.requests.items) |*captured| captured.deinit(self.allocator);
+        self.requests.deinit(self.allocator);
+    }
+
+    fn asTransport(self: *ScriptedTransport) *core.http.HttpTransport {
+        return &self.transport;
+    }
+
+    fn sendImpl(
+        transport: *core.http.HttpTransport,
+        request: *core.http.Request,
+    ) anyerror!core.http.Response {
+        const self: *ScriptedTransport = @alignCast(@fieldParentPtr("transport", transport));
+
+        var captured = Captured{
+            .url = try self.allocator.dupe(u8, request.url),
+            .headers = std.StringHashMap([]const u8).init(self.allocator),
+        };
+        var iterator = request.headers.iterator();
+        while (iterator.next()) |entry| {
+            try captured.headers.put(
+                try self.allocator.dupe(u8, entry.key_ptr.*),
+                try self.allocator.dupe(u8, entry.value_ptr.*),
+            );
+        }
+        try self.requests.append(self.allocator, captured);
+
+        const reply = self.replies[@min(self.index, self.replies.len - 1)];
+        self.index += 1;
+
+        var headers = core.http.ResponseHeaders.init(self.allocator);
+        if (reply.etag) |etag| try headers.append("ETag", etag);
+
+        return .{
+            .status_code = reply.status,
+            .headers = std.StringHashMap([]const u8).init(self.allocator),
+            .body = try self.allocator.dupe(u8, reply.body),
+            .allocator = self.allocator,
+            .response_headers = headers,
+        };
+    }
+};

--- a/checkpoint_store_blob/README.md
+++ b/checkpoint_store_blob/README.md
@@ -5,3 +5,33 @@ Blob-backed checkpoint storage for Azure Event Hubs consumers.
 The namespace is exposed through `azure_sdk_eventhubs.checkpoint_store_blob`
 and versions with the [`azure_sdk_eventhubs`](../README.md) package. Its
 implementation remains in `sdk/messaging/eventhubs/checkpoint_store.zig`.
+
+## Wire format
+
+State lives in blob **metadata**, not in the blob body, so a container can be
+shared with processors built on the Go and Rust Event Hubs SDKs. Blob bodies
+are always empty.
+
+| Blob | Path | Metadata |
+| --- | --- | --- |
+| Checkpoint | `{namespace}/{hub}/{group}/checkpoint/{partition}` | `sequencenumber`, `offset` |
+| Ownership | `{namespace}/{hub}/{group}/ownership/{partition}` | `ownerid` |
+
+`offset` is an opaque service-defined token, not a number. Event Hubs returns
+non-numeric offsets under geo-disaster-recovery, so it is carried as a string.
+
+Ownership additionally uses the blob's own `ETag` and `Last-Modified`:
+
+- `claimOwnership` renews an existing claim with `If-Match` on the caller's
+  ETag, and creates a new one with `If-None-Match: *`. A partition lost to
+  another processor is omitted from the result rather than reported as an
+  error.
+- `listOwnership` returns the ETag needed for the next compare-and-swap and
+  `last_modified_time` in Unix seconds, which load balancing uses to expire
+  ownership a processor stopped renewing.
+- An empty `owner_id` means a previous owner relinquished the partition. The
+  service omits metadata keys with empty values, so a missing `ownerid` is
+  read back as relinquished.
+
+Slices returned by the store are allocator-owned; free them with
+`freeCheckpoints` or `freeOwnerships`.

--- a/root.zig
+++ b/root.zig
@@ -11,6 +11,8 @@ pub const ConnectionStringProperties = messaging_common.ConnectionStringProperti
 pub const Checkpoint = checkpoint.Checkpoint;
 pub const PartitionOwnership = checkpoint.PartitionOwnership;
 pub const CheckpointStore = checkpoint.CheckpointStore;
+pub const freeCheckpoints = checkpoint.freeCheckpoints;
+pub const freeOwnerships = checkpoint.freeOwnerships;
 pub const checkpoint_store_blob = @import("checkpoint_store.zig");
 
 // ─────────────────────── Models ───────────────────────


### PR DESCRIPTION
## Summary

The store wrote JSON blob bodies, so a container could not be shared with a Go or Rust processor. Both of those SDKs keep state in blob **metadata**. This switches to that format. Blob paths were already correct and are unchanged.

| Blob | Path | Metadata |
| --- | --- | --- |
| Checkpoint | `{namespace}/{hub}/{group}/checkpoint/{partition}` | `sequencenumber`, `offset` |
| Ownership | `{namespace}/{hub}/{group}/ownership/{partition}` | `ownerid` |

- `Checkpoint.offset` becomes `?[]const u8`. Event Hubs offsets are opaque service tokens and are non-numeric under geo-disaster-recovery; Go uses `*string` and Rust `Option<String>`. Parsing them as `i64` silently dropped such checkpoints.
- `claimOwnership` now does a real compare-and-swap: `If-Match` on the caller's ETag to renew, `If-None-Match: *` to claim an unowned partition. A partition lost to another processor (412 or 409) is omitted from the result rather than failing the batch, matching Go. Any other status is a genuine error.
- `listOwnership` populates `etag` and `last_modified_time`, without which renewal and expiry were impossible. `Last-Modified` is parsed from its HTTP-date to Unix seconds.
- An empty `owner_id` means relinquished. The service omits metadata keys with empty values, so a missing `ownerid` reads back as relinquished, matching Go's handling.
- `updateCheckpoint` sets metadata on the existing blob and falls back to creating an empty blob on 404, as Go does. It applies no precondition, since ownership is assumed.
- Listing now filters server-side with a prefix and `include=metadata`, instead of listing the whole container and issuing one download per blob.
- Returned slices are now allocator-owned with `freeCheckpoints` / `freeOwnerships`. The previous `listOwnership` returned `partition_id` as a slice into a blob name it had already freed, and leaked `owner_id`.

Repins `azure_sdk_storage_blobs` onto #211, which added the metadata-capable container client, and aligns `azure_sdk_core` (0.1.2 to 0.1.3) and `serde` with the pins that package uses so the graph resolves to one copy of each.

## Validation

```
zig fmt --check $(git ls-files '*.zig' 'build.zig.zon')
zig build test --summary all   # 34/34 tests pass, was 23/23
```

New tests cover: metadata keys and empty bodies on checkpoint writes, non-numeric offsets surviving a round trip, the 404 create-fallback, non-404 failures surfacing, checkpoint and ownership listing including ETag and Last-Modified, `If-None-Match` claims and `If-Match` renewals, conflicts being dropped while genuine failures propagate, relinquishment, HTTP-date parsing including a leap day, and partition-id extraction.

Fixes #192
Part of #191