### PR TITLE
amqp: export the scripted-peer helpers and share the uamqp module

### DIFF
--- a/root.zig
+++ b/root.zig
@@ -14,6 +14,9 @@ pub const link = @import("link.zig");
 pub const rpc = @import("rpc.zig");
 pub const cbs = @import("cbs.zig");
 pub const management = @import("management.zig");
+/// Scripted-peer helpers. Exported so packages built on this one can drive a
+/// client against a canned peer without re-implementing the handshake.
+pub const test_peer = @import("test_peer.zig");
 
 // Transports.
 pub const Transport = transport.Transport;
@@ -114,6 +117,7 @@ test {
     _ = rpc;
     _ = cbs;
     _ = management;
+    _ = test_peer;
 }
 
 // ─────────────────────── Tests ───────────────────────


### PR DESCRIPTION
Prep for #203, which builds Event Hubs `$management` operations on this package.

## Export `test_peer`

`test_peer.zig` is already a published file, but nothing re-exported it, so a package depending on `azure_sdk_amqp` cannot reach `Peer`, `Fixture`, `EmittedFrames`, or `scriptHandshake`. Event Hubs needs them to assert the exact application-property map its `$management` requests put on the wire; without the export it would have to re-implement the AMQP handshake in its own test file.

## Register `uamqp` by name

`b.createModule` produces a **fresh** module on every call. Event Hubs also builds uamqp from source, so it would end up with a second module — and therefore a second, incompatible copy of every type in it. Passing an `AmqpValue` across the package boundary then fails to compile even though both sides resolve to the same file at the same revision.

`b.addModule("uamqp", ...)` registers this instance under a name, so a dependent can reuse it with `amqp_dep.module("uamqp")` rather than building its own.

96/96 pass. No new files, so no `eng/packages.zig` change.