### PR TITLE
Register eventhubs batch.zig and sender.zig

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -457,6 +457,8 @@ pub const all = [_]Package{
             "build.zig.zon",
             "root.zig",
             "event_data.zig",
+            "batch.zig",
+            "sender.zig",
             "errors.zig",
             "checkpoint.zig",
             "checkpoint_store.zig",


### PR DESCRIPTION
Pairs with #283, which adds the two files to `sdk/eventhubs`.

`sender.zig` holds the sender-link pool that publishes a batch as a single
`0x80013700` transfer. `EventDataBatch` moves out of `root.zig` into
`batch.zig` so `sender.zig` can use it without importing the module root.

`zig build package-check`: 22 packages valid.