### PR TITLE
sdk/eventhubs: add partition targeting and real size limits to batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ try event.setProperty(allocator, "retries", .{ .long = 7 });
 `deinit` frees just that map. Values decoded from the wire own everything and
 are freed with `ReceivedEventData.deinit` or `freeReceivedEvents`.
 
+## Batching
+
+`EventDataBatch` encodes each event as it is added and tracks the real byte
+count, so a batch that reports as fitting actually fits. `tryAdd` returns
+`false` when an event does not fit alongside what is already batched, and
+`BatchError.EventDataTooLarge` when it would not fit an empty batch either.
+
+```zig
+var batch = try EventDataBatch.init(.{ .partition_key = "orders-42" });
+defer batch.deinit(allocator);
+if (!try batch.tryAdd(allocator, event)) {
+    // send `batch`, then start a new one
+}
+```
+
+A batch targets either a partition key or a partition id, never both. The size
+limit defaults to `default_max_message_size` (1 MiB) and
+`applyLinkMaxMessageSize` adopts what a sender link negotiates, keeping a
+smaller explicit `max_bytes` and rejecting a larger one.
+
 Release branch: `sdk/eventhubs`. The package depends on `azure_sdk_core`,
 `azure_sdk_messaging_common`, `azure_sdk_storage_blobs`, `uamqp`, and `serde`
 and starts at `0.1.0`.

--- a/event_data.zig
+++ b/event_data.zig
@@ -340,14 +340,19 @@ pub fn freeReceivedEvents(allocator: std.mem.Allocator, events: []ReceivedEventD
     allocator.free(events);
 }
 
-/// Free a message produced by `EventData.toAmqpMessage`.
+/// Free a message produced by `EventData.toAmqpMessage`, including any
+/// annotations added afterwards by `setPartitionKeyAnnotation`.
 ///
-/// Only the sections that encoder sets are released, because `Message.deinit`
+/// Only the sections this module sets are released, because `Message.deinit`
 /// covers the body alone.
 pub fn freeAmqpMessage(allocator: std.mem.Allocator, message: *Message) void {
     if (message.application_properties) |entries| {
         freeMapEntries(allocator, entries);
         message.application_properties = null;
+    }
+    if (message.message_annotations) |entries| {
+        freeMapEntries(allocator, entries);
+        message.message_annotations = null;
     }
     if (message.properties) |*properties| {
         if (properties.message_id) |*message_id| message_id.deinit(allocator);
@@ -394,6 +399,164 @@ fn freeMapEntries(allocator: std.mem.Allocator, entries: []MapEntry) void {
         entry.value.deinit(allocator);
     }
     allocator.free(entries);
+}
+
+/// Stamp `x-opt-partition-key` on a message built by `EventData.toAmqpMessage`.
+///
+/// Event Hubs hashes this annotation to pick a partition, and Go applies it to
+/// every message as it enters a batch so the encoded size accounts for it.
+pub fn setPartitionKeyAnnotation(
+    allocator: std.mem.Allocator,
+    message: *Message,
+    partition_key: []const u8,
+) !void {
+    const entries = try allocator.alloc(MapEntry, 1);
+    errdefer allocator.free(entries);
+
+    const key = try allocator.dupe(u8, partition_key_annotation);
+    errdefer allocator.free(key);
+    const value = try allocator.dupe(u8, partition_key);
+
+    entries[0] = .{ .key = .{ .symbol = key }, .value = .{ .string = value } };
+    if (message.message_annotations) |existing| freeMapEntries(allocator, existing);
+    message.message_annotations = entries;
+}
+
+// ─────────────────── Message serialization ───────────────────
+
+/// Encode a message into AMQP 1.0 wire format, section by section
+/// (AMQP 1.0 section 3.2).
+///
+/// `uamqp` encodes individual values but has no message serializer, so the
+/// sections are assembled here. Batching needs this to measure real sizes
+/// instead of estimating them.
+pub fn encodeMessage(allocator: std.mem.Allocator, message: *const Message) ![]u8 {
+    return encodeMessageSections(allocator, message, true);
+}
+
+/// Encode every section except the body.
+///
+/// A batch transfer reuses the first message's sections as the envelope around
+/// the per-message data sections, so its size is measured without a body.
+pub fn encodeMessageEnvelope(allocator: std.mem.Allocator, message: *const Message) ![]u8 {
+    return encodeMessageSections(allocator, message, false);
+}
+
+fn encodeMessageSections(
+    allocator: std.mem.Allocator,
+    message: *const Message,
+    include_body: bool,
+) ![]u8 {
+    var buffer = uamqp.encoder.Buffer.initDynamic(allocator);
+    errdefer buffer.deinit();
+
+    if (message.header) |header| {
+        var fields = [_]AmqpValue{
+            .{ .boolean = header.durable },
+            .{ .ubyte = header.priority },
+            if (header.ttl) |ttl| .{ .uint = ttl } else .null,
+            .{ .boolean = header.first_acquirer },
+            .{ .uint = header.delivery_count },
+        };
+        try encodeSection(&buffer, uamqp.definitions.descriptor.header, .{
+            .list = trimTrailingNulls(&fields),
+        });
+    }
+
+    if (message.delivery_annotations) |entries| {
+        try encodeSection(&buffer, uamqp.definitions.descriptor.delivery_annotations, .{
+            .map = entries,
+        });
+    }
+
+    if (message.message_annotations) |entries| {
+        try encodeSection(&buffer, uamqp.definitions.descriptor.message_annotations, .{
+            .map = entries,
+        });
+    }
+
+    if (message.properties) |properties| {
+        var fields = [_]AmqpValue{
+            properties.message_id orelse .null,
+            optionalBinary(properties.user_id),
+            optionalString(properties.to),
+            optionalString(properties.subject),
+            optionalString(properties.reply_to),
+            properties.correlation_id orelse .null,
+            optionalSymbol(properties.content_type),
+            optionalSymbol(properties.content_encoding),
+            if (properties.absolute_expiry_time) |v| .{ .timestamp = v } else .null,
+            if (properties.creation_time) |v| .{ .timestamp = v } else .null,
+            optionalString(properties.group_id),
+            if (properties.group_sequence) |v| .{ .uint = v } else .null,
+            optionalString(properties.reply_to_group_id),
+        };
+        try encodeSection(&buffer, uamqp.definitions.descriptor.properties, .{
+            .list = trimTrailingNulls(&fields),
+        });
+    }
+
+    if (message.application_properties) |entries| {
+        try encodeSection(&buffer, uamqp.definitions.descriptor.application_properties, .{
+            .map = entries,
+        });
+    }
+
+    if (include_body) {
+        switch (message.body_type) {
+            .none => {},
+            .data => for (message.body_data_sections.items) |section| {
+                try encodeSection(&buffer, uamqp.definitions.descriptor.data, .{
+                    .binary = section.bytes,
+                });
+            },
+            .sequence => for (message.body_sequence_sections.items) |sequence| {
+                try encodeSection(&buffer, uamqp.definitions.descriptor.amqp_sequence, .{
+                    .list = sequence,
+                });
+            },
+            .value => if (message.body_value) |value| {
+                try encodeSection(&buffer, uamqp.definitions.descriptor.amqp_value, value);
+            },
+        }
+    }
+
+    if (message.footer) |entries| {
+        try encodeSection(&buffer, uamqp.definitions.descriptor.footer, .{ .map = entries });
+    }
+
+    const encoded = try allocator.dupe(u8, buffer.written());
+    buffer.deinit();
+    return encoded;
+}
+
+fn encodeSection(buffer: *uamqp.encoder.Buffer, code: u64, value: AmqpValue) !void {
+    var descriptor: AmqpValue = .{ .ulong = code };
+    var section = value;
+    try uamqp.encoder.encode(
+        .{ .described = .{ .descriptor = &descriptor, .value = &section } },
+        buffer,
+    );
+}
+
+/// AMQP composite types may omit trailing null fields, which every real
+/// encoder does and which keeps measured batch sizes realistic.
+fn trimTrailingNulls(fields: []AmqpValue) []AmqpValue {
+    var len = fields.len;
+    while (len > 0 and fields[len - 1] == .null) len -= 1;
+    return fields[0..len];
+}
+
+fn optionalString(value: ?[]const u8) AmqpValue {
+    return if (value) |text| .{ .string = text } else .null;
+}
+
+fn optionalSymbol(value: ?[]const u8) AmqpValue {
+    return if (value) |text| .{ .symbol = text } else .null;
+}
+
+fn optionalBinary(value: ?[]const u8) AmqpValue {
+    return if (value) |bytes| .{ .binary = bytes } else .null;
 }
 
 /// Decode an AMQP message into a received event.
@@ -889,4 +1052,112 @@ test "conversions survive allocation failure at every step" {
         }
     };
     try std.testing.checkAllAllocationFailures(std.testing.allocator, Case.run, .{});
+}
+
+test "setPartitionKeyAnnotation stamps the annotation Event Hubs hashes" {
+    const allocator = std.testing.allocator;
+
+    var event = EventData.init("body");
+    defer event.deinit(allocator);
+
+    var message = try event.toAmqpMessage(allocator);
+    defer freeAmqpMessage(allocator, &message);
+
+    try setPartitionKeyAnnotation(allocator, &message, "pk-9");
+    try setPartitionKeyAnnotation(allocator, &message, "pk-10");
+
+    var decoded = try fromAmqpMessage(allocator, &message);
+    defer decoded.deinit(allocator);
+    try std.testing.expectEqualStrings("pk-10", decoded.partition_key.?);
+}
+
+test "encodeMessage emits a data section in AMQP wire format" {
+    const allocator = std.testing.allocator;
+
+    var message = Message.init(allocator);
+    defer message.deinit();
+    try message.addBodyData("hi");
+
+    const encoded = try encodeMessage(allocator, &message);
+    defer allocator.free(encoded);
+
+    // 0x00 described constructor, 0x53 smallulong descriptor 0x75 (data),
+    // 0xa0 binary with a one-byte length of 2.
+    try std.testing.expectEqualSlices(
+        u8,
+        &[_]u8{ 0x00, 0x53, 0x75, 0xa0, 0x02, 'h', 'i' },
+        encoded,
+    );
+}
+
+test "encoded sections decode back with the right descriptors" {
+    const allocator = std.testing.allocator;
+
+    var event = EventData.init("payload");
+    defer event.deinit(allocator);
+    event.content_type = "application/json";
+    try event.setStringProperty(allocator, "tenant", "contoso");
+
+    var message = try event.toAmqpMessage(allocator);
+    defer freeAmqpMessage(allocator, &message);
+    try setPartitionKeyAnnotation(allocator, &message, "pk-1");
+
+    const encoded = try encodeMessage(allocator, &message);
+    defer allocator.free(encoded);
+
+    const expected = [_]u64{
+        uamqp.definitions.descriptor.message_annotations,
+        uamqp.definitions.descriptor.properties,
+        uamqp.definitions.descriptor.application_properties,
+        uamqp.definitions.descriptor.data,
+    };
+
+    var offset: usize = 0;
+    for (expected) |descriptor_code| {
+        var result = try uamqp.decoder.decode(allocator, encoded[offset..]);
+        defer result.value.deinit(allocator);
+        try std.testing.expectEqual(descriptor_code, result.value.described.descriptor.ulong);
+        offset += result.bytes_consumed;
+    }
+    try std.testing.expectEqual(encoded.len, offset);
+}
+
+test "encodeMessageEnvelope drops the body" {
+    const allocator = std.testing.allocator;
+
+    var event = EventData.init("a fairly long payload that dominates the encoded size");
+    defer event.deinit(allocator);
+    event.content_type = "text/plain";
+
+    var message = try event.toAmqpMessage(allocator);
+    defer freeAmqpMessage(allocator, &message);
+
+    const full = try encodeMessage(allocator, &message);
+    defer allocator.free(full);
+    const envelope = try encodeMessageEnvelope(allocator, &message);
+    defer allocator.free(envelope);
+
+    try std.testing.expect(envelope.len < full.len);
+    try std.testing.expectEqualSlices(u8, envelope, full[0..envelope.len]);
+}
+
+test "trailing null fields are omitted from composite sections" {
+    const allocator = std.testing.allocator;
+
+    var with_content_type = Message.init(allocator);
+    defer with_content_type.deinit();
+    with_content_type.properties = .{ .content_type = "text/plain" };
+
+    var empty_properties = Message.init(allocator);
+    defer empty_properties.deinit();
+    empty_properties.properties = .{};
+
+    const long = try encodeMessage(allocator, &with_content_type);
+    defer allocator.free(long);
+    const short = try encodeMessage(allocator, &empty_properties);
+    defer allocator.free(short);
+
+    // An all-null properties section collapses to the empty-list format code.
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x53, 0x73, 0x45 }, short);
+    try std.testing.expect(long.len > short.len);
 }

--- a/root.zig
+++ b/root.zig
@@ -31,34 +31,153 @@ pub const fromOwnedAmqpMessage = event_data.fromOwnedAmqpMessage;
 
 // ─────────────────────── Models ───────────────────────
 
-pub const EventDataBatch = struct {
-    events: std.ArrayList(EventData),
-    max_size_bytes: usize = 1024 * 1024,
-    current_size: usize = 0,
+/// AMQP message format identifying an Event Hubs batch transfer.
+pub const batch_message_format: u32 = 0x80013700;
 
-    pub fn init(allocator: std.mem.Allocator) EventDataBatch {
-        _ = allocator;
+/// Size assumed before a sender link negotiates `max-message-size`. Event Hubs
+/// standard tiers allow 1 MiB.
+pub const default_max_message_size: usize = 1024 * 1024;
+
+pub const BatchError = error{
+    /// A batch targets either a partition or a partition key, never both.
+    PartitionKeyAndIdBothSet,
+    /// The event cannot fit an empty batch, so no batch size would accept it.
+    EventDataTooLarge,
+    /// The requested `max_bytes` is above what the sender link negotiated.
+    MaxBytesExceedsLinkLimit,
+    /// The link limit can only be adopted before events are added.
+    BatchNotEmpty,
+};
+
+pub const EventDataBatchOptions = struct {
+    /// Upper bound on the encoded batch size. Defaults to the sender link's
+    /// negotiated maximum, or `default_max_message_size` until one exists.
+    max_bytes: ?usize = null,
+    /// Route related events to one partition by hash. Mutually exclusive with
+    /// `partition_id`.
+    partition_key: ?[]const u8 = null,
+    /// Send to an explicit partition. Mutually exclusive with `partition_key`.
+    partition_id: ?[]const u8 = null,
+};
+
+/// Packs events into a single AMQP batch transfer.
+///
+/// Events are encoded as they are added and the batch tracks the real byte
+/// count, so a batch that reports as fitting actually fits. Go and Rust both
+/// work this way; estimating from body length under-counts properties,
+/// annotations, and per-message framing.
+pub const EventDataBatch = struct {
+    /// Fully encoded sub-messages, each of which becomes one data section of
+    /// the batch transfer.
+    marshaled: std.ArrayList([]u8) = .empty,
+    /// Encoded non-body sections of the first event, which become the batch
+    /// envelope. Go reuses the first message this way.
+    envelope: ?[]u8 = null,
+    max_size_bytes: usize = default_max_message_size,
+    current_size: usize = 0,
+    partition_key: ?[]const u8 = null,
+    partition_id: ?[]const u8 = null,
+    /// Set when the caller pinned `max_bytes`, so a link cannot raise it.
+    requested_max_bytes: ?usize = null,
+
+    pub fn init(options: EventDataBatchOptions) BatchError!EventDataBatch {
+        if (options.partition_key != null and options.partition_id != null) {
+            return BatchError.PartitionKeyAndIdBothSet;
+        }
         return .{
-            .events = .empty,
+            .max_size_bytes = options.max_bytes orelse default_max_message_size,
+            .partition_key = options.partition_key,
+            .partition_id = options.partition_id,
+            .requested_max_bytes = options.max_bytes,
         };
     }
 
+    pub fn deinit(self: *EventDataBatch, allocator: std.mem.Allocator) void {
+        for (self.marshaled.items) |encoded| allocator.free(encoded);
+        self.marshaled.deinit(allocator);
+        if (self.envelope) |envelope| allocator.free(envelope);
+        self.envelope = null;
+        self.current_size = 0;
+    }
+
+    /// Adopt the `max-message-size` a sender link negotiated.
+    ///
+    /// An explicitly requested `max_bytes` is kept when it is smaller and
+    /// rejected when it exceeds what the link allows, matching Go.
+    pub fn applyLinkMaxMessageSize(
+        self: *EventDataBatch,
+        link_max_bytes: usize,
+    ) BatchError!void {
+        if (self.marshaled.items.len > 0) return BatchError.BatchNotEmpty;
+        if (self.requested_max_bytes) |requested| {
+            if (requested > link_max_bytes) return BatchError.MaxBytesExceedsLinkLimit;
+            return;
+        }
+        self.max_size_bytes = link_max_bytes;
+    }
+
+    /// Encode `event` and add it if the batch still has room.
+    ///
+    /// Returns `false` when the event does not fit alongside what is already
+    /// batched, and `BatchError.EventDataTooLarge` when it would not fit even
+    /// an empty batch.
     pub fn tryAdd(self: *EventDataBatch, allocator: std.mem.Allocator, event: EventData) !bool {
-        const event_size = event.body.len + 64; // approximate overhead
-        if (self.current_size + event_size > self.max_size_bytes) return false;
-        try self.events.append(allocator, event);
-        self.current_size += event_size;
+        var message = try event.toAmqpMessage(allocator);
+        defer event_data.freeAmqpMessage(allocator, &message);
+
+        if (self.partition_key) |partition_key| {
+            try event_data.setPartitionKeyAnnotation(allocator, &message, partition_key);
+        }
+
+        // Both buffers are discarded unless the event is actually adopted,
+        // which includes the `false` return when it simply does not fit.
+        var adopted = false;
+
+        const encoded = try event_data.encodeMessage(allocator, &message);
+        defer if (!adopted) allocator.free(encoded);
+
+        // The first event also fixes the envelope, so its cost is charged here.
+        const is_first = self.marshaled.items.len == 0;
+        const envelope: ?[]u8 = if (is_first)
+            try event_data.encodeMessageEnvelope(allocator, &message)
+        else
+            null;
+        defer if (!adopted) {
+            if (envelope) |bytes| allocator.free(bytes);
+        };
+
+        const envelope_size = if (envelope) |bytes| bytes.len else 0;
+        const projected = self.current_size + envelope_size + dataSectionSize(encoded.len);
+        if (projected > self.max_size_bytes) {
+            if (is_first) return BatchError.EventDataTooLarge;
+            return false;
+        }
+
+        try self.marshaled.append(allocator, encoded);
+        if (envelope) |bytes| self.envelope = bytes;
+        self.current_size = projected;
+        adopted = true;
         return true;
     }
 
     pub fn count(self: EventDataBatch) usize {
-        return self.events.items.len;
+        return self.marshaled.items.len;
     }
 
-    pub fn deinit(self: *EventDataBatch, allocator: std.mem.Allocator) void {
-        self.events.deinit(allocator);
+    /// Encoded size of the batch as it would go on the wire.
+    pub fn sizeInBytes(self: EventDataBatch) usize {
+        return self.current_size;
     }
 };
+
+/// Wrapping a payload in a data section costs a described-type constructor, the
+/// descriptor, and a binary length prefix. Go's `calcActualSizeForPayload`
+/// uses the same constants.
+fn dataSectionSize(payload_len: usize) usize {
+    const vbin8_overhead = 5;
+    const vbin32_overhead = 8;
+    return if (payload_len < 256) vbin8_overhead + payload_len else vbin32_overhead + payload_len;
+}
 
 pub const PartitionProperties = struct {
     id: []const u8,
@@ -200,9 +319,10 @@ pub const UamqpTransport = struct {
         const amqp_target = uamqp.messaging.createTarget(target);
         _ = amqp_target;
 
-        for (batch.events.items) |event| {
-            var msg = try event.toAmqpMessage(allocator);
-            defer event_data.freeAmqpMessage(allocator, &msg);
+        // Each batched event is already encoded; a real send wraps them in the
+        // batch envelope and writes one transfer with `batch_message_format`.
+        for (batch.marshaled.items) |encoded| {
+            std.debug.assert(encoded.len > 0);
         }
     }
 
@@ -357,9 +477,17 @@ pub const ProducerClient = struct {
         return self.amqp_transport.sendBatch(allocator, address, batch);
     }
 
-    pub fn createBatch(self: *ProducerClient, _: std.mem.Allocator) EventDataBatch {
+    /// Create a batch sized for this producer.
+    ///
+    /// The limit stays at `default_max_message_size` until a sender link
+    /// negotiates `max-message-size`, at which point `applyLinkMaxMessageSize`
+    /// adopts it.
+    pub fn createBatch(
+        self: *ProducerClient,
+        options: EventDataBatchOptions,
+    ) BatchError!EventDataBatch {
         _ = self;
-        return .{ .events = .empty };
+        return EventDataBatch.init(options);
     }
 
     pub fn getEventHubProperties(self: *ProducerClient, allocator: std.mem.Allocator) !EventHubProperties {
@@ -471,13 +599,133 @@ test "EventData init" {
 
 test "EventDataBatch tryAdd" {
     const allocator = std.testing.allocator;
-    var batch = EventDataBatch.init(allocator);
+    var batch = try EventDataBatch.init(.{});
     defer batch.deinit(allocator);
     var e1 = EventData.init("event-1");
     defer e1.deinit(allocator);
     const added = try batch.tryAdd(allocator, e1);
     try std.testing.expect(added);
     try std.testing.expectEqual(@as(usize, 1), batch.count());
+    try std.testing.expect(batch.sizeInBytes() > 0);
+    try std.testing.expect(batch.envelope != null);
+}
+
+test "EventDataBatch rejects a partition key and id together" {
+    try std.testing.expectError(
+        BatchError.PartitionKeyAndIdBothSet,
+        EventDataBatch.init(.{ .partition_key = "pk", .partition_id = "0" }),
+    );
+    const by_key = try EventDataBatch.init(.{ .partition_key = "pk" });
+    try std.testing.expectEqualStrings("pk", by_key.partition_key.?);
+    const by_id = try EventDataBatch.init(.{ .partition_id = "3" });
+    try std.testing.expectEqualStrings("3", by_id.partition_id.?);
+}
+
+test "EventDataBatch defaults to one mebibyte" {
+    const batch = try EventDataBatch.init(.{});
+    try std.testing.expectEqual(default_max_message_size, batch.max_size_bytes);
+    try std.testing.expectEqual(@as(usize, 1024 * 1024), default_max_message_size);
+}
+
+test "EventDataBatch fills up without exceeding max_bytes" {
+    const allocator = std.testing.allocator;
+    var batch = try EventDataBatch.init(.{ .max_bytes = 512 });
+    defer batch.deinit(allocator);
+
+    var event = EventData.init("x" ** 32);
+    defer event.deinit(allocator);
+
+    var added: usize = 0;
+    while (try batch.tryAdd(allocator, event)) : (added += 1) {
+        try std.testing.expect(batch.sizeInBytes() <= 512);
+    }
+
+    try std.testing.expect(added > 1);
+    try std.testing.expectEqual(added, batch.count());
+    try std.testing.expect(batch.sizeInBytes() <= 512);
+    // The next event still does not fit, and that stays a `false` rather than
+    // an error because the batch is not empty.
+    try std.testing.expect(!try batch.tryAdd(allocator, event));
+}
+
+test "EventDataBatch reports an oversized event distinctly" {
+    const allocator = std.testing.allocator;
+    var batch = try EventDataBatch.init(.{ .max_bytes = 32 });
+    defer batch.deinit(allocator);
+
+    var event = EventData.init("y" ** 256);
+    defer event.deinit(allocator);
+
+    try std.testing.expectError(BatchError.EventDataTooLarge, batch.tryAdd(allocator, event));
+    try std.testing.expectEqual(@as(usize, 0), batch.count());
+    try std.testing.expectEqual(@as(usize, 0), batch.sizeInBytes());
+    try std.testing.expect(batch.envelope == null);
+}
+
+test "EventDataBatch size matches the encoded bytes" {
+    const allocator = std.testing.allocator;
+    var batch = try EventDataBatch.init(.{});
+    defer batch.deinit(allocator);
+
+    var first = EventData.init("first event");
+    defer first.deinit(allocator);
+    try first.setStringProperty(allocator, "tenant", "contoso");
+    var second = EventData.init("second event body which is a little longer");
+    defer second.deinit(allocator);
+
+    try std.testing.expect(try batch.tryAdd(allocator, first));
+    try std.testing.expect(try batch.tryAdd(allocator, second));
+
+    var expected = batch.envelope.?.len;
+    for (batch.marshaled.items) |encoded| {
+        expected += if (encoded.len < 256) 5 + encoded.len else 8 + encoded.len;
+    }
+    try std.testing.expectEqual(expected, batch.sizeInBytes());
+}
+
+test "EventDataBatch charges for the partition key annotation" {
+    const allocator = std.testing.allocator;
+
+    var event = EventData.init("event");
+    defer event.deinit(allocator);
+
+    var plain = try EventDataBatch.init(.{});
+    defer plain.deinit(allocator);
+    try std.testing.expect(try plain.tryAdd(allocator, event));
+
+    var keyed = try EventDataBatch.init(.{ .partition_key = "a-partition-key" });
+    defer keyed.deinit(allocator);
+    try std.testing.expect(try keyed.tryAdd(allocator, event));
+
+    try std.testing.expect(keyed.sizeInBytes() > plain.sizeInBytes());
+}
+
+test "EventDataBatch adopts the link negotiated size" {
+    const allocator = std.testing.allocator;
+
+    var negotiated = try EventDataBatch.init(.{});
+    try negotiated.applyLinkMaxMessageSize(256 * 1024);
+    try std.testing.expectEqual(@as(usize, 256 * 1024), negotiated.max_size_bytes);
+
+    var smaller = try EventDataBatch.init(.{ .max_bytes = 4096 });
+    try smaller.applyLinkMaxMessageSize(256 * 1024);
+    try std.testing.expectEqual(@as(usize, 4096), smaller.max_size_bytes);
+
+    var too_large = try EventDataBatch.init(.{ .max_bytes = 2 * 1024 * 1024 });
+    try std.testing.expectError(
+        BatchError.MaxBytesExceedsLinkLimit,
+        too_large.applyLinkMaxMessageSize(1024 * 1024),
+    );
+
+    var started = try EventDataBatch.init(.{});
+    defer started.deinit(allocator);
+    var event = EventData.init("event");
+    defer event.deinit(allocator);
+    try std.testing.expect(try started.tryAdd(allocator, event));
+    try std.testing.expectError(
+        BatchError.BatchNotEmpty,
+        started.applyLinkMaxMessageSize(256 * 1024),
+    );
 }
 
 test "EventPosition earliest filter" {
@@ -525,7 +773,7 @@ test "ProducerClient createBatch" {
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), amqp.asTransport());
-    var batch = producer.createBatch(allocator);
+    var batch = try producer.createBatch(.{});
     defer batch.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 0), batch.count());
 }
@@ -544,7 +792,7 @@ test "ProducerClient sendBatch" {
         .event_hub_name = "my-hub",
     }, cred.asCredential(), amqp.asTransport());
 
-    var batch = producer.createBatch(allocator);
+    var batch = try producer.createBatch(.{});
     defer batch.deinit(allocator);
     var e1 = EventData.init("event-1");
     defer e1.deinit(allocator);
@@ -569,7 +817,7 @@ test "ProducerClient sendBatch empty returns error" {
         .event_hub_name = "my-hub",
     }, cred.asCredential(), amqp.asTransport());
 
-    var batch = producer.createBatch(allocator);
+    var batch = try producer.createBatch(.{});
     defer batch.deinit(allocator);
 
     const result = producer.sendBatch(allocator, batch);
@@ -618,7 +866,7 @@ test "UamqpTransport sendBatch encodes messages" {
     const allocator = std.testing.allocator;
     var transport = UamqpTransport.init(allocator, "ns.servicebus.windows.net");
 
-    var batch = EventDataBatch.init(allocator);
+    var batch = try EventDataBatch.init(.{});
     defer batch.deinit(allocator);
     var e1 = EventData.init("hello");
     defer e1.deinit(allocator);
@@ -657,4 +905,37 @@ test "ConsumerClient fromConnectionString" {
     try std.testing.expectEqualStrings("ns.servicebus.windows.net", consumer.options.fully_qualified_namespace);
     try std.testing.expectEqualStrings("hub", consumer.options.event_hub_name);
     try std.testing.expectEqualStrings("$Default", consumer.options.consumer_group);
+}
+
+test "EventDataBatch survives allocation failure at every step" {
+    const Case = struct {
+        fn run(allocator: std.mem.Allocator) !void {
+            var batch = try EventDataBatch.init(.{ .partition_key = "pk-1" });
+            defer batch.deinit(allocator);
+
+            var event = EventData.init("payload");
+            defer event.deinit(allocator);
+            event.content_type = "application/json";
+            try event.setStringProperty(allocator, "tenant", "contoso");
+
+            _ = try batch.tryAdd(allocator, event);
+            _ = try batch.tryAdd(allocator, event);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Case.run, .{});
+}
+
+test "EventDataBatch does not leak when an event does not fit" {
+    const allocator = std.testing.allocator;
+    var batch = try EventDataBatch.init(.{ .max_bytes = 128 });
+    defer batch.deinit(allocator);
+
+    var small = EventData.init("s");
+    defer small.deinit(allocator);
+    try std.testing.expect(try batch.tryAdd(allocator, small));
+
+    var large = EventData.init("z" ** 200);
+    defer large.deinit(allocator);
+    try std.testing.expect(!try batch.tryAdd(allocator, large));
+    try std.testing.expectEqual(@as(usize, 1), batch.count());
 }


### PR DESCRIPTION
## Summary

`EventDataBatch` hardcoded a 1 MiB ceiling and estimated each event as
`body.len + 64`, which ignores properties, annotations, and per-message
framing, so a batch could report as fitting and then be rejected by the
service. Go and Rust both measure the actual serialized size instead.

- The batch now encodes each event as it is added and keeps the encoded bytes,
  which is what a batch transfer sends. The first event also fixes the batch
  envelope, whose encoded size is charged up front, and each event is wrapped
  with the same data-section overhead as Go's `calcActualSizeForPayload`.
- `EventDataBatchOptions` adds `max_bytes`, `partition_key`, and
  `partition_id`. The last two are mutually exclusive.
- A partition key is stamped on each message as `x-opt-partition-key` as it
  enters the batch, so its cost is counted rather than discovered at send time.
- `applyLinkMaxMessageSize` adopts a sender link's negotiated
  `max-message-size`, keeps a smaller explicit `max_bytes`, and rejects one
  that is larger.
- `tryAdd` returns `false` when an event does not fit alongside what is already
  batched, and `BatchError.EventDataTooLarge` when it would not fit an empty
  batch either.

### Message serialization

`uamqp` encodes individual `AmqpValue`s but has no message serializer, so
`encodeMessage` and `encodeMessageEnvelope` assemble the AMQP 1.0 section 3.2
sections: header, delivery and message annotations, properties, application
properties, body, and footer. Trailing null fields are trimmed from composite
sections, as real encoders do, so measured sizes stay realistic. The sending
path in a later issue needs the same code.

## Validation

- `zig build test --summary all` — 66/66 tests, up from 52
- `zig fmt --check` over all tracked Zig sources
- The serializer is checked against the wire format directly: a single data
  section is asserted byte for byte, an all-null properties section is asserted
  to collapse to the empty-list format code, and a full message is decoded back
  through `uamqp.decoder` to confirm each section descriptor and that the
  sections consume exactly the encoded length
- Batch coverage for filling to the limit, oversized events, reported size
  matching the encoded bytes, partition key cost, and link size negotiation
- `std.testing.checkAllAllocationFailures` drives `tryAdd` through every
  allocation point; it caught a leak on the "does not fit" return, which is why
  the buffers are released with `defer` rather than `errdefer`

Fixes #194
Part of #191