### PR TITLE
eventhubs: send event batches over real AMQP sender links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,46 @@ A connection string carrying a pre-formed `SharedAccessSignature` instead of a
 key cannot be re-signed, so `credential.isRefreshable()` reports `false` and the
 client cannot outlive that signature.
 
+## Sending
+
+A batch leaves as a single AMQP transfer whose `message-format` is
+`0x80013700`. Its body is the first event's non-body sections reused as an
+envelope, followed by one data section per event, each holding a fully encoded
+AMQP message. The service splits it back apart. Go and Rust produce the same
+shape.
+
+```zig
+var pool = SenderPool.init(allocator, &session, .{ .deadline_ms = deadline });
+defer pool.deinit();
+
+var transport = LinkTransport.init(management_client, .{
+    .senders = &pool,
+    .deadline_ms = deadline,
+});
+
+var batch = try producer.createBatch(allocator, .{ .partition_key = "orders" });
+defer batch.deinit(allocator);
+_ = try batch.tryAdd(allocator, EventData.init("hello"));
+try producer.sendBatch(allocator, batch);
+```
+
+The link target is the entity path, not the namespace: `{hub}` lets the service
+pick a partition, and `{hub}/Partitions/{id}` pins one. A batch created with a
+`partition_id` routes itself. One link is attached per address and reused,
+because credit and `max-message-size` are both per link.
+
+`createBatch` asks the link for its negotiated `max-message-size` and sizes the
+batch by it, so a batch that reports as fitting actually fits. An explicit
+`max_bytes` above what the link allows is refused rather than truncated.
+
+A partition key becomes an `x-opt-partition-key` message annotation on every
+event and on the envelope, which is the copy the service routes by.
+
+The senders belong to the session, which detaches and frees them; the pool only
+owns the addresses it keys them by. When the broker refuses a delivery,
+`lastSendError` carries the AMQP condition and description that the Zig error
+cannot.
+
 ## Metadata
 
 `getEventHubProperties` and `getPartitionProperties` are `READ` operations on
@@ -46,13 +86,13 @@ the `$management` link, distinguished by entity type — `com.microsoft:eventhub
 returns the hub's partition list, `com.microsoft:partition` returns one
 partition's sequence number range.
 
-`ManagementTransport` performs them against an already-open
+`LinkTransport` performs them against an already-open
 `azure_sdk_amqp.Management` client. It borrows the client rather than opening
 one, because the connection, its CBS authorisation, and its session outlive any
 single operation.
 
 ```zig
-var transport = ManagementTransport.init(management_client, .{
+var transport = LinkTransport.init(management_client, .{
     .security_token = token.token,
     .deadline_ms = deadline,
     .retry = .{ .sleeper = &sleeper, .random = prng.random() },

--- a/batch.zig
+++ b/batch.zig
@@ -1,0 +1,154 @@
+//! Packing events into a single Event Hubs batch transfer.
+
+const std = @import("std");
+const event_data = @import("event_data.zig");
+
+const EventData = event_data.EventData;
+
+/// AMQP message format identifying an Event Hubs batch transfer.
+pub const batch_message_format: u32 = 0x80013700;
+
+/// Size assumed before a sender link negotiates `max-message-size`. Event Hubs
+/// standard tiers allow 1 MiB.
+pub const default_max_message_size: usize = 1024 * 1024;
+
+pub const BatchError = error{
+    /// A batch targets either a partition or a partition key, never both.
+    PartitionKeyAndIdBothSet,
+    /// The event cannot fit an empty batch, so no batch size would accept it.
+    EventDataTooLarge,
+    /// The requested `max_bytes` is above what the sender link negotiated.
+    MaxBytesExceedsLinkLimit,
+    /// The link limit can only be adopted before events are added.
+    BatchNotEmpty,
+};
+
+pub const EventDataBatchOptions = struct {
+    /// Upper bound on the encoded batch size. Defaults to the sender link's
+    /// negotiated maximum, or `default_max_message_size` until one exists.
+    max_bytes: ?usize = null,
+    /// Route related events to one partition by hash. Mutually exclusive with
+    /// `partition_id`.
+    partition_key: ?[]const u8 = null,
+    /// Send to an explicit partition. Mutually exclusive with `partition_key`.
+    partition_id: ?[]const u8 = null,
+};
+
+/// Packs events into a single AMQP batch transfer.
+///
+/// Events are encoded as they are added and the batch tracks the real byte
+/// count, so a batch that reports as fitting actually fits. Go and Rust both
+/// work this way; estimating from body length under-counts properties,
+/// annotations, and per-message framing.
+pub const EventDataBatch = struct {
+    /// Fully encoded sub-messages, each of which becomes one data section of
+    /// the batch transfer.
+    marshaled: std.ArrayList([]u8) = .empty,
+    /// Encoded non-body sections of the first event, which become the batch
+    /// envelope. Go reuses the first message this way.
+    envelope: ?[]u8 = null,
+    max_size_bytes: usize = default_max_message_size,
+    current_size: usize = 0,
+    partition_key: ?[]const u8 = null,
+    partition_id: ?[]const u8 = null,
+    /// Set when the caller pinned `max_bytes`, so a link cannot raise it.
+    requested_max_bytes: ?usize = null,
+
+    pub fn init(options: EventDataBatchOptions) BatchError!EventDataBatch {
+        if (options.partition_key != null and options.partition_id != null) {
+            return BatchError.PartitionKeyAndIdBothSet;
+        }
+        return .{
+            .max_size_bytes = options.max_bytes orelse default_max_message_size,
+            .partition_key = options.partition_key,
+            .partition_id = options.partition_id,
+            .requested_max_bytes = options.max_bytes,
+        };
+    }
+
+    pub fn deinit(self: *EventDataBatch, allocator: std.mem.Allocator) void {
+        for (self.marshaled.items) |encoded| allocator.free(encoded);
+        self.marshaled.deinit(allocator);
+        if (self.envelope) |envelope| allocator.free(envelope);
+        self.envelope = null;
+        self.current_size = 0;
+    }
+
+    /// Adopt the `max-message-size` a sender link negotiated.
+    ///
+    /// An explicitly requested `max_bytes` is kept when it is smaller and
+    /// rejected when it exceeds what the link allows, matching Go.
+    pub fn applyLinkMaxMessageSize(
+        self: *EventDataBatch,
+        link_max_bytes: usize,
+    ) BatchError!void {
+        if (self.marshaled.items.len > 0) return BatchError.BatchNotEmpty;
+        if (self.requested_max_bytes) |requested| {
+            if (requested > link_max_bytes) return BatchError.MaxBytesExceedsLinkLimit;
+            return;
+        }
+        self.max_size_bytes = link_max_bytes;
+    }
+
+    /// Encode `event` and add it if the batch still has room.
+    ///
+    /// Returns `false` when the event does not fit alongside what is already
+    /// batched, and `BatchError.EventDataTooLarge` when it would not fit even
+    /// an empty batch.
+    pub fn tryAdd(self: *EventDataBatch, allocator: std.mem.Allocator, event: EventData) !bool {
+        var message = try event.toAmqpMessage(allocator);
+        defer event_data.freeAmqpMessage(allocator, &message);
+
+        if (self.partition_key) |partition_key| {
+            try event_data.setPartitionKeyAnnotation(allocator, &message, partition_key);
+        }
+
+        // Both buffers are discarded unless the event is actually adopted,
+        // which includes the `false` return when it simply does not fit.
+        var adopted = false;
+
+        const encoded = try event_data.encodeMessage(allocator, &message);
+        defer if (!adopted) allocator.free(encoded);
+
+        // The first event also fixes the envelope, so its cost is charged here.
+        const is_first = self.marshaled.items.len == 0;
+        const envelope: ?[]u8 = if (is_first)
+            try event_data.encodeMessageEnvelope(allocator, &message)
+        else
+            null;
+        defer if (!adopted) {
+            if (envelope) |bytes| allocator.free(bytes);
+        };
+
+        const envelope_size = if (envelope) |bytes| bytes.len else 0;
+        const projected = self.current_size + envelope_size + dataSectionSize(encoded.len);
+        if (projected > self.max_size_bytes) {
+            if (is_first) return BatchError.EventDataTooLarge;
+            return false;
+        }
+
+        try self.marshaled.append(allocator, encoded);
+        if (envelope) |bytes| self.envelope = bytes;
+        self.current_size = projected;
+        adopted = true;
+        return true;
+    }
+
+    pub fn count(self: EventDataBatch) usize {
+        return self.marshaled.items.len;
+    }
+
+    /// Encoded size of the batch as it would go on the wire.
+    pub fn sizeInBytes(self: EventDataBatch) usize {
+        return self.current_size;
+    }
+};
+
+/// Wrapping a payload in a data section costs a described-type constructor, the
+/// descriptor, and a binary length prefix. Go's `calcActualSizeForPayload`
+/// uses the same constants.
+fn dataSectionSize(payload_len: usize) usize {
+    const vbin8_overhead = 5;
+    const vbin32_overhead = 8;
+    return if (payload_len < 256) vbin8_overhead + payload_len else vbin32_overhead + payload_len;
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.1.0-I5lGdlJ7CgCiJaJDvHH7ukhtln4baXBvqfvrDGCOhiVD",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#7cf871c3cc9a6541f601f3e07242eb48e9e43ae5",
-            .hash = "azure_sdk_amqp-0.1.0-fUByf_teBADElN-o5BreZApnLGcLcxlb8ykLJ3GF-Mc4",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#e91e345f852b2a9b8ac33c0a494d82deace30f38",
+            .hash = "azure_sdk_amqp-0.1.0-fUByf3l2BADNnCWXU2h6TZCgZmAmaXNfmjOr0yTHE4JR",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
@@ -31,6 +31,8 @@
         "build.zig.zon",
         "root.zig",
         "event_data.zig",
+        "batch.zig",
+        "sender.zig",
         "errors.zig",
         "checkpoint.zig",
         "checkpoint_store.zig",

--- a/event_data.zig
+++ b/event_data.zig
@@ -530,6 +530,30 @@ fn encodeMessageSections(
     return encoded;
 }
 
+/// Append one data section per payload to an already encoded prefix.
+///
+/// This is how an Event Hubs batch is laid out: the envelope from
+/// `encodeMessageEnvelope` followed by the contained messages, each wrapped in
+/// its own data section. `EventData.toAmqpMessage` produces no footer, so
+/// nothing in the envelope has to follow the body.
+pub fn encodeDataSections(
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    payloads: []const []u8,
+) ![]u8 {
+    var buffer = uamqp.encoder.Buffer.initDynamic(allocator);
+    errdefer buffer.deinit();
+
+    try buffer.writeAll(prefix);
+    for (payloads) |payload| {
+        try encodeSection(&buffer, uamqp.definitions.descriptor.data, .{ .binary = payload });
+    }
+
+    const encoded = try allocator.dupe(u8, buffer.written());
+    buffer.deinit();
+    return encoded;
+}
+
 fn encodeSection(buffer: *uamqp.encoder.Buffer, code: u64, value: AmqpValue) !void {
     var descriptor: AmqpValue = .{ .ulong = code };
     var section = value;

--- a/root.zig
+++ b/root.zig
@@ -48,153 +48,19 @@ pub const retry = errors.retry;
 
 // ─────────────────────── Models ───────────────────────
 
-/// AMQP message format identifying an Event Hubs batch transfer.
-pub const batch_message_format: u32 = 0x80013700;
+// Not re-exported as a namespace: `batch` is the natural name for a
+// parameter throughout this file, and Zig forbids the shadowing.
+const batching = @import("batch.zig");
+pub const batch_message_format = batching.batch_message_format;
+pub const default_max_message_size = batching.default_max_message_size;
+pub const BatchError = batching.BatchError;
+pub const EventDataBatchOptions = batching.EventDataBatchOptions;
+pub const EventDataBatch = batching.EventDataBatch;
 
-/// Size assumed before a sender link negotiates `max-message-size`. Event Hubs
-/// standard tiers allow 1 MiB.
-pub const default_max_message_size: usize = 1024 * 1024;
-
-pub const BatchError = error{
-    /// A batch targets either a partition or a partition key, never both.
-    PartitionKeyAndIdBothSet,
-    /// The event cannot fit an empty batch, so no batch size would accept it.
-    EventDataTooLarge,
-    /// The requested `max_bytes` is above what the sender link negotiated.
-    MaxBytesExceedsLinkLimit,
-    /// The link limit can only be adopted before events are added.
-    BatchNotEmpty,
-};
-
-pub const EventDataBatchOptions = struct {
-    /// Upper bound on the encoded batch size. Defaults to the sender link's
-    /// negotiated maximum, or `default_max_message_size` until one exists.
-    max_bytes: ?usize = null,
-    /// Route related events to one partition by hash. Mutually exclusive with
-    /// `partition_id`.
-    partition_key: ?[]const u8 = null,
-    /// Send to an explicit partition. Mutually exclusive with `partition_key`.
-    partition_id: ?[]const u8 = null,
-};
-
-/// Packs events into a single AMQP batch transfer.
-///
-/// Events are encoded as they are added and the batch tracks the real byte
-/// count, so a batch that reports as fitting actually fits. Go and Rust both
-/// work this way; estimating from body length under-counts properties,
-/// annotations, and per-message framing.
-pub const EventDataBatch = struct {
-    /// Fully encoded sub-messages, each of which becomes one data section of
-    /// the batch transfer.
-    marshaled: std.ArrayList([]u8) = .empty,
-    /// Encoded non-body sections of the first event, which become the batch
-    /// envelope. Go reuses the first message this way.
-    envelope: ?[]u8 = null,
-    max_size_bytes: usize = default_max_message_size,
-    current_size: usize = 0,
-    partition_key: ?[]const u8 = null,
-    partition_id: ?[]const u8 = null,
-    /// Set when the caller pinned `max_bytes`, so a link cannot raise it.
-    requested_max_bytes: ?usize = null,
-
-    pub fn init(options: EventDataBatchOptions) BatchError!EventDataBatch {
-        if (options.partition_key != null and options.partition_id != null) {
-            return BatchError.PartitionKeyAndIdBothSet;
-        }
-        return .{
-            .max_size_bytes = options.max_bytes orelse default_max_message_size,
-            .partition_key = options.partition_key,
-            .partition_id = options.partition_id,
-            .requested_max_bytes = options.max_bytes,
-        };
-    }
-
-    pub fn deinit(self: *EventDataBatch, allocator: std.mem.Allocator) void {
-        for (self.marshaled.items) |encoded| allocator.free(encoded);
-        self.marshaled.deinit(allocator);
-        if (self.envelope) |envelope| allocator.free(envelope);
-        self.envelope = null;
-        self.current_size = 0;
-    }
-
-    /// Adopt the `max-message-size` a sender link negotiated.
-    ///
-    /// An explicitly requested `max_bytes` is kept when it is smaller and
-    /// rejected when it exceeds what the link allows, matching Go.
-    pub fn applyLinkMaxMessageSize(
-        self: *EventDataBatch,
-        link_max_bytes: usize,
-    ) BatchError!void {
-        if (self.marshaled.items.len > 0) return BatchError.BatchNotEmpty;
-        if (self.requested_max_bytes) |requested| {
-            if (requested > link_max_bytes) return BatchError.MaxBytesExceedsLinkLimit;
-            return;
-        }
-        self.max_size_bytes = link_max_bytes;
-    }
-
-    /// Encode `event` and add it if the batch still has room.
-    ///
-    /// Returns `false` when the event does not fit alongside what is already
-    /// batched, and `BatchError.EventDataTooLarge` when it would not fit even
-    /// an empty batch.
-    pub fn tryAdd(self: *EventDataBatch, allocator: std.mem.Allocator, event: EventData) !bool {
-        var message = try event.toAmqpMessage(allocator);
-        defer event_data.freeAmqpMessage(allocator, &message);
-
-        if (self.partition_key) |partition_key| {
-            try event_data.setPartitionKeyAnnotation(allocator, &message, partition_key);
-        }
-
-        // Both buffers are discarded unless the event is actually adopted,
-        // which includes the `false` return when it simply does not fit.
-        var adopted = false;
-
-        const encoded = try event_data.encodeMessage(allocator, &message);
-        defer if (!adopted) allocator.free(encoded);
-
-        // The first event also fixes the envelope, so its cost is charged here.
-        const is_first = self.marshaled.items.len == 0;
-        const envelope: ?[]u8 = if (is_first)
-            try event_data.encodeMessageEnvelope(allocator, &message)
-        else
-            null;
-        defer if (!adopted) {
-            if (envelope) |bytes| allocator.free(bytes);
-        };
-
-        const envelope_size = if (envelope) |bytes| bytes.len else 0;
-        const projected = self.current_size + envelope_size + dataSectionSize(encoded.len);
-        if (projected > self.max_size_bytes) {
-            if (is_first) return BatchError.EventDataTooLarge;
-            return false;
-        }
-
-        try self.marshaled.append(allocator, encoded);
-        if (envelope) |bytes| self.envelope = bytes;
-        self.current_size = projected;
-        adopted = true;
-        return true;
-    }
-
-    pub fn count(self: EventDataBatch) usize {
-        return self.marshaled.items.len;
-    }
-
-    /// Encoded size of the batch as it would go on the wire.
-    pub fn sizeInBytes(self: EventDataBatch) usize {
-        return self.current_size;
-    }
-};
-
-/// Wrapping a payload in a data section costs a described-type constructor, the
-/// descriptor, and a binary length prefix. Go's `calcActualSizeForPayload`
-/// uses the same constants.
-fn dataSectionSize(payload_len: usize) usize {
-    const vbin8_overhead = 5;
-    const vbin32_overhead = 8;
-    return if (payload_len < 256) vbin8_overhead + payload_len else vbin32_overhead + payload_len;
-}
+pub const sending = @import("sender.zig");
+pub const SenderPool = sending.SenderPool;
+pub const SendError = sending.SendError;
+pub const entityPathFor = sending.entityPathFor;
 
 /// Metadata models and the `$management` operations that produce them. Both
 /// carry an optional arena, so a decoded value owns its strings and one built
@@ -329,6 +195,9 @@ pub const AmqpTransport = struct {
     receiveFn: *const fn (self: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) anyerror![]ReceivedEventData,
     getHubPropertiesFn: *const fn (self: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) anyerror!EventHubProperties,
     getPartitionPropertiesFn: *const fn (self: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) anyerror!PartitionProperties,
+    /// The peer's `max-message-size` for `address`, or null when it advertised
+    /// no limit or the transport cannot ask. `createBatch` sizes itself by it.
+    maxMessageSizeFn: *const fn (self: *AmqpTransport, address: []const u8) anyerror!?u64,
     closeFn: *const fn (self: *AmqpTransport) void,
 
     pub fn sendBatch(self: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) !void {
@@ -347,118 +216,38 @@ pub const AmqpTransport = struct {
         return self.getPartitionPropertiesFn(self, allocator, hub_name, partition_id);
     }
 
+    pub fn maxMessageSize(self: *AmqpTransport, address: []const u8) !?u64 {
+        return self.maxMessageSizeFn(self, address);
+    }
+
     pub fn close(self: *AmqpTransport) void {
         self.closeFn(self);
     }
 };
 
-/// AMQP transport backed by the uamqp library.
+/// A transport backed by real AMQP links.
 ///
-/// Creates proper AMQP objects (Connection, Session, Message encoding)
-/// for Event Hub operations. Full network I/O integration requires
-/// a TLS transport layer (see azure-uamqp-zig).
-pub const UamqpTransport = struct {
-    allocator: std.mem.Allocator,
-    hostname: []const u8,
-    transport: AmqpTransport,
-
-    pub fn init(allocator: std.mem.Allocator, hostname: []const u8) UamqpTransport {
-        return .{
-            .allocator = allocator,
-            .hostname = hostname,
-            .transport = .{
-                .sendBatchFn = &sendBatchImpl,
-                .receiveFn = &receiveImpl,
-                .getHubPropertiesFn = &getHubPropsImpl,
-                .getPartitionPropertiesFn = &getPartitionPropsImpl,
-                .closeFn = &closeImpl,
-            },
-        };
-    }
-
-    pub fn asTransport(self: *UamqpTransport) *AmqpTransport {
-        return &self.transport;
-    }
-
-    fn sendBatchImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) !void {
-        const self: *UamqpTransport = @fieldParentPtr("transport", t);
-
-        var conn = uamqp.connection.Connection.init(allocator, "azure-sdk-zig", self.hostname, .{});
-        defer conn.deinit();
-
-        var session = uamqp.session.Session.init(allocator, &conn, .{});
-        defer session.deinit();
-
-        const amqp_target = uamqp.messaging.createTarget(target);
-        _ = amqp_target;
-
-        // Each batched event is already encoded; a real send wraps them in the
-        // batch envelope and writes one transfer with `batch_message_format`.
-        for (batch.marshaled.items) |encoded| {
-            std.debug.assert(encoded.len > 0);
-        }
-    }
-
-    fn receiveImpl(t: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) ![]ReceivedEventData {
-        const self: *UamqpTransport = @fieldParentPtr("transport", t);
-        _ = max_count;
-        _ = filter; // Filter applied via AMQP source filter map entries (requires I/O)
-
-        var conn = uamqp.connection.Connection.init(allocator, "azure-sdk-zig", self.hostname, .{});
-        defer conn.deinit();
-
-        var session = uamqp.session.Session.init(allocator, &conn, .{});
-        defer session.deinit();
-
-        const amqp_source = uamqp.messaging.createSource(source);
-        _ = amqp_source;
-
-        return &.{};
-    }
-
-    // These used to echo the caller's own arguments back, which reads as a
-    // successful metadata read and is indistinguishable from one. Failing is
-    // the honest answer until this transport can actually reach the service;
-    // `ManagementTransport` does the real RPC today.
-    fn getHubPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) !EventHubProperties {
-        _ = t;
-        _ = allocator;
-        _ = hub_name;
-        return error.NotConnected;
-    }
-
-    fn getPartitionPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) !PartitionProperties {
-        _ = t;
-        _ = allocator;
-        _ = hub_name;
-        _ = partition_id;
-        return error.NotConnected;
-    }
-
-    fn closeImpl(t: *AmqpTransport) void {
-        _ = t;
-    }
-};
-
-/// A transport whose metadata operations are real `$management` RPCs.
-///
-/// It borrows an already-open management client rather than opening one,
-/// because the connection, its CBS authorisation, and its session outlive any
-/// single operation and are owned by the caller. Sending and receiving events
-/// still belong to the link-based transport and are not implemented here.
-pub const ManagementTransport = struct {
+/// Metadata operations are `$management` RPCs and sends go out over sender
+/// links attached to the entity address. It borrows an already-open management
+/// client and session rather than opening them, because the connection and its
+/// CBS authorisation outlive any single operation and are owned by the caller.
+pub const LinkTransport = struct {
     management_client: *amqp.Management,
+    /// Sender links, attached on demand. Sending fails as unimplemented while
+    /// this is null, which is what a metadata-only client wants.
+    senders: ?*SenderPool = null,
     /// The CBS token for the hub audience. Event Hubs wants it on the message
     /// as well as on the link.
     security_token: ?[]const u8 = null,
     deadline_ms: i64,
-    /// When set, both operations run under the Event Hubs retry schedule.
+    /// When set, operations run under the Event Hubs retry schedule.
     retry: ?errors.RetryConfig = null,
     transport: AmqpTransport,
 
-    pub fn init(management_client: *amqp.Management, options: Options) ManagementTransport {
+    pub fn init(management_client: *amqp.Management, options: Options) LinkTransport {
         return .{
             .management_client = management_client,
+            .senders = options.senders,
             .security_token = options.security_token,
             .deadline_ms = options.deadline_ms,
             .retry = options.retry,
@@ -467,33 +256,51 @@ pub const ManagementTransport = struct {
                 .receiveFn = &receiveImpl,
                 .getHubPropertiesFn = &getHubPropsImpl,
                 .getPartitionPropertiesFn = &getPartitionPropsImpl,
+                .maxMessageSizeFn = &maxMessageSizeImpl,
                 .closeFn = &closeImpl,
             },
         };
     }
 
     pub const Options = struct {
+        senders: ?*SenderPool = null,
         security_token: ?[]const u8 = null,
         deadline_ms: i64,
         retry: ?errors.RetryConfig = null,
     };
 
-    pub fn asTransport(self: *ManagementTransport) *AmqpTransport {
+    pub fn asTransport(self: *LinkTransport) *AmqpTransport {
         return &self.transport;
     }
 
-    /// The broker's status and description for the most recent failure, which
-    /// a Zig error cannot carry.
-    pub fn lastError(self: *ManagementTransport) ?amqp.ManagementStatusError {
+    /// The broker's status and description for the most recent failed
+    /// metadata operation, which a Zig error cannot carry.
+    pub fn lastError(self: *LinkTransport) ?amqp.ManagementStatusError {
         return self.management_client.last_error;
     }
 
+    /// Why the broker refused the most recent send.
+    pub fn lastSendError(self: *LinkTransport) ?errors.EventHubsError {
+        const pool = self.senders orelse return null;
+        return pool.lastError();
+    }
+
     fn sendBatchImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) !void {
-        _ = t;
-        _ = allocator;
-        _ = target;
-        _ = batch;
-        return error.Unimplemented;
+        const self: *LinkTransport = @fieldParentPtr("transport", t);
+        const pool = self.senders orelse return error.Unimplemented;
+        if (self.retry) |config| {
+            return switch (pool.sendWithRetry(allocator, target, batch, config)) {
+                .ok => {},
+                .failed => |failure| failure.err,
+            };
+        }
+        return pool.send(allocator, target, batch);
+    }
+
+    fn maxMessageSizeImpl(t: *AmqpTransport, address: []const u8) !?u64 {
+        const self: *LinkTransport = @fieldParentPtr("transport", t);
+        const pool = self.senders orelse return null;
+        return pool.maxMessageSize(address);
     }
 
     fn receiveImpl(t: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) ![]ReceivedEventData {
@@ -506,7 +313,7 @@ pub const ManagementTransport = struct {
     }
 
     fn getHubPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) !EventHubProperties {
-        const self: *ManagementTransport = @fieldParentPtr("transport", t);
+        const self: *LinkTransport = @fieldParentPtr("transport", t);
         if (self.retry) |config| {
             return switch (management.getEventHubPropertiesWithRetry(
                 allocator,
@@ -530,7 +337,7 @@ pub const ManagementTransport = struct {
     }
 
     fn getPartitionPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) !PartitionProperties {
-        const self: *ManagementTransport = @fieldParentPtr("transport", t);
+        const self: *LinkTransport = @fieldParentPtr("transport", t);
         if (self.retry) |config| {
             return switch (management.getPartitionPropertiesWithRetry(
                 allocator,
@@ -564,11 +371,18 @@ pub const ManagementTransport = struct {
 pub const MockAmqpTransport = struct {
     send_called: bool = false,
     send_batch_count: u32 = 0,
+    /// The address the most recent send was routed to, so a test can assert
+    /// partition targeting without a peer. Copied, because the caller builds
+    /// the address on the stack or frees it as soon as the call returns.
+    send_target_buf: [256]u8 = undefined,
+    send_target_len: ?usize = null,
     /// Returned verbatim by `receive`, unlike a real transport which allocates.
     /// Tests keep ownership and must not call `freeReceivedEvents` on it.
     receive_result: []ReceivedEventData = &.{},
     hub_properties: EventHubProperties = .{ .name = "test-hub" },
     partition_properties: PartitionProperties = .{ .id = "0" },
+    /// Stands in for a sender link's negotiated limit.
+    link_max_message_size: ?u64 = null,
     transport: AmqpTransport,
 
     pub fn init() MockAmqpTransport {
@@ -578,6 +392,7 @@ pub const MockAmqpTransport = struct {
                 .receiveFn = &receiveImpl,
                 .getHubPropertiesFn = &getHubPropsImpl,
                 .getPartitionPropertiesFn = &getPartitionPropsImpl,
+                .maxMessageSizeFn = &maxMessageSizeImpl,
                 .closeFn = &closeImpl,
             },
         };
@@ -589,10 +404,24 @@ pub const MockAmqpTransport = struct {
 
     fn sendBatchImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) !void {
         _ = allocator;
-        _ = target;
         const self: *MockAmqpTransport = @fieldParentPtr("transport", t);
         self.send_called = true;
         self.send_batch_count += @intCast(batch.count());
+        const len = @min(target.len, self.send_target_buf.len);
+        @memcpy(self.send_target_buf[0..len], target[0..len]);
+        self.send_target_len = len;
+    }
+
+    /// The address of the most recent send, or null if there was none.
+    pub fn sendTarget(self: *const MockAmqpTransport) ?[]const u8 {
+        const len = self.send_target_len orelse return null;
+        return self.send_target_buf[0..len];
+    }
+
+    fn maxMessageSizeImpl(t: *AmqpTransport, address: []const u8) !?u64 {
+        _ = address;
+        const self: *MockAmqpTransport = @fieldParentPtr("transport", t);
+        return self.link_max_message_size;
     }
 
     fn receiveImpl(t: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) ![]ReceivedEventData {
@@ -776,29 +605,45 @@ pub const ProducerClient = struct {
         return self.credential.getToken(ctx);
     }
 
+    /// The AMQP address a batch is published to: the hub, letting the service
+    /// pick a partition, or `{hub}/Partitions/{id}`. Caller owns the result.
+    pub fn entityPath(
+        self: *ProducerClient,
+        allocator: std.mem.Allocator,
+        partition_id: ?[]const u8,
+    ) ![]u8 {
+        return entityPathFor(allocator, self.options.event_hub_name, partition_id);
+    }
+
     /// Send a batch of events over AMQP.
     pub fn sendBatch(self: *ProducerClient, allocator: std.mem.Allocator, batch: EventDataBatch) !void {
-        if (batch.count() == 0) return error.EmptyBatch;
-        const address = try std.fmt.allocPrint(
-            allocator,
-            "{s}/{s}",
-            .{ self.options.fully_qualified_namespace, self.options.event_hub_name },
-        );
+        if (batch.count() == 0) return SendError.EmptyBatch;
+        const address = try self.entityPath(allocator, batch.partition_id);
         defer allocator.free(address);
         return self.amqp_transport.sendBatch(allocator, address, batch);
     }
 
     /// Create a batch sized for this producer.
     ///
-    /// The limit stays at `default_max_message_size` until a sender link
-    /// negotiates `max-message-size`, at which point `applyLinkMaxMessageSize`
-    /// adopts it.
+    /// The limit comes from the sender link's negotiated `max-message-size`
+    /// when the transport can report one, and stays at
+    /// `default_max_message_size` otherwise. Go likewise attaches the link
+    /// inside `NewEventDataBatch` so the batch knows its real ceiling.
     pub fn createBatch(
         self: *ProducerClient,
+        allocator: std.mem.Allocator,
         options: EventDataBatchOptions,
-    ) BatchError!EventDataBatch {
-        _ = self;
-        return EventDataBatch.init(options);
+    ) !EventDataBatch {
+        var new_batch = try EventDataBatch.init(options);
+        errdefer new_batch.deinit(allocator);
+
+        const address = try self.entityPath(allocator, options.partition_id);
+        defer allocator.free(address);
+
+        if (try self.amqp_transport.maxMessageSize(address)) |limit| {
+            try new_batch.applyLinkMaxMessageSize(@intCast(limit));
+        }
+        return new_batch;
     }
 
     pub fn getEventHubProperties(self: *ProducerClient, allocator: std.mem.Allocator) !EventHubProperties {
@@ -911,8 +756,9 @@ pub const ConsumerClient = struct {
 
     /// Receive events from a specific partition.
     ///
-    /// The returned slice comes from the transport. `UamqpTransport` allocates
-    /// it, so free it with `freeReceivedEvents`; `MockAmqpTransport` returns
+    /// The returned slice comes from the transport. A link-backed transport
+    /// allocates it, so free it with `freeReceivedEvents`; `MockAmqpTransport`
+    /// returns
     /// the slice a test handed it and keeps ownership.
     pub fn receiveEvents(
         self: *ConsumerClient,
@@ -1140,7 +986,7 @@ test "ProducerClient createBatch" {
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
-    var batch = try producer.createBatch(.{});
+    var batch = try producer.createBatch(allocator, .{});
     defer batch.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 0), batch.count());
 }
@@ -1159,7 +1005,7 @@ test "ProducerClient sendBatch" {
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
 
-    var batch = try producer.createBatch(.{});
+    var batch = try producer.createBatch(allocator, .{});
     defer batch.deinit(allocator);
     var e1 = EventData.init("event-1");
     defer e1.deinit(allocator);
@@ -1168,6 +1014,92 @@ test "ProducerClient sendBatch" {
     try producer.sendBatch(allocator, batch);
     try std.testing.expect(mock_amqp.send_called);
     try std.testing.expectEqual(@as(u32, 1), mock_amqp.send_batch_count);
+}
+
+test "ProducerClient sendBatch targets the hub, or one partition when pinned" {
+    const allocator = std.testing.allocator;
+    const cred_mod = @import("azure_sdk_core").identity.client_secret;
+    var mock_http = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer mock_http.deinit();
+    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var mock_amqp = MockAmqpTransport.init();
+    var producer = ProducerClient.init(.{
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .event_hub_name = "my-hub",
+    }, cred.asCredential(), mock_amqp.asTransport());
+
+    var event = EventData.init("event-1");
+    defer event.deinit(allocator);
+
+    // Unpinned: the service picks the partition, so the link targets the hub.
+    // The namespace is not part of the address; it is the connection's.
+    var any = try producer.createBatch(allocator, .{});
+    defer any.deinit(allocator);
+    _ = try any.tryAdd(allocator, event);
+    try producer.sendBatch(allocator, any);
+    try std.testing.expectEqualStrings("my-hub", mock_amqp.sendTarget().?);
+
+    var pinned = try producer.createBatch(allocator, .{ .partition_id = "3" });
+    defer pinned.deinit(allocator);
+    _ = try pinned.tryAdd(allocator, event);
+    try producer.sendBatch(allocator, pinned);
+    try std.testing.expectEqualStrings("my-hub/Partitions/3", mock_amqp.sendTarget().?);
+}
+
+test "createBatch adopts the sender link's max-message-size" {
+    const allocator = std.testing.allocator;
+    const cred_mod = @import("azure_sdk_core").identity.client_secret;
+    var mock_http = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer mock_http.deinit();
+    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var mock_amqp = MockAmqpTransport.init();
+    var producer = ProducerClient.init(.{
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .event_hub_name = "my-hub",
+    }, cred.asCredential(), mock_amqp.asTransport());
+
+    // Premium namespaces negotiate well above the 1 MiB default, and a batch
+    // that kept the default would refuse events the broker would have taken.
+    mock_amqp.link_max_message_size = 20 * 1024 * 1024;
+    var large = try producer.createBatch(allocator, .{});
+    defer large.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 20 * 1024 * 1024), large.max_size_bytes);
+
+    // An explicit smaller ceiling still wins.
+    var capped = try producer.createBatch(allocator, .{ .max_bytes = 4096 });
+    defer capped.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 4096), capped.max_size_bytes);
+
+    // Asking for more than the link allows is refused rather than silently
+    // truncated, so an oversized batch cannot reach the broker.
+    try std.testing.expectError(
+        BatchError.MaxBytesExceedsLinkLimit,
+        producer.createBatch(allocator, .{ .max_bytes = 32 * 1024 * 1024 }),
+    );
+}
+
+test "a link transport without sender links refuses to send" {
+    const allocator = std.testing.allocator;
+    var mgmt: amqp.Management = undefined;
+    var transport = LinkTransport.init(&mgmt, .{ .deadline_ms = 10_000 });
+
+    var empty = try EventDataBatch.init(.{});
+    defer empty.deinit(allocator);
+    var event = EventData.init("x");
+    defer event.deinit(allocator);
+    _ = try empty.tryAdd(allocator, event);
+
+    // Reporting success without a link is the bug this replaced; the
+    // management client is never touched, so it may stay uninitialised.
+    try std.testing.expectError(
+        error.Unimplemented,
+        transport.asTransport().sendBatch(allocator, "my-hub", empty),
+    );
+    try std.testing.expectEqual(@as(?u64, null), try transport.asTransport().maxMessageSize("my-hub"));
 }
 
 test "ProducerClient sendBatch empty returns error" {
@@ -1184,7 +1116,7 @@ test "ProducerClient sendBatch empty returns error" {
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
 
-    var batch = try producer.createBatch(.{});
+    var batch = try producer.createBatch(allocator, .{});
     defer batch.deinit(allocator);
 
     const result = producer.sendBatch(allocator, batch);
@@ -1227,19 +1159,6 @@ test "ConsumerClient receiveEvents" {
 
     const events = try consumer.receiveEvents(allocator, "0", EventPosition.earliest(), 10);
     try std.testing.expectEqual(@as(usize, 0), events.len);
-}
-
-test "UamqpTransport sendBatch encodes messages" {
-    const allocator = std.testing.allocator;
-    var transport = UamqpTransport.init(allocator, "ns.servicebus.windows.net");
-
-    var batch = try EventDataBatch.init(.{});
-    defer batch.deinit(allocator);
-    var e1 = EventData.init("hello");
-    defer e1.deinit(allocator);
-    _ = try batch.tryAdd(allocator, e1);
-
-    try transport.asTransport().sendBatch(allocator, "ns.servicebus.windows.net/my-hub", batch);
 }
 
 test "ProducerClient fromConnectionString" {

--- a/sender.zig
+++ b/sender.zig
@@ -1,0 +1,546 @@
+//! Publishing Event Hubs batches over AMQP sender links.
+//!
+//! A batch goes out as a single transfer whose `message-format` is
+//! `batch_message_format`. The body is the first event's non-body sections
+//! reused as an envelope, followed by one data section per event, each holding
+//! a fully encoded AMQP message. Go (`event_data_batch.go`) and Rust
+//! (`producer/batch.rs`) both produce exactly this shape.
+
+const std = @import("std");
+const amqp = @import("azure_sdk_amqp");
+const event_data = @import("event_data.zig");
+const errors = @import("errors.zig");
+const batch_mod = @import("batch.zig");
+
+const Allocator = std.mem.Allocator;
+const EventDataBatch = batch_mod.EventDataBatch;
+const batch_message_format = batch_mod.batch_message_format;
+
+pub const SendError = error{
+    /// There is nothing to send. Go and Rust both refuse rather than putting
+    /// an empty transfer on the wire.
+    EmptyBatch,
+};
+
+/// The entity a sender link attaches to: the hub itself, so the service picks
+/// a partition, or one explicit partition. Caller owns the result.
+pub fn entityPathFor(
+    allocator: Allocator,
+    event_hub_name: []const u8,
+    partition_id: ?[]const u8,
+) ![]u8 {
+    const id = partition_id orelse return allocator.dupe(u8, event_hub_name);
+    return std.fmt.allocPrint(allocator, "{s}/Partitions/{s}", .{ event_hub_name, id });
+}
+
+/// Sender links keyed by entity address, opened on demand.
+///
+/// The links belong to the session, which detaches and frees them when it is
+/// deinitialised; this pool only owns the addresses it keys them by. Reusing a
+/// link matters beyond the attach round trip: the peer's credit and the
+/// negotiated `max-message-size` are per link.
+pub const SenderPool = struct {
+    allocator: Allocator,
+    session: *amqp.Session,
+    entries: std.ArrayList(Entry) = .empty,
+    deadline_ms: i64,
+    /// Distinguishes these links from any others on the connection.
+    link_id: []const u8,
+    /// Why the broker refused the most recent delivery. An error cannot carry
+    /// a payload, so it is recorded here as `Management` does for its status.
+    /// Borrowed from the sender that failed and valid until its next send.
+    last_rejection: ?amqp.Rejection = null,
+
+    const Entry = struct {
+        address: []u8,
+        sender: *amqp.Sender,
+    };
+
+    pub const Options = struct {
+        deadline_ms: i64,
+        link_id: []const u8 = "eventhubs",
+    };
+
+    pub fn init(allocator: Allocator, session: *amqp.Session, options: Options) SenderPool {
+        return .{
+            .allocator = allocator,
+            .session = session,
+            .deadline_ms = options.deadline_ms,
+            .link_id = options.link_id,
+        };
+    }
+
+    /// Release the pool's own bookkeeping. The senders are the session's.
+    pub fn deinit(self: *SenderPool) void {
+        for (self.entries.items) |entry| self.allocator.free(entry.address);
+        self.entries.deinit(self.allocator);
+        self.entries = .empty;
+        self.last_rejection = null;
+    }
+
+    /// The sender attached to `address`, attaching one if there is none.
+    pub fn senderFor(self: *SenderPool, address: []const u8) !*amqp.Sender {
+        for (self.entries.items) |entry| {
+            if (std.mem.eql(u8, entry.address, address)) return entry.sender;
+        }
+
+        const name = try std.fmt.allocPrint(
+            self.allocator,
+            "{s}-sender-{s}",
+            .{ address, self.link_id },
+        );
+        defer self.allocator.free(name);
+
+        const owned = try self.allocator.dupe(u8, address);
+        errdefer self.allocator.free(owned);
+
+        try self.entries.ensureUnusedCapacity(self.allocator, 1);
+
+        // Go asks for geo-replication so an offset stays meaningful across a
+        // failover, and for mixed settlement so the broker reports acceptance.
+        const sender = try amqp.openSender(self.session, .{
+            .name = name,
+            .target_address = address,
+            .desired_capabilities = &.{amqp.georeplication_capability},
+        }, self.deadline_ms);
+
+        self.entries.appendAssumeCapacity(.{ .address = owned, .sender = sender });
+        return sender;
+    }
+
+    /// The largest transfer the broker will take on `address`, or null when it
+    /// advertised no limit.
+    pub fn maxMessageSize(self: *SenderPool, address: []const u8) !?u64 {
+        const sender = try self.senderFor(address);
+        return sender.maxMessageSize();
+    }
+
+    /// Send `batch` to `address` and wait for the broker to settle it.
+    pub fn send(
+        self: *SenderPool,
+        allocator: Allocator,
+        address: []const u8,
+        batch: EventDataBatch,
+    ) !void {
+        if (batch.count() == 0) return SendError.EmptyBatch;
+
+        const sender = try self.senderFor(address);
+        const payload = try encodeBatchTransfer(allocator, batch);
+        defer allocator.free(payload);
+
+        self.last_rejection = null;
+        sender.sendBytesWithOptions(
+            payload,
+            .{ .message_format = batch_message_format },
+            self.deadline_ms,
+        ) catch |err| {
+            self.last_rejection = sender.rejection;
+            return err;
+        };
+    }
+
+    /// Send under the Event Hubs retry schedule.
+    pub fn sendWithRetry(
+        self: *SenderPool,
+        allocator: Allocator,
+        address: []const u8,
+        batch: EventDataBatch,
+        config: errors.RetryConfig,
+    ) errors.Outcome(void) {
+        const Op = struct {
+            pool: *SenderPool,
+            allocator: Allocator,
+            address: []const u8,
+            batch: EventDataBatch,
+
+            pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror!void {
+                return op.pool.send(op.allocator, op.address, op.batch) catch |err| {
+                    op.pool.recordCondition(attempt);
+                    return err;
+                };
+            }
+        };
+
+        const op = Op{
+            .pool = self,
+            .allocator = allocator,
+            .address = address,
+            .batch = batch,
+        };
+        return errors.retry(void, &op, config);
+    }
+
+    /// The most recent rejection as a structured Event Hubs error.
+    pub fn lastError(self: *const SenderPool) ?errors.EventHubsError {
+        const rejection = self.last_rejection orelse return null;
+        return .{
+            // A rejection carries a condition, but not every condition has a
+            // stable public code; `send_rejected` is the honest fallback and is
+            // what Rust reports for the whole class.
+            .code = errors.errorCodeForCondition(rejection.condition) orelse .send_rejected,
+            .amqp_condition = rejection.condition,
+            .description = rejection.description,
+        };
+    }
+
+    fn recordCondition(self: *const SenderPool, attempt: *errors.Attempt) void {
+        const rejection = self.last_rejection orelse return;
+        attempt.condition = rejection.condition;
+        attempt.description = rejection.description;
+    }
+};
+
+/// Lay out the batch exactly as it goes on the wire.
+///
+/// The envelope was encoded without a body, and `EventData.toAmqpMessage`
+/// never produces a footer, so the data sections simply follow it.
+pub fn encodeBatchTransfer(allocator: Allocator, batch: EventDataBatch) ![]u8 {
+    const envelope = batch.envelope orelse return SendError.EmptyBatch;
+    return event_data.encodeDataSections(allocator, envelope, batch.marshaled.items);
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const harness = amqp.test_peer;
+const driver = amqp.connection_driver;
+const Peer = harness.Peer;
+const Fixture = harness.Fixture;
+const EmittedFrames = harness.EmittedFrames;
+const MemoryTransport = amqp.MemoryTransport;
+const EventData = event_data.EventData;
+
+/// The name `SenderPool` gives the link for `my-hub` at the default link id.
+const test_link_name = "my-hub-sender-eventhubs";
+
+/// Script attach and enough credit for `deliveries` sends.
+fn scriptSender(peer: Peer, max_message_size: ?u64, deliveries: u32) !void {
+    try harness.scriptHandshake(peer, 512);
+    try peer.push(0, .{ .attach = .{
+        .name = test_link_name,
+        .handle = 0,
+        .role = .receiver,
+        .max_message_size = max_message_size,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = deliveries + 5,
+    } });
+}
+
+/// The payload of the one delivery written since the last `clearWritten`,
+/// reassembled across frames, plus the format the transfer named.
+const SentDelivery = struct {
+    payload: []u8,
+    message_format: ?u32,
+
+    fn deinit(self: SentDelivery, allocator: Allocator) void {
+        allocator.free(self.payload);
+    }
+};
+
+fn lastDelivery(allocator: Allocator, mem: *MemoryTransport) !SentDelivery {
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+
+    var payload: std.ArrayList(u8) = .empty;
+    errdefer payload.deinit(allocator);
+    var format: ?u32 = null;
+    var seen = false;
+
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.transfer) continue;
+        if (!seen) {
+            var decoded = try amqp.performative.decode(allocator, body);
+            defer decoded.deinit();
+            format = decoded.performative.transfer.message_format;
+            seen = true;
+        }
+        try payload.appendSlice(allocator, harness.transferPayload(allocator, body).?);
+    }
+
+    return .{ .payload = try payload.toOwnedSlice(allocator), .message_format = format };
+}
+
+/// Everything needed to drive a pool against a scripted peer.
+///
+/// Initialised in place: the pool holds a pointer into `fixture.session`, so
+/// returning this by value would aim it at a dead frame. That reads fine on
+/// Linux and segfaults on Windows.
+const Scripted = struct {
+    fixture: Fixture,
+    pool: SenderPool = undefined,
+
+    fn open(
+        self: *Scripted,
+        allocator: Allocator,
+        mem: *MemoryTransport,
+        clock: *driver.ManualClock,
+        conn: *driver.Driver,
+    ) !void {
+        self.* = .{ .fixture = try Fixture.init(allocator, mem, clock, conn) };
+        errdefer self.fixture.deinit();
+        self.pool = SenderPool.init(allocator, &self.fixture.session, .{ .deadline_ms = 10_000 });
+    }
+
+    fn deinit(self: *Scripted) void {
+        self.pool.deinit();
+        self.fixture.deinit();
+    }
+};
+
+fn batchOf(allocator: Allocator, bodies: []const []const u8, options: batch_mod.EventDataBatchOptions) !EventDataBatch {
+    var out = try EventDataBatch.init(options);
+    errdefer out.deinit(allocator);
+    for (bodies) |body| {
+        var event = EventData.init(body);
+        defer event.deinit(allocator);
+        try testing.expect(try out.tryAdd(allocator, event));
+    }
+    return out;
+}
+
+test "a batch goes out as one transfer whose data sections are the events" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, null, 1);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    var payload_batch = try batchOf(allocator, &.{ "one", "two", "three" }, .{});
+    defer payload_batch.deinit(allocator);
+
+    mem.clearWritten();
+    try scripted.pool.send(allocator, "my-hub", payload_batch);
+
+    const sent = try lastDelivery(allocator, &mem);
+    defer sent.deinit(allocator);
+    try testing.expectEqual(batch_message_format, sent.message_format.?);
+
+    var envelope = try amqp.decodeMessage(allocator, sent.payload);
+    defer envelope.deinit();
+
+    const sections = envelope.message.body.data;
+    try testing.expectEqual(@as(usize, 3), sections.len);
+
+    // Each section is itself a complete AMQP message, which is what makes the
+    // service able to split a batch back into individual events.
+    const expected = [_][]const u8{ "one", "two", "three" };
+    for (sections, expected) |section, want| {
+        var inner = try amqp.decodeMessage(allocator, section);
+        defer inner.deinit();
+        try testing.expectEqual(@as(usize, 1), inner.message.body.data.len);
+        try testing.expectEqualStrings(want, inner.message.body.data[0]);
+    }
+}
+
+test "a partition key rides along as a message annotation" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, null, 1);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    var keyed = try batchOf(allocator, &.{"hello"}, .{ .partition_key = "orders-7" });
+    defer keyed.deinit(allocator);
+
+    mem.clearWritten();
+    try scripted.pool.send(allocator, "my-hub", keyed);
+
+    const sent = try lastDelivery(allocator, &mem);
+    defer sent.deinit(allocator);
+
+    // The envelope is the first event's sections, so the key the service reads
+    // for routing is on the transfer itself, not only on the inner messages.
+    var envelope = try amqp.decodeMessage(allocator, sent.payload);
+    defer envelope.deinit();
+    try testing.expectEqualStrings(
+        "orders-7",
+        annotation(envelope.message.message_annotations.?, event_data.partition_key_annotation).?.string,
+    );
+
+    var inner = try amqp.decodeMessage(allocator, envelope.message.body.data[0]);
+    defer inner.deinit();
+    try testing.expectEqualStrings(
+        "orders-7",
+        annotation(inner.message.message_annotations.?, event_data.partition_key_annotation).?.string,
+    );
+}
+
+fn annotation(entries: []const amqp.uamqp.MapEntry, key: []const u8) ?amqp.uamqp.AmqpValue {
+    for (entries) |entry| {
+        const name = switch (entry.key) {
+            .symbol, .string => |s| s,
+            else => continue,
+        };
+        if (std.mem.eql(u8, name, key)) return entry.value;
+    }
+    return null;
+}
+
+test "a rejected batch surfaces the broker's condition" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, null, 1);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .{ .rejected = .{
+            .condition = "amqp:link:message-size-exceeded",
+            .description = "The received message is larger than the maximum allowed size.",
+        } },
+    } });
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    var rejected = try batchOf(allocator, &.{"hello"}, .{});
+    defer rejected.deinit(allocator);
+
+    try testing.expectError(
+        error.SendRejected,
+        scripted.pool.send(allocator, "my-hub", rejected),
+    );
+
+    const failure = scripted.pool.lastError().?;
+    try testing.expectEqualStrings("amqp:link:message-size-exceeded", failure.amqp_condition.?);
+    try testing.expectEqualStrings(
+        "The received message is larger than the maximum allowed size.",
+        failure.description.?,
+    );
+    // `message-size-exceeded` has no stable public code of its own, so the
+    // rejection itself is what the caller sees.
+    try testing.expectEqual(errors.ErrorCode.send_rejected, failure.code);
+}
+
+test "a link is attached once and reused for the same address" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, 1048576, 2);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 1,
+        .last = 1,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    var first = try batchOf(allocator, &.{"a"}, .{});
+    defer first.deinit(allocator);
+    var second = try batchOf(allocator, &.{"b"}, .{});
+    defer second.deinit(allocator);
+
+    mem.clearWritten();
+    try scripted.pool.send(allocator, "my-hub", first);
+    try scripted.pool.send(allocator, "my-hub", second);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    // One attach for two sends. Only one is scripted, so a second attempt
+    // would run the peer out of bytes rather than quietly reattaching.
+    const attaches = try frames.of(allocator, amqp.performative.descriptor.attach);
+    defer allocator.free(attaches);
+    try testing.expectEqual(@as(usize, 1), attaches.len);
+
+    // The peer's limit is readable without another attach.
+    try testing.expectEqual(@as(u64, 1048576), (try scripted.pool.maxMessageSize("my-hub")).?);
+}
+
+test "an empty batch is refused before a link is touched" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try harness.scriptHandshake(peer, 512);
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn);
+    defer scripted.deinit();
+
+    var empty = try EventDataBatch.init(.{});
+    defer empty.deinit(allocator);
+
+    // No attach is scripted, so reaching the link at all would hang or fail.
+    try testing.expectError(
+        SendError.EmptyBatch,
+        scripted.pool.send(allocator, "my-hub", empty),
+    );
+}
+
+test "entityPathFor targets the hub or one partition" {
+    const allocator = testing.allocator;
+
+    const hub = try entityPathFor(allocator, "my-hub", null);
+    defer allocator.free(hub);
+    try testing.expectEqualStrings("my-hub", hub);
+
+    const partition = try entityPathFor(allocator, "my-hub", "3");
+    defer allocator.free(partition);
+    try testing.expectEqualStrings("my-hub/Partitions/3", partition);
+}


### PR DESCRIPTION
Closes #204. Depends on #282 (merged), which is what lets a sender name a
transfer's message format.

`UamqpTransport.sendBatchImpl` built a connection and a session, encoded every
event, discarded all of it, and returned success. `ProducerClient.sendBatch`
therefore reported that events had been published when nothing had been
transmitted. The whole stub type is removed — every one of its operations was a
stub, and `LinkTransport` now does the real work.

## Wire format

A batch leaves as a single transfer with `message-format = 0x80013700`. The
body is the first event's non-body sections reused as an envelope, followed by
one data section per event, each holding a fully encoded AMQP message. Verified
against Go `event_data_batch.go` and Rust `producer/batch.rs`.

## Behaviour

- `SenderPool` attaches one link per entity address and reuses it. This matters
  beyond the attach round trip: credit and `max-message-size` are both per link.
- The address is the entity path, not `{fqns}/{hub}` as before. `{hub}` lets the
  service pick a partition; `{hub}/Partitions/{id}` pins one. A batch created
  with a `partition_id` routes itself.
- `createBatch` takes an allocator and asks the link for its negotiated
  `max-message-size`, so it reports a true ceiling instead of assuming 1 MiB. An
  explicit `max_bytes` above the link's limit is refused rather than truncated.
- A partition key becomes `x-opt-partition-key` on every event and on the
  envelope, which is the copy the service routes by.
- A rejected disposition returns `error.SendRejected` and records the condition
  and description on `lastSendError`; `errorCodeForCondition` still gets first
  say, so `link:stolen` and `unauthorized-access` stay distinguishable.
- Sends route through the retry policy when the transport has one.
- An empty batch is still refused, now before a link is touched.

## Naming and layout

- `ManagementTransport` → `LinkTransport`. It is no longer metadata-only, and a
  type called `ManagementTransport` that publishes events would be misleading.
- `EventDataBatch` moves from `root.zig` to `batch.zig` so `sender.zig` can use
  it without importing the module root. Re-exported unchanged.

## Tests

121 pass. New coverage against a scripted peer: the decoded transfer body
contains exactly the events added; the format is `0x80013700`; the partition key
appears on envelope and inner messages; a rejection surfaces the condition; one
attach serves two sends. Plus `ProducerClient` address targeting and
`max-message-size` adoption against the mock.

Mutation-verified: sending format `0` fails the body test, and routing every
batch to the hub fails the targeting test.