### PR TITLE
Re-pin azure_sdk_core to 0.1.3 for TLS request body flush fix

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,16 +5,16 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#da55987aa3c90393a726fc1fa5e86ccd69d72271",
-            .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
+            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
             .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
         },
         .azure_rest_data_tables = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#67d001426e73385a944a1bacde8d482b81dbf5ae",
-            .hash = "azure_rest_data_tables-0.1.0-CqXnR3B2AQBJhSOC2e17bpbGPj5hN9RjLcpQ01OfFGkf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b218272ec35cbb7feaadcdb77fc7c34f6cfd3339",
+            .hash = "azure_rest_data_tables-0.1.0-CqXnR3B2AQAHRViUkjfOeAz-3hAkn2W4x1xF2zcL7JRf",
         },
     },
     .paths = .{


### PR DESCRIPTION
azure_sdk_core 0.1.2 does not flush the underlying socket writer after writing a request body over TLS. `BodyWriter.end()` flushes only the TLS writer, which encrypts plaintext into the socket writer's buffer but never pushes it to the socket; only `Connection.flush()` flushes both layers.

The effect is size-dependent. Request bodies large enough to overflow the socket writer's buffer (~1 KB in practice) get written as a side effect of that overflow and succeed, while smaller bodies are never sent at all. The server then waits for a request that never arrives and returns HTTP 408, or the client hangs until its own deadline. Reusing a half-written connection from the pool could also surface as a TLS initialization error.

azure_sdk_core 0.1.3 (#146) adds the missing connection flush in the std transport.

This package also re-pins azure_rest_data_tables to the commit that picks up the same core version. Bumping core alone does not build here: the generated REST package and this package would resolve to two different azure_sdk_core instances, so core types no longer unify across the boundary and compilation fails. Re-pinning both keeps a single core in the dependency graph.
