### PR TITLE
eventhubs: implement hub and partition properties over the management link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,42 @@ A connection string carrying a pre-formed `SharedAccessSignature` instead of a
 key cannot be re-signed, so `credential.isRefreshable()` reports `false` and the
 client cannot outlive that signature.
 
+## Metadata
+
+`getEventHubProperties` and `getPartitionProperties` are `READ` operations on
+the `$management` link, distinguished by entity type — `com.microsoft:eventhub`
+returns the hub's partition list, `com.microsoft:partition` returns one
+partition's sequence number range.
+
+`ManagementTransport` performs them against an already-open
+`azure_sdk_amqp.Management` client. It borrows the client rather than opening
+one, because the connection, its CBS authorisation, and its session outlive any
+single operation.
+
+```zig
+var transport = ManagementTransport.init(management_client, .{
+    .security_token = token.token,
+    .deadline_ms = deadline,
+    .retry = .{ .sleeper = &sleeper, .random = prng.random() },
+});
+var props = try producer.getEventHubProperties(allocator);
+defer props.deinit();
+```
+
+Decoded properties own their strings through an arena; ones built by hand leave
+it null and borrow instead, so `deinit` is always correct and is idempotent.
+
+The wire names are not guessable and are taken from the Go SDK. In a partition
+reply `name` is the *hub* and `partition` is the partition; the first sequence
+number is `begin_sequence_number`; geo-replication is reported as a *factor*
+that the client turns into a boolean, so a factor of one is not
+geo-replication.
+
+Failures carry the broker's status and description, which a Zig error cannot,
+on `Management.last_error`. Both operations optionally run under the Event Hubs
+retry schedule, which classifies a management status into the AMQP condition it
+corresponds to — a 404 is fatal and is not retried, a 503 is not.
+
 ## Event models
 
 `EventData` holds only what a producer sends: `body`, `properties`,

--- a/build.zig
+++ b/build.zig
@@ -22,11 +22,15 @@ pub fn build(b: *std.Build) void {
     });
     const blobs_mod = blobs_dep.module("azure_sdk_storage_blobs");
 
-    const uamqp_dep = b.dependency("uamqp", .{});
-    const uamqp_mod = b.createModule(.{
-        .root_source_file = uamqp_dep.path("src/zig/uamqp.zig"),
+    const amqp_dep = b.dependency("azure_sdk_amqp", .{
         .target = target,
+        .optimize = optimize,
     });
+    const amqp_mod = amqp_dep.module("azure_sdk_amqp");
+    // Reuse the AMQP package's uamqp module rather than building a second one.
+    // Two modules over the same source produce two incompatible copies of
+    // every type, so an `AmqpValue` could not cross the package boundary.
+    const uamqp_mod = amqp_dep.module("uamqp");
 
     const serde_dep = b.dependency("serde", .{
         .target = target,
@@ -44,6 +48,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "azure_sdk_core", .module = core_mod },
             .{ .name = "azure_sdk_messaging_common", .module = common_mod },
             .{ .name = "azure_sdk_storage_blobs", .module = blobs_mod },
+            .{ .name = "azure_sdk_amqp", .module = amqp_mod },
             .{ .name = "uamqp", .module = uamqp_mod },
             .{ .name = "serde", .module = serde_mod },
         },
@@ -58,7 +63,8 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "azure_sdk_core", .module = core_mod },
                 .{ .name = "azure_sdk_messaging_common", .module = common_mod },
                 .{ .name = "azure_sdk_storage_blobs", .module = blobs_mod },
-                .{ .name = "uamqp", .module = uamqp_mod },
+                .{ .name = "azure_sdk_amqp", .module = amqp_mod },
+            .{ .name = "uamqp", .module = uamqp_mod },
                 .{ .name = "serde", .module = serde_mod },
             },
         }),

--- a/build.zig
+++ b/build.zig
@@ -64,7 +64,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "azure_sdk_messaging_common", .module = common_mod },
                 .{ .name = "azure_sdk_storage_blobs", .module = blobs_mod },
                 .{ .name = "azure_sdk_amqp", .module = amqp_mod },
-            .{ .name = "uamqp", .module = uamqp_mod },
+                .{ .name = "uamqp", .module = uamqp_mod },
                 .{ .name = "serde", .module = serde_mod },
             },
         }),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,9 +16,9 @@
             .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#547a1f88972a9a245f4af15479f592a0e1f8344b",
             .hash = "azure_sdk_storage_blobs-0.1.0-I5lGdlJ7CgCiJaJDvHH7ukhtln4baXBvqfvrDGCOhiVD",
         },
-        .uamqp = .{
-            .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",
-            .hash = "uamqp-0.1.0-lXMcafDqAQD3LSUZbUbyfrWhQfGG7OevKFUwhWxvGZDU",
+        .azure_sdk_amqp = .{
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#7cf871c3cc9a6541f601f3e07242eb48e9e43ae5",
+            .hash = "azure_sdk_amqp-0.1.0-fUByf_teBADElN-o5BreZApnLGcLcxlb8ykLJ3GF-Mc4",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
@@ -34,6 +34,7 @@
         "errors.zig",
         "checkpoint.zig",
         "checkpoint_store.zig",
+        "management.zig",
         "checkpoint_store_blob",
         "README.md",
         "LICENSE.txt",

--- a/management.zig
+++ b/management.zig
@@ -1,0 +1,919 @@
+//! Event Hub and partition metadata over the `$management` link.
+//!
+//! Both operations are a `READ` against the hub, distinguished by the entity
+//! type: `com.microsoft:eventhub` returns the hub's partition list, and
+//! `com.microsoft:partition` returns one partition's sequence number range.
+//! The reply arrives as an AMQP map in the message value body.
+//!
+//! The wire names here are taken from the Go SDK's `mgmt.go` and match Rust's
+//! `common/management.rs`. They are not guessable — the partition reply calls
+//! the hub `name` and the partition `partition`, the first sequence number is
+//! `begin_sequence_number` rather than `beginning_`, and geo-replication is
+//! reported as a *factor* that the client turns into a boolean.
+
+const std = @import("std");
+const amqp = @import("azure_sdk_amqp");
+const uamqp = @import("uamqp");
+const errors = @import("errors.zig");
+
+const Allocator = std.mem.Allocator;
+const AmqpValue = uamqp.AmqpValue;
+const MapEntry = uamqp.MapEntry;
+
+/// The entity type for hub-wide metadata.
+pub const entity_type_eventhub = "com.microsoft:eventhub";
+/// The entity type for a single partition's metadata.
+pub const entity_type_partition = "com.microsoft:partition";
+
+/// The request property naming the partition, alongside the standard four.
+pub const partition_key = "partition";
+
+/// Reply property names. The hub and partition replies overlap on `name`,
+/// which means the hub in both.
+pub const reply = struct {
+    pub const name = "name";
+    pub const partition_ids = "partition_ids";
+    pub const created_at = "created_at";
+    /// A count, not a flag: greater than one means geo-replication is on.
+    pub const georeplication_factor = "georeplication_factor";
+    pub const partition = "partition";
+    pub const begin_sequence_number = "begin_sequence_number";
+    pub const last_enqueued_sequence_number = "last_enqueued_sequence_number";
+    pub const last_enqueued_offset = "last_enqueued_offset";
+    pub const last_enqueued_time_utc = "last_enqueued_time_utc";
+    pub const is_partition_empty = "is_partition_empty";
+};
+
+pub const PropertiesError = amqp.ManagementError || error{
+    /// The reply body was not an AMQP map.
+    MalformedReplyBody,
+    /// The reply omitted a property the operation is defined to return.
+    MissingProperty,
+    /// A property was present but not of the expected type.
+    InvalidProperty,
+};
+
+/// Properties of an Event Hub.
+///
+/// Strings are owned by `arena` when one is set, which is the case for
+/// anything decoded from the service. A value built by hand — the mock
+/// transport, or a test — leaves it null and borrows instead, so `deinit` is
+/// always safe to call and always correct.
+pub const EventHubProperties = struct {
+    name: []const u8,
+    partition_ids: []const []const u8 = &.{},
+    /// Milliseconds since the Unix epoch, as AMQP timestamps are defined.
+    created_on: ?i64 = null,
+    /// True when the namespace has geo-replication enabled, which the service
+    /// reports as a geo-replication factor greater than one.
+    geo_replication_enabled: bool = false,
+    arena: ?*std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *EventHubProperties) void {
+        releaseArena(&self.arena);
+    }
+};
+
+/// Properties of one partition of an Event Hub.
+pub const PartitionProperties = struct {
+    id: []const u8,
+    /// Name of the Event Hub the partition belongs to.
+    event_hub_name: []const u8 = "",
+    beginning_sequence_number: i64 = 0,
+    last_enqueued_sequence_number: i64 = 0,
+    last_enqueued_offset: ?[]const u8 = null,
+    /// Milliseconds since the Unix epoch.
+    last_enqueued_time: ?i64 = null,
+    is_empty: bool = true,
+    arena: ?*std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *PartitionProperties) void {
+        releaseArena(&self.arena);
+    }
+};
+
+fn releaseArena(slot: *?*std.heap.ArenaAllocator) void {
+    if (slot.*) |arena| {
+        const parent = arena.child_allocator;
+        arena.deinit();
+        parent.destroy(arena);
+    }
+    slot.* = null;
+}
+
+fn newArena(allocator: Allocator) !*std.heap.ArenaAllocator {
+    const arena = try allocator.create(std.heap.ArenaAllocator);
+    arena.* = .init(allocator);
+    return arena;
+}
+
+// ─────────────────────── Operations ───────────────────────
+
+/// Read the hub's metadata.
+///
+/// `security_token` is the CBS token for the hub audience. Event Hubs wants it
+/// on the message as well as on the link, which is why it is a parameter here
+/// rather than something the management client remembers.
+pub fn getEventHubProperties(
+    allocator: Allocator,
+    mgmt: *amqp.Management,
+    hub_name: []const u8,
+    security_token: ?[]const u8,
+    deadline_ms: i64,
+) PropertiesError!EventHubProperties {
+    var response = try mgmt.call(.{
+        .entity_type = entity_type_eventhub,
+        .name = hub_name,
+        .security_token = security_token,
+    }, deadline_ms);
+    defer response.deinit();
+
+    return parseEventHubProperties(allocator, response.msg().body);
+}
+
+/// Read one partition's metadata.
+pub fn getPartitionProperties(
+    allocator: Allocator,
+    mgmt: *amqp.Management,
+    hub_name: []const u8,
+    partition_id: []const u8,
+    security_token: ?[]const u8,
+    deadline_ms: i64,
+) PropertiesError!PartitionProperties {
+    const extra = [_]MapEntry{.{
+        .key = .{ .string = partition_key },
+        .value = .{ .string = partition_id },
+    }};
+
+    var response = try mgmt.call(.{
+        .entity_type = entity_type_partition,
+        .name = hub_name,
+        .security_token = security_token,
+        .properties = &extra,
+    }, deadline_ms);
+    defer response.deinit();
+
+    return parsePartitionProperties(allocator, response.msg().body);
+}
+
+// ─────────────────────── Reply decoding ───────────────────────
+
+pub fn parseEventHubProperties(
+    allocator: Allocator,
+    body: amqp.MessageBody,
+) PropertiesError!EventHubProperties {
+    const map = try bodyMap(body);
+
+    const arena = try newArena(allocator);
+    errdefer {
+        var slot: ?*std.heap.ArenaAllocator = arena;
+        releaseArena(&slot);
+    }
+    const arena_allocator = arena.allocator();
+
+    const name = try arena_allocator.dupe(u8, try requireString(map, reply.name));
+    const ids = try dupeStringArray(arena_allocator, map, reply.partition_ids);
+
+    // Go rejects a reply with no factor. A broker that predates
+    // geo-replication simply omits it, so treat absence as disabled rather
+    // than as a malformed reply.
+    const factor = if (lookup(map, reply.georeplication_factor)) |value|
+        asInt(value) orelse return error.InvalidProperty
+    else
+        0;
+
+    return .{
+        .name = name,
+        .partition_ids = ids,
+        .created_on = if (lookup(map, reply.created_at)) |value|
+            asTimestamp(value) orelse return error.InvalidProperty
+        else
+            null,
+        .geo_replication_enabled = factor > 1,
+        .arena = arena,
+    };
+}
+
+pub fn parsePartitionProperties(
+    allocator: Allocator,
+    body: amqp.MessageBody,
+) PropertiesError!PartitionProperties {
+    const map = try bodyMap(body);
+
+    const arena = try newArena(allocator);
+    errdefer {
+        var slot: ?*std.heap.ArenaAllocator = arena;
+        releaseArena(&slot);
+    }
+    const arena_allocator = arena.allocator();
+
+    const hub = try arena_allocator.dupe(u8, try requireString(map, reply.name));
+    const id = try arena_allocator.dupe(u8, try requireString(map, reply.partition));
+
+    const offset = if (lookup(map, reply.last_enqueued_offset)) |value|
+        try arena_allocator.dupe(u8, asString(value) orelse return error.InvalidProperty)
+    else
+        null;
+
+    return .{
+        .id = id,
+        .event_hub_name = hub,
+        .beginning_sequence_number = try requireInt(map, reply.begin_sequence_number),
+        .last_enqueued_sequence_number = try requireInt(map, reply.last_enqueued_sequence_number),
+        .last_enqueued_offset = offset,
+        .last_enqueued_time = if (lookup(map, reply.last_enqueued_time_utc)) |value|
+            asTimestamp(value) orelse return error.InvalidProperty
+        else
+            null,
+        // A partition that has never been written to may omit the flag; an
+        // empty partition is the safe reading of a missing one.
+        .is_empty = if (lookup(map, reply.is_partition_empty)) |value|
+            asBool(value) orelse return error.InvalidProperty
+        else
+            true,
+        .arena = arena,
+    };
+}
+
+fn bodyMap(body: amqp.MessageBody) PropertiesError![]const MapEntry {
+    return switch (body) {
+        .value => |value| switch (value) {
+            .map => |entries| entries,
+            else => error.MalformedReplyBody,
+        },
+        else => error.MalformedReplyBody,
+    };
+}
+
+/// Look a key up in an AMQP map. Keys arrive as strings from Event Hubs, but
+/// symbols are accepted because they are the same thing on the wire to a
+/// broker that chooses to encode them that way.
+fn lookup(map: []const MapEntry, key: []const u8) ?AmqpValue {
+    for (map) |entry| {
+        const entry_key = switch (entry.key) {
+            .string, .symbol => |s| s,
+            else => continue,
+        };
+        if (std.mem.eql(u8, entry_key, key)) return entry.value;
+    }
+    return null;
+}
+
+fn asString(value: AmqpValue) ?[]const u8 {
+    return switch (value) {
+        .string, .symbol => |s| s,
+        else => null,
+    };
+}
+
+/// Widen any integral encoding to `i64`.
+///
+/// The service is free to pick the smallest encoding that fits, so a sequence
+/// number that happens to be small arrives as a `byte` or `int` rather than a
+/// `long`. Go's `ConvertToInt64` exists for exactly this.
+fn asInt(value: AmqpValue) ?i64 {
+    return switch (value) {
+        .byte => |v| v,
+        .short => |v| v,
+        .int => |v| v,
+        .long => |v| v,
+        .ubyte => |v| v,
+        .ushort => |v| v,
+        .uint => |v| v,
+        .ulong => |v| std.math.cast(i64, v),
+        else => null,
+    };
+}
+
+/// A timestamp, or any integral standing in for one. Both are milliseconds
+/// since the Unix epoch.
+fn asTimestamp(value: AmqpValue) ?i64 {
+    return switch (value) {
+        .timestamp => |v| v,
+        else => asInt(value),
+    };
+}
+
+fn asBool(value: AmqpValue) ?bool {
+    return switch (value) {
+        .boolean => |v| v,
+        else => null,
+    };
+}
+
+fn requireString(map: []const MapEntry, key: []const u8) PropertiesError![]const u8 {
+    const value = lookup(map, key) orelse return error.MissingProperty;
+    return asString(value) orelse error.InvalidProperty;
+}
+
+fn requireInt(map: []const MapEntry, key: []const u8) PropertiesError!i64 {
+    const value = lookup(map, key) orelse return error.MissingProperty;
+    return asInt(value) orelse error.InvalidProperty;
+}
+
+/// Copy an array of strings out of a reply.
+///
+/// Event Hubs sends `partition_ids` as an AMQP array, but a list of the same
+/// strings is indistinguishable to a caller and some brokers send one, so both
+/// are accepted.
+fn dupeStringArray(
+    arena: Allocator,
+    map: []const MapEntry,
+    key: []const u8,
+) PropertiesError![]const []const u8 {
+    const value = lookup(map, key) orelse return error.MissingProperty;
+    const items = switch (value) {
+        .array, .list => |items| items,
+        else => return error.InvalidProperty,
+    };
+
+    const out = try arena.alloc([]const u8, items.len);
+    for (items, 0..) |item, i| {
+        out[i] = try arena.dupe(u8, asString(item) orelse return error.InvalidProperty);
+    }
+    return out;
+}
+
+// ─────────────────────── Retry ───────────────────────
+
+/// Run `getEventHubProperties` under the Event Hubs retry schedule.
+///
+/// A management call goes over a link, so a transient detach or a
+/// `com.microsoft:server-busy` has to be retried rather than surfaced. The
+/// broker's condition is handed to the retrier so it can tell a retryable
+/// failure from a fatal one.
+pub fn getEventHubPropertiesWithRetry(
+    allocator: Allocator,
+    mgmt: *amqp.Management,
+    hub_name: []const u8,
+    security_token: ?[]const u8,
+    deadline_ms: i64,
+    config: errors.RetryConfig,
+) errors.Outcome(EventHubProperties) {
+    const Op = struct {
+        allocator: Allocator,
+        mgmt: *amqp.Management,
+        hub_name: []const u8,
+        security_token: ?[]const u8,
+        deadline_ms: i64,
+
+        pub fn call(self: *const @This(), attempt: *errors.Attempt) anyerror!EventHubProperties {
+            return getEventHubProperties(
+                self.allocator,
+                self.mgmt,
+                self.hub_name,
+                self.security_token,
+                self.deadline_ms,
+            ) catch |e| {
+                recordCondition(self.mgmt, attempt);
+                return e;
+            };
+        }
+    };
+
+    const op = Op{
+        .allocator = allocator,
+        .mgmt = mgmt,
+        .hub_name = hub_name,
+        .security_token = security_token,
+        .deadline_ms = deadline_ms,
+    };
+    return errors.retry(EventHubProperties, &op, config);
+}
+
+/// Run `getPartitionProperties` under the Event Hubs retry schedule.
+pub fn getPartitionPropertiesWithRetry(
+    allocator: Allocator,
+    mgmt: *amqp.Management,
+    hub_name: []const u8,
+    partition_id: []const u8,
+    security_token: ?[]const u8,
+    deadline_ms: i64,
+    config: errors.RetryConfig,
+) errors.Outcome(PartitionProperties) {
+    const Op = struct {
+        allocator: Allocator,
+        mgmt: *amqp.Management,
+        hub_name: []const u8,
+        partition_id: []const u8,
+        security_token: ?[]const u8,
+        deadline_ms: i64,
+
+        pub fn call(self: *const @This(), attempt: *errors.Attempt) anyerror!PartitionProperties {
+            return getPartitionProperties(
+                self.allocator,
+                self.mgmt,
+                self.hub_name,
+                self.partition_id,
+                self.security_token,
+                self.deadline_ms,
+            ) catch |e| {
+                recordCondition(self.mgmt, attempt);
+                return e;
+            };
+        }
+    };
+
+    const op = Op{
+        .allocator = allocator,
+        .mgmt = mgmt,
+        .hub_name = hub_name,
+        .partition_id = partition_id,
+        .security_token = security_token,
+        .deadline_ms = deadline_ms,
+    };
+    return errors.retry(PartitionProperties, &op, config);
+}
+
+/// Translate the broker's reply into the AMQP condition the retrier
+/// classifies on.
+///
+/// A management failure carries an HTTP-shaped status code rather than an AMQP
+/// error condition, so the mapping has to be made explicitly. Go does the same
+/// in `TransformError`.
+fn recordCondition(mgmt: *amqp.Management, attempt: *errors.Attempt) void {
+    const status = mgmt.last_error orelse return;
+    attempt.description = status.description;
+    attempt.condition = switch (status.code) {
+        401, 403 => errors.condition.unauthorized_access,
+        404 => errors.condition.not_found,
+        408 => errors.condition.timeout,
+        429, 503 => errors.condition.server_busy,
+        else => if (status.code >= 500)
+            errors.condition.internal_error
+        else
+            errors.condition.not_allowed,
+    };
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const harness = amqp.test_peer;
+const Peer = harness.Peer;
+const Fixture = harness.Fixture;
+const EmittedFrames = harness.EmittedFrames;
+const MemoryTransport = amqp.MemoryTransport;
+const driver = amqp.connection_driver;
+
+fn mapEntry(key: []const u8, value: AmqpValue) MapEntry {
+    return .{ .key = .{ .string = key }, .value = value };
+}
+
+test "an event hub reply decodes into fully populated properties" {
+    const allocator = testing.allocator;
+    var ids = [_]AmqpValue{
+        .{ .string = "0" },
+        .{ .string = "1" },
+        .{ .string = "2" },
+    };
+    var map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "my-hub" }),
+        mapEntry(reply.partition_ids, .{ .array = &ids }),
+        mapEntry(reply.created_at, .{ .timestamp = 1_700_000_000_000 }),
+        mapEntry(reply.georeplication_factor, .{ .int = 2 }),
+    };
+
+    var props = try parseEventHubProperties(allocator, .{ .value = .{ .map = &map } });
+    defer props.deinit();
+
+    try testing.expectEqualStrings("my-hub", props.name);
+    try testing.expectEqual(@as(usize, 3), props.partition_ids.len);
+    try testing.expectEqualStrings("0", props.partition_ids[0]);
+    try testing.expectEqualStrings("2", props.partition_ids[2]);
+    try testing.expectEqual(@as(?i64, 1_700_000_000_000), props.created_on);
+    try testing.expect(props.geo_replication_enabled);
+}
+
+test "a geo-replication factor of one is not geo-replication" {
+    const allocator = testing.allocator;
+    var ids = [_]AmqpValue{.{ .string = "0" }};
+    var map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "hub" }),
+        mapEntry(reply.partition_ids, .{ .array = &ids }),
+        mapEntry(reply.georeplication_factor, .{ .int = 1 }),
+    };
+
+    var props = try parseEventHubProperties(allocator, .{ .value = .{ .map = &map } });
+    defer props.deinit();
+    try testing.expect(!props.geo_replication_enabled);
+}
+
+test "a reply with no geo-replication factor is not malformed" {
+    const allocator = testing.allocator;
+    var ids = [_]AmqpValue{.{ .string = "0" }};
+    var map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "hub" }),
+        mapEntry(reply.partition_ids, .{ .array = &ids }),
+    };
+
+    var props = try parseEventHubProperties(allocator, .{ .value = .{ .map = &map } });
+    defer props.deinit();
+    try testing.expect(!props.geo_replication_enabled);
+    try testing.expectEqual(@as(?i64, null), props.created_on);
+}
+
+test "partition ids may arrive as a list rather than an array" {
+    const allocator = testing.allocator;
+    var ids = [_]AmqpValue{ .{ .string = "0" }, .{ .string = "1" } };
+    var map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "hub" }),
+        mapEntry(reply.partition_ids, .{ .list = &ids }),
+    };
+
+    var props = try parseEventHubProperties(allocator, .{ .value = .{ .map = &map } });
+    defer props.deinit();
+    try testing.expectEqual(@as(usize, 2), props.partition_ids.len);
+    try testing.expectEqualStrings("1", props.partition_ids[1]);
+}
+
+test "a partition reply decodes into fully populated properties" {
+    const allocator = testing.allocator;
+    var map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "my-hub" }),
+        mapEntry(reply.partition, .{ .string = "3" }),
+        mapEntry(reply.begin_sequence_number, .{ .long = 100 }),
+        mapEntry(reply.last_enqueued_sequence_number, .{ .long = 4096 }),
+        mapEntry(reply.last_enqueued_offset, .{ .string = "12345" }),
+        mapEntry(reply.last_enqueued_time_utc, .{ .timestamp = 1_700_000_000_000 }),
+        mapEntry(reply.is_partition_empty, .{ .boolean = false }),
+    };
+
+    var props = try parsePartitionProperties(allocator, .{ .value = .{ .map = &map } });
+    defer props.deinit();
+
+    try testing.expectEqualStrings("3", props.id);
+    try testing.expectEqualStrings("my-hub", props.event_hub_name);
+    try testing.expectEqual(@as(i64, 100), props.beginning_sequence_number);
+    try testing.expectEqual(@as(i64, 4096), props.last_enqueued_sequence_number);
+    try testing.expectEqualStrings("12345", props.last_enqueued_offset.?);
+    try testing.expectEqual(@as(?i64, 1_700_000_000_000), props.last_enqueued_time);
+    try testing.expect(!props.is_empty);
+}
+
+test "sequence numbers widen from whatever encoding the service chose" {
+    const allocator = testing.allocator;
+    // A partition that has just been created reports small numbers, which the
+    // service is free to encode as a byte.
+    var map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "hub" }),
+        mapEntry(reply.partition, .{ .string = "0" }),
+        mapEntry(reply.begin_sequence_number, .{ .byte = 0 }),
+        mapEntry(reply.last_enqueued_sequence_number, .{ .int = 7 }),
+        mapEntry(reply.is_partition_empty, .{ .boolean = true }),
+    };
+
+    var props = try parsePartitionProperties(allocator, .{ .value = .{ .map = &map } });
+    defer props.deinit();
+    try testing.expectEqual(@as(i64, 0), props.beginning_sequence_number);
+    try testing.expectEqual(@as(i64, 7), props.last_enqueued_sequence_number);
+    try testing.expect(props.is_empty);
+    try testing.expectEqual(@as(?[]const u8, null), props.last_enqueued_offset);
+}
+
+test "a reply missing a required property is rejected" {
+    const allocator = testing.allocator;
+    var map = [_]MapEntry{mapEntry(reply.name, .{ .string = "hub" })};
+    try testing.expectError(
+        error.MissingProperty,
+        parseEventHubProperties(allocator, .{ .value = .{ .map = &map } }),
+    );
+
+    var partition_map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "hub" }),
+        mapEntry(reply.partition, .{ .string = "0" }),
+    };
+    try testing.expectError(
+        error.MissingProperty,
+        parsePartitionProperties(allocator, .{ .value = .{ .map = &partition_map } }),
+    );
+}
+
+test "a reply whose body is not a map is rejected" {
+    const allocator = testing.allocator;
+    try testing.expectError(
+        error.MalformedReplyBody,
+        parseEventHubProperties(allocator, .{ .data = &.{"not a map"} }),
+    );
+    try testing.expectError(
+        error.MalformedReplyBody,
+        parsePartitionProperties(allocator, .empty),
+    );
+}
+
+test "properties built by hand carry no arena and free cleanly" {
+    var props = EventHubProperties{ .name = "borrowed" };
+    props.deinit();
+    props.deinit();
+    try testing.expectEqualStrings("borrowed", props.name);
+}
+
+// ─────────────── Scripted-peer tests ───────────────
+
+/// Script the peer's side of attaching a `$management` link pair.
+fn scriptAttach(peer: Peer, credit: u32) !void {
+    try harness.scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "$management-sender-eh",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "$management-receiver-eh",
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = credit,
+    } });
+}
+
+/// The request the client sent as delivery `n - 1` is settled by the peer.
+fn scriptSettle(peer: Peer, n: u64) !void {
+    const delivery_id: u32 = @intCast(n - 1);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = delivery_id,
+        .last = delivery_id,
+        .settled = true,
+        .state = .accepted,
+    } });
+}
+
+/// Push a reply to request `n` carrying `body`.
+fn scriptReply(
+    peer: Peer,
+    allocator: Allocator,
+    n: u64,
+    status: i32,
+    description: []const u8,
+    body: amqp.MessageBody,
+    delivery_id: u32,
+) !void {
+    var id_buf: [64]u8 = undefined;
+    const correlation = try std.fmt.bufPrint(&id_buf, "management-reply-to-eh:{d}", .{n});
+    const props = [_]MapEntry{
+        .{ .key = .{ .string = amqp.rpc.status_code_key }, .value = .{ .int = status } },
+        .{
+            .key = .{ .string = amqp.rpc.status_description_key },
+            .value = .{ .string = description },
+        },
+    };
+    const payload = try amqp.encodeMessageAlloc(allocator, .{
+        .properties = .{ .correlation_id = .{ .string = correlation } },
+        .application_properties = &props,
+        .body = body,
+    });
+    defer allocator.free(payload);
+
+    try peer.pushTransfer(0, .{
+        .handle = 1,
+        .delivery_id = delivery_id,
+        .delivery_tag = "r",
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, payload);
+}
+
+fn propertyValue(props: []const MapEntry, key: []const u8) ?AmqpValue {
+    return lookup(props, key);
+}
+
+/// A driver, session, and management client wired to a scripted peer.
+const Scripted = struct {
+    allocator: Allocator,
+    mem: *MemoryTransport,
+    clock: *driver.ManualClock,
+    conn: *driver.Driver,
+    fixture: Fixture,
+    client: *amqp.Management,
+
+    fn init(allocator: Allocator, mem: *MemoryTransport, clock: *driver.ManualClock, conn: *driver.Driver) !Scripted {
+        var fixture = try Fixture.init(allocator, mem, clock, conn);
+        errdefer fixture.deinit();
+        const client = try amqp.Management.open(&fixture.session, .{ .link_id = "eh" }, 10_000);
+        return .{
+            .allocator = allocator,
+            .mem = mem,
+            .clock = clock,
+            .conn = conn,
+            .fixture = fixture,
+            .client = client,
+        };
+    }
+
+    fn deinit(self: *Scripted) void {
+        self.client.deinit();
+        self.fixture.deinit();
+    }
+
+    /// The application properties of the single request written since the last
+    /// `clearWritten`.
+    fn sentProperties(self: *Scripted, decoded: *amqp.message_codec.Decoded) ![]const MapEntry {
+        var frames = try EmittedFrames.parse(self.allocator, self.mem.written());
+        defer frames.deinit();
+        const transfers = try frames.of(self.allocator, 0x14);
+        defer self.allocator.free(transfers);
+        try testing.expectEqual(@as(usize, 1), transfers.len);
+
+        decoded.* = try amqp.decodeMessage(
+            self.allocator,
+            harness.transferPayload(self.allocator, transfers[0]).?,
+        );
+        return decoded.message.application_properties.?;
+    }
+};
+
+test "an event hub read puts the exact application properties on the wire" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    var ids = [_]AmqpValue{ .{ .string = "0" }, .{ .string = "1" } };
+    // A list rather than an array: uamqp's array encoder writes a wrong
+    // length prefix (cataggar/azure-uamqp-zig), so an array cannot yet make
+    // the round trip through a real frame. Decoding an array is covered
+    // directly above.
+    var body_map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "my-hub" }),
+        mapEntry(reply.partition_ids, .{ .list = &ids }),
+        mapEntry(reply.created_at, .{ .timestamp = 1_700_000_000_000 }),
+        mapEntry(reply.georeplication_factor, .{ .int = 3 }),
+    };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    try scriptReply(peer, allocator, 1, 200, "OK", .{ .value = .{ .map = &body_map } }, 0);
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    mem.clearWritten();
+    var props = try getEventHubProperties(
+        allocator,
+        scripted.client,
+        "my-hub",
+        "SharedAccessSignature sr=x&sig=y",
+        10_000,
+    );
+    defer props.deinit();
+
+    var decoded: amqp.message_codec.Decoded = undefined;
+    const sent = try scripted.sentProperties(&decoded);
+    defer decoded.deinit();
+
+    try testing.expectEqualStrings("READ", propertyValue(sent, "operation").?.string);
+    try testing.expectEqualStrings(entity_type_eventhub, propertyValue(sent, "type").?.string);
+    try testing.expectEqualStrings("my-hub", propertyValue(sent, "name").?.string);
+    try testing.expectEqualStrings(
+        "SharedAccessSignature sr=x&sig=y",
+        propertyValue(sent, "security_token").?.string,
+    );
+    // A hub read must not name a partition, or the broker answers the
+    // partition operation instead.
+    try testing.expect(propertyValue(sent, partition_key) == null);
+
+    try testing.expectEqualStrings("my-hub", props.name);
+    try testing.expectEqual(@as(usize, 2), props.partition_ids.len);
+    try testing.expect(props.geo_replication_enabled);
+}
+
+test "a partition read names the partition and uses the partition entity type" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    var body_map = [_]MapEntry{
+        mapEntry(reply.name, .{ .string = "my-hub" }),
+        mapEntry(reply.partition, .{ .string = "3" }),
+        mapEntry(reply.begin_sequence_number, .{ .long = 5 }),
+        mapEntry(reply.last_enqueued_sequence_number, .{ .long = 99 }),
+        mapEntry(reply.last_enqueued_offset, .{ .string = "4242" }),
+        mapEntry(reply.last_enqueued_time_utc, .{ .timestamp = 1_700_000_000_000 }),
+        mapEntry(reply.is_partition_empty, .{ .boolean = false }),
+    };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    try scriptReply(peer, allocator, 1, 200, "OK", .{ .value = .{ .map = &body_map } }, 0);
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    mem.clearWritten();
+    var props = try getPartitionProperties(allocator, scripted.client, "my-hub", "3", "token", 10_000);
+    defer props.deinit();
+
+    var decoded: amqp.message_codec.Decoded = undefined;
+    const sent = try scripted.sentProperties(&decoded);
+    defer decoded.deinit();
+
+    try testing.expectEqualStrings("READ", propertyValue(sent, "operation").?.string);
+    try testing.expectEqualStrings(entity_type_partition, propertyValue(sent, "type").?.string);
+    // `name` is the hub, not the partition — the partition goes in its own
+    // property. Swapping them is the obvious mistake and the broker answers
+    // with a not-found rather than an error that says so.
+    try testing.expectEqualStrings("my-hub", propertyValue(sent, "name").?.string);
+    try testing.expectEqualStrings("3", propertyValue(sent, partition_key).?.string);
+    try testing.expectEqualStrings("token", propertyValue(sent, "security_token").?.string);
+
+    try testing.expectEqualStrings("3", props.id);
+    try testing.expectEqualStrings("my-hub", props.event_hub_name);
+    try testing.expectEqual(@as(i64, 5), props.beginning_sequence_number);
+    try testing.expectEqualStrings("4242", props.last_enqueued_offset.?);
+}
+
+test "a management error status surfaces with the broker's description" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    try scriptReply(peer, allocator, 1, 404, "The messaging entity could not be found.", .empty, 0);
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    try testing.expectError(
+        error.RequestFailed,
+        getEventHubProperties(allocator, scripted.client, "missing-hub", null, 10_000),
+    );
+
+    // A Zig error carries no payload, so the status and description are read
+    // back off the client.
+    const status = scripted.client.last_error.?;
+    try testing.expectEqual(@as(i32, 404), status.code);
+    try testing.expectEqualStrings("The messaging entity could not be found.", status.description.?);
+}
+
+test "a not-found status is classified as fatal rather than retried" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptAttach(peer, 10);
+    try scriptSettle(peer, 1);
+    try scriptReply(peer, allocator, 1, 404, "not found", .empty, 0);
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    // A no-op sleeper: a fatal failure must not reach a backoff at all, so any
+    // sleep here would be a bug.
+    var sleeper = errors.Sleeper{ .sleepFn = &struct {
+        fn noSleep(_: *errors.Sleeper, _: u64) errors.SleepError!void {
+            return error.Canceled;
+        }
+    }.noSleep };
+    var prng = std.Random.DefaultPrng.init(0);
+
+    const outcome = getEventHubPropertiesWithRetry(
+        allocator,
+        scripted.client,
+        "missing-hub",
+        null,
+        10_000,
+        .{ .sleeper = &sleeper, .random = prng.random() },
+    );
+
+    switch (outcome) {
+        .ok => |props| {
+            var owned = props;
+            owned.deinit();
+            return error.TestUnexpectedResult;
+        },
+        .failed => |failure| {
+            // One attempt: 404 maps to `amqp:not-found`, which is fatal, so
+            // the retrier stopped immediately rather than backing off.
+            try testing.expectEqual(@as(u32, 1), failure.attempts);
+            try testing.expectEqualStrings(errors.condition.not_found, failure.info.amqp_condition.?);
+            try testing.expectEqualStrings("not found", failure.info.description.?);
+        },
+    }
+}

--- a/management.zig
+++ b/management.zig
@@ -692,23 +692,29 @@ fn propertyValue(props: []const MapEntry, key: []const u8) ?AmqpValue {
 const Scripted = struct {
     allocator: Allocator,
     mem: *MemoryTransport,
-    clock: *driver.ManualClock,
-    conn: *driver.Driver,
     fixture: Fixture,
-    client: *amqp.Management,
+    client: *amqp.Management = undefined,
 
-    fn init(allocator: Allocator, mem: *MemoryTransport, clock: *driver.ManualClock, conn: *driver.Driver) !Scripted {
-        var fixture = try Fixture.init(allocator, mem, clock, conn);
-        errdefer fixture.deinit();
-        const client = try amqp.Management.open(&fixture.session, .{ .link_id = "eh" }, 10_000);
-        return .{
+    /// Initialised in place rather than returned by value.
+    ///
+    /// The management client keeps a pointer into `fixture.session`, so a
+    /// `Scripted` built in a local and then returned would leave that pointer
+    /// aimed at the dead frame it was built in. That reads fine on Linux,
+    /// where the stack is usually still intact, and segfaults on Windows.
+    fn open(
+        self: *Scripted,
+        allocator: Allocator,
+        mem: *MemoryTransport,
+        clock: *driver.ManualClock,
+        conn: *driver.Driver,
+    ) !void {
+        self.* = .{
             .allocator = allocator,
             .mem = mem,
-            .clock = clock,
-            .conn = conn,
-            .fixture = fixture,
-            .client = client,
+            .fixture = try Fixture.init(allocator, mem, clock, conn),
         };
+        errdefer self.fixture.deinit();
+        self.client = try amqp.Management.open(&self.fixture.session, .{ .link_id = "eh" }, 10_000);
     }
 
     fn deinit(self: *Scripted) void {
@@ -758,7 +764,8 @@ test "an event hub read puts the exact application properties on the wire" {
 
     var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
     defer conn.deinit();
-    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
     defer scripted.deinit();
 
     mem.clearWritten();
@@ -814,7 +821,8 @@ test "a partition read names the partition and uses the partition entity type" {
 
     var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
     defer conn.deinit();
-    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
     defer scripted.deinit();
 
     mem.clearWritten();
@@ -853,7 +861,8 @@ test "a management error status surfaces with the broker's description" {
 
     var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
     defer conn.deinit();
-    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
     defer scripted.deinit();
 
     try testing.expectError(
@@ -881,7 +890,8 @@ test "a not-found status is classified as fatal rather than retried" {
 
     var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
     defer conn.deinit();
-    var scripted = try Scripted.init(allocator, &mem, &clock, &conn);
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
     defer scripted.deinit();
 
     // A no-op sleeper: a fatal failure must not reach a backoff at all, so any

--- a/root.zig
+++ b/root.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 const uamqp = @import("uamqp");
+const amqp = @import("azure_sdk_amqp");
 const messaging_common = @import("azure_sdk_messaging_common");
 const checkpoint = @import("checkpoint.zig");
 const event_data = @import("event_data.zig");
@@ -195,25 +196,12 @@ fn dataSectionSize(payload_len: usize) usize {
     return if (payload_len < 256) vbin8_overhead + payload_len else vbin32_overhead + payload_len;
 }
 
-pub const PartitionProperties = struct {
-    id: []const u8,
-    /// Name of the Event Hub the partition belongs to.
-    event_hub_name: []const u8 = "",
-    beginning_sequence_number: i64 = 0,
-    last_enqueued_sequence_number: i64 = 0,
-    last_enqueued_offset: ?[]const u8 = null,
-    last_enqueued_time: ?i64 = null,
-    is_empty: bool = true,
-};
-
-pub const EventHubProperties = struct {
-    name: []const u8,
-    partition_ids: []const []const u8 = &.{},
-    created_on: ?i64 = null,
-    /// True when the namespace has geo-replication enabled, which the service
-    /// reports as a geo-replication factor greater than one.
-    geo_replication_enabled: bool = false,
-};
+/// Metadata models and the `$management` operations that produce them. Both
+/// carry an optional arena, so a decoded value owns its strings and one built
+/// by hand borrows them; `deinit` is correct either way.
+pub const management = @import("management.zig");
+pub const PartitionProperties = management.PartitionProperties;
+pub const EventHubProperties = management.EventHubProperties;
 
 /// Where in a partition a consumer starts reading.
 ///
@@ -428,16 +416,143 @@ pub const UamqpTransport = struct {
         return &.{};
     }
 
+    // These used to echo the caller's own arguments back, which reads as a
+    // successful metadata read and is indistinguishable from one. Failing is
+    // the honest answer until this transport can actually reach the service;
+    // `ManagementTransport` does the real RPC today.
     fn getHubPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) !EventHubProperties {
         _ = t;
         _ = allocator;
-        return .{ .name = hub_name };
+        _ = hub_name;
+        return error.NotConnected;
     }
 
     fn getPartitionPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) !PartitionProperties {
         _ = t;
         _ = allocator;
-        return .{ .id = partition_id, .event_hub_name = hub_name };
+        _ = hub_name;
+        _ = partition_id;
+        return error.NotConnected;
+    }
+
+    fn closeImpl(t: *AmqpTransport) void {
+        _ = t;
+    }
+};
+
+/// A transport whose metadata operations are real `$management` RPCs.
+///
+/// It borrows an already-open management client rather than opening one,
+/// because the connection, its CBS authorisation, and its session outlive any
+/// single operation and are owned by the caller. Sending and receiving events
+/// still belong to the link-based transport and are not implemented here.
+pub const ManagementTransport = struct {
+    management_client: *amqp.Management,
+    /// The CBS token for the hub audience. Event Hubs wants it on the message
+    /// as well as on the link.
+    security_token: ?[]const u8 = null,
+    deadline_ms: i64,
+    /// When set, both operations run under the Event Hubs retry schedule.
+    retry: ?errors.RetryConfig = null,
+    transport: AmqpTransport,
+
+    pub fn init(management_client: *amqp.Management, options: Options) ManagementTransport {
+        return .{
+            .management_client = management_client,
+            .security_token = options.security_token,
+            .deadline_ms = options.deadline_ms,
+            .retry = options.retry,
+            .transport = .{
+                .sendBatchFn = &sendBatchImpl,
+                .receiveFn = &receiveImpl,
+                .getHubPropertiesFn = &getHubPropsImpl,
+                .getPartitionPropertiesFn = &getPartitionPropsImpl,
+                .closeFn = &closeImpl,
+            },
+        };
+    }
+
+    pub const Options = struct {
+        security_token: ?[]const u8 = null,
+        deadline_ms: i64,
+        retry: ?errors.RetryConfig = null,
+    };
+
+    pub fn asTransport(self: *ManagementTransport) *AmqpTransport {
+        return &self.transport;
+    }
+
+    /// The broker's status and description for the most recent failure, which
+    /// a Zig error cannot carry.
+    pub fn lastError(self: *ManagementTransport) ?amqp.ManagementStatusError {
+        return self.management_client.last_error;
+    }
+
+    fn sendBatchImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) !void {
+        _ = t;
+        _ = allocator;
+        _ = target;
+        _ = batch;
+        return error.Unimplemented;
+    }
+
+    fn receiveImpl(t: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) ![]ReceivedEventData {
+        _ = t;
+        _ = allocator;
+        _ = source;
+        _ = filter;
+        _ = max_count;
+        return error.Unimplemented;
+    }
+
+    fn getHubPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) !EventHubProperties {
+        const self: *ManagementTransport = @fieldParentPtr("transport", t);
+        if (self.retry) |config| {
+            return switch (management.getEventHubPropertiesWithRetry(
+                allocator,
+                self.management_client,
+                hub_name,
+                self.security_token,
+                self.deadline_ms,
+                config,
+            )) {
+                .ok => |props| props,
+                .failed => |failure| failure.err,
+            };
+        }
+        return management.getEventHubProperties(
+            allocator,
+            self.management_client,
+            hub_name,
+            self.security_token,
+            self.deadline_ms,
+        );
+    }
+
+    fn getPartitionPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) !PartitionProperties {
+        const self: *ManagementTransport = @fieldParentPtr("transport", t);
+        if (self.retry) |config| {
+            return switch (management.getPartitionPropertiesWithRetry(
+                allocator,
+                self.management_client,
+                hub_name,
+                partition_id,
+                self.security_token,
+                self.deadline_ms,
+                config,
+            )) {
+                .ok => |props| props,
+                .failed => |failure| failure.err,
+            };
+        }
+        return management.getPartitionProperties(
+            allocator,
+            self.management_client,
+            hub_name,
+            partition_id,
+            self.security_token,
+            self.deadline_ms,
+        );
     }
 
     fn closeImpl(t: *AmqpTransport) void {
@@ -1020,11 +1135,11 @@ test "ProducerClient createBatch" {
     );
     defer mock.deinit();
     var cred = cred_mod.ClientSecretCredential.init(allocator, mock.asTransport(), "t", "c", "s");
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
-    }, cred.asCredential(), amqp.asTransport());
+    }, cred.asCredential(), mock_amqp.asTransport());
     var batch = try producer.createBatch(.{});
     defer batch.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 0), batch.count());
@@ -1038,11 +1153,11 @@ test "ProducerClient sendBatch" {
     );
     defer mock_http.deinit();
     var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
-    }, cred.asCredential(), amqp.asTransport());
+    }, cred.asCredential(), mock_amqp.asTransport());
 
     var batch = try producer.createBatch(.{});
     defer batch.deinit(allocator);
@@ -1051,8 +1166,8 @@ test "ProducerClient sendBatch" {
     _ = try batch.tryAdd(allocator, e1);
 
     try producer.sendBatch(allocator, batch);
-    try std.testing.expect(amqp.send_called);
-    try std.testing.expectEqual(@as(u32, 1), amqp.send_batch_count);
+    try std.testing.expect(mock_amqp.send_called);
+    try std.testing.expectEqual(@as(u32, 1), mock_amqp.send_batch_count);
 }
 
 test "ProducerClient sendBatch empty returns error" {
@@ -1063,11 +1178,11 @@ test "ProducerClient sendBatch empty returns error" {
     );
     defer mock_http.deinit();
     var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
-    }, cred.asCredential(), amqp.asTransport());
+    }, cred.asCredential(), mock_amqp.asTransport());
 
     var batch = try producer.createBatch(.{});
     defer batch.deinit(allocator);
@@ -1084,12 +1199,12 @@ test "ProducerClient getEventHubProperties" {
     );
     defer mock_http.deinit();
     var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
-    var amqp = MockAmqpTransport.init();
-    amqp.hub_properties = .{ .name = "my-hub", .partition_ids = &.{ "0", "1", "2" } };
+    var mock_amqp = MockAmqpTransport.init();
+    mock_amqp.hub_properties = .{ .name = "my-hub", .partition_ids = &.{ "0", "1", "2" } };
     var producer = ProducerClient.init(.{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
-    }, cred.asCredential(), amqp.asTransport());
+    }, cred.asCredential(), mock_amqp.asTransport());
 
     const props = try producer.getEventHubProperties(allocator);
     try std.testing.expectEqualStrings("my-hub", props.name);
@@ -1104,11 +1219,11 @@ test "ConsumerClient receiveEvents" {
     );
     defer mock_http.deinit();
     var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     var consumer = ConsumerClient.init(.{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
-    }, cred.asCredential(), amqp.asTransport());
+    }, cred.asCredential(), mock_amqp.asTransport());
 
     const events = try consumer.receiveEvents(allocator, "0", EventPosition.earliest(), 10);
     try std.testing.expectEqual(@as(usize, 0), events.len);
@@ -1129,9 +1244,9 @@ test "UamqpTransport sendBatch encodes messages" {
 
 test "ProducerClient fromConnectionString" {
     const allocator = std.testing.allocator;
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=mykey;SharedAccessKey=abc123=;EntityPath=myhub";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
     defer producer.deinit();
     try std.testing.expectEqualStrings("mynamespace.servicebus.windows.net", producer.options.fully_qualified_namespace);
     try std.testing.expectEqualStrings("myhub", producer.options.event_hub_name);
@@ -1144,26 +1259,26 @@ test "ProducerClient fromConnectionString" {
 
 test "ProducerClient fromConnectionString with override" {
     const allocator = std.testing.allocator;
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub1";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, "hub2", amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, cs, "hub2", mock_amqp.asTransport());
     defer producer.deinit();
     try std.testing.expectEqualStrings("hub2", producer.options.event_hub_name);
     try std.testing.expectEqualStrings("amqps://ns.servicebus.windows.net/hub2", producer.owned_audience.?);
 }
 
 test "ProducerClient fromConnectionString missing hub" {
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v";
-    const result = ProducerClient.fromConnectionString(std.testing.allocator, cs, null, amqp.asTransport());
+    const result = ProducerClient.fromConnectionString(std.testing.allocator, cs, null, mock_amqp.asTransport());
     try std.testing.expectError(error.MissingEventHubName, result);
 }
 
 test "ConsumerClient fromConnectionString" {
     const allocator = std.testing.allocator;
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
-    var consumer = try ConsumerClient.fromConnectionString(allocator, cs, null, amqp.asTransport());
+    var consumer = try ConsumerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
     defer consumer.deinit();
     try std.testing.expectEqualStrings("ns.servicebus.windows.net", consumer.options.fully_qualified_namespace);
     try std.testing.expectEqualStrings("hub", consumer.options.event_hub_name);
@@ -1216,9 +1331,9 @@ test "audienceFor uses the connection string scheme" {
 
 test "connection string credential signs the parsed entity" {
     const allocator = std.testing.allocator;
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=policy;SharedAccessKey=c2VjcmV0;EntityPath=hub";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
     defer producer.deinit();
 
     try std.testing.expect(producer.credential == .sas);
@@ -1241,12 +1356,12 @@ test "connection string credential signs the parsed entity" {
 }
 
 test "AAD credential is asked for the Event Hubs scope" {
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     var recorder = ScopeRecordingCredential.init();
     var producer = ProducerClient.init(.{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "hub",
-    }, recorder.asCredential(), amqp.asTransport());
+    }, recorder.asCredential(), mock_amqp.asTransport());
     defer producer.deinit();
 
     try std.testing.expect(producer.credential == .token);
@@ -1266,13 +1381,13 @@ test "AAD credential is asked for the Event Hubs scope" {
 
 test "entityAudience matches the hub, partitionAudience the consumer group path" {
     const allocator = std.testing.allocator;
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     var recorder = ScopeRecordingCredential.init();
     var consumer = ConsumerClient.init(.{
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "hub",
         .consumer_group = "cg",
-    }, recorder.asCredential(), amqp.asTransport());
+    }, recorder.asCredential(), mock_amqp.asTransport());
     defer consumer.deinit();
 
     const entity = try consumer.entityAudience(allocator);
@@ -1289,13 +1404,13 @@ test "entityAudience matches the hub, partitionAudience the consumer group path"
 
 test "a SAS credential survives being returned by value" {
     const allocator = std.testing.allocator;
-    var amqp = MockAmqpTransport.init();
+    var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=dg==;EntityPath=hub";
 
     // `SasCredential` recovers itself with `@fieldParentPtr`, so a pointer
     // taken before the client was moved would dangle. Resolving lazily
     // through the moved client must still produce a usable token.
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
     defer producer.deinit();
     var moved = producer;
     producer.owned_audience = null;


### PR DESCRIPTION
Refs #203.

`getHubPropsImpl` returned `.{ .name = hub_name }` and `getPartitionPropsImpl` returned `.{ .id = partition_id }` — the caller’s own arguments echoed back. Neither contacted the service, so both clients reported fabricated metadata that was indistinguishable from a real read.

## What changed

- New `management.zig` issuing the real `$management` RPCs. Both are `READ`, distinguished by entity type: `com.microsoft:eventhub` for the hub’s partition list, `com.microsoft:partition` for one partition’s range.
- New `ManagementTransport` performs them against an already-open `azure_sdk_amqp.Management`. It **borrows** the client rather than opening one, because the connection, its CBS authorisation, and its session all outlive any single operation.
- `UamqpTransport`’s stubs now fail with `error.NotConnected` rather than fabricating a successful read.
- Adds `azure_sdk_amqp` as a dependency, and takes `uamqp` **from it** rather than building a second copy — two modules over the same source produce two incompatible sets of types (fixed in #278).

## Wire details that are not guessable

Taken from Go’s `mgmt.go`, cross-checked against Rust’s `common/management.rs`:

- In a **partition** reply, `name` is the **hub** and `partition` is the partition. Swapping them yields a not-found that says nothing about the cause, so there is a scripted-peer test asserting the exact property map for both operations.
- The first sequence number is `begin_sequence_number`, not `beginning_`.
- Geo-replication arrives as a **factor**, not a flag: a factor of one is *not* geo-replication.

Integral fields are widened from whatever encoding the service chose (Go has `ConvertToInt64` for the same reason) — a small sequence number arrives as a `byte`. Absent optional fields are treated as absent rather than malformed, since a broker predating geo-replication simply omits the factor; Go rejects the whole reply in that case.

## Ownership

Decoded properties own their strings through an arena; ones built by hand leave it null and borrow. `deinit` is correct either way and is idempotent, so `MockAmqpTransport` keeps working unchanged.

## Retry

Both operations optionally run under the retry schedule from #196. A management failure carries an HTTP-shaped status rather than an AMQP condition, so the mapping is made explicitly: 404 → `amqp:not-found` (fatal, not retried), 503/429 → `com.microsoft:server-busy`, 5xx → `amqp:internal-error`.

## Testing

113/113 pass. Scripted-peer tests assert the exact application-property map for both operations, a realistic reply decodes into fully populated properties including `geo_replication_enabled`, an error status surfaces with the broker’s description, and a 404 stops after one attempt. The partition request test was mutation-verified by swapping `name` and `partition`.

One test uses an AMQP `list` rather than an `array` for `partition_ids`, because uamqp’s array encoder writes a wrong length prefix and an array cannot yet survive a real frame. Decoding an array is covered by a direct-parse test.

Paired `eng/packages.zig` PR on `main` registers the new file.