### PR TITLE
Re-pin azure_sdk_core to 0.1.3 for TLS request body flush fix

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,12 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5c37f2997b0a9dcc2db91f83baf0a492342621a2",
-            .hash = "azure_sdk_core-0.1.0-eFY0EtlTBQDltjWjN0xVytGGsv4kqwm1JP_PY18iWFb3",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
+            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
         },
         .azure_rest_arm_avs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#fe7662a3416f599794c10d038854262bf22a664a",
-            .hash = "azure_rest_arm_avs-0.1.0-JCvS8N8JBwB4fO6MqfXfCFCjkjOMuuZvcAAWx9LI_2Vx",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#20a2807f813864dabc0673ad72d400ee7d104945",
+            .hash = "azure_rest_arm_avs-0.1.0-JCvS8N8JBwCoC36NQdwOM4AN5LGy434N2sZP9ENPSINW",
         },
     },
     .paths = .{


### PR DESCRIPTION
azure_sdk_core 0.1.2 and earlier do not flush the underlying socket writer after writing a request body over TLS. `BodyWriter.end()` flushes only the TLS writer, which encrypts plaintext into the socket writer's buffer but never pushes it to the socket; only `Connection.flush()` flushes both layers.

The effect is size-dependent. Request bodies large enough to overflow the socket writer's buffer (~1 KB in practice) get written as a side effect of that overflow and succeed, while smaller bodies are never sent at all. The server then waits for a request that never arrives and returns HTTP 408, or the client hangs until its own deadline. Reusing a half-written connection from the pool could also surface as a TLS initialization error.

azure_sdk_core 0.1.3 (#146) adds the missing connection flush in the std transport. This example was still pinned to core 0.1.0, so it also picks up the 0.1.1 and 0.1.2 changes.

The package this example depends on is re-pinned in the same commit. Bumping core alone does not build: the example and its dependency would resolve to two different azure_sdk_core instances, so core types no longer unify across the boundary and compilation fails. Re-pinning both keeps a single core in the dependency graph.
