### PR TITLE
Register management.zig for azure_sdk_amqp

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -54,6 +54,7 @@ pub const all = [_]Package{
             "link.zig",
             "rpc.zig",
             "cbs.zig",
+            "management.zig",
             "test_peer.zig",
             "README.md",
             "LICENSE.txt",


### PR DESCRIPTION
Pairs with #274, which adds the `$management` request/response link on `sdk/amqp`.

`eng/package_branch_tool.zig` compares `publish_paths` against the branch manifest with `expectExactSet`, so the new file has to be registered here for the package branch to validate.

Part of #191, supporting #200.

`zig build package-check` passes.