### PR TITLE
amqp: register the uamqp module by name so dependents can share it

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,12 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const uamqp_dep = b.dependency("uamqp", .{});
-    const uamqp_mod = b.createModule(.{
+    // Registered by name rather than created anonymously so dependents can
+    // reuse this exact module. Two `createModule` calls over the same source
+    // produce two modules, and therefore two incompatible copies of every
+    // type in them, which breaks any dependent that passes an `AmqpValue`
+    // across the package boundary.
+    const uamqp_mod = b.addModule("uamqp", .{
         .root_source_file = uamqp_dep.path("src/zig/uamqp.zig"),
         .target = target,
     });


### PR DESCRIPTION
Prep for #203. Follow-up to #277, which merged before this commit landed.

`b.createModule` produces a **fresh** module on every call. Event Hubs also builds uamqp from source, so it ends up with a second module — and therefore a second, incompatible copy of every type in it. Passing an `AmqpValue` across the package boundary then fails to compile even though both sides resolve to the same file at the same revision.

`b.addModule("uamqp", ...)` registers this instance under a name, so a dependent can reuse it with `amqp_dep.module("uamqp")` rather than building its own. That also makes this package the single place the uamqp revision is chosen.

96/96 pass. No new files, so no `eng/packages.zig` change.