### PR TITLE
eng: publish sas.zig and the core dependency for messaging_common

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -416,11 +416,13 @@ pub const all = [_]Package{
         .name = "azure_sdk_messaging_common",
         .module_name = "azure_sdk_messaging_common",
         .branch = "sdk/messaging_common",
+        .dependencies = &.{"azure_sdk_core"},
         .publish_paths = &.{
             ".gitignore",
             "build.zig",
             "build.zig.zon",
             "root.zig",
+            "sas.zig",
             "README.md",
             "LICENSE.txt",
         },


### PR DESCRIPTION
`sdk/messaging_common` gains `sas.zig` and takes `azure_sdk_core` as a dependency in #221, for SAS token generation and a `TokenCredential` implementation. `expectExactSet` in `eng/package_branch_tool.zig` compares the branch manifest against this registry entry, so the two have to move together.

Part of #191.