### PR TITLE
Add AMQP sessions, links, and a message codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,59 @@ try driver.open(deadline_ms);
 const remote_channel = try driver.beginSession(0, .{}, deadline_ms);
 ```
 
-CBS authentication, the `$management` link, and message transfer are not here
-yet.
+## Message codec
+
+`message.zig` encodes and decodes the AMQP message sections — header, delivery
+and message annotations, properties, application properties, body, and footer.
+The body is a `data`, `sequence`, or `value` section.
+
+```zig
+const bytes = try amqp.encodeMessageAlloc(allocator, .{
+    .properties = .{ .message_id = .{ .string = id } },
+    .application_properties = props,
+    .body = .{ .data = &.{payload} },
+});
+defer allocator.free(bytes);
+```
+
+## Sessions and links
+
+`link.zig` builds sessions, senders, and receivers on top of the driver:
+
+- attach and detach, matched to the peer's echoed attach by link name
+- flow control, including credit rebasing onto our delivery count (§2.6.7) and
+  draining, which waits for the sender to consume the outstanding credit
+- multi-frame transfers, split to the negotiated `max-frame-size` on send and
+  reassembled on receive
+- settlement: accepted, rejected, and released outcomes, with a rejection
+  surfacing the peer's error condition
+- the Event Hubs link properties the Go and Rust clients send —
+  `com.microsoft:receiver-name`, `com.microsoft:epoch`, and the
+  `apache.org:selector-filter:string` filter used to pick a starting offset
+
+```zig
+var session = try amqp.Session.begin(allocator, &driver, 0, .{}, deadline_ms);
+defer session.deinit();
+
+const filters = [_]amqp.performative.Filter{
+    .selector("amqp.annotation.x-opt-offset > '@latest'"),
+};
+const receiver = try amqp.openReceiver(&session, .{
+    .name = link_name,
+    .source_address = "myhub/ConsumerGroups/$Default/Partitions/0",
+    .filters = &filters,
+    .prefetch = 300,
+}, deadline_ms);
+
+const delivery = try receiver.receive(deadline_ms);
+try receiver.accept(delivery);
+```
+
+A handle in an inbound frame is scoped to the peer that sent it, so links are
+looked up by the handle the peer chose, never by our own. A session holding both
+a CBS link and an events link would otherwise cross its deliveries.
+
+CBS authentication and the `$management` link are not here yet.
 
 Run its independent tests from this directory:
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .uamqp = .{
-            .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",
-            .hash = "uamqp-0.1.0-lXMcafDqAQD3LSUZbUbyfrWhQfGG7OevKFUwhWxvGZDU",
+            .url = "git+https://github.com/cataggar/azure-uamqp-zig#593310683d2a60da5388aa02d1e464a393a51f23",
+            .hash = "uamqp-0.1.0-lXMcaSv6AQCOX3VGEAULcjka6Retcu8O6XMRo4m4Esr4",
         },
     },
     .paths = .{
@@ -17,6 +17,8 @@
         "transport.zig",
         "performative.zig",
         "connection.zig",
+        "message.zig",
+        "link.zig",
         "README.md",
         "LICENSE.txt",
     },

--- a/connection.zig
+++ b/connection.zig
@@ -176,10 +176,19 @@ pub const RemoteError = struct {
     condition: []const u8,
     description: ?[]const u8,
 
-    fn deinit(self: *RemoteError, allocator: Allocator) void {
+    /// Copy an inbound error so it outlives the frame it arrived in.
+    pub fn dupe(allocator: Allocator, err: perf.AmqpError) Allocator.Error!RemoteError {
+        const condition = try allocator.dupe(u8, err.condition);
+        errdefer allocator.free(condition);
+        return .{
+            .condition = condition,
+            .description = if (err.description) |d| try allocator.dupe(u8, d) else null,
+        };
+    }
+
+    pub fn deinit(self: RemoteError, allocator: Allocator) void {
         allocator.free(self.condition);
         if (self.description) |d| allocator.free(d);
-        self.* = undefined;
     }
 };
 
@@ -465,13 +474,11 @@ pub const Driver = struct {
         self.state = .closed;
     }
 
-    fn recordRemoteError(self: *Driver, err: ?perf.AmqpError) ConnectionError!void {
+    pub fn recordRemoteError(self: *Driver, err: ?perf.AmqpError) ConnectionError!void {
         const e = err orelse return;
-        if (self.remote_error) |*old| old.deinit(self.allocator);
-        const condition = try self.allocator.dupe(u8, e.condition);
-        errdefer self.allocator.free(condition);
-        const description = if (e.description) |d| try self.allocator.dupe(u8, d) else null;
-        self.remote_error = .{ .condition = condition, .description = description };
+        const copy = try RemoteError.dupe(self.allocator, e);
+        if (self.remote_error) |old| old.deinit(self.allocator);
+        self.remote_error = copy;
     }
 
     // ── Channel routing ──

--- a/link.zig
+++ b/link.zig
@@ -1,0 +1,1628 @@
+//! AMQP 1.0 sessions and links.
+//!
+//! `uamqp.protocol.link` and `uamqp.protocol.session` are stubs that never
+//! encode anything, so this module drives attach, credit, transfer, and
+//! settlement over the connection `Driver`.
+//!
+//! Everything here is synchronous and deadline-driven, like the driver: a call
+//! that can wait takes a deadline in milliseconds on the driver's clock.
+
+const std = @import("std");
+const uamqp = @import("uamqp");
+const perf = @import("performative.zig");
+const message = @import("message.zig");
+const connection = @import("connection.zig");
+
+const Allocator = std.mem.Allocator;
+const Driver = connection.Driver;
+const frame = uamqp.frame;
+const FrameType = uamqp.frame.FrameType;
+
+pub const LinkError = connection.ConnectionError || error{
+    /// The peer detached the link; inspect `remoteError`.
+    LinkDetached,
+    /// The peer rejected the delivery; inspect `rejection`.
+    SendRejected,
+    /// The peer released or modified the delivery rather than accepting it.
+    SendNotAccepted,
+    /// A message exceeded the peer's advertised `max-message-size`.
+    MessageTooLarge,
+    /// A transfer arrived for a handle no link owns.
+    UnknownHandle,
+    /// The peer sent a transfer without the credit to do so.
+    CreditExceeded,
+};
+
+/// Set on a receiver so Event Hubs can name the owner in its error text.
+pub const receiver_name_property = "com.microsoft:receiver-name";
+
+/// Set on a receiver to claim exclusive ownership of a partition.
+pub const epoch_property = "com.microsoft:epoch";
+
+/// What the peer said about a delivery it would not accept.
+pub const Rejection = struct {
+    condition: []const u8,
+    description: ?[]const u8 = null,
+
+    pub fn deinit(self: Rejection, allocator: Allocator) void {
+        allocator.free(self.condition);
+        if (self.description) |d| allocator.free(d);
+    }
+};
+
+// ─────────────────────── Session ───────────────────────
+
+pub const SessionOptions = struct {
+    /// Window sizes. Rust opens sessions with very large windows so the
+    /// service is never the one throttling.
+    incoming_window: u32 = std.math.maxInt(u32),
+    outgoing_window: u32 = std.math.maxInt(u32),
+    handle_max: u32 = std.math.maxInt(u32),
+};
+
+/// A session, owning the links attached to one channel.
+pub const Session = struct {
+    allocator: Allocator,
+    driver: *Driver,
+    channel: u16,
+    remote_channel: u16,
+
+    next_outgoing_id: u32 = 0,
+    next_incoming_id: u32 = 0,
+    incoming_window: u32,
+    outgoing_window: u32,
+    /// The peer's remaining capacity to receive transfers.
+    remote_incoming_window: u32 = 0,
+
+    next_handle: u32 = 0,
+    senders: std.ArrayList(*Sender) = .empty,
+    receivers: std.ArrayList(*Receiver) = .empty,
+
+    /// Begin a session on `channel`.
+    pub fn begin(
+        allocator: Allocator,
+        driver: *Driver,
+        channel: u16,
+        options: SessionOptions,
+        deadline_ms: i64,
+    ) LinkError!Session {
+        const remote = try driver.beginSession(channel, .{
+            .next_outgoing_id = 0,
+            .incoming_window = options.incoming_window,
+            .outgoing_window = options.outgoing_window,
+            .handle_max = options.handle_max,
+        }, deadline_ms);
+
+        return .{
+            .allocator = allocator,
+            .driver = driver,
+            .channel = channel,
+            .remote_channel = remote,
+            .incoming_window = options.incoming_window,
+            .outgoing_window = options.outgoing_window,
+        };
+    }
+
+    pub fn deinit(self: *Session) void {
+        for (self.senders.items) |s| s.deinit();
+        for (self.receivers.items) |r| r.deinit();
+        self.senders.deinit(self.allocator);
+        self.receivers.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    /// End the session on the wire.
+    pub fn end(self: *Session, deadline_ms: i64) LinkError!void {
+        try self.driver.endSession(self.channel, deadline_ms);
+    }
+
+    fn allocateHandle(self: *Session) u32 {
+        const handle = self.next_handle;
+        self.next_handle += 1;
+        return handle;
+    }
+
+    /// Read one frame and apply it to the session and its links.
+    ///
+    /// Returns true when the frame was consumed. A frame for another channel
+    /// is ignored, which keeps a single-session connection simple.
+    pub fn pump(self: *Session, deadline_ms: i64) LinkError!bool {
+        const inbound = try self.driver.receiveFrame(deadline_ms);
+        if (inbound.header.channel != self.remote_channel) return false;
+
+        var decoded = try self.driver.decodeBody(inbound.body);
+        defer decoded.deinit();
+
+        const body = inbound.body;
+        switch (decoded.performative) {
+            .flow => |f| try self.applyFlow(f),
+            .disposition => |d| try self.applyDisposition(d),
+            .transfer => |t| try self.applyTransfer(t, body),
+            .attach => |a| try self.applyAttach(a),
+            .detach => |d| try self.applyDetach(d),
+            .end => |e| {
+                try self.driver.recordRemoteError(e.err);
+                return error.RemoteClosed;
+            },
+            .close => |c| {
+                try self.driver.recordRemoteError(c.err);
+                return error.RemoteClosed;
+            },
+            else => return false,
+        }
+        return true;
+    }
+
+    // A handle in an inbound frame is scoped to the peer that sent it
+    // (§2.6.2), so it is matched against `remote_handle` only. Matching our
+    // own handle too would collide whenever a session holds both a sender and
+    // a receiver, which is the shape CBS and $management use.
+    fn senderFor(self: *Session, handle: u32) ?*Sender {
+        for (self.senders.items) |s| {
+            if (s.attached and s.remote_handle == handle) return s;
+        }
+        return null;
+    }
+
+    fn receiverFor(self: *Session, handle: u32) ?*Receiver {
+        for (self.receivers.items) |r| {
+            if (r.attached and r.remote_handle == handle) return r;
+        }
+        return null;
+    }
+
+    fn applyFlow(self: *Session, f: perf.Flow) LinkError!void {
+        self.next_incoming_id = f.next_outgoing_id;
+        self.remote_incoming_window = f.incoming_window;
+
+        const handle = f.handle orelse return;
+        if (self.senderFor(handle)) |s| {
+            if (f.link_credit) |credit| {
+                // The peer states credit relative to its view of our delivery
+                // count, so rebase onto ours (§2.6.7).
+                const their_count = f.delivery_count orelse s.delivery_count;
+                const consumed = s.delivery_count -% their_count;
+                s.credit = credit -| consumed;
+            }
+            s.drain = f.drain;
+        }
+        if (self.receiverFor(handle)) |r| {
+            // For a receiving link the peer is the sender, so its flow reports
+            // where its delivery count has reached. Rebase the credit we still
+            // hold onto our own count; a drain response advances the count to
+            // consume the remainder, leaving us at zero.
+            const credit = f.link_credit orelse r.credit;
+            if (f.drain) {
+                // A drain response advances the sender's count over whatever
+                // credit went unused, so its count is authoritative.
+                if (f.delivery_count) |their_count| r.delivery_count = their_count;
+                r.credit = credit;
+            } else if (f.delivery_count) |their_count| {
+                const limit = their_count +% credit;
+                r.credit = limit -% r.delivery_count;
+            } else {
+                r.credit = credit;
+            }
+        }
+        if (f.echo) try self.sendFlow(null);
+    }
+
+    fn applyDisposition(self: *Session, d: perf.Disposition) LinkError!void {
+        // A disposition from the receiving side settles what we sent.
+        if (d.role != .receiver) return;
+        const last = d.last orelse d.first;
+        for (self.senders.items) |s| {
+            try s.applyDisposition(d.first, last, d.state);
+        }
+    }
+
+    fn applyAttach(self: *Session, a: perf.Attach) LinkError!void {
+        // Match by link name: the peer echoes it and picks its own handle.
+        for (self.senders.items) |s| {
+            if (std.mem.eql(u8, s.name, a.name)) {
+                s.remote_handle = a.handle;
+                s.max_message_size = a.max_message_size;
+                if (a.initial_delivery_count) |c| s.delivery_count = c;
+                s.attached = true;
+                return;
+            }
+        }
+        for (self.receivers.items) |r| {
+            if (std.mem.eql(u8, r.name, a.name)) {
+                r.remote_handle = a.handle;
+                r.max_message_size = a.max_message_size;
+                r.attached = true;
+                return;
+            }
+        }
+    }
+
+    fn applyDetach(self: *Session, d: perf.Detach) LinkError!void {
+        if (self.senderFor(d.handle)) |s| {
+            s.attached = false;
+            try s.recordDetach(d.err);
+            return;
+        }
+        if (self.receiverFor(d.handle)) |r| {
+            r.attached = false;
+            try r.recordDetach(d.err);
+        }
+    }
+
+    fn applyTransfer(self: *Session, t: perf.Transfer, body: []const u8) LinkError!void {
+        self.next_incoming_id +%= 1;
+        if (self.incoming_window > 0) self.incoming_window -= 1;
+
+        const receiver = self.receiverFor(t.handle) orelse return error.UnknownHandle;
+        // The payload is whatever follows the performative in the frame.
+        const consumed = performativeLength(self.allocator, body) orelse return error.MalformedFrame;
+        try receiver.acceptTransfer(t, body[consumed..]);
+    }
+
+    /// Emit a session `flow`, optionally carrying link credit.
+    fn sendFlow(self: *Session, link: ?*Receiver) LinkError!void {
+        var f = perf.Flow{
+            .next_incoming_id = self.next_incoming_id,
+            .incoming_window = self.incoming_window,
+            .next_outgoing_id = self.next_outgoing_id,
+            .outgoing_window = self.outgoing_window,
+        };
+        if (link) |r| {
+            f.handle = r.handle;
+            f.link_credit = r.credit;
+            f.delivery_count = r.delivery_count;
+            f.drain = r.drain;
+        }
+        try self.driver.sendPerformative(.amqp, self.channel, .{ .flow = f });
+    }
+};
+
+/// Byte length of the described performative at the head of a frame body.
+///
+/// A transfer frame carries the message payload immediately after the
+/// performative, so the split has to be found by measuring the performative.
+fn performativeLength(allocator: Allocator, body: []const u8) ?usize {
+    var arena: std.heap.ArenaAllocator = .init(allocator);
+    defer arena.deinit();
+    const result = uamqp.decoder.decode(arena.allocator(), body) catch return null;
+    return result.bytes_consumed;
+}
+
+// ─────────────────────── Sender ───────────────────────
+
+pub const SenderOptions = struct {
+    name: []const u8,
+    /// The entity the messages go to, such as `eh` or `eh/Partitions/3`.
+    target_address: []const u8,
+    source_address: ?[]const u8 = null,
+    /// Go asks for mixed settlement with receiver-settle-mode first.
+    snd_settle_mode: perf.SenderSettleMode = .mixed,
+    rcv_settle_mode: perf.ReceiverSettleMode = .first,
+    desired_capabilities: ?[]const []const u8 = null,
+    properties: ?perf.Fields = null,
+};
+
+pub const Sender = struct {
+    allocator: Allocator,
+    session: *Session,
+    name: []const u8,
+    handle: u32,
+    remote_handle: u32 = std.math.maxInt(u32),
+    attached: bool = false,
+
+    credit: u32 = 0,
+    drain: bool = false,
+    delivery_count: u32 = 0,
+    /// Peer's `max-message-size`; null or 0 means unlimited.
+    max_message_size: ?u64 = null,
+
+    /// Outcome of the delivery currently awaiting settlement.
+    pending_id: ?u32 = null,
+    outcome: ?perf.DeliveryState = null,
+    rejection: ?Rejection = null,
+    detach_error: ?connection.RemoteError = null,
+
+    pub fn deinit(self: *Sender) void {
+        self.allocator.free(self.name);
+        if (self.rejection) |r| r.deinit(self.allocator);
+        if (self.detach_error) |e| e.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
+
+    /// The largest message the peer will take, or null when unlimited.
+    pub fn maxMessageSize(self: *const Sender) ?u64 {
+        const size = self.max_message_size orelse return null;
+        return if (size == 0) null else size;
+    }
+
+    fn recordDetach(self: *Sender, err: ?perf.AmqpError) LinkError!void {
+        if (self.detach_error) |e| e.deinit(self.allocator);
+        self.detach_error = null;
+        const e = err orelse return;
+        self.detach_error = try connection.RemoteError.dupe(self.allocator, e);
+    }
+
+    fn applyDisposition(
+        self: *Sender,
+        first: u32,
+        last: u32,
+        state: ?perf.DeliveryState,
+    ) LinkError!void {
+        const id = self.pending_id orelse return;
+        if (id < first or id > last) return;
+        self.outcome = state orelse .accepted;
+        if (state) |s| switch (s) {
+            .rejected => |maybe_err| {
+                if (self.rejection) |r| r.deinit(self.allocator);
+                self.rejection = null;
+                if (maybe_err) |e| self.rejection = .{
+                    .condition = try self.allocator.dupe(u8, e.condition),
+                    .description = if (e.description) |d|
+                        try self.allocator.dupe(u8, d)
+                    else
+                        null,
+                };
+            },
+            else => {},
+        };
+    }
+
+    /// Send a message and wait for the peer to settle it.
+    pub fn send(self: *Sender, msg: message.Message, deadline_ms: i64) LinkError!void {
+        const payload = try message.encodeAlloc(self.allocator, msg);
+        defer self.allocator.free(payload);
+        try self.sendBytes(payload, deadline_ms);
+    }
+
+    /// Send an already encoded message payload.
+    pub fn sendBytes(self: *Sender, payload: []const u8, deadline_ms: i64) LinkError!void {
+        if (self.maxMessageSize()) |limit| {
+            if (payload.len > limit) return error.MessageTooLarge;
+        }
+        try self.awaitCredit(deadline_ms);
+
+        const delivery_id = self.session.next_outgoing_id;
+        var tag: [4]u8 = undefined;
+        std.mem.writeInt(u32, &tag, delivery_id, .big);
+
+        var offset: usize = 0;
+        var first = true;
+        while (first or offset < payload.len) {
+            const budget = try self.chunkBudget(delivery_id, &tag, first);
+            const take = @min(budget, payload.len - offset);
+            const more = offset + take < payload.len;
+
+            const xfer = perf.Transfer{
+                .handle = self.handle,
+                .delivery_id = if (first) delivery_id else null,
+                .delivery_tag = if (first) &tag else null,
+                .message_format = if (first) 0 else null,
+                .settled = false,
+                .more = more,
+            };
+            try self.sendTransfer(xfer, payload[offset..][0..take]);
+
+            offset += take;
+            first = false;
+        }
+
+        self.session.next_outgoing_id +%= 1;
+        self.delivery_count +%= 1;
+        self.credit -|= 1;
+        if (self.session.remote_incoming_window > 0) self.session.remote_incoming_window -= 1;
+
+        self.pending_id = delivery_id;
+        self.outcome = null;
+        defer self.pending_id = null;
+
+        while (self.outcome == null) {
+            if (!self.attached) return error.LinkDetached;
+            _ = try self.session.pump(deadline_ms);
+        }
+
+        switch (self.outcome.?) {
+            .accepted => {},
+            .rejected => return error.SendRejected,
+            .released, .modified => return error.SendNotAccepted,
+        }
+    }
+
+    /// How many payload bytes fit alongside the transfer performative.
+    fn chunkBudget(self: *Sender, delivery_id: u32, tag: *const [4]u8, first: bool) LinkError!usize {
+        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
+        defer buf.deinit();
+        // Encode with `more` set so the measurement is never an underestimate:
+        // a true boolean is written where a defaulted false would be elided.
+        try perf.encodeTransfer(self.allocator, .{
+            .handle = self.handle,
+            .delivery_id = if (first) delivery_id else null,
+            .delivery_tag = if (first) tag else null,
+            .message_format = if (first) 0 else null,
+            .settled = false,
+            .more = true,
+        }, &buf);
+
+        const available = self.session.driver.maxOutgoingBody();
+        if (available <= buf.written().len) return error.FrameTooLarge;
+        return available - buf.written().len;
+    }
+
+    fn sendTransfer(self: *Sender, xfer: perf.Transfer, chunk: []const u8) LinkError!void {
+        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
+        defer buf.deinit();
+        try perf.encodeTransfer(self.allocator, xfer, &buf);
+        try buf.writeAll(chunk);
+        try self.session.driver.sendFrame(.amqp, self.session.channel, buf.written());
+    }
+
+    fn awaitCredit(self: *Sender, deadline_ms: i64) LinkError!void {
+        while (self.credit == 0) {
+            if (!self.attached) return error.LinkDetached;
+            _ = try self.session.pump(deadline_ms);
+        }
+    }
+};
+
+/// Attach a sender and wait for the peer's attach.
+pub fn openSender(
+    session: *Session,
+    options: SenderOptions,
+    deadline_ms: i64,
+) LinkError!*Sender {
+    const sender = try session.allocator.create(Sender);
+    errdefer session.allocator.destroy(sender);
+
+    const name = try session.allocator.dupe(u8, options.name);
+    errdefer session.allocator.free(name);
+
+    sender.* = .{
+        .allocator = session.allocator,
+        .session = session,
+        .name = name,
+        .handle = session.allocateHandle(),
+    };
+
+    try session.senders.append(session.allocator, sender);
+    errdefer _ = session.senders.pop();
+
+    try session.driver.sendPerformative(.amqp, session.channel, .{ .attach = .{
+        .name = name,
+        .handle = sender.handle,
+        .role = .sender,
+        .snd_settle_mode = options.snd_settle_mode,
+        .rcv_settle_mode = options.rcv_settle_mode,
+        .source = .{ .address = options.source_address },
+        .target = .{ .address = options.target_address },
+        .initial_delivery_count = 0,
+        .desired_capabilities = options.desired_capabilities,
+        .properties = options.properties,
+    } });
+
+    while (!sender.attached) {
+        if (sender.detach_error != null) return error.LinkDetached;
+        _ = try session.pump(deadline_ms);
+    }
+    return sender;
+}
+
+// ─────────────────────── Receiver ───────────────────────
+
+pub const ReceiverOptions = struct {
+    name: []const u8,
+    /// The entity to read from, such as
+    /// `eh/ConsumerGroups/$default/Partitions/0`.
+    source_address: []const u8,
+    target_address: ?[]const u8 = null,
+    rcv_settle_mode: perf.ReceiverSettleMode = .first,
+    /// Source filters; Event Hubs carries the starting position in a selector.
+    filters: ?[]const perf.Filter = null,
+    desired_capabilities: ?[]const []const u8 = null,
+    properties: ?perf.Fields = null,
+    /// Credit issued on attach and topped back up as deliveries arrive. Zero
+    /// disables prefetch, leaving credit to `issueCredit`.
+    prefetch: u32 = 300,
+};
+
+/// One received message, valid until the next `receive`.
+pub const Delivery = struct {
+    id: u32,
+    tag: []const u8,
+    payload: []const u8,
+    settled: bool,
+};
+
+pub const Receiver = struct {
+    allocator: Allocator,
+    session: *Session,
+    name: []const u8,
+    handle: u32,
+    remote_handle: u32 = std.math.maxInt(u32),
+    attached: bool = false,
+
+    credit: u32 = 0,
+    prefetch: u32 = 0,
+    drain: bool = false,
+    delivery_count: u32 = 0,
+    max_message_size: ?u64 = null,
+    detach_error: ?connection.RemoteError = null,
+
+    /// Bytes of the delivery currently being assembled.
+    partial: std.ArrayList(u8) = .empty,
+    partial_id: ?u32 = null,
+    partial_tag: std.ArrayList(u8) = .empty,
+    partial_settled: bool = false,
+    /// Completed deliveries not yet handed to the caller.
+    ready: std.ArrayList(Delivery) = .empty,
+    /// Backing storage for the delivery most recently returned.
+    current: std.ArrayList(u8) = .empty,
+    current_tag: std.ArrayList(u8) = .empty,
+
+    pub fn deinit(self: *Receiver) void {
+        self.allocator.free(self.name);
+        if (self.detach_error) |e| e.deinit(self.allocator);
+        self.partial.deinit(self.allocator);
+        self.partial_tag.deinit(self.allocator);
+        for (self.ready.items) |d| {
+            self.allocator.free(d.payload);
+            self.allocator.free(d.tag);
+        }
+        self.ready.deinit(self.allocator);
+        self.current.deinit(self.allocator);
+        self.current_tag.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
+
+    fn recordDetach(self: *Receiver, err: ?perf.AmqpError) LinkError!void {
+        if (self.detach_error) |e| e.deinit(self.allocator);
+        self.detach_error = null;
+        const e = err orelse return;
+        self.detach_error = try connection.RemoteError.dupe(self.allocator, e);
+    }
+
+    fn acceptTransfer(self: *Receiver, t: perf.Transfer, chunk: []const u8) LinkError!void {
+        if (t.delivery_id) |id| {
+            // A new delivery starts here.
+            self.partial.clearRetainingCapacity();
+            self.partial_tag.clearRetainingCapacity();
+            self.partial_id = id;
+            self.partial_settled = t.settled orelse false;
+            if (t.delivery_tag) |tag| try self.partial_tag.appendSlice(self.allocator, tag);
+        }
+        if (self.partial_id == null) return error.MalformedFrame;
+
+        if (self.maxMessageSize()) |limit| {
+            if (self.partial.items.len + chunk.len > limit) return error.MessageTooLarge;
+        }
+        try self.partial.appendSlice(self.allocator, chunk);
+
+        if (t.more) return;
+
+        // The delivery is complete.
+        const payload = try self.allocator.dupe(u8, self.partial.items);
+        errdefer self.allocator.free(payload);
+        const tag = try self.allocator.dupe(u8, self.partial_tag.items);
+        errdefer self.allocator.free(tag);
+
+        try self.ready.append(self.allocator, .{
+            .id = self.partial_id.?,
+            .tag = tag,
+            .payload = payload,
+            .settled = self.partial_settled,
+        });
+        self.partial.clearRetainingCapacity();
+        self.partial_tag.clearRetainingCapacity();
+        self.partial_id = null;
+
+        self.delivery_count +%= 1;
+        self.credit -|= 1;
+    }
+
+    /// The largest message the peer will send, or null when unlimited.
+    pub fn maxMessageSize(self: *const Receiver) ?u64 {
+        const size = self.max_message_size orelse return null;
+        return if (size == 0) null else size;
+    }
+
+    /// Grant `count` more credit to the peer.
+    pub fn issueCredit(self: *Receiver, count: u32) LinkError!void {
+        self.credit += count;
+        try self.session.sendFlow(self);
+    }
+
+    /// Top prefetch credit back up once half of it has been consumed, so a
+    /// prefetching receiver never stalls waiting for the caller.
+    fn replenish(self: *Receiver) LinkError!void {
+        if (self.prefetch == 0) return;
+        if (self.credit > self.prefetch / 2) return;
+        self.credit = self.prefetch;
+        try self.session.sendFlow(self);
+    }
+
+    /// Wait for the next complete delivery.
+    ///
+    /// The returned slices stay valid until the next `receive`.
+    pub fn receive(self: *Receiver, deadline_ms: i64) LinkError!Delivery {
+        while (self.ready.items.len == 0) {
+            if (!self.attached) return error.LinkDetached;
+            try self.replenish();
+            _ = try self.session.pump(deadline_ms);
+        }
+
+        const delivery = self.ready.orderedRemove(0);
+        defer {
+            self.allocator.free(delivery.payload);
+            self.allocator.free(delivery.tag);
+        }
+
+        self.current.clearRetainingCapacity();
+        try self.current.appendSlice(self.allocator, delivery.payload);
+        self.current_tag.clearRetainingCapacity();
+        try self.current_tag.appendSlice(self.allocator, delivery.tag);
+
+        try self.replenish();
+        return .{
+            .id = delivery.id,
+            .tag = self.current_tag.items,
+            .payload = self.current.items,
+            .settled = delivery.settled,
+        };
+    }
+
+    /// Settle a delivery with a terminal state.
+    pub fn settle(
+        self: *Receiver,
+        delivery: Delivery,
+        state: perf.DeliveryState,
+    ) LinkError!void {
+        try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .disposition = .{
+                .role = .receiver,
+                .first = delivery.id,
+                .last = delivery.id,
+                .settled = true,
+                .state = state,
+            },
+        });
+    }
+
+    pub fn accept(self: *Receiver, delivery: Delivery) LinkError!void {
+        try self.settle(delivery, .accepted);
+    }
+
+    pub fn release(self: *Receiver, delivery: Delivery) LinkError!void {
+        try self.settle(delivery, .released);
+    }
+
+    /// Drain outstanding credit so the peer reports what it has left.
+    pub fn drainCredit(self: *Receiver, deadline_ms: i64) LinkError!void {
+        self.drain = true;
+        try self.session.sendFlow(self);
+        // The sender answers a drain by advancing its delivery count over the
+        // outstanding credit (§2.6.7), so wait until that lands rather than
+        // leaving the link in a half-drained state.
+        while (self.credit > 0 and self.attached) {
+            _ = self.session.pump(deadline_ms) catch |e| switch (e) {
+                error.RemoteClosed, error.ConnectionClosed => break,
+                else => return e,
+            };
+        }
+        self.drain = false;
+    }
+
+    /// Detach the link, waiting for the peer's detach.
+    pub fn detach(self: *Receiver, deadline_ms: i64) LinkError!void {
+        try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{ .handle = self.handle, .closed = true },
+        });
+        while (self.attached) {
+            _ = self.session.pump(deadline_ms) catch |e| switch (e) {
+                error.RemoteClosed, error.ConnectionClosed => return,
+                else => return e,
+            };
+        }
+    }
+};
+
+/// Attach a receiver and wait for the peer's attach.
+pub fn openReceiver(
+    session: *Session,
+    options: ReceiverOptions,
+    deadline_ms: i64,
+) LinkError!*Receiver {
+    const receiver = try session.allocator.create(Receiver);
+    errdefer session.allocator.destroy(receiver);
+
+    const name = try session.allocator.dupe(u8, options.name);
+    errdefer session.allocator.free(name);
+
+    receiver.* = .{
+        .allocator = session.allocator,
+        .session = session,
+        .name = name,
+        .handle = session.allocateHandle(),
+        .prefetch = options.prefetch,
+    };
+
+    try session.receivers.append(session.allocator, receiver);
+    errdefer _ = session.receivers.pop();
+
+    try session.driver.sendPerformative(.amqp, session.channel, .{ .attach = .{
+        .name = name,
+        .handle = receiver.handle,
+        .role = .receiver,
+        .rcv_settle_mode = options.rcv_settle_mode,
+        .source = .{
+            .address = options.source_address,
+            .filters = options.filters,
+        },
+        .target = .{ .address = options.target_address },
+        .initial_delivery_count = 0,
+        .desired_capabilities = options.desired_capabilities,
+        .properties = options.properties,
+    } });
+
+    while (!receiver.attached) {
+        if (receiver.detach_error != null) return error.LinkDetached;
+        _ = try session.pump(deadline_ms);
+    }
+
+    if (options.prefetch > 0) try receiver.issueCredit(options.prefetch);
+    return receiver;
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const MemoryTransport = @import("transport.zig").MemoryTransport;
+const FrameHeader = uamqp.frame.FrameHeader;
+
+/// Scripts peer bytes and reads back what the driver emitted.
+const Peer = struct {
+    allocator: Allocator,
+    mem: *MemoryTransport,
+
+    fn pushHeader(self: Peer, header: *const [8]u8) !void {
+        try self.mem.pushPeerBytes(header);
+    }
+
+    fn push(self: Peer, channel: u16, p: perf.Performative) !void {
+        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
+        defer buf.deinit();
+        try perf.encode(self.allocator, p, &buf);
+        try self.pushRaw(channel, buf.written());
+    }
+
+    /// Push a transfer performative followed by a payload chunk.
+    fn pushTransfer(self: Peer, channel: u16, t: perf.Transfer, chunk: []const u8) !void {
+        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
+        defer buf.deinit();
+        try perf.encodeTransfer(self.allocator, t, &buf);
+        try buf.writeAll(chunk);
+        try self.pushRaw(channel, buf.written());
+    }
+
+    fn pushRaw(self: Peer, channel: u16, body: []const u8) !void {
+        const header = FrameHeader{
+            .size = @intCast(frame.frame_header_size + body.len),
+            .doff = 2,
+            .frame_type = .amqp,
+            .channel = channel,
+        };
+        const bytes = header.serialize();
+        try self.mem.pushPeerBytes(&bytes);
+        try self.mem.pushPeerBytes(body);
+    }
+};
+
+/// Every frame body the driver wrote, in order.
+const EmittedFrames = struct {
+    bodies: std.ArrayList([]const u8),
+    allocator: Allocator,
+
+    fn parse(allocator: Allocator, written: []const u8) !EmittedFrames {
+        var bodies: std.ArrayList([]const u8) = .empty;
+        errdefer bodies.deinit(allocator);
+        // A protocol header only leads the buffer before it is cleared.
+        var offset: usize = if (std.mem.startsWith(u8, written, "AMQP")) 8 else 0;
+        while (offset + frame.frame_header_size <= written.len) {
+            const header = try FrameHeader.parse(written[offset..][0..8]);
+            const body_len = header.size - @as(u32, header.doff) * 4;
+            const start = offset + @as(usize, header.doff) * 4;
+            try bodies.append(allocator, written[start..][0..body_len]);
+            offset += header.size;
+        }
+        return .{ .bodies = bodies, .allocator = allocator };
+    }
+
+    fn deinit(self: *EmittedFrames) void {
+        self.bodies.deinit(self.allocator);
+    }
+
+    /// Bodies whose descriptor matches `code`.
+    fn of(self: EmittedFrames, allocator: Allocator, code: u64) ![]const []const u8 {
+        var out: std.ArrayList([]const u8) = .empty;
+        for (self.bodies.items) |b| {
+            if (perf.peekDescriptor(b) == code) try out.append(allocator, b);
+        }
+        return out.toOwnedSlice(allocator);
+    }
+};
+
+const test_options = connection.Options{
+    .container_id = "test-container",
+    .hostname = "ns.servicebus.windows.net",
+    .sasl = .none,
+    .max_frame_size = 512,
+    .idle_timeout_ms = 0,
+};
+
+/// A driver opened against a scripted peer, plus a begun session.
+const Fixture = struct {
+    allocator: Allocator,
+    mem: *MemoryTransport,
+    clock: *connection.ManualClock,
+    driver: *Driver,
+    session: Session,
+
+    fn init(allocator: Allocator, mem: *MemoryTransport, clock: *connection.ManualClock, driver: *Driver) !Fixture {
+        try driver.open(10_000);
+        const session = try Session.begin(allocator, driver, 0, .{
+            .incoming_window = 100,
+            .outgoing_window = 100,
+        }, 10_000);
+        return .{
+            .allocator = allocator,
+            .mem = mem,
+            .clock = clock,
+            .driver = driver,
+            .session = session,
+        };
+    }
+
+    fn deinit(self: *Fixture) void {
+        self.session.deinit();
+    }
+};
+
+/// Script the peer's side of open + begin.
+fn scriptHandshake(peer: Peer, max_frame_size: u32) !void {
+    try peer.pushHeader(&frame.amqp_header);
+    try peer.push(0, .{ .open = .{
+        .container_id = "service-bus",
+        .max_frame_size = max_frame_size,
+        .channel_max = 255,
+    } });
+    try peer.push(0, .{ .begin = .{
+        .remote_channel = 0,
+        .next_outgoing_id = 1,
+        .incoming_window = 1000,
+        .outgoing_window = 1000,
+    } });
+}
+
+test "a sender attaches and reports the peer's max-message-size" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .max_message_size = 1048576,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+        .desired_capabilities = &.{connection.georeplication_capability},
+    }, 10_000);
+
+    try testing.expect(sender.attached);
+    try testing.expectEqual(@as(u64, 1048576), sender.maxMessageSize().?);
+
+    // The attach carried the target address and the geo-replication capability.
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const attaches = try frames.of(allocator, perf.descriptor.attach);
+    defer allocator.free(attaches);
+    try testing.expectEqual(@as(usize, 1), attaches.len);
+
+    var decoded = try perf.decode(allocator, attaches[0]);
+    defer decoded.deinit();
+    const a = decoded.performative.attach;
+    try testing.expectEqualStrings("producer", a.name);
+    try testing.expectEqual(perf.Role.sender, a.role);
+    try testing.expectEqualStrings("eh", a.target.?.address.?);
+    try testing.expectEqual(perf.SenderSettleMode.mixed, a.snd_settle_mode);
+    try testing.expectEqual(perf.ReceiverSettleMode.first, a.rcv_settle_mode);
+    try testing.expectEqualStrings(
+        connection.georeplication_capability,
+        a.desired_capabilities.?[0],
+    );
+}
+
+test "a message past max-frame-size is split and reassembles to the original" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    // 512 is the spec minimum, so the payload must span several frames.
+    try scriptHandshake(peer, 512);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 10,
+    } });
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    const big = try allocator.alloc(u8, 1500);
+    defer allocator.free(big);
+    for (big, 0..) |*b, i| b.* = @intCast(i % 251);
+
+    mem.clearWritten();
+    try sender.sendBytes(big, 10_000);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+
+    // Reassemble exactly as a peer would: concatenate the payload that follows
+    // each transfer performative, stopping at the frame without `more`.
+    var reassembled: std.ArrayList(u8) = .empty;
+    defer reassembled.deinit(allocator);
+
+    var count: usize = 0;
+    var saw_final = false;
+    var first_delivery_id: ?u32 = null;
+    var first_tag: ?[]const u8 = null;
+
+    for (frames.bodies.items) |body| {
+        if (perf.peekDescriptor(body) != perf.descriptor.transfer) continue;
+        count += 1;
+        var decoded = try perf.decode(allocator, body);
+        defer decoded.deinit();
+        const t = decoded.performative.transfer;
+
+        if (count == 1) {
+            first_delivery_id = t.delivery_id;
+            first_tag = t.delivery_tag;
+            try testing.expectEqual(@as(u32, 0), t.message_format.?);
+        } else {
+            // Continuation frames must not repeat the delivery id or tag.
+            try testing.expectEqual(@as(?u32, null), t.delivery_id);
+            try testing.expectEqual(@as(?[]const u8, null), t.delivery_tag);
+        }
+
+        const consumed = performativeLength(allocator, body).?;
+        try reassembled.appendSlice(allocator, body[consumed..]);
+        if (!t.more) saw_final = true;
+    }
+
+    try testing.expect(count > 1);
+    try testing.expect(saw_final);
+    try testing.expectEqualSlices(u8, big, reassembled.items);
+    try testing.expectEqual(@as(u32, 0), first_delivery_id.?);
+    // The tag is the delivery id in network order.
+    try testing.expectEqualSlices(u8, &.{ 0, 0, 0, 0 }, first_tag.?);
+
+    // Every frame stayed inside the peer's advertised limit.
+    for (frames.bodies.items) |body| {
+        try testing.expect(body.len + frame.frame_header_size <= 512);
+    }
+}
+
+test "a rejected disposition surfaces the AMQP condition" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 5,
+    } });
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .{ .rejected = .{
+            .condition = "amqp:link:message-size-exceeded",
+            .description = "The received message is larger than the maximum allowed size.",
+        } },
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    try testing.expectError(error.SendRejected, sender.sendBytes("payload", 10_000));
+    try testing.expectEqualStrings(
+        "amqp:link:message-size-exceeded",
+        sender.rejection.?.condition,
+    );
+    try testing.expectEqualStrings(
+        "The received message is larger than the maximum allowed size.",
+        sender.rejection.?.description.?,
+    );
+}
+
+test "a message past the peer's max-message-size is refused before sending" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .max_message_size = 16,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    mem.clearWritten();
+    try testing.expectError(
+        error.MessageTooLarge,
+        sender.sendBytes("this payload is well past sixteen bytes", 10_000),
+    );
+    // Nothing went on the wire.
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+}
+
+test "a receiver applies the epoch and receiver-name link properties" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const props = [_]uamqp.MapEntry{
+        .{ .key = .{ .symbol = receiver_name_property }, .value = .{ .string = "instance-7" } },
+        .{ .key = .{ .symbol = epoch_property }, .value = .{ .long = 5 } },
+    };
+    const filters = [_]perf.Filter{
+        perf.Filter.selector("amqp.annotation.x-opt-offset > '100'"),
+    };
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        .target_address = "instance-7",
+        .filters = &filters,
+        .properties = &props,
+        .desired_capabilities = &.{connection.georeplication_capability},
+        .prefetch = 0,
+    }, 10_000);
+    try testing.expect(receiver.attached);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const attaches = try frames.of(allocator, perf.descriptor.attach);
+    defer allocator.free(attaches);
+    try testing.expectEqual(@as(usize, 1), attaches.len);
+
+    var decoded = try perf.decode(allocator, attaches[0]);
+    defer decoded.deinit();
+    const a = decoded.performative.attach;
+    try testing.expectEqual(perf.Role.receiver, a.role);
+    try testing.expectEqualStrings(
+        "eh/ConsumerGroups/$default/Partitions/0",
+        a.source.?.address.?,
+    );
+    try testing.expectEqualStrings("instance-7", a.target.?.address.?);
+
+    try testing.expectEqualStrings(receiver_name_property, a.properties.?[0].key.symbol);
+    try testing.expectEqualStrings("instance-7", a.properties.?[0].value.string);
+    try testing.expectEqualStrings(epoch_property, a.properties.?[1].key.symbol);
+    try testing.expectEqual(@as(i64, 5), a.properties.?[1].value.long);
+
+    const f = a.source.?.filters.?[0];
+    try testing.expectEqualStrings(perf.selector_filter_name, f.name);
+    try testing.expectEqual(perf.selector_filter_code, f.code.?);
+    try testing.expectEqualStrings("amqp.annotation.x-opt-offset > '100'", f.value.string);
+}
+
+test "a receiver reassembles a multi-frame delivery" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 4,
+        .delivery_tag = "\x00\x00\x00\x04",
+        .message_format = 0,
+        .settled = false,
+        .more = true,
+    }, "part-one|");
+    try peer.pushTransfer(0, .{ .handle = 0, .more = true }, "part-two|");
+    try peer.pushTransfer(0, .{ .handle = 0, .more = false }, "part-three");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        .prefetch = 0,
+    }, 10_000);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 4), delivery.id);
+    try testing.expectEqualSlices(u8, "\x00\x00\x00\x04", delivery.tag);
+    try testing.expectEqualStrings("part-one|part-two|part-three", delivery.payload);
+
+    mem.clearWritten();
+    try receiver.accept(delivery);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    try testing.expectEqual(@as(usize, 1), frames.bodies.items.len);
+    var decoded = try perf.decode(allocator, frames.bodies.items[0]);
+    defer decoded.deinit();
+    const d = decoded.performative.disposition;
+    try testing.expectEqual(perf.Role.receiver, d.role);
+    try testing.expectEqual(@as(u32, 4), d.first);
+    try testing.expect(d.settled);
+    try testing.expectEqual(perf.DeliveryState.accepted, d.state.?);
+}
+
+test "a prefetching receiver replenishes credit rather than stalling" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    const prefetch: u32 = 4;
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    // More deliveries than the prefetch window, so credit must be topped up.
+    var i: u32 = 0;
+    while (i < 12) : (i += 1) {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = i,
+            .delivery_tag = "t",
+            .message_format = 0,
+            .settled = true,
+            .more = false,
+        }, "event");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        .prefetch = prefetch,
+    }, 10_000);
+
+    mem.clearWritten();
+    i = 0;
+    while (i < 12) : (i += 1) {
+        const delivery = try receiver.receive(10_000);
+        try testing.expectEqualStrings("event", delivery.payload);
+        try testing.expectEqual(i, delivery.id);
+    }
+
+    // Credit was re-issued as flows; without them the peer would have stalled.
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expect(flows.len > 1);
+
+    for (flows) |body| {
+        var decoded = try perf.decode(allocator, body);
+        defer decoded.deinit();
+        const f = decoded.performative.flow;
+        try testing.expectEqual(receiver.handle, f.handle.?);
+        try testing.expectEqual(prefetch, f.link_credit.?);
+    }
+    try testing.expect(receiver.credit > 0);
+}
+
+test "the attach flow issues the requested prefetch credit" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh",
+        .prefetch = 250,
+    }, 10_000);
+    try testing.expectEqual(@as(u32, 250), receiver.credit);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u32, 250), decoded.performative.flow.link_credit.?);
+}
+
+test "a detach surfaces the condition that stole the link" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{
+            .condition = "amqp:link:stolen",
+            .description = "New receiver with higher epoch of '1' is created.",
+        },
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh",
+        .prefetch = 0,
+    }, 10_000);
+
+    try testing.expectError(error.LinkDetached, receiver.receive(10_000));
+    try testing.expect(!receiver.attached);
+    try testing.expectEqualStrings("amqp:link:stolen", receiver.detach_error.?.condition);
+}
+
+test "credit from the peer is rebased onto our delivery count" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    // The peer grants 10 from a delivery count of 0. By the time we apply it we
+    // have already sent 3, so only 7 remain usable.
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 10,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    sender.delivery_count = 3;
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 7), sender.credit);
+}
+
+test "a message round-trips from the sender's encoding to the receiver's payload" {
+    const allocator = testing.allocator;
+    const app_props = [_]uamqp.MapEntry{
+        .{ .key = .{ .string = "operation" }, .value = .{ .string = "put-token" } },
+    };
+    const msg = message.Message{
+        .properties = .{ .to = "$cbs", .message_id = .{ .string = "req-1" } },
+        .application_properties = &app_props,
+        .body = .{ .value = .{ .string = "token" } },
+    };
+
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "cbs-sender",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 1,
+    } });
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "cbs-sender",
+        .target_address = "$cbs",
+    }, 10_000);
+
+    mem.clearWritten();
+    try sender.send(msg, 10_000);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    try testing.expectEqual(@as(usize, 1), frames.bodies.items.len);
+
+    const body = frames.bodies.items[0];
+    const consumed = performativeLength(allocator, body).?;
+    var decoded = try message.decode(allocator, body[consumed..]);
+    defer decoded.deinit();
+
+    try testing.expectEqualStrings("$cbs", decoded.message.properties.to.?);
+    try testing.expectEqualStrings("req-1", decoded.message.properties.message_id.?.string);
+    try testing.expectEqualStrings("put-token", decoded.message.application_properties.?[0].value.string);
+    try testing.expectEqualStrings("token", decoded.message.body.value.string);
+}
+
+test "a session routes transfers by the peer's handle, not our own" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    // Two receivers on one session, as a client holding both a CBS link and an
+    // events link has. The peer numbers its handles independently of ours, so
+    // here they cross over: our handle 0 is the peer's 7, and our 1 is its 0.
+    try peer.push(0, .{ .attach = .{
+        .name = "cbs-receiver",
+        .handle = 7,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "events-receiver",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    // Addressed to the peer's handle 0, which is the events link. A lookup that
+    // also matched our own handles would hand this to the CBS receiver, whose
+    // local handle happens to be 0.
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "e",
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, "event-body");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const cbs = try openReceiver(&fixture.session, .{
+        .name = "cbs-receiver",
+        .source_address = "$cbs",
+        .prefetch = 0,
+    }, 10_000);
+    const events = try openReceiver(&fixture.session, .{
+        .name = "events-receiver",
+        .source_address = "partition/0",
+        .prefetch = 0,
+    }, 10_000);
+
+    try testing.expectEqual(@as(u32, 0), cbs.handle);
+    try testing.expectEqual(@as(u32, 7), cbs.remote_handle);
+    try testing.expectEqual(@as(u32, 1), events.handle);
+    try testing.expectEqual(@as(u32, 0), events.remote_handle);
+
+    const delivery = try events.receive(10_000);
+    try testing.expectEqualStrings("event-body", delivery.payload);
+    try testing.expectEqual(@as(usize, 0), cbs.ready.items.len);
+    try testing.expectEqual(@as(usize, 0), cbs.partial.items.len);
+}
+
+test "draining a receiver waits for the sender to consume the outstanding credit" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "drainable",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    // One message, then a drain response advancing the delivery count over the
+    // four credits left unused.
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "d",
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, "last");
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 5,
+        .link_credit = 0,
+        .drain = true,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "drainable",
+        .source_address = "partition/0",
+        .prefetch = 5,
+    }, 10_000);
+    try testing.expectEqual(@as(u32, 5), receiver.credit);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("last", delivery.payload);
+
+    try receiver.drainCredit(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expect(!receiver.drain);
+}

--- a/message.zig
+++ b/message.zig
@@ -1,0 +1,560 @@
+//! AMQP 1.0 message encoding and decoding (§3.2).
+//!
+//! `uamqp.message.Message` models a message but ships no codec, so a message
+//! cannot be put on the wire. This module encodes the bare message sections in
+//! the order the specification requires and decodes them back.
+//!
+//! Section slices borrow from the `Decoded` that produced them and become
+//! invalid once it is released.
+
+const std = @import("std");
+const uamqp = @import("uamqp");
+const perf = @import("performative.zig");
+
+const Allocator = std.mem.Allocator;
+const AmqpValue = uamqp.AmqpValue;
+const MapEntry = uamqp.MapEntry;
+const encoder = uamqp.encoder;
+const decoder = uamqp.decoder;
+const descriptor = uamqp.definitions.descriptor;
+
+pub const Fields = perf.Fields;
+
+pub const EncodeError = error{OutOfMemory};
+
+pub const DecodeError = error{
+    OutOfMemory,
+    MalformedBody,
+    /// A section appeared that is not a legal message section.
+    UnexpectedSection,
+};
+
+/// header (§3.2.1).
+pub const Header = struct {
+    durable: bool = false,
+    priority: ?u8 = null,
+    ttl: ?u32 = null,
+    first_acquirer: bool = false,
+    delivery_count: ?u32 = null,
+
+    fn isEmpty(self: Header) bool {
+        return !self.durable and self.priority == null and self.ttl == null and
+            !self.first_acquirer and self.delivery_count == null;
+    }
+};
+
+/// properties (§3.2.4).
+pub const Properties = struct {
+    message_id: ?AmqpValue = null,
+    user_id: ?[]const u8 = null,
+    to: ?[]const u8 = null,
+    subject: ?[]const u8 = null,
+    reply_to: ?[]const u8 = null,
+    correlation_id: ?AmqpValue = null,
+    content_type: ?[]const u8 = null,
+    content_encoding: ?[]const u8 = null,
+    absolute_expiry_time: ?i64 = null,
+    creation_time: ?i64 = null,
+    group_id: ?[]const u8 = null,
+    group_sequence: ?u32 = null,
+    reply_to_group_id: ?[]const u8 = null,
+
+    fn isEmpty(self: Properties) bool {
+        inline for (@typeInfo(Properties).@"struct".fields) |f| {
+            if (@field(self, f.name) != null) return false;
+        }
+        return true;
+    }
+};
+
+/// The message body (§3.2.5-3.2.7).
+///
+/// `data` holds one or more binary sections; Event Hubs uses a single one for
+/// an event, and a sequence of them for a batch envelope.
+pub const Body = union(enum) {
+    empty,
+    data: []const []const u8,
+    sequence: []const []const AmqpValue,
+    value: AmqpValue,
+};
+
+/// A bare AMQP message plus its annotations.
+pub const Message = struct {
+    header: Header = .{},
+    delivery_annotations: ?Fields = null,
+    message_annotations: ?Fields = null,
+    properties: Properties = .{},
+    application_properties: ?Fields = null,
+    body: Body = .empty,
+    footer: ?Fields = null,
+};
+
+// ─────────────────────── Encoding ───────────────────────
+
+fn writeDescriptor(code: u64, buf: *encoder.Buffer) EncodeError!void {
+    try buf.writeByte(0x00);
+    try encoder.encode(.{ .ulong = code }, buf);
+}
+
+/// Write a described list, dropping trailing null fields.
+fn writeList(
+    allocator: Allocator,
+    code: u64,
+    values: []const ?AmqpValue,
+    buf: *encoder.Buffer,
+) EncodeError!void {
+    var count = values.len;
+    while (count > 0 and values[count - 1] == null) count -= 1;
+
+    try writeDescriptor(code, buf);
+    if (count == 0) return buf.writeByte(0x45);
+
+    var body = encoder.Buffer.initDynamic(allocator);
+    defer body.deinit();
+    for (values[0..count]) |v| {
+        if (v) |value| try encoder.encode(value, &body) else try body.writeByte(0x40);
+    }
+
+    const bytes = body.written();
+    if (bytes.len + 1 <= 0xff and count <= 0xff) {
+        try buf.writeByte(0xc0);
+        try buf.writeByte(@intCast(bytes.len + 1));
+        try buf.writeByte(@intCast(count));
+    } else {
+        try buf.writeByte(0xd0);
+        var size: [4]u8 = undefined;
+        std.mem.writeInt(u32, &size, @intCast(bytes.len + 4), .big);
+        try buf.writeAll(&size);
+        std.mem.writeInt(u32, &size, @intCast(count), .big);
+        try buf.writeAll(&size);
+    }
+    try buf.writeAll(bytes);
+}
+
+fn writeMapSection(code: u64, map: Fields, buf: *encoder.Buffer) EncodeError!void {
+    try writeDescriptor(code, buf);
+    try encoder.encode(.{ .map = @constCast(map) }, buf);
+}
+
+fn optBool(v: bool) ?AmqpValue {
+    return if (v) .{ .boolean = true } else null;
+}
+
+fn optString(v: ?[]const u8) ?AmqpValue {
+    return if (v) |s| .{ .string = s } else null;
+}
+
+fn optBinary(v: ?[]const u8) ?AmqpValue {
+    return if (v) |s| .{ .binary = s } else null;
+}
+
+fn optSymbol(v: ?[]const u8) ?AmqpValue {
+    return if (v) |s| .{ .symbol = s } else null;
+}
+
+fn optUint(v: ?u32) ?AmqpValue {
+    return if (v) |n| .{ .uint = n } else null;
+}
+
+fn optUbyte(v: ?u8) ?AmqpValue {
+    return if (v) |n| .{ .ubyte = n } else null;
+}
+
+fn optTimestamp(v: ?i64) ?AmqpValue {
+    return if (v) |n| .{ .timestamp = n } else null;
+}
+
+/// Encode a message into `buf` in the section order §3.2 mandates.
+pub fn encode(allocator: Allocator, msg: Message, buf: *encoder.Buffer) EncodeError!void {
+    if (!msg.header.isEmpty()) {
+        const values = [_]?AmqpValue{
+            optBool(msg.header.durable),
+            optUbyte(msg.header.priority),
+            optUint(msg.header.ttl),
+            optBool(msg.header.first_acquirer),
+            optUint(msg.header.delivery_count),
+        };
+        try writeList(allocator, descriptor.header, &values, buf);
+    }
+
+    if (msg.delivery_annotations) |m| {
+        try writeMapSection(descriptor.delivery_annotations, m, buf);
+    }
+    if (msg.message_annotations) |m| {
+        try writeMapSection(descriptor.message_annotations, m, buf);
+    }
+
+    if (!msg.properties.isEmpty()) {
+        const p = msg.properties;
+        const values = [_]?AmqpValue{
+            p.message_id,
+            optBinary(p.user_id),
+            optString(p.to),
+            optString(p.subject),
+            optString(p.reply_to),
+            p.correlation_id,
+            optSymbol(p.content_type),
+            optSymbol(p.content_encoding),
+            optTimestamp(p.absolute_expiry_time),
+            optTimestamp(p.creation_time),
+            optString(p.group_id),
+            optUint(p.group_sequence),
+            optString(p.reply_to_group_id),
+        };
+        try writeList(allocator, descriptor.properties, &values, buf);
+    }
+
+    if (msg.application_properties) |m| {
+        try writeMapSection(descriptor.application_properties, m, buf);
+    }
+
+    switch (msg.body) {
+        .empty => {},
+        .data => |sections| for (sections) |section| {
+            try writeDescriptor(descriptor.data, buf);
+            try encoder.encode(.{ .binary = section }, buf);
+        },
+        .sequence => |sections| for (sections) |section| {
+            try writeDescriptor(descriptor.amqp_sequence, buf);
+            try encoder.encode(.{ .list = @constCast(section) }, buf);
+        },
+        .value => |v| {
+            try writeDescriptor(descriptor.amqp_value, buf);
+            try encoder.encode(v, buf);
+        },
+    }
+
+    if (msg.footer) |m| try writeMapSection(descriptor.footer, m, buf);
+}
+
+/// Encode a message into a freshly allocated buffer owned by the caller.
+pub fn encodeAlloc(allocator: Allocator, msg: Message) EncodeError![]u8 {
+    var buf = encoder.Buffer.initDynamic(allocator);
+    defer buf.deinit();
+    try encode(allocator, msg, &buf);
+    return allocator.dupe(u8, buf.written());
+}
+
+// ─────────────────────── Decoding ───────────────────────
+
+/// A decoded message together with the arena backing its slices.
+pub const Decoded = struct {
+    arena: *std.heap.ArenaAllocator,
+    message: Message,
+
+    pub fn deinit(self: *Decoded) void {
+        const child = self.arena.child_allocator;
+        self.arena.deinit();
+        child.destroy(self.arena);
+        self.* = undefined;
+    }
+};
+
+/// Decode a whole message payload, which is a concatenation of sections.
+pub fn decode(allocator: Allocator, payload: []const u8) DecodeError!Decoded {
+    const arena = try allocator.create(std.heap.ArenaAllocator);
+    errdefer allocator.destroy(arena);
+    arena.* = .init(allocator);
+    errdefer arena.deinit();
+
+    const a = arena.allocator();
+    var msg = Message{};
+
+    var data: std.ArrayList([]const u8) = .empty;
+    var sequences: std.ArrayList([]const AmqpValue) = .empty;
+
+    var offset: usize = 0;
+    while (offset < payload.len) {
+        const result = decoder.decode(a, payload[offset..]) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.MalformedBody,
+        };
+        if (result.bytes_consumed == 0) return error.MalformedBody;
+        offset += result.bytes_consumed;
+
+        if (result.value != .described) return error.UnexpectedSection;
+        const code = switch (result.value.described.descriptor.*) {
+            .ulong => |c| c,
+            else => return error.UnexpectedSection,
+        };
+        const inner = result.value.described.value.*;
+
+        switch (code) {
+            descriptor.header => msg.header = try headerFrom(inner),
+            descriptor.delivery_annotations => msg.delivery_annotations = try mapFrom(inner),
+            descriptor.message_annotations => msg.message_annotations = try mapFrom(inner),
+            descriptor.properties => msg.properties = try propertiesFrom(inner),
+            descriptor.application_properties => msg.application_properties = try mapFrom(inner),
+            descriptor.data => try data.append(a, switch (inner) {
+                .binary, .string => |b| b,
+                else => return error.MalformedBody,
+            }),
+            descriptor.amqp_sequence => try sequences.append(a, switch (inner) {
+                .list => |items| items,
+                else => return error.MalformedBody,
+            }),
+            descriptor.amqp_value => msg.body = .{ .value = inner },
+            descriptor.footer => msg.footer = try mapFrom(inner),
+            else => return error.UnexpectedSection,
+        }
+    }
+
+    if (data.items.len > 0) {
+        msg.body = .{ .data = data.items };
+    } else if (sequences.items.len > 0) {
+        msg.body = .{ .sequence = sequences.items };
+    }
+
+    return .{ .arena = arena, .message = msg };
+}
+
+fn listOf(value: AmqpValue) DecodeError![]const AmqpValue {
+    return switch (value) {
+        .list => |items| items,
+        .null => &.{},
+        else => error.MalformedBody,
+    };
+}
+
+fn mapFrom(value: AmqpValue) DecodeError!Fields {
+    return switch (value) {
+        .map => |m| m,
+        .null => &.{},
+        else => error.MalformedBody,
+    };
+}
+
+fn headerFrom(value: AmqpValue) DecodeError!Header {
+    const list = try listOf(value);
+    return .{
+        .durable = (try boolAt(list, 0)) orelse false,
+        .priority = try ubyteAt(list, 1),
+        .ttl = try uintAt(list, 2),
+        .first_acquirer = (try boolAt(list, 3)) orelse false,
+        .delivery_count = try uintAt(list, 4),
+    };
+}
+
+fn propertiesFrom(value: AmqpValue) DecodeError!Properties {
+    const list = try listOf(value);
+    return .{
+        .message_id = at(list, 0),
+        .user_id = try bytesAt(list, 1),
+        .to = try bytesAt(list, 2),
+        .subject = try bytesAt(list, 3),
+        .reply_to = try bytesAt(list, 4),
+        .correlation_id = at(list, 5),
+        .content_type = try bytesAt(list, 6),
+        .content_encoding = try bytesAt(list, 7),
+        .absolute_expiry_time = try timestampAt(list, 8),
+        .creation_time = try timestampAt(list, 9),
+        .group_id = try bytesAt(list, 10),
+        .group_sequence = try uintAt(list, 11),
+        .reply_to_group_id = try bytesAt(list, 12),
+    };
+}
+
+fn at(list: []const AmqpValue, index: usize) ?AmqpValue {
+    if (index >= list.len) return null;
+    if (list[index] == .null) return null;
+    return list[index];
+}
+
+fn bytesAt(list: []const AmqpValue, index: usize) DecodeError!?[]const u8 {
+    const v = at(list, index) orelse return null;
+    return switch (v) {
+        .string, .symbol, .binary => |s| s,
+        else => error.MalformedBody,
+    };
+}
+
+fn boolAt(list: []const AmqpValue, index: usize) DecodeError!?bool {
+    const v = at(list, index) orelse return null;
+    return switch (v) {
+        .boolean => |b| b,
+        else => error.MalformedBody,
+    };
+}
+
+fn uintAt(list: []const AmqpValue, index: usize) DecodeError!?u32 {
+    const v = at(list, index) orelse return null;
+    return switch (v) {
+        .uint => |n| n,
+        .ushort => |n| n,
+        .ubyte => |n| n,
+        else => error.MalformedBody,
+    };
+}
+
+fn ubyteAt(list: []const AmqpValue, index: usize) DecodeError!?u8 {
+    const v = at(list, index) orelse return null;
+    return switch (v) {
+        .ubyte => |n| n,
+        .ushort => |n| std.math.cast(u8, n) orelse error.MalformedBody,
+        .uint => |n| std.math.cast(u8, n) orelse error.MalformedBody,
+        else => error.MalformedBody,
+    };
+}
+
+fn timestampAt(list: []const AmqpValue, index: usize) DecodeError!?i64 {
+    const v = at(list, index) orelse return null;
+    return switch (v) {
+        .timestamp, .long => |n| n,
+        .int => |n| n,
+        else => error.MalformedBody,
+    };
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+
+test "a data message round-trips" {
+    const allocator = testing.allocator;
+    const app_props = [_]MapEntry{
+        .{ .key = .{ .string = "operation" }, .value = .{ .string = "put-token" } },
+    };
+    const msg = Message{
+        .properties = .{ .message_id = .{ .string = "id-1" }, .to = "$cbs" },
+        .application_properties = &app_props,
+        .body = .{ .data = &.{"hello"} },
+    };
+
+    const bytes = try encodeAlloc(allocator, msg);
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = decoded.message;
+    try testing.expectEqualStrings("id-1", got.properties.message_id.?.string);
+    try testing.expectEqualStrings("$cbs", got.properties.to.?);
+    try testing.expectEqualStrings("operation", got.application_properties.?[0].key.string);
+    try testing.expectEqualStrings("put-token", got.application_properties.?[0].value.string);
+    try testing.expectEqual(@as(usize, 1), got.body.data.len);
+    try testing.expectEqualStrings("hello", got.body.data[0]);
+}
+
+test "a value body round-trips" {
+    const allocator = testing.allocator;
+    const msg = Message{ .body = .{ .value = .{ .string = "SharedAccessSignature sr=..." } } };
+    const bytes = try encodeAlloc(allocator, msg);
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+    try testing.expectEqualStrings("SharedAccessSignature sr=...", decoded.message.body.value.string);
+}
+
+test "multiple data sections are kept in order" {
+    const allocator = testing.allocator;
+    const msg = Message{ .body = .{ .data = &.{ "one", "two", "three" } } };
+    const bytes = try encodeAlloc(allocator, msg);
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const sections = decoded.message.body.data;
+    try testing.expectEqual(@as(usize, 3), sections.len);
+    try testing.expectEqualStrings("one", sections[0]);
+    try testing.expectEqualStrings("two", sections[1]);
+    try testing.expectEqualStrings("three", sections[2]);
+}
+
+test "header and annotations round-trip" {
+    const allocator = testing.allocator;
+    const annotations = [_]MapEntry{
+        .{ .key = .{ .symbol = "x-opt-partition-key" }, .value = .{ .string = "pk" } },
+    };
+    const msg = Message{
+        .header = .{ .durable = true, .priority = 4, .ttl = 60000 },
+        .message_annotations = &annotations,
+        .body = .{ .data = &.{"x"} },
+    };
+    const bytes = try encodeAlloc(allocator, msg);
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = decoded.message;
+    try testing.expect(got.header.durable);
+    try testing.expectEqual(@as(u8, 4), got.header.priority.?);
+    try testing.expectEqual(@as(u32, 60000), got.header.ttl.?);
+    try testing.expectEqualStrings("pk", got.message_annotations.?[0].value.string);
+}
+
+test "an empty message encodes to nothing" {
+    const allocator = testing.allocator;
+    const bytes = try encodeAlloc(allocator, .{});
+    defer allocator.free(bytes);
+    try testing.expectEqual(@as(usize, 0), bytes.len);
+
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+    try testing.expectEqual(Body.empty, decoded.message.body);
+}
+
+test "sections are written in the order the spec requires" {
+    const allocator = testing.allocator;
+    const app_props = [_]MapEntry{
+        .{ .key = .{ .string = "k" }, .value = .{ .string = "v" } },
+    };
+    const annotations = [_]MapEntry{
+        .{ .key = .{ .symbol = "a" }, .value = .{ .string = "b" } },
+    };
+    const msg = Message{
+        .header = .{ .durable = true },
+        .message_annotations = &annotations,
+        .properties = .{ .to = "dest" },
+        .application_properties = &app_props,
+        .body = .{ .data = &.{"body"} },
+        .footer = &annotations,
+    };
+    const bytes = try encodeAlloc(allocator, msg);
+    defer allocator.free(bytes);
+
+    // Walk the sections and check the descriptor codes appear in order.
+    const expected = [_]u64{
+        descriptor.header,
+        descriptor.message_annotations,
+        descriptor.properties,
+        descriptor.application_properties,
+        descriptor.data,
+        descriptor.footer,
+    };
+    var arena: std.heap.ArenaAllocator = .init(allocator);
+    defer arena.deinit();
+
+    var offset: usize = 0;
+    var index: usize = 0;
+    while (offset < bytes.len) : (index += 1) {
+        const result = try decoder.decode(arena.allocator(), bytes[offset..]);
+        offset += result.bytes_consumed;
+        try testing.expectEqual(expected[index], result.value.described.descriptor.ulong);
+    }
+    try testing.expectEqual(expected.len, index);
+}
+
+test "a payload that is not a described section is rejected" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.UnexpectedSection, decode(allocator, &.{0x41}));
+}
+
+test "decoding survives allocation failure" {
+    const Case = struct {
+        fn run(allocator: Allocator) !void {
+            const app_props = [_]MapEntry{
+                .{ .key = .{ .string = "operation" }, .value = .{ .string = "put-token" } },
+            };
+            const msg = Message{
+                .properties = .{ .to = "$cbs" },
+                .application_properties = &app_props,
+                .body = .{ .data = &.{ "a", "b" } },
+            };
+            const bytes = try encodeAlloc(allocator, msg);
+            defer allocator.free(bytes);
+            var decoded = try decode(allocator, bytes);
+            defer decoded.deinit();
+            try testing.expectEqual(@as(usize, 2), decoded.message.body.data.len);
+        }
+    };
+    try testing.checkAllAllocationFailures(testing.allocator, Case.run, .{});
+}

--- a/performative.zig
+++ b/performative.zig
@@ -98,6 +98,165 @@ pub const SaslOutcome = struct {
     additional_data: ?[]const u8 = null,
 };
 
+// ─────────────────────── Link layer ───────────────────────
+
+/// Descriptor code for the standard selector filter.
+///
+/// `<descriptor name="apache.org:selector-filter:string" code="0x0000468C:0x00000004"/>`.
+/// Event Hubs uses it to carry the starting offset expression.
+pub const selector_filter_name = "apache.org:selector-filter:string";
+pub const selector_filter_code: u64 = 0x0000468C00000004;
+
+pub const Role = enum(u1) {
+    sender = 0,
+    receiver = 1,
+
+    pub fn isReceiver(self: Role) bool {
+        return self == .receiver;
+    }
+};
+
+/// sender-settle-mode (§3.8.7).
+pub const SenderSettleMode = enum(u8) {
+    unsettled = 0,
+    settled = 1,
+    mixed = 2,
+};
+
+/// receiver-settle-mode (§3.8.8).
+pub const ReceiverSettleMode = enum(u8) {
+    /// Settle on the first disposition. What Event Hubs expects.
+    first = 0,
+    second = 1,
+};
+
+/// One entry of a filter-set: a symbol key naming a described value.
+pub const Filter = struct {
+    name: []const u8,
+    /// Descriptor code; when null the `name` symbol is used as the descriptor.
+    code: ?u64 = null,
+    value: AmqpValue,
+
+    /// The selector filter Event Hubs reads the starting position from.
+    pub fn selector(expression: []const u8) Filter {
+        return .{
+            .name = selector_filter_name,
+            .code = selector_filter_code,
+            .value = .{ .string = expression },
+        };
+    }
+};
+
+/// Source (§3.5.3). Only the fields Event Hubs uses are modelled.
+pub const Source = struct {
+    address: ?[]const u8 = null,
+    durable: u32 = 0,
+    expiry_policy: ?[]const u8 = null,
+    timeout: ?u32 = null,
+    dynamic: bool = false,
+    distribution_mode: ?[]const u8 = null,
+    filters: ?[]const Filter = null,
+    capabilities: ?[]const []const u8 = null,
+};
+
+/// Target (§3.5.4).
+pub const Target = struct {
+    address: ?[]const u8 = null,
+    durable: u32 = 0,
+    expiry_policy: ?[]const u8 = null,
+    timeout: ?u32 = null,
+    dynamic: bool = false,
+    capabilities: ?[]const []const u8 = null,
+};
+
+/// A terminal delivery state (§3.4).
+pub const DeliveryState = union(enum) {
+    accepted,
+    released,
+    rejected: ?AmqpError,
+    modified: Modified,
+
+    pub const Modified = struct {
+        delivery_failed: bool = false,
+        undeliverable_here: bool = false,
+        message_annotations: ?Fields = null,
+    };
+
+    pub fn descriptorCode(self: DeliveryState) u64 {
+        return switch (self) {
+            .accepted => descriptor.accepted,
+            .released => descriptor.released,
+            .rejected => descriptor.rejected,
+            .modified => descriptor.modified,
+        };
+    }
+};
+
+/// Attach (§2.7.3).
+pub const Attach = struct {
+    name: []const u8,
+    handle: u32,
+    role: Role,
+    snd_settle_mode: SenderSettleMode = .mixed,
+    rcv_settle_mode: ReceiverSettleMode = .first,
+    source: ?Source = null,
+    target: ?Target = null,
+    incomplete_unsettled: bool = false,
+    initial_delivery_count: ?u32 = null,
+    max_message_size: ?u64 = null,
+    offered_capabilities: ?[]const []const u8 = null,
+    desired_capabilities: ?[]const []const u8 = null,
+    properties: ?Fields = null,
+};
+
+/// Flow (§2.7.4).
+pub const Flow = struct {
+    next_incoming_id: ?u32 = null,
+    incoming_window: u32,
+    next_outgoing_id: u32,
+    outgoing_window: u32,
+    handle: ?u32 = null,
+    delivery_count: ?u32 = null,
+    link_credit: ?u32 = null,
+    available: ?u32 = null,
+    drain: bool = false,
+    echo: bool = false,
+    properties: ?Fields = null,
+};
+
+/// Transfer (§2.7.5). The message payload follows the performative in the
+/// same frame and is not part of the described list.
+pub const Transfer = struct {
+    handle: u32,
+    delivery_id: ?u32 = null,
+    delivery_tag: ?[]const u8 = null,
+    message_format: ?u32 = null,
+    settled: ?bool = null,
+    more: bool = false,
+    rcv_settle_mode: ?ReceiverSettleMode = null,
+    state: ?DeliveryState = null,
+    resume_: bool = false,
+    aborted: bool = false,
+    batchable: bool = false,
+};
+
+/// Disposition (§2.7.6).
+pub const Disposition = struct {
+    role: Role,
+    first: u32,
+    last: ?u32 = null,
+    settled: bool = false,
+    state: ?DeliveryState = null,
+    batchable: bool = false,
+};
+
+/// Detach (§2.7.7).
+pub const Detach = struct {
+    handle: u32,
+    closed: bool = false,
+    err: ?AmqpError = null,
+};
+
 /// A performative the connection driver understands.
 ///
 /// Slices borrow from the `Decoded` that produced them and become invalid once
@@ -107,6 +266,11 @@ pub const Performative = union(enum) {
     begin: Begin,
     end: End,
     close: Close,
+    attach: Attach,
+    flow: Flow,
+    transfer: Transfer,
+    disposition: Disposition,
+    detach: Detach,
     sasl_mechanisms: SaslMechanisms,
     sasl_init: SaslInit,
     sasl_outcome: SaslOutcome,
@@ -117,6 +281,11 @@ pub const Performative = union(enum) {
             .begin => descriptor.begin,
             .end => descriptor.end,
             .close => descriptor.close,
+            .attach => descriptor.attach,
+            .flow => descriptor.flow,
+            .transfer => descriptor.transfer,
+            .disposition => descriptor.disposition,
+            .detach => descriptor.detach,
             .sasl_mechanisms => descriptor.sasl_mechanisms,
             .sasl_init => descriptor.sasl_init,
             .sasl_outcome => descriptor.sasl_outcome,
@@ -136,6 +305,11 @@ const Field = union(enum) {
     value: AmqpValue,
     symbols: []const []const u8,
     err: AmqpError,
+    source: Source,
+    target: Target,
+    delivery_state: DeliveryState,
+    /// A filter-set: a symbol-keyed map whose values are described.
+    filters: []const Filter,
 };
 
 fn optionalString(v: ?[]const u8) Field {
@@ -166,6 +340,37 @@ fn optionalError(v: ?AmqpError) Field {
     return if (v) |e| .{ .err = e } else .null;
 }
 
+fn optionalBool(v: ?bool) Field {
+    return if (v) |b| .{ .value = .{ .boolean = b } } else .null;
+}
+
+/// A boolean that is only written when it differs from the spec default.
+fn defaultedBool(v: bool, default: bool) Field {
+    return if (v == default) .null else .{ .value = .{ .boolean = v } };
+}
+
+fn optionalUlong(v: ?u64) Field {
+    return if (v) |n| .{ .value = .{ .ulong = n } } else .null;
+}
+
+fn optionalSource(v: ?Source) Field {
+    return if (v) |x| .{ .source = x } else .null;
+}
+
+fn optionalTarget(v: ?Target) Field {
+    return if (v) |x| .{ .target = x } else .null;
+}
+
+fn optionalDeliveryState(v: ?DeliveryState) Field {
+    return if (v) |x| .{ .delivery_state = x } else .null;
+}
+
+fn optionalFilters(v: ?[]const Filter) Field {
+    const list = v orelse return .null;
+    if (list.len == 0) return .null;
+    return .{ .filters = list };
+}
+
 fn optionalSymbols(v: ?[]const []const u8) Field {
     const list = v orelse return .null;
     if (list.len == 0) return .null;
@@ -184,6 +389,10 @@ fn encodeField(allocator: Allocator, field: Field, buf: *encoder.Buffer) EncodeE
         .value => |v| try encoder.encode(v, buf),
         .symbols => |s| try encodeSymbolMultiple(s, buf),
         .err => |e| try encodeError(allocator, e, buf),
+        .source => |v| try encodeSource(allocator, v, buf),
+        .target => |v| try encodeTarget(allocator, v, buf),
+        .delivery_state => |v| try encodeDeliveryState(allocator, v, buf),
+        .filters => |v| try encodeFilterSet(allocator, v, buf),
     }
 }
 
@@ -276,6 +485,91 @@ fn encodeError(allocator: Allocator, e: AmqpError, buf: *encoder.Buffer) EncodeE
     try encodeDescribedList(allocator, error_descriptor, &fields, buf);
 }
 
+pub fn encodeSource(allocator: Allocator, src: Source, buf: *encoder.Buffer) EncodeError!void {
+    const fields = [_]Field{
+        optionalString(src.address),
+        .{ .value = .{ .uint = src.durable } },
+        optionalSymbol(src.expiry_policy),
+        optionalUint(src.timeout),
+        defaultedBool(src.dynamic, false),
+        .null, // dynamic-node-properties
+        optionalSymbol(src.distribution_mode),
+        optionalFilters(src.filters),
+        .null, // default-outcome
+        .null, // outcomes
+        optionalSymbols(src.capabilities),
+    };
+    try encodeDescribedList(allocator, descriptor.source, &fields, buf);
+}
+
+pub fn encodeTarget(allocator: Allocator, tgt: Target, buf: *encoder.Buffer) EncodeError!void {
+    const fields = [_]Field{
+        optionalString(tgt.address),
+        .{ .value = .{ .uint = tgt.durable } },
+        optionalSymbol(tgt.expiry_policy),
+        optionalUint(tgt.timeout),
+        defaultedBool(tgt.dynamic, false),
+        .null, // dynamic-node-properties
+        optionalSymbols(tgt.capabilities),
+    };
+    try encodeDescribedList(allocator, descriptor.target, &fields, buf);
+}
+
+/// Encode a filter-set: a symbol-keyed map of described values (§3.5.8).
+fn encodeFilterSet(allocator: Allocator, filters: []const Filter, buf: *encoder.Buffer) EncodeError!void {
+    var body = encoder.Buffer.initDynamic(allocator);
+    defer body.deinit();
+
+    for (filters) |f| {
+        try encoder.encode(.{ .symbol = f.name }, &body);
+        try body.writeByte(0x00);
+        if (f.code) |code| {
+            try encoder.encode(.{ .ulong = code }, &body);
+        } else {
+            try encoder.encode(.{ .symbol = f.name }, &body);
+        }
+        try encoder.encode(f.value, &body);
+    }
+
+    const bytes = body.written();
+    const count = filters.len * 2;
+    if (bytes.len + 1 <= 0xff and count <= 0xff) {
+        try buf.writeByte(0xc1); // map8
+        try buf.writeByte(@intCast(bytes.len + 1));
+        try buf.writeByte(@intCast(count));
+    } else {
+        try buf.writeByte(0xd1); // map32
+        var size_bytes: [4]u8 = undefined;
+        std.mem.writeInt(u32, &size_bytes, @intCast(bytes.len + 4), .big);
+        try buf.writeAll(&size_bytes);
+        std.mem.writeInt(u32, &size_bytes, @intCast(count), .big);
+        try buf.writeAll(&size_bytes);
+    }
+    try buf.writeAll(bytes);
+}
+
+pub fn encodeDeliveryState(
+    allocator: Allocator,
+    state: DeliveryState,
+    buf: *encoder.Buffer,
+) EncodeError!void {
+    switch (state) {
+        .accepted, .released => try encodeDescribedList(allocator, state.descriptorCode(), &.{}, buf),
+        .rejected => |e| {
+            const fields = [_]Field{optionalError(e)};
+            try encodeDescribedList(allocator, descriptor.rejected, &fields, buf);
+        },
+        .modified => |m| {
+            const fields = [_]Field{
+                defaultedBool(m.delivery_failed, false),
+                defaultedBool(m.undeliverable_here, false),
+                optionalFields(m.message_annotations),
+            };
+            try encodeDescribedList(allocator, descriptor.modified, &fields, buf);
+        },
+    }
+}
+
 // ─────────────────────── Performative encoding ───────────────────────
 
 /// Encode any supported performative into `buf`.
@@ -285,6 +579,11 @@ pub fn encode(allocator: Allocator, p: Performative, buf: *encoder.Buffer) Encod
         .begin => |v| try encodeBegin(allocator, v, buf),
         .end => |v| try encodeEnd(allocator, v, buf),
         .close => |v| try encodeClose(allocator, v, buf),
+        .attach => |v| try encodeAttach(allocator, v, buf),
+        .flow => |v| try encodeFlow(allocator, v, buf),
+        .transfer => |v| try encodeTransfer(allocator, v, buf),
+        .disposition => |v| try encodeDisposition(allocator, v, buf),
+        .detach => |v| try encodeDetach(allocator, v, buf),
         .sasl_mechanisms => |v| try encodeSaslMechanisms(allocator, v, buf),
         .sasl_init => |v| try encodeSaslInit(allocator, v, buf),
         .sasl_outcome => |v| try encodeSaslOutcome(allocator, v, buf),
@@ -337,6 +636,87 @@ pub fn encodeEnd(allocator: Allocator, end: End, buf: *encoder.Buffer) EncodeErr
 pub fn encodeClose(allocator: Allocator, close: Close, buf: *encoder.Buffer) EncodeError!void {
     const fields = [_]Field{optionalError(close.err)};
     try encodeDescribedList(allocator, descriptor.close, &fields, buf);
+}
+
+pub fn encodeAttach(allocator: Allocator, attach: Attach, buf: *encoder.Buffer) EncodeError!void {
+    const fields = [_]Field{
+        .{ .value = .{ .string = attach.name } },
+        .{ .value = .{ .uint = attach.handle } },
+        .{ .value = .{ .boolean = attach.role.isReceiver() } },
+        .{ .value = .{ .ubyte = @intFromEnum(attach.snd_settle_mode) } },
+        .{ .value = .{ .ubyte = @intFromEnum(attach.rcv_settle_mode) } },
+        optionalSource(attach.source),
+        optionalTarget(attach.target),
+        .null, // unsettled
+        defaultedBool(attach.incomplete_unsettled, false),
+        optionalUint(attach.initial_delivery_count),
+        optionalUlong(attach.max_message_size),
+        optionalSymbols(attach.offered_capabilities),
+        optionalSymbols(attach.desired_capabilities),
+        optionalFields(attach.properties),
+    };
+    try encodeDescribedList(allocator, descriptor.attach, &fields, buf);
+}
+
+pub fn encodeFlow(allocator: Allocator, flow: Flow, buf: *encoder.Buffer) EncodeError!void {
+    const fields = [_]Field{
+        optionalUint(flow.next_incoming_id),
+        .{ .value = .{ .uint = flow.incoming_window } },
+        .{ .value = .{ .uint = flow.next_outgoing_id } },
+        .{ .value = .{ .uint = flow.outgoing_window } },
+        optionalUint(flow.handle),
+        optionalUint(flow.delivery_count),
+        optionalUint(flow.link_credit),
+        optionalUint(flow.available),
+        defaultedBool(flow.drain, false),
+        defaultedBool(flow.echo, false),
+        optionalFields(flow.properties),
+    };
+    try encodeDescribedList(allocator, descriptor.flow, &fields, buf);
+}
+
+/// Encode the transfer performative only; the payload is appended by the
+/// caller so a message can be split across frames.
+pub fn encodeTransfer(allocator: Allocator, xfer: Transfer, buf: *encoder.Buffer) EncodeError!void {
+    const fields = [_]Field{
+        .{ .value = .{ .uint = xfer.handle } },
+        optionalUint(xfer.delivery_id),
+        optionalBinary(xfer.delivery_tag),
+        optionalUint(xfer.message_format),
+        optionalBool(xfer.settled),
+        defaultedBool(xfer.more, false),
+        if (xfer.rcv_settle_mode) |m| Field{ .value = .{ .ubyte = @intFromEnum(m) } } else .null,
+        optionalDeliveryState(xfer.state),
+        defaultedBool(xfer.resume_, false),
+        defaultedBool(xfer.aborted, false),
+        defaultedBool(xfer.batchable, false),
+    };
+    try encodeDescribedList(allocator, descriptor.transfer, &fields, buf);
+}
+
+pub fn encodeDisposition(
+    allocator: Allocator,
+    d: Disposition,
+    buf: *encoder.Buffer,
+) EncodeError!void {
+    const fields = [_]Field{
+        .{ .value = .{ .boolean = d.role.isReceiver() } },
+        .{ .value = .{ .uint = d.first } },
+        optionalUint(d.last),
+        defaultedBool(d.settled, false),
+        optionalDeliveryState(d.state),
+        defaultedBool(d.batchable, false),
+    };
+    try encodeDescribedList(allocator, descriptor.disposition, &fields, buf);
+}
+
+pub fn encodeDetach(allocator: Allocator, d: Detach, buf: *encoder.Buffer) EncodeError!void {
+    const fields = [_]Field{
+        .{ .value = .{ .uint = d.handle } },
+        defaultedBool(d.closed, false),
+        optionalError(d.err),
+    };
+    try encodeDescribedList(allocator, descriptor.detach, &fields, buf);
 }
 
 pub fn encodeSaslInit(allocator: Allocator, init: SaslInit, buf: *encoder.Buffer) EncodeError!void {
@@ -450,6 +830,65 @@ fn fromValue(allocator: Allocator, value: AmqpValue) DecodeError!Performative {
             .desired_capabilities = try symbolsAt(allocator, list, 6),
             .properties = try fieldsAt(list, 7),
         } },
+        descriptor.attach => .{ .attach = .{
+            .name = (try stringAt(list, 0)) orelse "",
+            .handle = (try uintAt(list, 1)) orelse 0,
+            .role = if ((try boolAt(list, 2)) orelse false) .receiver else .sender,
+            .snd_settle_mode = senderModeFromInt((try ubyteAt(list, 3)) orelse 2) orelse
+                return error.MalformedBody,
+            .rcv_settle_mode = receiverModeFromInt((try ubyteAt(list, 4)) orelse 0) orelse
+                return error.MalformedBody,
+            .source = try sourceAt(allocator, list, 5),
+            .target = try targetAt(allocator, list, 6),
+            .incomplete_unsettled = (try boolAt(list, 8)) orelse false,
+            .initial_delivery_count = try uintAt(list, 9),
+            .max_message_size = try ulongAt(list, 10),
+            .offered_capabilities = try symbolsAt(allocator, list, 11),
+            .desired_capabilities = try symbolsAt(allocator, list, 12),
+            .properties = try fieldsAt(list, 13),
+        } },
+        descriptor.flow => .{ .flow = .{
+            .next_incoming_id = try uintAt(list, 0),
+            .incoming_window = (try uintAt(list, 1)) orelse 0,
+            .next_outgoing_id = (try uintAt(list, 2)) orelse 0,
+            .outgoing_window = (try uintAt(list, 3)) orelse 0,
+            .handle = try uintAt(list, 4),
+            .delivery_count = try uintAt(list, 5),
+            .link_credit = try uintAt(list, 6),
+            .available = try uintAt(list, 7),
+            .drain = (try boolAt(list, 8)) orelse false,
+            .echo = (try boolAt(list, 9)) orelse false,
+            .properties = try fieldsAt(list, 10),
+        } },
+        descriptor.transfer => .{ .transfer = .{
+            .handle = (try uintAt(list, 0)) orelse 0,
+            .delivery_id = try uintAt(list, 1),
+            .delivery_tag = try binaryAt(list, 2),
+            .message_format = try uintAt(list, 3),
+            .settled = try boolAt(list, 4),
+            .more = (try boolAt(list, 5)) orelse false,
+            .rcv_settle_mode = if (try ubyteAt(list, 6)) |m|
+                receiverModeFromInt(m) orelse return error.MalformedBody
+            else
+                null,
+            .state = try deliveryStateAt(list, 7),
+            .resume_ = (try boolAt(list, 8)) orelse false,
+            .aborted = (try boolAt(list, 9)) orelse false,
+            .batchable = (try boolAt(list, 10)) orelse false,
+        } },
+        descriptor.disposition => .{ .disposition = .{
+            .role = if ((try boolAt(list, 0)) orelse false) .receiver else .sender,
+            .first = (try uintAt(list, 1)) orelse 0,
+            .last = try uintAt(list, 2),
+            .settled = (try boolAt(list, 3)) orelse false,
+            .state = try deliveryStateAt(list, 4),
+            .batchable = (try boolAt(list, 5)) orelse false,
+        } },
+        descriptor.detach => .{ .detach = .{
+            .handle = (try uintAt(list, 0)) orelse 0,
+            .closed = (try boolAt(list, 1)) orelse false,
+            .err = try errorAt(list, 2),
+        } },
         descriptor.end => .{ .end = .{ .err = try errorAt(list, 0) } },
         descriptor.close => .{ .close = .{ .err = try errorAt(list, 0) } },
         descriptor.sasl_mechanisms => .{ .sasl_mechanisms = .{
@@ -466,6 +905,23 @@ fn fromValue(allocator: Allocator, value: AmqpValue) DecodeError!Performative {
             .additional_data = try binaryAt(list, 1),
         } },
         else => error.UnknownDescriptor,
+    };
+}
+
+fn senderModeFromInt(value: u8) ?SenderSettleMode {
+    return switch (value) {
+        0 => .unsettled,
+        1 => .settled,
+        2 => .mixed,
+        else => null,
+    };
+}
+
+fn receiverModeFromInt(value: u8) ?ReceiverSettleMode {
+    return switch (value) {
+        0 => .first,
+        1 => .second,
+        else => null,
     };
 }
 
@@ -533,6 +989,128 @@ fn ubyteAt(list: []const AmqpValue, index: usize) DecodeError!?u8 {
         .ubyte => |n| n,
         .ushort => |n| std.math.cast(u8, n) orelse error.MalformedBody,
         .uint => |n| std.math.cast(u8, n) orelse error.MalformedBody,
+        else => error.MalformedBody,
+    };
+}
+
+fn boolAt(list: []const AmqpValue, index: usize) DecodeError!?bool {
+    const v = at(list, index) orelse return null;
+    return switch (v) {
+        .boolean => |b| b,
+        else => error.MalformedBody,
+    };
+}
+
+fn ulongAt(list: []const AmqpValue, index: usize) DecodeError!?u64 {
+    const v = at(list, index) orelse return null;
+    return switch (v) {
+        .ulong => |n| n,
+        .uint => |n| n,
+        .ushort => |n| n,
+        .ubyte => |n| n,
+        else => error.MalformedBody,
+    };
+}
+
+/// Unwrap a described value at `index`, checking its descriptor code.
+fn describedAt(
+    list: []const AmqpValue,
+    index: usize,
+    code: u64,
+) DecodeError!?[]const AmqpValue {
+    const v = at(list, index) orelse return null;
+    if (v != .described) return error.MalformedBody;
+    const actual = switch (v.described.descriptor.*) {
+        .ulong => |c| c,
+        else => return error.MalformedBody,
+    };
+    if (actual != code) return error.MalformedBody;
+    return switch (v.described.value.*) {
+        .list => |items| items,
+        .null => &.{},
+        else => error.MalformedBody,
+    };
+}
+
+fn sourceAt(allocator: Allocator, list: []const AmqpValue, index: usize) DecodeError!?Source {
+    const inner = try describedAt(list, index, descriptor.source) orelse return null;
+    return .{
+        .address = try stringAt(inner, 0),
+        .durable = (try uintAt(inner, 1)) orelse 0,
+        .expiry_policy = try symbolAt(inner, 2),
+        .timeout = try uintAt(inner, 3),
+        .dynamic = (try boolAt(inner, 4)) orelse false,
+        .distribution_mode = try symbolAt(inner, 6),
+        .filters = try filtersAt(allocator, inner, 7),
+        .capabilities = try symbolsAt(allocator, inner, 10),
+    };
+}
+
+fn targetAt(allocator: Allocator, list: []const AmqpValue, index: usize) DecodeError!?Target {
+    const inner = try describedAt(list, index, descriptor.target) orelse return null;
+    return .{
+        .address = try stringAt(inner, 0),
+        .durable = (try uintAt(inner, 1)) orelse 0,
+        .expiry_policy = try symbolAt(inner, 2),
+        .timeout = try uintAt(inner, 3),
+        .dynamic = (try boolAt(inner, 4)) orelse false,
+        .capabilities = try symbolsAt(allocator, inner, 6),
+    };
+}
+
+fn filtersAt(
+    allocator: Allocator,
+    list: []const AmqpValue,
+    index: usize,
+) DecodeError!?[]const Filter {
+    const v = at(list, index) orelse return null;
+    const entries = switch (v) {
+        .map => |m| m,
+        else => return error.MalformedBody,
+    };
+    const out = try allocator.alloc(Filter, entries.len);
+    for (entries, 0..) |entry, i| {
+        const name = switch (entry.key) {
+            .symbol, .string => |sym| sym,
+            else => return error.MalformedBody,
+        };
+        switch (entry.value) {
+            .described => |d| out[i] = .{
+                .name = name,
+                .code = switch (d.descriptor.*) {
+                    .ulong => |c| c,
+                    else => null,
+                },
+                .value = d.value.*,
+            },
+            else => out[i] = .{ .name = name, .code = null, .value = entry.value },
+        }
+    }
+    return out;
+}
+
+fn deliveryStateAt(list: []const AmqpValue, index: usize) DecodeError!?DeliveryState {
+    const v = at(list, index) orelse return null;
+    if (v != .described) return error.MalformedBody;
+    const code = switch (v.described.descriptor.*) {
+        .ulong => |c| c,
+        else => return error.MalformedBody,
+    };
+    const inner: []const AmqpValue = switch (v.described.value.*) {
+        .list => |items| items,
+        .null => &.{},
+        else => return error.MalformedBody,
+    };
+    return switch (code) {
+        descriptor.accepted => .accepted,
+        descriptor.released => .released,
+        descriptor.rejected => .{ .rejected = try errorAt(inner, 0) },
+        descriptor.modified => .{ .modified = .{
+            .delivery_failed = (try boolAt(inner, 0)) orelse false,
+            .undeliverable_here = (try boolAt(inner, 1)) orelse false,
+            .message_annotations = try fieldsAt(inner, 2),
+        } },
+        // `received` and any non-terminal state are not modelled.
         else => error.MalformedBody,
     };
 }
@@ -827,8 +1405,8 @@ test "decode rejects bodies that are not described types" {
 
 test "decode reports unknown descriptors" {
     const allocator = testing.allocator;
-    // 0x12 is `attach`, which this driver does not model yet.
-    try testing.expectError(error.UnknownDescriptor, decode(allocator, &.{ 0x00, 0x53, 0x12, 0x45 }));
+    // 0x42 is `sasl-challenge`, which this driver does not model.
+    try testing.expectError(error.UnknownDescriptor, decode(allocator, &.{ 0x00, 0x53, 0x42, 0x45 }));
 }
 
 test "encoding survives allocation failure" {
@@ -847,4 +1425,195 @@ test "encoding survives allocation failure" {
         }
     };
     try testing.checkAllAllocationFailures(testing.allocator, Case.run, .{});
+}
+
+test "attach round-trips with source, target, and properties" {
+    const allocator = testing.allocator;
+    const props = [_]MapEntry{
+        .{ .key = .{ .symbol = "com.microsoft:receiver-name" }, .value = .{ .string = "inst-1" } },
+        .{ .key = .{ .symbol = "com.microsoft:epoch" }, .value = .{ .long = 3 } },
+    };
+    const filters = [_]Filter{Filter.selector("amqp.annotation.x-opt-offset > '42'")};
+
+    const attach = Attach{
+        .name = "eh/ConsumerGroups/$default/Partitions/0",
+        .handle = 7,
+        .role = .receiver,
+        .snd_settle_mode = .mixed,
+        .rcv_settle_mode = .first,
+        .source = .{
+            .address = "eh/ConsumerGroups/$default/Partitions/0",
+            .filters = &filters,
+        },
+        .target = .{ .address = "inst-1" },
+        .max_message_size = 1048576,
+        .desired_capabilities = &.{"com.microsoft:georeplication"},
+        .properties = &props,
+    };
+
+    const bytes = try encodeAlloc(allocator, .{ .attach = attach });
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = decoded.performative.attach;
+    try testing.expectEqualStrings(attach.name, got.name);
+    try testing.expectEqual(@as(u32, 7), got.handle);
+    try testing.expectEqual(Role.receiver, got.role);
+    try testing.expectEqual(SenderSettleMode.mixed, got.snd_settle_mode);
+    try testing.expectEqual(ReceiverSettleMode.first, got.rcv_settle_mode);
+    try testing.expectEqualStrings(attach.source.?.address.?, got.source.?.address.?);
+    try testing.expectEqualStrings("inst-1", got.target.?.address.?);
+    try testing.expectEqual(@as(u64, 1048576), got.max_message_size.?);
+    try testing.expectEqualStrings("com.microsoft:georeplication", got.desired_capabilities.?[0]);
+    try testing.expectEqual(@as(usize, 2), got.properties.?.len);
+    try testing.expectEqualStrings("inst-1", got.properties.?[0].value.string);
+    try testing.expectEqual(@as(i64, 3), got.properties.?[1].value.long);
+
+    const got_filter = got.source.?.filters.?[0];
+    try testing.expectEqualStrings(selector_filter_name, got_filter.name);
+    try testing.expectEqual(selector_filter_code, got_filter.code.?);
+    try testing.expectEqualStrings("amqp.annotation.x-opt-offset > '42'", got_filter.value.string);
+}
+
+test "a selector filter encodes as a described value in a symbol-keyed map" {
+    const allocator = testing.allocator;
+    var buf = encoder.Buffer.initDynamic(allocator);
+    defer buf.deinit();
+    const filters = [_]Filter{Filter.selector("x")};
+    try encodeFilterSet(allocator, &filters, &buf);
+
+    // map8, size, count=2, sym8 "apache.org:selector-filter:string",
+    // then 0x00 descriptor ulong 0x0000468C00000004, then str8 "x".
+    const name = selector_filter_name;
+    var expected = std.ArrayList(u8).empty;
+    defer expected.deinit(allocator);
+    try expected.appendSlice(allocator, &.{ 0xc1, 0, 2, 0xa3, @intCast(name.len) });
+    try expected.appendSlice(allocator, name);
+    try expected.appendSlice(allocator, &.{ 0x00, 0x80, 0x00, 0x00, 0x46, 0x8c, 0x00, 0x00, 0x00, 0x04 });
+    try expected.appendSlice(allocator, &.{ 0xa1, 1, 'x' });
+    // map8 size counts the body plus the count byte, not the size byte itself.
+    expected.items[1] = @intCast(expected.items.len - 2);
+
+    try testing.expectEqualSlices(u8, expected.items, buf.written());
+}
+
+test "flow and disposition round-trip" {
+    const allocator = testing.allocator;
+    const flow = Flow{
+        .next_incoming_id = 3,
+        .incoming_window = 2048,
+        .next_outgoing_id = 9,
+        .outgoing_window = 100,
+        .handle = 1,
+        .delivery_count = 42,
+        .link_credit = 300,
+        .drain = true,
+    };
+    const flow_bytes = try encodeAlloc(allocator, .{ .flow = flow });
+    defer allocator.free(flow_bytes);
+    var flow_decoded = try decode(allocator, flow_bytes);
+    defer flow_decoded.deinit();
+    try testing.expectEqual(flow, flow_decoded.performative.flow);
+
+    const d = Disposition{
+        .role = .receiver,
+        .first = 5,
+        .last = 9,
+        .settled = true,
+        .state = .accepted,
+    };
+    const d_bytes = try encodeAlloc(allocator, .{ .disposition = d });
+    defer allocator.free(d_bytes);
+    var d_decoded = try decode(allocator, d_bytes);
+    defer d_decoded.deinit();
+    const got = d_decoded.performative.disposition;
+    try testing.expectEqual(Role.receiver, got.role);
+    try testing.expectEqual(@as(u32, 5), got.first);
+    try testing.expectEqual(@as(u32, 9), got.last.?);
+    try testing.expect(got.settled);
+    try testing.expectEqual(DeliveryState.accepted, got.state.?);
+}
+
+test "a rejected disposition carries the condition" {
+    const allocator = testing.allocator;
+    const d = Disposition{
+        .role = .receiver,
+        .first = 1,
+        .state = .{ .rejected = .{
+            .condition = "amqp:link:message-size-exceeded",
+            .description = "too big",
+        } },
+    };
+    const bytes = try encodeAlloc(allocator, .{ .disposition = d });
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const err = decoded.performative.disposition.state.?.rejected.?;
+    try testing.expectEqualStrings("amqp:link:message-size-exceeded", err.condition);
+    try testing.expectEqualStrings("too big", err.description.?);
+}
+
+test "transfer round-trips and elides defaulted booleans" {
+    const allocator = testing.allocator;
+    const xfer = Transfer{
+        .handle = 2,
+        .delivery_id = 11,
+        .delivery_tag = "\x00\x00\x00\x0b",
+        .message_format = 0,
+        .settled = false,
+        .more = true,
+    };
+    const bytes = try encodeAlloc(allocator, .{ .transfer = xfer });
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = decoded.performative.transfer;
+    try testing.expectEqual(@as(u32, 2), got.handle);
+    try testing.expectEqual(@as(u32, 11), got.delivery_id.?);
+    try testing.expectEqualSlices(u8, "\x00\x00\x00\x0b", got.delivery_tag.?);
+    try testing.expectEqual(@as(u32, 0), got.message_format.?);
+    try testing.expectEqual(false, got.settled.?);
+    try testing.expect(got.more);
+    try testing.expect(!got.aborted);
+    try testing.expect(!got.batchable);
+
+    try testing.expectEqual(descriptor.transfer, peekDescriptor(bytes).?);
+}
+
+test "detach round-trips with a closed flag and an error" {
+    const allocator = testing.allocator;
+    const d = Detach{
+        .handle = 4,
+        .closed = true,
+        .err = .{ .condition = "amqp:link:stolen", .description = "higher epoch" },
+    };
+    const bytes = try encodeAlloc(allocator, .{ .detach = d });
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = decoded.performative.detach;
+    try testing.expectEqual(@as(u32, 4), got.handle);
+    try testing.expect(got.closed);
+    try testing.expectEqualStrings("amqp:link:stolen", got.err.?.condition);
+}
+
+test "a modified delivery state round-trips" {
+    const allocator = testing.allocator;
+    const d = Disposition{
+        .role = .receiver,
+        .first = 0,
+        .state = .{ .modified = .{ .delivery_failed = true, .undeliverable_here = true } },
+    };
+    const bytes = try encodeAlloc(allocator, .{ .disposition = d });
+    defer allocator.free(bytes);
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    const m = decoded.performative.disposition.state.?.modified;
+    try testing.expect(m.delivery_failed);
+    try testing.expect(m.undeliverable_here);
 }

--- a/root.zig
+++ b/root.zig
@@ -9,6 +9,8 @@ pub const uamqp = @import("uamqp");
 pub const transport = @import("transport.zig");
 pub const performative = @import("performative.zig");
 pub const connection_driver = @import("connection.zig");
+pub const message_codec = @import("message.zig");
+pub const link = @import("link.zig");
 
 // Transports.
 pub const Transport = transport.Transport;
@@ -34,11 +36,29 @@ pub const buildProperties = connection_driver.buildProperties;
 pub const defaultClientInfo = connection_driver.defaultClientInfo;
 pub const georeplication_capability = connection_driver.georeplication_capability;
 
-// Re-export core protocol types.
-pub const Connection = uamqp.connection.Connection;
-pub const Session = uamqp.session.Session;
-pub const Link = uamqp.link.Link;
-pub const Message = uamqp.message.Message;
+// Sessions and links.
+pub const Session = link.Session;
+pub const SessionOptions = link.SessionOptions;
+pub const Sender = link.Sender;
+pub const SenderOptions = link.SenderOptions;
+pub const Receiver = link.Receiver;
+pub const ReceiverOptions = link.ReceiverOptions;
+pub const Delivery = link.Delivery;
+pub const Rejection = link.Rejection;
+pub const LinkError = link.LinkError;
+pub const openSender = link.openSender;
+pub const openReceiver = link.openReceiver;
+pub const receiver_name_property = link.receiver_name_property;
+pub const epoch_property = link.epoch_property;
+
+// Message codec.
+pub const Message = message_codec.Message;
+pub const MessageBody = message_codec.Body;
+pub const MessageHeader = message_codec.Header;
+pub const MessageProperties = message_codec.Properties;
+pub const encodeMessage = message_codec.encode;
+pub const encodeMessageAlloc = message_codec.encodeAlloc;
+pub const decodeMessage = message_codec.decode;
 
 // Re-export AMQP type system.
 pub const AmqpValue = uamqp.AmqpValue;
@@ -54,12 +74,6 @@ pub const definitions = uamqp.definitions;
 pub const SaslPlain = uamqp.sasl.plain.Plain;
 pub const SaslAnonymous = uamqp.sasl.anonymous.Anonymous;
 pub const SaslMechanism = uamqp.sasl.mechanism.Mechanism;
-
-// Re-export CBS (Claims-Based Security).
-pub const Cbs = uamqp.cbs.Cbs;
-
-// Re-export management operations.
-pub const Management = uamqp.management.Management;
 
 // Re-export messaging helpers.
 pub const messaging = uamqp.messaging;
@@ -83,32 +97,22 @@ test {
     _ = transport;
     _ = performative;
     _ = connection_driver;
+    _ = message_codec;
+    _ = link;
 }
 
 // ─────────────────────── Tests ───────────────────────
 
-test "Connection init and deinit" {
+test "the re-exported message codec round-trips a body" {
     const allocator = std.testing.allocator;
-    var conn = Connection.init(allocator, "azure-sdk-zig", "mynamespace.servicebus.windows.net", .{});
-    defer conn.deinit();
-    try std.testing.expectEqualStrings("azure-sdk-zig", conn.container_id);
-}
+    const bytes = try encodeMessageAlloc(allocator, .{
+        .body = .{ .data = &.{"hello, event hub!"} },
+    });
+    defer allocator.free(bytes);
 
-test "Session init" {
-    const allocator = std.testing.allocator;
-    var conn = Connection.init(allocator, "test", null, .{});
-    defer conn.deinit();
-    var session = Session.init(allocator, &conn, .{});
-    defer session.deinit();
-    try std.testing.expectEqual(@as(u32, 0), session.next_outgoing_id);
-}
-
-test "Message create and add body data" {
-    const allocator = std.testing.allocator;
-    var msg = Message.init(allocator);
-    defer msg.deinit();
-    try msg.addBodyData("hello, event hub!");
-    try std.testing.expectEqual(@as(usize, 1), msg.bodyDataCount());
+    var decoded = try decodeMessage(allocator, bytes);
+    defer decoded.deinit();
+    try std.testing.expectEqualStrings("hello, event hub!", decoded.message.body.data[0]);
 }
 
 test "SASL Plain mechanism" {


### PR DESCRIPTION
Part of #191. Implements #201.

uamqp's `link.zig`, `message.zig`, `cbs.zig`, and `management.zig` are inert stubs that encode nothing. This adds the real implementations.

I reordered this ahead of #199 (CBS) and #200 (`$management`) because both are request/response over a sender + receiver link pair, making links a hard prerequisite.

## `message.zig`

The AMQP message sections: header, delivery annotations, message annotations, properties, application properties, a `data`/`sequence`/`value` body, and footer.

## `link.zig`

- attach and detach, matched to the peer's echoed attach by link name
- flow control with credit rebased onto our delivery count (§2.6.7), and a drain that waits for the sender to consume the outstanding credit rather than leaving the link half-drained
- multi-frame transfers, split to the negotiated `max-frame-size` on send and reassembled on receive
- accepted, rejected, and released outcomes, with a rejection surfacing the peer's error condition
- the Event Hubs link properties Go and Rust send: `com.microsoft:receiver-name`, `com.microsoft:epoch`, and the `apache.org:selector-filter:string` filter carrying the start offset

## `performative.zig`

Adds attach, flow, transfer, disposition, and detach, plus source, target, delivery states, and filter sets.

## A bug worth calling out

A handle in an inbound frame is scoped to the peer that sent it (§2.6.2). My first cut looked links up by `remote_handle` **or** our own `handle`. That crosses deliveries as soon as a session holds two links of the same role — which is exactly the shape CBS uses. Fixed to match the peer's handle only; `a session routes transfers by the peer's handle, not our own` covers it, and I verified it fails against the old lookup.

## Re-exports

`Message`, `Session`, `Link`, `Cbs`, and `Management` pointed at the uamqp stubs. Nothing in the repo referenced them, and leaving them next to a working codec invites calling a no-op, so they now point at the real implementations.

## Dependency

The uamqp pin moves up to pick up the merged decoder memory-safety fix (cataggar/azure-uamqp-zig#1) — malformed frame bytes could free uninitialized memory. `message.zig`'s allocation-failure test hit it.

Paired registry PR on `main` adds the two new published files.

75 tests pass; `zig fmt --check` is clean.