### PR TITLE
Install Zig via ghr instead of mlugg/setup-zig

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -20,9 +20,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - name: Install Zig via ghr
+        uses: cataggar/ghr/actions/install@v0.7.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: 0.16.0
+          tools: |
+            cataggar/zig@v0.16.0 RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
       - name: Check formatting
         shell: bash
         run: git ls-files -z -- '*.zig' 'build.zig.zon' | xargs -0 zig fmt --check
@@ -41,9 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
+      - name: Install Zig via ghr
+        uses: cataggar/ghr/actions/install@v0.7.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: 0.16.0
+          tools: |
+            cataggar/zig@v0.16.0 RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
       - name: Run configured Azurite Tables integration tests
         shell: bash
         run: |


### PR DESCRIPTION
Replaces the third-party `mlugg/setup-zig` action with the ghr installer already used in other repositories, so Zig comes from a pinned release verified against a known signing key rather than an external action.

The matching change to `eng/package_branch_template` on `main` keeps regenerated package branches from reintroducing the old action.

The job name and build matrix are unchanged, so the required status checks keep their existing names.
