### PR TITLE
Add CBS authentication over a request/response link pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,54 @@ A handle in an inbound frame is scoped to the peer that sent it, so links are
 looked up by the handle the peer chose, never by our own. A session holding both
 a CBS link and an events link would otherwise cross its deliveries.
 
-CBS authentication and the `$management` link are not here yet.
+## Request/response links
 
-Run its independent tests from this directory:
+`rpc.zig` pairs a sender with a receiver attached to a private reply address,
+correlating each reply to its request by message id. Both `$cbs` and
+`$management` are built on it, as they are in the Go client.
+
+A reply's status rides in application properties rather than in the delivery
+outcome, so a refused request still arrives as an accepted transfer. Both
+spellings brokers use — `status-code` and `statusCode` — are accepted, as is
+any integral encoding of the code.
+
+## CBS authentication
+
+Event Hubs carries no credential in the SASL exchange, so every entity is
+authorised separately by putting a token to `$cbs` before a link on that path
+attaches. `cbs.zig` sends the `operation`, `type`, `name`, and `expiration`
+application properties with the token as the message value, matching Go's
+layout exactly, and maps a 401 to `error.Unauthorized` so callers do not retry
+a refused credential.
+
+```zig
+const client = try amqp.Cbs.open(&session, .{ .link_id = id }, deadline_ms);
+defer client.deinit();
+
+try client.authorize(audience, credential.tokenProvider(), now_ms, deadline_ms);
+```
+
+Tokens are cached per audience and refreshed six minutes before expiry with up
+to five seconds of jitter, backing off thirty seconds after a failure — the
+same policy as the Rust client. A pre-formed SAS from a connection string is
+marked non-refreshable and schedules nothing, since renewing it returns the
+same expiry; the broker still enforces it, and `invalidateAll` re-authorises
+every path after a connection is recovered.
+
+Acquiring the token is the credential's job. `TokenProvider` is a
+function-pointer struct, so this module does not depend on the credential type,
+and it is only consulted when a round-trip is actually needed.
+
+The `$management` link is not here yet.
+
+## Tests
+
+`test_peer.zig` drives the far end of a `MemoryTransport`, writing the frames a
+broker would send and parsing back what the driver emitted. The link, RPC, and
+CBS tests share it, since they all need the same open/begin/attach preamble
+before the behaviour under test starts.
+
+Run the package's independent tests from this directory:
 
 ```bash
 zig build test --summary all

--- a/cbs.zig
+++ b/cbs.zig
@@ -1,0 +1,768 @@
+//! Claims-Based Security: authorising a path over the `$cbs` endpoint.
+//!
+//! Event Hubs carries no credential in the AMQP SASL exchange — the driver
+//! authenticates anonymously — so every entity has to be authorised separately
+//! by putting a token to `$cbs` before any link on that path attaches. The
+//! token is a SAS signature or an AAD JWT; acquiring it is the credential's
+//! job, not this module's.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const link = @import("link.zig");
+const message = @import("message.zig");
+const perf = @import("performative.zig");
+const rpc = @import("rpc.zig");
+const uamqp = @import("uamqp");
+
+const AmqpValue = uamqp.AmqpValue;
+const MapEntry = uamqp.MapEntry;
+
+pub const address = "$cbs";
+
+pub const operation_key = "operation";
+pub const put_token_operation = "put-token";
+pub const token_type_key = "type";
+pub const audience_key = "name";
+pub const expiration_key = "expiration";
+
+pub const CbsError = rpc.RpcError || error{
+    /// No token has been cached for the requested audience.
+    NotAuthorized,
+};
+
+/// The token kinds Azure accepts over CBS.
+pub const TokenType = enum {
+    sas,
+    jwt,
+
+    pub fn toString(self: TokenType) []const u8 {
+        return switch (self) {
+            .sas => "servicebus.windows.net:sastoken",
+            .jwt => "jwt",
+        };
+    }
+};
+
+pub const AccessToken = struct {
+    /// The signature or bearer token itself.
+    token: []const u8,
+    /// Expiry as milliseconds since the Unix epoch.
+    expires_on_ms: i64,
+    kind: TokenType,
+    /// False for a pre-formed SAS supplied in a connection string. Refreshing
+    /// one returns the same expiry it already had, so scheduling a refresh
+    /// would spin without ever extending it. The broker still enforces the
+    /// real expiry, and recovery re-authorises the path if a link drops.
+    refreshable: bool = true,
+};
+
+/// Supplies tokens on demand. A function-pointer struct so a credential can
+/// back it without this module depending on the credential type.
+pub const TokenProvider = struct {
+    ctx: *anyopaque,
+    getTokenFn: *const fn (ctx: *anyopaque, audience: []const u8) anyerror!AccessToken,
+
+    pub fn getToken(self: TokenProvider, audience: []const u8) anyerror!AccessToken {
+        return self.getTokenFn(self.ctx, audience);
+    }
+};
+
+/// When to refresh, relative to expiry. The defaults match the Rust client.
+pub const RefreshPolicy = struct {
+    /// Refresh this long before the token expires.
+    bias_ms: i64 = 6 * std.time.ms_per_min,
+    /// Jitter added to the bias, so a fleet of clients does not stampede.
+    /// The minimum is negative, meaning it can push the refresh later.
+    jitter_min_ms: i64 = -5 * std.time.ms_per_s,
+    jitter_max_ms: i64 = 5 * std.time.ms_per_s,
+    /// How long to wait before retrying a refresh that failed.
+    failure_backoff_ms: i64 = 30 * std.time.ms_per_s,
+};
+
+/// The instant a token expiring at `expires_on_ms` should be refreshed.
+pub fn refreshAtMs(policy: RefreshPolicy, expires_on_ms: i64, jitter_ms: i64) i64 {
+    return expires_on_ms -| (policy.bias_ms +| jitter_ms);
+}
+
+const CachedToken = struct {
+    token: []const u8,
+    expires_on_ms: i64,
+    kind: TokenType,
+    refreshable: bool,
+    /// When a refresh is next due, or null when the token cannot be renewed.
+    refresh_at_ms: ?i64,
+
+    fn deinit(self: CachedToken, allocator: Allocator) void {
+        allocator.free(self.token);
+    }
+};
+
+pub const Options = struct {
+    /// Distinguishes this link pair from any other on the connection.
+    link_id: []const u8,
+    policy: RefreshPolicy = .{},
+    /// Seed for the refresh jitter. Fixed in tests for determinism.
+    jitter_seed: u64 = 0,
+};
+
+/// A `$cbs` client: the RPC link pair plus a per-audience token cache.
+pub const Cbs = struct {
+    allocator: Allocator,
+    rpc_link: *rpc.RpcLink,
+    policy: RefreshPolicy,
+    prng: std.Random.DefaultPrng,
+    /// Cached tokens keyed by audience. Both keys and values are owned.
+    tokens: std.StringHashMapUnmanaged(CachedToken) = .empty,
+
+    pub fn open(
+        session: *link.Session,
+        options: Options,
+        deadline_ms: i64,
+    ) CbsError!*Cbs {
+        const allocator = session.allocator;
+        const self = try allocator.create(Cbs);
+        errdefer allocator.destroy(self);
+
+        const rpc_link = try rpc.RpcLink.open(session, .{
+            .address = address,
+            .link_id = options.link_id,
+        }, deadline_ms);
+        errdefer rpc_link.deinit();
+
+        self.* = .{
+            .allocator = allocator,
+            .rpc_link = rpc_link,
+            .policy = options.policy,
+            .prng = std.Random.DefaultPrng.init(options.jitter_seed),
+        };
+        return self;
+    }
+
+    pub fn deinit(self: *Cbs) void {
+        var it = self.tokens.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(self.allocator);
+        }
+        self.tokens.deinit(self.allocator);
+        self.rpc_link.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn close(self: *Cbs, deadline_ms: i64) CbsError!void {
+        try self.rpc_link.close(deadline_ms);
+    }
+
+    /// Put a token to `$cbs` for `audience`, unconditionally.
+    ///
+    /// The application-property map matches Go's exactly: `operation`,
+    /// `type`, `name`, and `expiration`, with the token as the message value.
+    pub fn putToken(
+        self: *Cbs,
+        audience: []const u8,
+        token: AccessToken,
+        deadline_ms: i64,
+    ) CbsError!void {
+        const props = [_]MapEntry{
+            .{
+                .key = .{ .string = operation_key },
+                .value = .{ .string = put_token_operation },
+            },
+            .{
+                .key = .{ .string = token_type_key },
+                .value = .{ .string = token.kind.toString() },
+            },
+            .{
+                .key = .{ .string = audience_key },
+                .value = .{ .string = audience },
+            },
+            .{
+                .key = .{ .string = expiration_key },
+                .value = .{ .timestamp = token.expires_on_ms },
+            },
+        };
+
+        var response = try self.rpc_link.call(.{
+            .application_properties = &props,
+            .body = .{ .value = .{ .string = token.token } },
+        }, deadline_ms);
+        defer response.deinit();
+
+        try rpc.checkStatus(response.status_code);
+    }
+
+    /// Authorise `audience`, reusing the cached token when it is still good.
+    ///
+    /// The provider is only consulted when a round-trip is actually needed, so
+    /// a cache hit costs nothing.
+    pub fn authorize(
+        self: *Cbs,
+        audience: []const u8,
+        provider: TokenProvider,
+        now_ms: i64,
+        deadline_ms: i64,
+    ) !void {
+        if (self.tokens.get(audience)) |cached| {
+            if (!isStale(cached, now_ms)) return;
+        }
+        const token = try provider.getToken(audience);
+        try self.putToken(audience, token, deadline_ms);
+        try self.store(audience, token);
+    }
+
+    /// Re-put every cached token that has come due, and report when the next
+    /// refresh is owed so a caller can decide how long to wait.
+    ///
+    /// A failure backs the audience off rather than propagating, because one
+    /// unreachable audience must not stop the others from being renewed.
+    pub fn refreshDue(
+        self: *Cbs,
+        provider: TokenProvider,
+        now_ms: i64,
+        deadline_ms: i64,
+    ) !void {
+        var it = self.tokens.iterator();
+        while (it.next()) |entry| {
+            const refresh_at = entry.value_ptr.refresh_at_ms orelse continue;
+            if (now_ms < refresh_at) continue;
+
+            const audience = entry.key_ptr.*;
+            const token = provider.getToken(audience) catch {
+                entry.value_ptr.refresh_at_ms = now_ms +| self.policy.failure_backoff_ms;
+                continue;
+            };
+            self.putToken(audience, token, deadline_ms) catch |e| switch (e) {
+                // A refused credential will not start working on a retry.
+                error.Unauthorized => return e,
+                else => {
+                    entry.value_ptr.refresh_at_ms = now_ms +| self.policy.failure_backoff_ms;
+                    continue;
+                },
+            };
+            try self.store(audience, token);
+            // `store` replaces the entry in place, so the iterator stays valid.
+            it = self.tokens.iterator();
+        }
+    }
+
+    /// The earliest instant at which any cached token needs refreshing, or
+    /// null when nothing is refreshable.
+    pub fn nextRefreshAtMs(self: *Cbs) ?i64 {
+        var earliest: ?i64 = null;
+        var it = self.tokens.valueIterator();
+        while (it.next()) |value| {
+            const at = value.refresh_at_ms orelse continue;
+            if (earliest == null or at < earliest.?) earliest = at;
+        }
+        return earliest;
+    }
+
+    /// The cached token for `audience`, if any.
+    pub fn cachedToken(self: *Cbs, audience: []const u8) ?AccessToken {
+        const cached = self.tokens.get(audience) orelse return null;
+        return .{
+            .token = cached.token,
+            .expires_on_ms = cached.expires_on_ms,
+            .kind = cached.kind,
+            .refreshable = cached.refreshable,
+        };
+    }
+
+    /// Drop every cached token, forcing re-authorisation. Used after a
+    /// connection is recovered, since the new connection carries no claims.
+    pub fn invalidateAll(self: *Cbs) void {
+        var it = self.tokens.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(self.allocator);
+        }
+        self.tokens.clearRetainingCapacity();
+    }
+
+    fn store(self: *Cbs, audience: []const u8, token: AccessToken) Allocator.Error!void {
+        const owned_token = try self.allocator.dupe(u8, token.token);
+        errdefer self.allocator.free(owned_token);
+
+        const refresh_at: ?i64 = if (token.refreshable)
+            refreshAtMs(self.policy, token.expires_on_ms, self.jitter())
+        else
+            null;
+
+        const entry = try self.tokens.getOrPut(self.allocator, audience);
+        if (entry.found_existing) {
+            entry.value_ptr.deinit(self.allocator);
+        } else {
+            entry.key_ptr.* = self.allocator.dupe(u8, audience) catch |e| {
+                _ = self.tokens.remove(audience);
+                return e;
+            };
+        }
+        entry.value_ptr.* = .{
+            .token = owned_token,
+            .expires_on_ms = token.expires_on_ms,
+            .kind = token.kind,
+            .refreshable = token.refreshable,
+            .refresh_at_ms = refresh_at,
+        };
+    }
+
+    fn jitter(self: *Cbs) i64 {
+        const min = self.policy.jitter_min_ms;
+        const max = self.policy.jitter_max_ms;
+        if (max <= min) return 0;
+        return self.prng.random().intRangeLessThan(i64, min, max);
+    }
+};
+
+/// A cached token is stale once its refresh time has passed, or once it has
+/// actually expired. A non-refreshable token is only stale when expired.
+fn isStale(cached: CachedToken, now_ms: i64) bool {
+    if (now_ms >= cached.expires_on_ms) return true;
+    const refresh_at = cached.refresh_at_ms orelse return false;
+    return now_ms >= refresh_at;
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const connection = @import("connection.zig");
+const harness = @import("test_peer.zig");
+const MemoryTransport = @import("transport.zig").MemoryTransport;
+const Peer = harness.Peer;
+const Fixture = harness.Fixture;
+const EmittedFrames = harness.EmittedFrames;
+
+/// A provider handing out a fixed token, counting how often it was asked.
+const StubProvider = struct {
+    token: AccessToken,
+    calls: usize = 0,
+
+    fn get(ctx: *anyopaque, audience: []const u8) anyerror!AccessToken {
+        _ = audience;
+        const self: *StubProvider = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.token;
+    }
+
+    fn provider(self: *StubProvider) TokenProvider {
+        return .{ .ctx = self, .getTokenFn = get };
+    }
+};
+
+/// Script the peer's side of opening a `$cbs` link pair: an attach for each
+/// link, then credit for the sender.
+fn scriptCbsAttach(peer: Peer) !void {
+    try harness.scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "$cbs-sender-test",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "$cbs-receiver-test",
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 10,
+    } });
+}
+
+/// Push the peer's answer to request `n`: a disposition settling the request,
+/// then the reply carrying `status`, correlated back to it.
+///
+/// The disposition is what a real broker sends — the sender leaves the
+/// transfer unsettled and blocks on the outcome, as Go's RPC link does.
+fn scriptCbsReply(peer: Peer, allocator: Allocator, n: u64, status: i32) !void {
+    const delivery_id: u32 = @intCast(n - 1);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = delivery_id,
+        .last = delivery_id,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var id_buf: [64]u8 = undefined;
+    const correlation = try std.fmt.bufPrint(&id_buf, "cbs-reply-to-test:{d}", .{n});
+    const props = [_]MapEntry{
+        .{ .key = .{ .string = rpc.status_code_key }, .value = .{ .int = status } },
+        .{
+            .key = .{ .string = rpc.status_description_key },
+            .value = .{ .string = if (status == 202) "Accepted" else "Unauthorized" },
+        },
+    };
+    const payload = try message.encodeAlloc(allocator, .{
+        .properties = .{ .correlation_id = .{ .string = correlation } },
+        .application_properties = &props,
+    });
+    defer allocator.free(payload);
+
+    try peer.pushTransfer(0, .{
+        .handle = 1,
+        .delivery_id = delivery_id,
+        .delivery_tag = "r",
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, payload);
+}
+
+/// The application properties of the single put-token request the driver sent.
+fn sentPutTokenProperties(allocator: Allocator, written: []const u8) !message.Decoded {
+    var frames = try EmittedFrames.parse(allocator, written);
+    defer frames.deinit();
+
+    const transfers = try frames.of(allocator, 0x14);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+
+    const payload = harness.transferPayload(allocator, transfers[0]).?;
+    return message.decode(allocator, payload);
+}
+
+fn propertyValue(props: perf.Fields, key: []const u8) ?AmqpValue {
+    for (props) |entry| {
+        const name = switch (entry.key) {
+            .string, .symbol => |str| str,
+            else => continue,
+        };
+        if (std.mem.eql(u8, name, key)) return entry.value;
+    }
+    return null;
+}
+
+test "token types use the strings Azure expects" {
+    try testing.expectEqualStrings("servicebus.windows.net:sastoken", TokenType.sas.toString());
+    try testing.expectEqualStrings("jwt", TokenType.jwt.toString());
+}
+
+test "the refresh instant sits a biased interval ahead of expiry" {
+    const policy = RefreshPolicy{};
+    const expiry: i64 = 3_600_000;
+    // Six minutes ahead of expiry, with no jitter.
+    try testing.expectEqual(@as(i64, 3_600_000 - 360_000), refreshAtMs(policy, expiry, 0));
+    // Jitter is added to the bias, so a positive value refreshes earlier and a
+    // negative one later, spreading a fleet's renewals either side of the bias.
+    try testing.expectEqual(@as(i64, 3_600_000 - 365_000), refreshAtMs(policy, expiry, 5_000));
+    try testing.expectEqual(@as(i64, 3_600_000 - 355_000), refreshAtMs(policy, expiry, -5_000));
+}
+
+test "a token is stale once its refresh time passes but a fixed one only at expiry" {
+    const refreshable = CachedToken{
+        .token = "t",
+        .expires_on_ms = 1_000_000,
+        .kind = .jwt,
+        .refreshable = true,
+        .refresh_at_ms = 640_000,
+    };
+    try testing.expect(!isStale(refreshable, 639_999));
+    try testing.expect(isStale(refreshable, 640_000));
+
+    const fixed = CachedToken{
+        .token = "t",
+        .expires_on_ms = 1_000_000,
+        .kind = .sas,
+        .refreshable = false,
+        .refresh_at_ms = null,
+    };
+    try testing.expect(!isStale(fixed, 999_999));
+    try testing.expect(isStale(fixed, 1_000_000));
+}
+
+test "put-token sends the exact application-property map for a JWT" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptCbsAttach(peer);
+    try scriptCbsReply(peer, allocator, 1, 202);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Cbs.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    mem.clearWritten();
+    try client.putToken("amqps://ns.servicebus.windows.net/eh", .{
+        .token = "aad-jwt",
+        .expires_on_ms = 1_700_000_000_000,
+        .kind = .jwt,
+    }, 10_000);
+
+    var decoded = try sentPutTokenProperties(allocator, mem.written());
+    defer decoded.deinit();
+    const props = decoded.message.application_properties.?;
+
+    try testing.expectEqual(@as(usize, 4), props.len);
+    try testing.expectEqualStrings("put-token", propertyValue(props, operation_key).?.string);
+    try testing.expectEqualStrings("jwt", propertyValue(props, token_type_key).?.string);
+    try testing.expectEqualStrings(
+        "amqps://ns.servicebus.windows.net/eh",
+        propertyValue(props, audience_key).?.string,
+    );
+    try testing.expectEqual(
+        @as(i64, 1_700_000_000_000),
+        propertyValue(props, expiration_key).?.timestamp,
+    );
+
+    // The token itself rides in the body as an AMQP value section.
+    try testing.expectEqualStrings("aad-jwt", decoded.message.body.value.string);
+    // The reply has to be routable back to us.
+    try testing.expectEqualStrings("cbs-reply-to-test", decoded.message.properties.reply_to.?);
+    try testing.expectEqualStrings("cbs-reply-to-test:1", decoded.message.properties.message_id.?.string);
+}
+
+test "put-token sends the SAS token type for a shared access signature" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptCbsAttach(peer);
+    try scriptCbsReply(peer, allocator, 1, 202);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Cbs.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    mem.clearWritten();
+    try client.putToken("amqps://ns.servicebus.windows.net/eh", .{
+        .token = "SharedAccessSignature sr=%2Feh&sig=abc&se=1700000000&skn=key",
+        .expires_on_ms = 1_700_000_000_000,
+        .kind = .sas,
+        .refreshable = false,
+    }, 10_000);
+
+    var decoded = try sentPutTokenProperties(allocator, mem.written());
+    defer decoded.deinit();
+    const props = decoded.message.application_properties.?;
+
+    try testing.expectEqualStrings(
+        "servicebus.windows.net:sastoken",
+        propertyValue(props, token_type_key).?.string,
+    );
+    try testing.expectEqualStrings(
+        "SharedAccessSignature sr=%2Feh&sig=abc&se=1700000000&skn=key",
+        decoded.message.body.value.string,
+    );
+}
+
+test "a 401 reply surfaces as unauthorized and is not retried" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptCbsAttach(peer);
+    try scriptCbsReply(peer, allocator, 1, 401);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Cbs.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    mem.clearWritten();
+    var stub = StubProvider{ .token = .{
+        .token = "expired",
+        .expires_on_ms = 1_700_000_000_000,
+        .kind = .jwt,
+    } };
+    try testing.expectError(
+        error.Unauthorized,
+        client.authorize("eh", stub.provider(), 0, 10_000),
+    );
+
+    // Exactly one request went out: a refused credential is not retried, and
+    // nothing was cached for the audience.
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, 0x14);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+    try testing.expectEqual(@as(usize, 1), stub.calls);
+    try testing.expect(client.cachedToken("eh") == null);
+}
+
+test "authorising the same audience twice reuses the cached token" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptCbsAttach(peer);
+    try scriptCbsReply(peer, allocator, 1, 202);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Cbs.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    mem.clearWritten();
+    var stub = StubProvider{ .token = .{
+        .token = "aad-jwt",
+        .expires_on_ms = 3_600_000,
+        .kind = .jwt,
+    } };
+
+    try client.authorize("eh", stub.provider(), 0, 10_000);
+    // Well inside the refresh window, so this must not go to the wire. Only
+    // one reply was scripted, so a second round-trip would block and fail.
+    try client.authorize("eh", stub.provider(), 1_000, 10_000);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, 0x14);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+    try testing.expectEqual(@as(usize, 1), stub.calls);
+    try testing.expectEqualStrings("aad-jwt", client.cachedToken("eh").?.token);
+}
+
+test "a refreshable token schedules a refresh but a fixed SAS does not" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptCbsAttach(peer);
+    try scriptCbsReply(peer, allocator, 1, 202);
+    try scriptCbsReply(peer, allocator, 2, 202);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Cbs.open(&fixture.session, .{
+        .link_id = "test",
+        .jitter_seed = 7,
+    }, 10_000);
+    defer client.deinit();
+
+    var refreshable = StubProvider{ .token = .{
+        .token = "aad-jwt",
+        .expires_on_ms = 3_600_000,
+        .kind = .jwt,
+    } };
+    try client.authorize("eh-aad", refreshable.provider(), 0, 10_000);
+
+    var fixed = StubProvider{ .token = .{
+        .token = "sas",
+        .expires_on_ms = 3_600_000,
+        .kind = .sas,
+        .refreshable = false,
+    } };
+    try client.authorize("eh-sas", fixed.provider(), 0, 10_000);
+
+    // The refresh is due roughly six minutes before expiry, jittered by at
+    // most five seconds either side.
+    const next = client.nextRefreshAtMs().?;
+    try testing.expect(next >= 3_600_000 - 365_000);
+    try testing.expect(next <= 3_600_000 - 355_000);
+
+    // Only the renewable token is scheduled; the fixed SAS would return the
+    // same expiry forever, so refreshing it would spin.
+    try testing.expect(client.tokens.get("eh-sas").?.refresh_at_ms == null);
+    try testing.expectEqual(next, client.tokens.get("eh-aad").?.refresh_at_ms.?);
+}
+
+test "a refresh that comes due re-puts the token" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptCbsAttach(peer);
+    try scriptCbsReply(peer, allocator, 1, 202);
+    try scriptCbsReply(peer, allocator, 2, 202);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Cbs.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    var stub = StubProvider{ .token = .{
+        .token = "aad-jwt",
+        .expires_on_ms = 3_600_000,
+        .kind = .jwt,
+    } };
+    try client.authorize("eh", stub.provider(), 0, 10_000);
+    const first_due = client.nextRefreshAtMs().?;
+
+    // Nothing is owed before the refresh instant.
+    try client.refreshDue(stub.provider(), first_due - 1, 10_000);
+    try testing.expectEqual(@as(usize, 1), stub.calls);
+
+    // Once it comes due the token goes back to the wire and is rescheduled
+    // against the new expiry.
+    stub.token.expires_on_ms = 7_200_000;
+    try client.refreshDue(stub.provider(), first_due, 10_000);
+    try testing.expectEqual(@as(usize, 2), stub.calls);
+    try testing.expect(client.nextRefreshAtMs().? > first_due);
+    try testing.expectEqual(@as(i64, 7_200_000), client.cachedToken("eh").?.expires_on_ms);
+}
+
+test "recovering a connection invalidates every cached claim" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptCbsAttach(peer);
+    try scriptCbsReply(peer, allocator, 1, 202);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Cbs.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    var stub = StubProvider{ .token = .{
+        .token = "aad-jwt",
+        .expires_on_ms = 3_600_000,
+        .kind = .jwt,
+    } };
+    try client.authorize("eh", stub.provider(), 0, 10_000);
+    try testing.expect(client.cachedToken("eh") != null);
+
+    // A new connection carries none of the old connection's claims.
+    client.invalidateAll();
+    try testing.expect(client.cachedToken("eh") == null);
+    try testing.expect(client.nextRefreshAtMs() == null);
+}

--- a/link.zig
+++ b/link.zig
@@ -281,7 +281,8 @@ pub const Session = struct {
 ///
 /// A transfer frame carries the message payload immediately after the
 /// performative, so the split has to be found by measuring the performative.
-fn performativeLength(allocator: Allocator, body: []const u8) ?usize {
+/// Byte length of the performative at the head of `body`; the rest is payload.
+pub fn performativeLength(allocator: Allocator, body: []const u8) ?usize {
     var arena: std.heap.ArenaAllocator = .init(allocator);
     defer arena.deinit();
     const result = uamqp.decoder.decode(arena.allocator(), body) catch return null;
@@ -774,131 +775,12 @@ pub fn openReceiver(
 
 const testing = std.testing;
 const MemoryTransport = @import("transport.zig").MemoryTransport;
-const FrameHeader = uamqp.frame.FrameHeader;
-
-/// Scripts peer bytes and reads back what the driver emitted.
-const Peer = struct {
-    allocator: Allocator,
-    mem: *MemoryTransport,
-
-    fn pushHeader(self: Peer, header: *const [8]u8) !void {
-        try self.mem.pushPeerBytes(header);
-    }
-
-    fn push(self: Peer, channel: u16, p: perf.Performative) !void {
-        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
-        defer buf.deinit();
-        try perf.encode(self.allocator, p, &buf);
-        try self.pushRaw(channel, buf.written());
-    }
-
-    /// Push a transfer performative followed by a payload chunk.
-    fn pushTransfer(self: Peer, channel: u16, t: perf.Transfer, chunk: []const u8) !void {
-        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
-        defer buf.deinit();
-        try perf.encodeTransfer(self.allocator, t, &buf);
-        try buf.writeAll(chunk);
-        try self.pushRaw(channel, buf.written());
-    }
-
-    fn pushRaw(self: Peer, channel: u16, body: []const u8) !void {
-        const header = FrameHeader{
-            .size = @intCast(frame.frame_header_size + body.len),
-            .doff = 2,
-            .frame_type = .amqp,
-            .channel = channel,
-        };
-        const bytes = header.serialize();
-        try self.mem.pushPeerBytes(&bytes);
-        try self.mem.pushPeerBytes(body);
-    }
-};
-
-/// Every frame body the driver wrote, in order.
-const EmittedFrames = struct {
-    bodies: std.ArrayList([]const u8),
-    allocator: Allocator,
-
-    fn parse(allocator: Allocator, written: []const u8) !EmittedFrames {
-        var bodies: std.ArrayList([]const u8) = .empty;
-        errdefer bodies.deinit(allocator);
-        // A protocol header only leads the buffer before it is cleared.
-        var offset: usize = if (std.mem.startsWith(u8, written, "AMQP")) 8 else 0;
-        while (offset + frame.frame_header_size <= written.len) {
-            const header = try FrameHeader.parse(written[offset..][0..8]);
-            const body_len = header.size - @as(u32, header.doff) * 4;
-            const start = offset + @as(usize, header.doff) * 4;
-            try bodies.append(allocator, written[start..][0..body_len]);
-            offset += header.size;
-        }
-        return .{ .bodies = bodies, .allocator = allocator };
-    }
-
-    fn deinit(self: *EmittedFrames) void {
-        self.bodies.deinit(self.allocator);
-    }
-
-    /// Bodies whose descriptor matches `code`.
-    fn of(self: EmittedFrames, allocator: Allocator, code: u64) ![]const []const u8 {
-        var out: std.ArrayList([]const u8) = .empty;
-        for (self.bodies.items) |b| {
-            if (perf.peekDescriptor(b) == code) try out.append(allocator, b);
-        }
-        return out.toOwnedSlice(allocator);
-    }
-};
-
-const test_options = connection.Options{
-    .container_id = "test-container",
-    .hostname = "ns.servicebus.windows.net",
-    .sasl = .none,
-    .max_frame_size = 512,
-    .idle_timeout_ms = 0,
-};
-
-/// A driver opened against a scripted peer, plus a begun session.
-const Fixture = struct {
-    allocator: Allocator,
-    mem: *MemoryTransport,
-    clock: *connection.ManualClock,
-    driver: *Driver,
-    session: Session,
-
-    fn init(allocator: Allocator, mem: *MemoryTransport, clock: *connection.ManualClock, driver: *Driver) !Fixture {
-        try driver.open(10_000);
-        const session = try Session.begin(allocator, driver, 0, .{
-            .incoming_window = 100,
-            .outgoing_window = 100,
-        }, 10_000);
-        return .{
-            .allocator = allocator,
-            .mem = mem,
-            .clock = clock,
-            .driver = driver,
-            .session = session,
-        };
-    }
-
-    fn deinit(self: *Fixture) void {
-        self.session.deinit();
-    }
-};
-
-/// Script the peer's side of open + begin.
-fn scriptHandshake(peer: Peer, max_frame_size: u32) !void {
-    try peer.pushHeader(&frame.amqp_header);
-    try peer.push(0, .{ .open = .{
-        .container_id = "service-bus",
-        .max_frame_size = max_frame_size,
-        .channel_max = 255,
-    } });
-    try peer.push(0, .{ .begin = .{
-        .remote_channel = 0,
-        .next_outgoing_id = 1,
-        .incoming_window = 1000,
-        .outgoing_window = 1000,
-    } });
-}
+const harness = @import("test_peer.zig");
+const Peer = harness.Peer;
+const EmittedFrames = harness.EmittedFrames;
+const test_options = harness.driver_options;
+const Fixture = harness.Fixture;
+const scriptHandshake = harness.scriptHandshake;
 
 test "a sender attaches and reports the peer's max-message-size" {
     const allocator = testing.allocator;

--- a/root.zig
+++ b/root.zig
@@ -11,6 +11,8 @@ pub const performative = @import("performative.zig");
 pub const connection_driver = @import("connection.zig");
 pub const message_codec = @import("message.zig");
 pub const link = @import("link.zig");
+pub const rpc = @import("rpc.zig");
+pub const cbs = @import("cbs.zig");
 
 // Transports.
 pub const Transport = transport.Transport;
@@ -51,6 +53,19 @@ pub const openReceiver = link.openReceiver;
 pub const receiver_name_property = link.receiver_name_property;
 pub const epoch_property = link.epoch_property;
 
+// Request/response and CBS.
+pub const RpcLink = rpc.RpcLink;
+pub const RpcOptions = rpc.Options;
+pub const RpcError = rpc.RpcError;
+pub const RpcResponse = rpc.Response;
+pub const Cbs = cbs.Cbs;
+pub const CbsOptions = cbs.Options;
+pub const CbsError = cbs.CbsError;
+pub const AccessToken = cbs.AccessToken;
+pub const TokenProvider = cbs.TokenProvider;
+pub const RefreshPolicy = cbs.RefreshPolicy;
+pub const cbs_address = cbs.address;
+
 // Message codec.
 pub const Message = message_codec.Message;
 pub const MessageBody = message_codec.Body;
@@ -79,17 +94,7 @@ pub const SaslMechanism = uamqp.sasl.mechanism.Mechanism;
 pub const messaging = uamqp.messaging;
 
 /// CBS token types used by Azure services.
-pub const CbsTokenType = enum {
-    sas,
-    jwt,
-
-    pub fn toString(self: CbsTokenType) []const u8 {
-        return switch (self) {
-            .sas => "servicebus.windows.net:sastoken",
-            .jwt => "jwt",
-        };
-    }
-};
+pub const CbsTokenType = cbs.TokenType;
 
 // Zig only analyzes a file that something actually references, so the
 // re-exports above are not enough to make these files' tests run.
@@ -99,6 +104,8 @@ test {
     _ = connection_driver;
     _ = message_codec;
     _ = link;
+    _ = rpc;
+    _ = cbs;
 }
 
 // ─────────────────────── Tests ───────────────────────

--- a/rpc.zig
+++ b/rpc.zig
@@ -1,0 +1,361 @@
+//! Request/response over a pair of AMQP links.
+//!
+//! Both CBS (`$cbs`) and the Event Hubs `$management` endpoint work the same
+//! way: a sender writes a message to a well-known address, and a receiver
+//! attached to a private reply address gets the answer back, correlated by
+//! message id. Go shares one `rpcLink` between them for exactly this reason,
+//! so the mechanism lives here rather than in either caller.
+//!
+//! The status of a reply is carried in application properties rather than in
+//! the AMQP delivery outcome, so a rejected request still arrives as an
+//! accepted transfer with a 4xx or 5xx `status-code`.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const link = @import("link.zig");
+const message = @import("message.zig");
+const perf = @import("performative.zig");
+const uamqp = @import("uamqp");
+
+const AmqpValue = uamqp.AmqpValue;
+const MapEntry = uamqp.MapEntry;
+
+pub const RpcError = link.LinkError || error{
+    /// The reply carried no `status-code` property.
+    MissingStatusCode,
+    /// The reply's `status-code` was not an integer.
+    InvalidStatusCode,
+    /// The service rejected the request; see `Response.status_code`.
+    RequestFailed,
+    /// The service refused the credential (401).
+    Unauthorized,
+    /// The reply body could not be parsed as an AMQP message.
+    MalformedReply,
+};
+
+/// The property names a reply's status arrives under. Go accepts both
+/// spellings because the Event Hubs and Service Bus brokers disagree.
+pub const status_code_key = "status-code";
+pub const status_description_key = "status-description";
+pub const alt_status_code_key = "statusCode";
+pub const alt_status_description_key = "statusDescription";
+
+/// A parsed reply. Owns its backing bytes; call `deinit`.
+pub const Response = struct {
+    allocator: Allocator,
+    decoded: message.Decoded,
+    payload: []const u8,
+    status_code: i32,
+    status_description: ?[]const u8,
+
+    pub fn deinit(self: *Response) void {
+        self.decoded.deinit();
+        self.allocator.free(self.payload);
+    }
+
+    pub fn msg(self: Response) message.Message {
+        return self.decoded.message;
+    }
+
+    /// The reply's application properties, or an empty slice.
+    pub fn properties(self: Response) perf.Fields {
+        return self.decoded.message.application_properties orelse &.{};
+    }
+};
+
+pub const Options = struct {
+    /// The well-known address to send to, such as `$cbs` or `$management`.
+    address: []const u8,
+    /// Distinguishes this link pair from others on the same connection.
+    /// Callers that open more than one must vary it.
+    link_id: []const u8,
+    desired_capabilities: ?[]const []const u8 = null,
+    properties: ?perf.Fields = null,
+};
+
+/// A sender/receiver pair implementing request/response against `address`.
+pub const RpcLink = struct {
+    allocator: Allocator,
+    session: *link.Session,
+    address: []const u8,
+    /// The private address replies are routed back to.
+    reply_to: []const u8,
+    sender: *link.Sender,
+    receiver: *link.Receiver,
+    /// Serial number behind the correlation id.
+    next_id: u64 = 1,
+
+    pub fn open(
+        session: *link.Session,
+        options: Options,
+        deadline_ms: i64,
+    ) RpcError!*RpcLink {
+        const allocator = session.allocator;
+        const self = try allocator.create(RpcLink);
+        errdefer allocator.destroy(self);
+
+        const address = try allocator.dupe(u8, options.address);
+        errdefer allocator.free(address);
+
+        const reply_to = try replyAddress(allocator, options.address, options.link_id);
+        errdefer allocator.free(reply_to);
+
+        const sender_name = try std.fmt.allocPrint(
+            allocator,
+            "{s}-sender-{s}",
+            .{ options.address, options.link_id },
+        );
+        defer allocator.free(sender_name);
+
+        const receiver_name = try std.fmt.allocPrint(
+            allocator,
+            "{s}-receiver-{s}",
+            .{ options.address, options.link_id },
+        );
+        defer allocator.free(receiver_name);
+
+        const sender = try link.openSender(session, .{
+            .name = sender_name,
+            .target_address = options.address,
+            .desired_capabilities = options.desired_capabilities,
+            .properties = options.properties,
+        }, deadline_ms);
+        errdefer sender.deinit();
+
+        // Replies arrive pre-settled: the reply carries its own status, so
+        // there is nothing useful to signal back with a disposition.
+        const receiver = try link.openReceiver(session, .{
+            .name = receiver_name,
+            .source_address = options.address,
+            .target_address = reply_to,
+            .rcv_settle_mode = .first,
+            .desired_capabilities = options.desired_capabilities,
+            .properties = options.properties,
+        }, deadline_ms);
+        errdefer receiver.deinit();
+
+        self.* = .{
+            .allocator = allocator,
+            .session = session,
+            .address = address,
+            .reply_to = reply_to,
+            .sender = sender,
+            .receiver = receiver,
+        };
+        return self;
+    }
+
+    pub fn deinit(self: *RpcLink) void {
+        self.allocator.free(self.address);
+        self.allocator.free(self.reply_to);
+        self.allocator.destroy(self);
+    }
+
+    /// Detach both links.
+    pub fn close(self: *RpcLink, deadline_ms: i64) RpcError!void {
+        self.receiver.detach(deadline_ms) catch {};
+        try self.sender.detach(deadline_ms);
+    }
+
+    /// Send `request` and wait for the reply correlated to it.
+    ///
+    /// `request.properties.message_id` and `.reply_to` are filled in here and
+    /// overwrite anything the caller set, since the correlation depends on
+    /// them.
+    pub fn call(
+        self: *RpcLink,
+        request: message.Message,
+        deadline_ms: i64,
+    ) RpcError!Response {
+        var buf: [48]u8 = undefined;
+        const id = self.nextMessageId(&buf);
+
+        var outgoing = request;
+        outgoing.properties.message_id = .{ .string = id };
+        outgoing.properties.reply_to = self.reply_to;
+
+        try self.sender.send(outgoing, deadline_ms);
+
+        // Replies for other requests can be in flight after a timeout, so keep
+        // reading until the correlation id matches rather than trusting order.
+        while (true) {
+            const delivery = try self.receiver.receive(deadline_ms);
+            var response = self.parse(delivery.payload) catch |e| switch (e) {
+                error.MalformedReply => {
+                    self.receiver.accept(delivery) catch {};
+                    continue;
+                },
+                else => return e,
+            };
+            errdefer response.deinit();
+            self.receiver.accept(delivery) catch {};
+
+            if (!correlates(response.decoded.message, id)) {
+                response.deinit();
+                continue;
+            }
+            return response;
+        }
+    }
+
+    fn nextMessageId(self: *RpcLink, buf: []u8) []const u8 {
+        const n = self.next_id;
+        self.next_id += 1;
+        return std.fmt.bufPrint(buf, "{s}:{d}", .{ self.reply_to, n }) catch
+            std.fmt.bufPrint(buf, "{d}", .{n}) catch unreachable;
+    }
+
+    fn parse(self: *RpcLink, payload: []const u8) RpcError!Response {
+        const owned = try self.allocator.dupe(u8, payload);
+        errdefer self.allocator.free(owned);
+
+        var decoded = message.decode(self.allocator, owned) catch
+            return error.MalformedReply;
+        errdefer decoded.deinit();
+
+        const props = decoded.message.application_properties orelse &.{};
+        const code = try statusCode(props);
+        return .{
+            .allocator = self.allocator,
+            .decoded = decoded,
+            .payload = owned,
+            .status_code = code,
+            .status_description = statusDescription(props),
+        };
+    }
+};
+
+/// The private address replies come back on.
+///
+/// Go intends to strip the leading `$` from the endpoint address, but its
+/// `strings.ReplaceAll("$", "", args.Address)` has the haystack and needle
+/// swapped, so it actually produces `$cbs$$cbs-reply-to-<id>`. Any unique
+/// address works, so this implements the intent rather than the accident.
+fn replyAddress(allocator: Allocator, address: []const u8, link_id: []const u8) Allocator.Error![]u8 {
+    const bare = std.mem.trimStart(u8, address, "$");
+    return std.fmt.allocPrint(allocator, "{s}-reply-to-{s}", .{ bare, link_id });
+}
+
+fn correlates(msg: message.Message, id: []const u8) bool {
+    const value = msg.properties.correlation_id orelse
+        // Some brokers echo the id in message-id instead.
+        msg.properties.message_id orelse return false;
+    return switch (value) {
+        .string, .binary, .symbol => |s| std.mem.eql(u8, s, id),
+        else => false,
+    };
+}
+
+fn lookup(props: perf.Fields, key: []const u8) ?AmqpValue {
+    for (props) |entry| {
+        const name = switch (entry.key) {
+            .string, .symbol => |s| s,
+            else => continue,
+        };
+        if (std.mem.eql(u8, name, key)) return entry.value;
+    }
+    return null;
+}
+
+/// Read the reply's status code, accepting either spelling and any integral
+/// encoding the broker chose.
+pub fn statusCode(props: perf.Fields) RpcError!i32 {
+    const value = lookup(props, status_code_key) orelse
+        lookup(props, alt_status_code_key) orelse
+        return error.MissingStatusCode;
+    return switch (value) {
+        .byte => |v| v,
+        .short => |v| v,
+        .int => |v| v,
+        .long => |v| std.math.cast(i32, v) orelse error.InvalidStatusCode,
+        .ubyte => |v| v,
+        .ushort => |v| v,
+        .uint => |v| std.math.cast(i32, v) orelse error.InvalidStatusCode,
+        .ulong => |v| std.math.cast(i32, v) orelse error.InvalidStatusCode,
+        else => error.InvalidStatusCode,
+    };
+}
+
+/// Read the reply's status description, accepting either spelling.
+pub fn statusDescription(props: perf.Fields) ?[]const u8 {
+    const value = lookup(props, status_description_key) orelse
+        lookup(props, alt_status_description_key) orelse
+        return null;
+    return switch (value) {
+        .string, .symbol => |s| s,
+        else => null,
+    };
+}
+
+/// Map a reply status onto an error. 2xx succeeds; a 401 is reported
+/// distinctly because callers must not retry it.
+pub fn checkStatus(code: i32) RpcError!void {
+    if (code >= 200 and code < 300) return;
+    if (code == 401) return error.Unauthorized;
+    return error.RequestFailed;
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+
+test "the reply address strips the endpoint's leading sigil" {
+    const allocator = testing.allocator;
+    const addr = try replyAddress(allocator, "$cbs", "abc");
+    defer allocator.free(addr);
+    try testing.expectEqualStrings("cbs-reply-to-abc", addr);
+
+    const mgmt = try replyAddress(allocator, "$management", "xyz");
+    defer allocator.free(mgmt);
+    try testing.expectEqualStrings("management-reply-to-xyz", mgmt);
+}
+
+test "a status code is read under either spelling and any integral encoding" {
+    try testing.expectEqual(@as(i32, 202), try statusCode(&.{
+        .{ .key = .{ .string = status_code_key }, .value = .{ .int = 202 } },
+    }));
+    try testing.expectEqual(@as(i32, 202), try statusCode(&.{
+        .{ .key = .{ .symbol = alt_status_code_key }, .value = .{ .ushort = 202 } },
+    }));
+    try testing.expectEqual(@as(i32, 401), try statusCode(&.{
+        .{ .key = .{ .string = status_code_key }, .value = .{ .long = 401 } },
+    }));
+    try testing.expectError(error.MissingStatusCode, statusCode(&.{
+        .{ .key = .{ .string = "other" }, .value = .{ .int = 200 } },
+    }));
+    try testing.expectError(error.InvalidStatusCode, statusCode(&.{
+        .{ .key = .{ .string = status_code_key }, .value = .{ .string = "200" } },
+    }));
+}
+
+test "a status description is read under either spelling" {
+    try testing.expectEqualStrings("ok", statusDescription(&.{
+        .{ .key = .{ .string = status_description_key }, .value = .{ .string = "ok" } },
+    }).?);
+    try testing.expectEqualStrings("bad", statusDescription(&.{
+        .{ .key = .{ .string = alt_status_description_key }, .value = .{ .string = "bad" } },
+    }).?);
+    try testing.expect(statusDescription(&.{}) == null);
+}
+
+test "a 401 is distinguished from other failures so it is not retried" {
+    try checkStatus(200);
+    try checkStatus(202);
+    try testing.expectError(error.Unauthorized, checkStatus(401));
+    try testing.expectError(error.RequestFailed, checkStatus(404));
+    try testing.expectError(error.RequestFailed, checkStatus(500));
+}
+
+test "a reply correlates on correlation-id, falling back to message-id" {
+    try testing.expect(correlates(.{
+        .properties = .{ .correlation_id = .{ .string = "id-1" } },
+    }, "id-1"));
+    try testing.expect(!correlates(.{
+        .properties = .{ .correlation_id = .{ .string = "id-2" } },
+    }, "id-1"));
+    try testing.expect(correlates(.{
+        .properties = .{ .message_id = .{ .string = "id-1" } },
+    }, "id-1"));
+    try testing.expect(!correlates(.{}, "id-1"));
+}

--- a/test_peer.zig
+++ b/test_peer.zig
@@ -1,0 +1,150 @@
+//! A scripted AMQP peer for tests.
+//!
+//! `MemoryTransport` gives a duplex byte pipe; this drives the far end of it,
+//! writing frames a real broker would send and parsing back what the driver
+//! emitted. Shared by the link, RPC, and CBS tests, which all need the same
+//! open/begin/attach preamble before the behaviour under test starts.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const connection = @import("connection.zig");
+const frame = uamqp.frame;
+const link = @import("link.zig");
+const perf = @import("performative.zig");
+const uamqp = @import("uamqp");
+
+const Driver = connection.Driver;
+const Session = link.Session;
+const MemoryTransport = @import("transport.zig").MemoryTransport;
+const FrameHeader = uamqp.frame.FrameHeader;
+
+/// Scripts peer bytes and reads back what the driver emitted.
+pub const Peer = struct {
+    allocator: Allocator,
+    mem: *MemoryTransport,
+
+    pub fn pushHeader(self: Peer, header: *const [8]u8) !void {
+        try self.mem.pushPeerBytes(header);
+    }
+
+    pub fn push(self: Peer, channel: u16, p: perf.Performative) !void {
+        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
+        defer buf.deinit();
+        try perf.encode(self.allocator, p, &buf);
+        try self.pushRaw(channel, buf.written());
+    }
+
+    /// Push a transfer performative followed by a payload chunk.
+    pub fn pushTransfer(self: Peer, channel: u16, t: perf.Transfer, chunk: []const u8) !void {
+        var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
+        defer buf.deinit();
+        try perf.encodeTransfer(self.allocator, t, &buf);
+        try buf.writeAll(chunk);
+        try self.pushRaw(channel, buf.written());
+    }
+
+    pub fn pushRaw(self: Peer, channel: u16, body: []const u8) !void {
+        const header = FrameHeader{
+            .size = @intCast(frame.frame_header_size + body.len),
+            .doff = 2,
+            .frame_type = .amqp,
+            .channel = channel,
+        };
+        const bytes = header.serialize();
+        try self.mem.pushPeerBytes(&bytes);
+        try self.mem.pushPeerBytes(body);
+    }
+};
+
+/// Every frame body the driver wrote, in order.
+pub const EmittedFrames = struct {
+    bodies: std.ArrayList([]const u8),
+    allocator: Allocator,
+
+    pub fn parse(allocator: Allocator, written: []const u8) !EmittedFrames {
+        var bodies: std.ArrayList([]const u8) = .empty;
+        errdefer bodies.deinit(allocator);
+        // A protocol header only leads the buffer before it is cleared.
+        var offset: usize = if (std.mem.startsWith(u8, written, "AMQP")) 8 else 0;
+        while (offset + frame.frame_header_size <= written.len) {
+            const header = try FrameHeader.parse(written[offset..][0..8]);
+            const body_len = header.size - @as(u32, header.doff) * 4;
+            const start = offset + @as(usize, header.doff) * 4;
+            try bodies.append(allocator, written[start..][0..body_len]);
+            offset += header.size;
+        }
+        return .{ .bodies = bodies, .allocator = allocator };
+    }
+
+    pub fn deinit(self: *EmittedFrames) void {
+        self.bodies.deinit(self.allocator);
+    }
+
+    /// Bodies whose descriptor matches `code`.
+    pub fn of(self: EmittedFrames, allocator: Allocator, code: u64) ![]const []const u8 {
+        var out: std.ArrayList([]const u8) = .empty;
+        for (self.bodies.items) |b| {
+            if (perf.peekDescriptor(b) == code) try out.append(allocator, b);
+        }
+        return out.toOwnedSlice(allocator);
+    }
+};
+
+pub const driver_options = connection.Options{
+    .container_id = "test-container",
+    .hostname = "ns.servicebus.windows.net",
+    .sasl = .none,
+    .max_frame_size = 512,
+    .idle_timeout_ms = 0,
+};
+
+/// A driver opened against a scripted peer, plus a begun session.
+pub const Fixture = struct {
+    allocator: Allocator,
+    mem: *MemoryTransport,
+    clock: *connection.ManualClock,
+    driver: *Driver,
+    session: Session,
+
+    pub fn init(allocator: Allocator, mem: *MemoryTransport, clock: *connection.ManualClock, driver: *Driver) !Fixture {
+        try driver.open(10_000);
+        const session = try Session.begin(allocator, driver, 0, .{
+            .incoming_window = 100,
+            .outgoing_window = 100,
+        }, 10_000);
+        return .{
+            .allocator = allocator,
+            .mem = mem,
+            .clock = clock,
+            .driver = driver,
+            .session = session,
+        };
+    }
+
+    pub fn deinit(self: *Fixture) void {
+        self.session.deinit();
+    }
+};
+
+/// Script the peer's side of open + begin.
+pub fn scriptHandshake(peer: Peer, max_frame_size: u32) !void {
+    try peer.pushHeader(&frame.amqp_header);
+    try peer.push(0, .{ .open = .{
+        .container_id = "service-bus",
+        .max_frame_size = max_frame_size,
+        .channel_max = 255,
+    } });
+    try peer.push(0, .{ .begin = .{
+        .remote_channel = 0,
+        .next_outgoing_id = 1,
+        .incoming_window = 1000,
+        .outgoing_window = 1000,
+    } });
+}
+
+/// The message payload carried after a transfer performative in `body`.
+pub fn transferPayload(allocator: Allocator, body: []const u8) ?[]const u8 {
+    const consumed = link.performativeLength(allocator, body) orelse return null;
+    return body[consumed..];
+}


### PR DESCRIPTION
Part of #191. Implements #199.

Event Hubs carries no credential in the SASL exchange — the driver authenticates anonymously — so every entity has to be authorised separately by putting a token to `$cbs` before any link on that path attaches. Nothing did that yet.

## `rpc.zig`

A sender paired with a receiver on a private reply address, correlating each reply to its request by message id. Go shares one `rpcLink` between CBS and `$management`, so #200 lands on this too rather than duplicating it.

A reply's status rides in application properties, not in the delivery outcome, so a refused request still arrives as an *accepted* transfer. Both spellings brokers use (`status-code` and `statusCode`) are accepted, as is any integral encoding of the code.

## `cbs.zig`

- `operation`, `type`, `name`, and `expiration` application properties with the token as the message value, matching Go's layout exactly
- 401 → `error.Unauthorized`, kept distinct so callers do not retry a refused credential
- per-audience token cache; the provider is only consulted when a round-trip is actually needed
- refresh six minutes before expiry with ±5s jitter and a 30s failure backoff, matching Rust
- a pre-formed SAS from a connection string is non-refreshable and schedules nothing, since renewing it returns the same expiry it already had
- `invalidateAll` for re-authorising every path after a connection recovery

`TokenProvider` is a function-pointer struct, so this module does not depend on the credential type — acquiring the token stays the credential's job, as the issue scopes it.

## A Go bug I did not copy

Go derives the reply address with `strings.ReplaceAll("$", "", args.Address)` (`internal/rpc.go:106`). The haystack and needle are swapped, so it actually produces `$cbs$$cbs-reply-to-<uuid>`. Any unique address works, which is why it has never been noticed. This implements the intent — `cbs-reply-to-<uuid>`.

## Refresh scheduling

The refresh *policy* is implemented and tested; there is no background thread. The driver is synchronous and deadline-based throughout, so spawning one would be an architectural commitment beyond this issue. `refreshDue` and `nextRefreshAtMs` give a caller everything needed to drive it from whatever loop it already has.

## Testing

The scripted-peer helpers move out of `link.zig` into `test_peer.zig` — the link, RPC, and CBS tests all need the same open/begin/attach preamble.

Covering the acceptance criteria: the exact application-property map is asserted for both a JWT and a SAS token, a 401 surfaces as unauthorized with exactly one request on the wire, a second `authorize` for the same audience makes no round-trip at all (only one reply is scripted, so a second would block), and a non-refreshable token schedules no refresh.

I mutation-tested the cache — removing the staleness check makes the cache test fail.

90 tests pass; `zig fmt --check` is clean.

Paired registry PR on `main` adds the three new published files.