### PR TITLE
Add the $management request/response link

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,35 @@ Acquiring the token is the credential's job. `TokenProvider` is a
 function-pointer struct, so this module does not depend on the credential type,
 and it is only consulted when a round-trip is actually needed.
 
-The `$management` link is not here yet.
+## Management
+
+`management.zig` drives the `$management` endpoint. A request carries the
+`operation` (`READ` for every metadata read), the entity `type`, the `name`,
+and the caller's `security_token`, with caller-supplied properties merged after
+them. The path has to be authorised over CBS before this link attaches.
+
+```zig
+const client = try amqp.Management.open(&session, .{ .link_id = id }, deadline_ms);
+defer client.deinit();
+
+var response = try client.call(.{
+    .entity_type = "com.microsoft:eventhub",
+    .name = hub_name,
+    .security_token = token,
+}, deadline_ms);
+defer response.deinit();
+```
+
+A non-2xx reply fails the call. Zig errors carry no payload, so the broker's
+status and description are recorded on `last_error`, the same way the
+connection driver records a remote error. `callRaw` returns the reply whatever
+its status, for callers that treat some codes as expected.
+
+`begin` and `awaitReply` are separate so several requests can be in flight at
+once; each is matched to its own reply however the broker orders them, and a
+reply that arrives before its caller asks for it is held rather than dropped. A
+detach fails everything outstanding instead of leaving a caller blocked until
+its deadline.
 
 ## Tests
 

--- a/management.zig
+++ b/management.zig
@@ -1,0 +1,517 @@
+//! The `$management` request/response endpoint.
+//!
+//! Event Hubs exposes hub and partition metadata here, and Service Bus uses
+//! the same endpoint for its own operations. The transport is the ordinary RPC
+//! link pair; what is specific to management is the request shape — an
+//! `operation`, an entity `type`, a `name`, and the caller's `security_token`
+//! — and turning a non-2xx reply into an error that carries the broker's
+//! description.
+//!
+//! The path has to be authorised over CBS before this link attaches.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const link = @import("link.zig");
+const message = @import("message.zig");
+const perf = @import("performative.zig");
+const rpc = @import("rpc.zig");
+const uamqp = @import("uamqp");
+
+const AmqpValue = uamqp.AmqpValue;
+const MapEntry = uamqp.MapEntry;
+
+pub const address = "$management";
+
+pub const operation_key = "operation";
+pub const type_key = "type";
+pub const name_key = "name";
+pub const security_token_key = "security_token";
+
+/// The operation every metadata read uses.
+pub const read_operation = "READ";
+
+pub const ManagementError = rpc.RpcError;
+
+/// A non-2xx reply, copied so it outlives the response it came from.
+pub const StatusError = struct {
+    code: i32,
+    description: ?[]const u8,
+
+    pub fn deinit(self: StatusError, allocator: Allocator) void {
+        if (self.description) |d| allocator.free(d);
+    }
+};
+
+pub const Request = struct {
+    /// Defaults to `READ`, which is what every metadata operation uses.
+    operation: []const u8 = read_operation,
+    /// The entity type, such as `com.microsoft:eventhub`.
+    entity_type: []const u8,
+    /// The entity the operation applies to.
+    name: []const u8,
+    /// The CBS token for the management path. Omitted when the broker does
+    /// not require it on the message itself.
+    security_token: ?[]const u8 = null,
+    /// Merged after the standard four. A caller may override any of them by
+    /// repeating the key, since the broker reads the last occurrence.
+    properties: ?perf.Fields = null,
+    body: message.Body = .empty,
+};
+
+pub const Options = struct {
+    /// Distinguishes this link pair from any other on the connection.
+    link_id: []const u8,
+};
+
+/// A `$management` client.
+pub const Management = struct {
+    allocator: Allocator,
+    rpc_link: *rpc.RpcLink,
+    /// The most recent non-2xx reply. Errors cannot carry a payload, so the
+    /// broker's status and description are recorded here, as the connection
+    /// driver does for remote errors.
+    last_error: ?StatusError = null,
+
+    pub fn open(
+        session: *link.Session,
+        options: Options,
+        deadline_ms: i64,
+    ) ManagementError!*Management {
+        const allocator = session.allocator;
+        const self = try allocator.create(Management);
+        errdefer allocator.destroy(self);
+
+        const rpc_link = try rpc.RpcLink.open(session, .{
+            .address = address,
+            .link_id = options.link_id,
+        }, deadline_ms);
+        errdefer rpc_link.deinit();
+
+        self.* = .{ .allocator = allocator, .rpc_link = rpc_link };
+        return self;
+    }
+
+    pub fn deinit(self: *Management) void {
+        self.clearError();
+        self.rpc_link.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn close(self: *Management, deadline_ms: i64) ManagementError!void {
+        try self.rpc_link.close(deadline_ms);
+    }
+
+    /// Send `request` and return the id its reply will be correlated by.
+    ///
+    /// Splitting the send from the wait lets a caller keep several requests in
+    /// flight; each is matched to its own reply however the broker orders
+    /// them.
+    pub fn begin(
+        self: *Management,
+        request: Request,
+        deadline_ms: i64,
+    ) ManagementError![]const u8 {
+        var props: std.ArrayList(MapEntry) = .empty;
+        defer props.deinit(self.allocator);
+
+        try props.append(self.allocator, .{
+            .key = .{ .string = operation_key },
+            .value = .{ .string = request.operation },
+        });
+        try props.append(self.allocator, .{
+            .key = .{ .string = type_key },
+            .value = .{ .string = request.entity_type },
+        });
+        try props.append(self.allocator, .{
+            .key = .{ .string = name_key },
+            .value = .{ .string = request.name },
+        });
+        if (request.security_token) |token| {
+            try props.append(self.allocator, .{
+                .key = .{ .string = security_token_key },
+                .value = .{ .string = token },
+            });
+        }
+        if (request.properties) |extra| {
+            try props.appendSlice(self.allocator, extra);
+        }
+
+        return self.rpc_link.begin(.{
+            .application_properties = props.items,
+            .body = request.body,
+        }, deadline_ms);
+    }
+
+    /// Wait for the reply to `id`, failing on a non-2xx status.
+    pub fn awaitReply(
+        self: *Management,
+        id: []const u8,
+        deadline_ms: i64,
+    ) ManagementError!rpc.Response {
+        var response = try self.rpc_link.awaitReply(id, deadline_ms);
+        errdefer response.deinit();
+        try self.check(response);
+        return response;
+    }
+
+    /// Give up on `id` without waiting for its reply.
+    pub fn abandon(self: *Management, id: []const u8) void {
+        self.rpc_link.abandon(id);
+    }
+
+    /// Send `request` and wait for its reply, failing on a non-2xx status.
+    ///
+    /// On failure `last_error` carries the broker's status and description.
+    pub fn call(
+        self: *Management,
+        request: Request,
+        deadline_ms: i64,
+    ) ManagementError!rpc.Response {
+        const id = try self.begin(request, deadline_ms);
+        return self.awaitReply(id, deadline_ms);
+    }
+
+    /// Send `request` and return the reply whatever its status, for callers
+    /// that treat some non-2xx codes as expected.
+    pub fn callRaw(
+        self: *Management,
+        request: Request,
+        deadline_ms: i64,
+    ) ManagementError!rpc.Response {
+        const id = try self.begin(request, deadline_ms);
+        return self.rpc_link.awaitReply(id, deadline_ms);
+    }
+
+    fn check(self: *Management, response: rpc.Response) ManagementError!void {
+        rpc.checkStatus(response.status_code) catch |e| {
+            self.recordError(response);
+            return e;
+        };
+        self.clearError();
+    }
+
+    fn recordError(self: *Management, response: rpc.Response) void {
+        self.clearError();
+        // A failure to copy the description must not mask the status itself.
+        const description = if (response.status_description) |d|
+            self.allocator.dupe(u8, d) catch null
+        else
+            null;
+        self.last_error = .{
+            .code = response.status_code,
+            .description = description,
+        };
+    }
+
+    fn clearError(self: *Management) void {
+        if (self.last_error) |e| e.deinit(self.allocator);
+        self.last_error = null;
+    }
+};
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const connection = @import("connection.zig");
+const harness = @import("test_peer.zig");
+const MemoryTransport = @import("transport.zig").MemoryTransport;
+const Peer = harness.Peer;
+const Fixture = harness.Fixture;
+const EmittedFrames = harness.EmittedFrames;
+
+/// Script the peer's side of attaching a `$management` link pair.
+fn scriptAttach(peer: Peer, credit: u32) !void {
+    try harness.scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "$management-sender-test",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "$management-receiver-test",
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = credit,
+    } });
+}
+
+/// Settle the request the client sent as delivery `n - 1`.
+fn scriptSettle(peer: Peer, n: u64) !void {
+    const delivery_id: u32 = @intCast(n - 1);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = delivery_id,
+        .last = delivery_id,
+        .settled = true,
+        .state = .accepted,
+    } });
+}
+
+/// Push a reply correlated to request `n`.
+fn scriptReply(
+    peer: Peer,
+    allocator: Allocator,
+    n: u64,
+    status: i32,
+    description: []const u8,
+    delivery_id: u32,
+) !void {
+    var id_buf: [64]u8 = undefined;
+    const correlation = try std.fmt.bufPrint(&id_buf, "management-reply-to-test:{d}", .{n});
+    const props = [_]MapEntry{
+        .{ .key = .{ .string = rpc.status_code_key }, .value = .{ .int = status } },
+        .{
+            .key = .{ .string = rpc.status_description_key },
+            .value = .{ .string = description },
+        },
+    };
+    const payload = try message.encodeAlloc(allocator, .{
+        .properties = .{ .correlation_id = .{ .string = correlation } },
+        .application_properties = &props,
+        .body = .{ .value = .{ .string = description } },
+    });
+    defer allocator.free(payload);
+
+    try peer.pushTransfer(0, .{
+        .handle = 1,
+        .delivery_id = delivery_id,
+        .delivery_tag = "r",
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, payload);
+}
+
+fn propertyValue(props: perf.Fields, key: []const u8) ?AmqpValue {
+    for (props) |entry| {
+        const name = switch (entry.key) {
+            .string, .symbol => |str| str,
+            else => continue,
+        };
+        if (std.mem.eql(u8, name, key)) return entry.value;
+    }
+    return null;
+}
+
+test "a request carries the operation, type, name, and security token" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    try scriptReply(peer, allocator, 1, 200, "OK", 0);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Management.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    mem.clearWritten();
+    const extra = [_]MapEntry{
+        .{ .key = .{ .string = "com.microsoft:partition" }, .value = .{ .string = "3" } },
+    };
+    var response = try client.call(.{
+        .entity_type = "com.microsoft:eventhub",
+        .name = "my-hub",
+        .security_token = "SharedAccessSignature sr=x&sig=y",
+        .properties = &extra,
+    }, 10_000);
+    defer response.deinit();
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, 0x14);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+
+    var decoded = try message.decode(allocator, harness.transferPayload(allocator, transfers[0]).?);
+    defer decoded.deinit();
+    const props = decoded.message.application_properties.?;
+
+    try testing.expectEqualStrings("READ", propertyValue(props, operation_key).?.string);
+    try testing.expectEqualStrings("com.microsoft:eventhub", propertyValue(props, type_key).?.string);
+    try testing.expectEqualStrings("my-hub", propertyValue(props, name_key).?.string);
+    try testing.expectEqualStrings(
+        "SharedAccessSignature sr=x&sig=y",
+        propertyValue(props, security_token_key).?.string,
+    );
+    // Caller properties are merged alongside the standard four.
+    try testing.expectEqualStrings("3", propertyValue(props, "com.microsoft:partition").?.string);
+    try testing.expectEqualStrings("management-reply-to-test", decoded.message.properties.reply_to.?);
+
+    try testing.expectEqual(@as(i32, 200), response.status_code);
+}
+
+test "two requests answered out of order each reach the right caller" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    try scriptSettle(peer, 2);
+    // The broker answers the second request first.
+    try scriptReply(peer, allocator, 2, 200, "second", 0);
+    try scriptReply(peer, allocator, 1, 200, "first", 1);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Management.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    const first = try client.begin(.{
+        .entity_type = "com.microsoft:eventhub",
+        .name = "hub-one",
+    }, 10_000);
+    const second = try client.begin(.{
+        .entity_type = "com.microsoft:eventhub",
+        .name = "hub-two",
+    }, 10_000);
+
+    // Awaiting the first has to hold the second's reply rather than discard
+    // it, since it arrives first.
+    var first_response = try client.awaitReply(first, 10_000);
+    defer first_response.deinit();
+    try testing.expectEqualStrings("first", first_response.status_description.?);
+
+    var second_response = try client.awaitReply(second, 10_000);
+    defer second_response.deinit();
+    try testing.expectEqualStrings("second", second_response.status_description.?);
+}
+
+test "a 404 reply fails the call and records the broker's description" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    try scriptReply(peer, allocator, 1, 404, "The messaging entity 'missing' could not be found.", 0);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Management.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    try testing.expectError(error.RequestFailed, client.call(.{
+        .entity_type = "com.microsoft:eventhub",
+        .name = "missing",
+    }, 10_000));
+
+    try testing.expectEqual(@as(i32, 404), client.last_error.?.code);
+    try testing.expectEqualStrings(
+        "The messaging entity 'missing' could not be found.",
+        client.last_error.?.description.?,
+    );
+}
+
+test "a detach fails an in-flight request instead of hanging" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    // The broker tears the reply link down without answering.
+    try peer.push(0, .{ .detach = .{
+        .handle = 1,
+        .closed = true,
+        .err = .{
+            .condition = "amqp:link:detach-forced",
+            .description = "The link was closed by the service.",
+        },
+    } });
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Management.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    const id = try client.begin(.{
+        .entity_type = "com.microsoft:eventhub",
+        .name = "my-hub",
+    }, 10_000);
+
+    try testing.expectError(error.LinkDetached, client.awaitReply(id, 10_000));
+}
+
+test "a request with no reply times out rather than blocking forever" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Management.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    const id = try client.begin(.{
+        .entity_type = "com.microsoft:eventhub",
+        .name = "my-hub",
+    }, 10_000);
+
+    // The peer has nothing more to say, so the read starves and the deadline
+    // decides the outcome.
+    mem.starve = true;
+    try testing.expectError(error.Timeout, client.awaitReply(id, clock.millis));
+}
+
+test "awaiting an unknown request id is an error, not a hang" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+
+    var driver = try connection.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const client = try Management.open(&fixture.session, .{ .link_id = "test" }, 10_000);
+    defer client.deinit();
+
+    try testing.expectError(error.UnknownRequest, client.awaitReply("never-sent", 10_000));
+}

--- a/root.zig
+++ b/root.zig
@@ -13,6 +13,7 @@ pub const message_codec = @import("message.zig");
 pub const link = @import("link.zig");
 pub const rpc = @import("rpc.zig");
 pub const cbs = @import("cbs.zig");
+pub const management = @import("management.zig");
 
 // Transports.
 pub const Transport = transport.Transport;
@@ -65,6 +66,12 @@ pub const AccessToken = cbs.AccessToken;
 pub const TokenProvider = cbs.TokenProvider;
 pub const RefreshPolicy = cbs.RefreshPolicy;
 pub const cbs_address = cbs.address;
+pub const Management = management.Management;
+pub const ManagementOptions = management.Options;
+pub const ManagementRequest = management.Request;
+pub const ManagementError = management.ManagementError;
+pub const ManagementStatusError = management.StatusError;
+pub const management_address = management.address;
 
 // Message codec.
 pub const Message = message_codec.Message;
@@ -106,6 +113,7 @@ test {
     _ = link;
     _ = rpc;
     _ = cbs;
+    _ = management;
 }
 
 // ─────────────────────── Tests ───────────────────────

--- a/rpc.zig
+++ b/rpc.zig
@@ -30,6 +30,8 @@ pub const RpcError = link.LinkError || error{
     RequestFailed,
     /// The service refused the credential (401).
     Unauthorized,
+    /// Awaited a request id that was never begun, or was already awaited.
+    UnknownRequest,
     /// The reply body could not be parsed as an AMQP message.
     MalformedReply,
 };
@@ -85,6 +87,9 @@ pub const RpcLink = struct {
     receiver: *link.Receiver,
     /// Serial number behind the correlation id.
     next_id: u64 = 1,
+    /// Requests awaiting a reply, keyed by correlation id. A filled value is a
+    /// reply that arrived before its caller asked for it.
+    pending: std.StringHashMapUnmanaged(?Response) = .empty,
 
     pub fn open(
         session: *link.Session,
@@ -147,6 +152,8 @@ pub const RpcLink = struct {
     }
 
     pub fn deinit(self: *RpcLink) void {
+        self.failAll();
+        self.pending.deinit(self.allocator);
         self.allocator.free(self.address);
         self.allocator.free(self.reply_to);
         self.allocator.destroy(self);
@@ -158,45 +165,125 @@ pub const RpcLink = struct {
         try self.sender.detach(deadline_ms);
     }
 
-    /// Send `request` and wait for the reply correlated to it.
+    /// Send `request` and return the id its reply will be correlated by.
     ///
     /// `request.properties.message_id` and `.reply_to` are filled in here and
     /// overwrite anything the caller set, since the correlation depends on
-    /// them.
-    pub fn call(
+    /// them. The returned id is owned by the link and stays valid until the
+    /// request is awaited or abandoned.
+    pub fn begin(
         self: *RpcLink,
         request: message.Message,
         deadline_ms: i64,
-    ) RpcError!Response {
-        var buf: [48]u8 = undefined;
-        const id = self.nextMessageId(&buf);
+    ) RpcError![]const u8 {
+        var buf: [64]u8 = undefined;
+        const id = try self.allocator.dupe(u8, self.nextMessageId(&buf));
+        errdefer self.allocator.free(id);
+
+        const entry = try self.pending.getOrPut(self.allocator, id);
+        std.debug.assert(!entry.found_existing);
+        entry.value_ptr.* = null;
+        errdefer _ = self.pending.remove(id);
 
         var outgoing = request;
         outgoing.properties.message_id = .{ .string = id };
         outgoing.properties.reply_to = self.reply_to;
 
         try self.sender.send(outgoing, deadline_ms);
+        return id;
+    }
 
-        // Replies for other requests can be in flight after a timeout, so keep
-        // reading until the correlation id matches rather than trusting order.
+    /// Wait for the reply to `id`.
+    ///
+    /// Replies for other outstanding requests are held rather than discarded,
+    /// so callers with several requests in flight each get their own answer
+    /// however the broker orders them.
+    pub fn awaitReply(
+        self: *RpcLink,
+        id: []const u8,
+        deadline_ms: i64,
+    ) RpcError!Response {
+        defer self.release(id);
         while (true) {
-            const delivery = try self.receiver.receive(deadline_ms);
-            var response = self.parse(delivery.payload) catch |e| switch (e) {
-                error.MalformedReply => {
-                    self.receiver.accept(delivery) catch {};
-                    continue;
-                },
+            if (self.pending.getEntry(id)) |entry| {
+                if (entry.value_ptr.*) |response| {
+                    entry.value_ptr.* = null;
+                    return response;
+                }
+            } else {
+                return error.UnknownRequest;
+            }
+
+            // A detached link will never answer, so fail rather than block
+            // until the deadline.
+            if (!self.receiver.attached) return error.LinkDetached;
+
+            const delivery = self.receiver.receive(deadline_ms) catch |e| {
+                if (e == error.LinkDetached) self.failAll();
+                return e;
+            };
+            self.deposit(delivery.payload) catch |e| switch (e) {
+                // A reply we cannot parse belongs to nobody; keep reading
+                // rather than failing a request that may still be answered.
+                error.MalformedReply => {},
                 else => return e,
             };
-            errdefer response.deinit();
             self.receiver.accept(delivery) catch {};
-
-            if (!correlates(response.decoded.message, id)) {
-                response.deinit();
-                continue;
-            }
-            return response;
         }
+    }
+
+    /// Give up on `id` without waiting for its reply.
+    pub fn abandon(self: *RpcLink, id: []const u8) void {
+        self.release(id);
+    }
+
+    /// Send `request` and wait for its reply.
+    pub fn call(
+        self: *RpcLink,
+        request: message.Message,
+        deadline_ms: i64,
+    ) RpcError!Response {
+        const id = try self.begin(request, deadline_ms);
+        return self.awaitReply(id, deadline_ms);
+    }
+
+    /// Park a reply against the request it answers, dropping it if no request
+    /// is waiting for it — a late answer to something already abandoned.
+    fn deposit(self: *RpcLink, payload: []const u8) RpcError!void {
+        var response = try self.parse(payload);
+        errdefer response.deinit();
+
+        const id = correlationOf(response.decoded.message) orelse {
+            response.deinit();
+            return;
+        };
+        const entry = self.pending.getEntry(id) orelse {
+            response.deinit();
+            return;
+        };
+        if (entry.value_ptr.*) |*existing| existing.deinit();
+        entry.value_ptr.* = response;
+    }
+
+    fn release(self: *RpcLink, id: []const u8) void {
+        if (self.pending.fetchRemove(id)) |removed| {
+            if (removed.value) |value| {
+                var response = value;
+                response.deinit();
+            }
+            self.allocator.free(removed.key);
+        }
+    }
+
+    /// Drop every outstanding request. Their callers get `error.LinkDetached`
+    /// on the next await rather than blocking for a reply that cannot come.
+    fn failAll(self: *RpcLink) void {
+        var it = self.pending.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.*) |*response| response.deinit();
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.pending.clearRetainingCapacity();
     }
 
     fn nextMessageId(self: *RpcLink, buf: []u8) []const u8 {
@@ -237,13 +324,14 @@ fn replyAddress(allocator: Allocator, address: []const u8, link_id: []const u8) 
     return std.fmt.allocPrint(allocator, "{s}-reply-to-{s}", .{ bare, link_id });
 }
 
-fn correlates(msg: message.Message, id: []const u8) bool {
+/// The request id a reply answers.
+fn correlationOf(msg: message.Message) ?[]const u8 {
     const value = msg.properties.correlation_id orelse
         // Some brokers echo the id in message-id instead.
-        msg.properties.message_id orelse return false;
+        msg.properties.message_id orelse return null;
     return switch (value) {
-        .string, .binary, .symbol => |s| std.mem.eql(u8, s, id),
-        else => false,
+        .string, .binary, .symbol => |s| s,
+        else => null,
     };
 }
 
@@ -348,14 +436,19 @@ test "a 401 is distinguished from other failures so it is not retried" {
 }
 
 test "a reply correlates on correlation-id, falling back to message-id" {
-    try testing.expect(correlates(.{
+    try testing.expectEqualStrings("id-1", correlationOf(.{
         .properties = .{ .correlation_id = .{ .string = "id-1" } },
-    }, "id-1"));
-    try testing.expect(!correlates(.{
-        .properties = .{ .correlation_id = .{ .string = "id-2" } },
-    }, "id-1"));
-    try testing.expect(correlates(.{
+    }).?);
+    // Some brokers echo the request id in message-id instead.
+    try testing.expectEqualStrings("id-1", correlationOf(.{
         .properties = .{ .message_id = .{ .string = "id-1" } },
-    }, "id-1"));
-    try testing.expect(!correlates(.{}, "id-1"));
+    }).?);
+    // correlation-id wins when both are present.
+    try testing.expectEqualStrings("id-1", correlationOf(.{
+        .properties = .{
+            .correlation_id = .{ .string = "id-1" },
+            .message_id = .{ .string = "id-2" },
+        },
+    }).?);
+    try testing.expect(correlationOf(.{}) == null);
 }


### PR DESCRIPTION
Part of #191. Implements #200.

Event Hubs exposes hub and partition metadata over `$management`, and Service Bus uses the same endpoint. Nothing drove it, so no management operation could be issued.

`management.zig` sits on the RPC link pair added for CBS in #272, as Go shares one `rpcLink` between the two.

## Request shape

`operation` (`READ` for every metadata read), the entity `type`, the `name`, and the caller's `security_token`, with caller-supplied properties merged after them — matching `internal/links_test.go:245-260`, which is the clearest statement of the shape in the Go tree.

## Errors

A non-2xx reply fails the call. Zig errors carry no payload, so the broker's status and description land on `last_error`, the same convention `connection.zig` uses for remote errors. `callRaw` returns the reply whatever its status, for callers that treat some codes as expected.

## A bug this surfaced in `rpc.zig`

The RPC link previously **discarded** any reply whose correlation id did not match the one being awaited. That is harmless for CBS, which only ever has one request outstanding, but it silently drops another request's answer the moment two are in flight — which is exactly what this issue asks for.

Replies are now parked against the request they answer, so `begin` and `awaitReply` can be split and each caller gets its own answer however the broker orders them. A detach fails everything outstanding rather than leaving a caller blocked until its deadline.

I mutation-tested this: restoring the drop-on-mismatch behaviour makes the out-of-order test fail.

## Testing

Covering the acceptance criteria: two requests answered in reverse order each reach the right caller, a 404 produces `error.RequestFailed` with the broker's description on `last_error`, a detach fails the in-flight request with `error.LinkDetached`, and a request with no reply times out. Awaiting an id that was never sent is `error.UnknownRequest` rather than a hang.

96 tests pass; `zig fmt --check` is clean.

Paired registry PR on `main` adds `management.zig`.