### PR TITLE
eng: publish event_data.zig for eventhubs

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -444,6 +444,7 @@ pub const all = [_]Package{
             "build.zig",
             "build.zig.zon",
             "root.zig",
+            "event_data.zig",
             "checkpoint.zig",
             "checkpoint_store.zig",
             "checkpoint_store_blob",


### PR DESCRIPTION
## Summary

`sdk/eventhubs` moves its message models (`EventData`, `ReceivedEventData`,
`MessageId`, `PropertyMap`, and the AMQP conversion helpers) into a new
`event_data.zig`. `eng/package_branch_tool.zig` requires `publish_paths` to be
an exact set match against the branch manifest's `.paths`, so the registry has
to learn the new file.

Pairs with the `sdk/eventhubs` branch PR for #193.

## Validation

- `zig fmt --check eng/packages.zig`
- `zig build package-check --summary all` — 22 packages valid

Part of #191