### PR TITLE
eng: register eventhubs management.zig and its azure_sdk_amqp dependency

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -448,6 +448,7 @@ pub const all = [_]Package{
             "azure_sdk_core",
             "azure_sdk_messaging_common",
             "azure_sdk_storage_blobs",
+            "azure_sdk_amqp",
         },
         .external_dependencies = &.{ "uamqp", "serde" },
         .publish_paths = &.{
@@ -459,6 +460,7 @@ pub const all = [_]Package{
             "errors.zig",
             "checkpoint.zig",
             "checkpoint_store.zig",
+            "management.zig",
             "checkpoint_store_blob",
             "README.md",
             "LICENSE.txt",


### PR DESCRIPTION
Pairs with #280 (#203).

`sdk/eventhubs` gains `management.zig`, which implements the hub and partition `READ` operations on the `$management` link, and takes `azure_sdk_amqp` as a dependency to reach it.

`zig build test`, `package-check`, and `package-history-check` all pass.