### PR TITLE
eng: publish errors.zig for eventhubs

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -445,6 +445,7 @@ pub const all = [_]Package{
             "build.zig.zon",
             "root.zig",
             "event_data.zig",
+            "errors.zig",
             "checkpoint.zig",
             "checkpoint_store.zig",
             "checkpoint_store_blob",


### PR DESCRIPTION
`sdk/eventhubs` gains `errors.zig` in #219, which adds Event Hubs error classification and the retry schedule. `expectExactSet` in `eng/package_branch_tool.zig` compares the branch manifest's `.paths` against this registry entry, so the two have to move together.

Part of #191.