### PR TITLE
Re-pin azure_sdk_core to 0.1.3 for TLS request body flush fix

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#da55987aa3c90393a726fc1fa5e86ccd69d72271",
-            .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
+            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
         },
     },
     .paths = .{


### PR DESCRIPTION
azure_sdk_core 0.1.2 does not flush the underlying socket writer after writing a request body over TLS. `BodyWriter.end()` flushes only the TLS writer, which encrypts plaintext into the socket writer's buffer but never pushes it to the socket; only `Connection.flush()` flushes both layers.

The effect is size-dependent. Request bodies large enough to overflow the socket writer's buffer (~1 KB in practice) get written as a side effect of that overflow and succeed, while smaller bodies are never sent at all. The server then waits for a request that never arrives and returns HTTP 408, or the client hangs until its own deadline. Reusing a half-written connection from the pool could also surface as a TLS initialization error.

azure_sdk_core 0.1.3 (#146) adds the missing connection flush in the std transport. This re-pin picks it up; no source changes are required.
