### PR TITLE
Read partitions over AMQP receiver links

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,54 @@ owns the addresses it keys them by. When the broker refuses a delivery,
 `lastSendError` carries the AMQP condition and description that the Zig error
 cannot.
 
+## Receiving
+
+A partition is read through one receiver link held open for the life of a
+`PartitionClient`. The link carries the reader's position, so reattaching
+without advancing it replays events that were already handed to the caller.
+
+```zig
+var pool = ReceiverPool.init(allocator, &session, .{
+    .instance_id = "reader-1",
+    .deadline_ms = deadline,
+});
+defer pool.deinit();
+
+var transport = LinkTransport.init(management_client, .{
+    .receivers = &pool,
+    .deadline_ms = deadline,
+});
+
+var partition: PartitionClient = undefined;
+try consumer.newPartitionClient(&partition, allocator, &session, "0", deadline, .{
+    .start_position = EventPosition.earliest(),
+    .owner_level = 1,
+});
+defer partition.deinit();
+
+const events = try partition.receiveEvents(allocator, 100);
+defer freeReceivedEvents(allocator, events);
+```
+
+The source is the entity path `{hub}/ConsumerGroups/{group}/Partitions/{id}`,
+and the link's target is the instance id, which is what makes a stolen-link
+error name the reader that took it. The start position becomes a selector
+filter on the attach. After every successful receive the filter is rewritten to
+`amqp.annotation.x-opt-sequence-number > '<last>'`, so a reattach resumes
+without replay; `ReceiverPool` therefore applies the caller's filter only on the
+first call for an address.
+
+`owner_level` attaches as an exclusive consumer via `com.microsoft:epoch`. A
+higher level detaches every lower one, which reports as `ownership_lost`.
+
+`prefetch` defaults to 300 credits, as Go and Rust do. A negative value
+disables prefetch and issues exactly the credit each receive needs, for a
+caller that wants to bound its own memory use. Neither prefetch nor a single
+receive may exceed 5000, the session's incoming window.
+
+A receive that asks for more events than arrive returns the ones that did
+rather than failing: a quiet partition is not an error.
+
 ## Metadata
 
 `getEventHubProperties` and `getPartitionProperties` are `READ` operations on

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,6 +33,8 @@
         "event_data.zig",
         "batch.zig",
         "sender.zig",
+        "position.zig",
+        "receiver.zig",
         "errors.zig",
         "checkpoint.zig",
         "checkpoint_store.zig",

--- a/event_data.zig
+++ b/event_data.zig
@@ -583,6 +583,62 @@ fn optionalBinary(value: ?[]const u8) AmqpValue {
     return if (value) |bytes| .{ .binary = bytes } else .null;
 }
 
+/// The parts of an AMQP message an Event Hubs event is decoded from.
+///
+/// A neutral shape, so a message decoded by any codec can be converted without
+/// first being rebuilt as a `uamqp.message.Message`.
+pub const RawMessage = struct {
+    /// The single data section Event Hubs uses for an event body. Null when
+    /// the message has none or has several, which Go treats the same way.
+    body: ?[]const u8 = null,
+    message_annotations: ?[]const MapEntry = null,
+    application_properties: ?[]const MapEntry = null,
+    message_id: ?AmqpValue = null,
+    correlation_id: ?AmqpValue = null,
+    content_type: ?[]const u8 = null,
+};
+
+/// Decode the parts of an AMQP message into a received event.
+///
+/// Everything is borrowed and copied out, so the result stays valid after the
+/// message it came from is freed.
+pub fn fromRawMessage(
+    allocator: std.mem.Allocator,
+    raw: RawMessage,
+) !ReceivedEventData {
+    var received: ReceivedEventData = .{};
+    errdefer received.deinit(allocator);
+
+    received.event_data.body = try allocator.dupe(u8, raw.body orelse "");
+
+    if (raw.content_type) |content_type| {
+        received.event_data.content_type = try allocator.dupe(u8, content_type);
+    }
+    if (raw.correlation_id) |correlation_id| {
+        if (MessageId.fromAmqpValue(correlation_id)) |parsed| {
+            received.event_data.correlation_id = try parsed.clone(allocator);
+        }
+    }
+    if (raw.message_id) |message_id| {
+        if (MessageId.fromAmqpValue(message_id)) |parsed| {
+            received.event_data.message_id = try parsed.clone(allocator);
+        }
+    }
+
+    if (raw.application_properties) |entries| {
+        for (entries) |entry| {
+            const key = keyOf(entry.key) orelse continue;
+            try received.event_data.properties.put(allocator, key, entry.value);
+        }
+    }
+
+    if (raw.message_annotations) |entries| {
+        try applyAnnotations(allocator, entries, &received);
+    }
+
+    return received;
+}
+
 /// Decode an AMQP message into a received event.
 ///
 /// `message` is borrowed and every field is copied out, so the result stays
@@ -592,44 +648,21 @@ pub fn fromAmqpMessage(
     allocator: std.mem.Allocator,
     message: *const Message,
 ) !ReceivedEventData {
-    var received: ReceivedEventData = .{};
-    errdefer received.deinit(allocator);
-
     // Go only treats a message as having a body when there is exactly one data
     // section; anything else is reachable through `raw_amqp_message`.
-    received.event_data.body = if (message.body_data_sections.items.len == 1)
-        try allocator.dupe(u8, message.body_data_sections.items[0].bytes)
+    const body: ?[]const u8 = if (message.body_data_sections.items.len == 1)
+        message.body_data_sections.items[0].bytes
     else
-        try allocator.dupe(u8, "");
+        null;
 
-    if (message.properties) |properties| {
-        if (properties.content_type) |content_type| {
-            received.event_data.content_type = try allocator.dupe(u8, content_type);
-        }
-        if (properties.correlation_id) |correlation_id| {
-            if (MessageId.fromAmqpValue(correlation_id)) |parsed| {
-                received.event_data.correlation_id = try parsed.clone(allocator);
-            }
-        }
-        if (properties.message_id) |message_id| {
-            if (MessageId.fromAmqpValue(message_id)) |parsed| {
-                received.event_data.message_id = try parsed.clone(allocator);
-            }
-        }
-    }
-
-    if (message.application_properties) |entries| {
-        for (entries) |entry| {
-            const key = keyOf(entry.key) orelse continue;
-            try received.event_data.properties.put(allocator, key, entry.value);
-        }
-    }
-
-    if (message.message_annotations) |entries| {
-        try applyAnnotations(allocator, entries, &received);
-    }
-
-    return received;
+    return fromRawMessage(allocator, .{
+        .body = body,
+        .message_annotations = message.message_annotations,
+        .application_properties = message.application_properties,
+        .message_id = if (message.properties) |p| p.message_id else null,
+        .correlation_id = if (message.properties) |p| p.correlation_id else null,
+        .content_type = if (message.properties) |p| p.content_type else null,
+    });
 }
 
 /// Decode an AMQP message and take ownership of it.
@@ -652,7 +685,7 @@ pub fn fromOwnedAmqpMessage(
 
 fn applyAnnotations(
     allocator: std.mem.Allocator,
-    entries: []MapEntry,
+    entries: []const MapEntry,
     received: *ReceivedEventData,
 ) !void {
     for (entries) |entry| {

--- a/position.zig
+++ b/position.zig
@@ -1,0 +1,123 @@
+//! Where a consumer starts reading a partition.
+//!
+//! Lives apart from the module root so the receiver can use it without
+//! importing the root back.
+
+const std = @import("std");
+
+/// Where in a partition a consumer starts reading.
+///
+/// Rust models this as a `StartLocation` enum and Go as a set of optional
+/// fields that it rejects when more than one is set. A tagged union makes the
+/// conflict unrepresentable.
+pub const StartLocation = union(enum) {
+    /// The oldest event the partition still retains.
+    earliest,
+    /// Only events enqueued after the consumer attaches. This is the default
+    /// in Go and Rust alike.
+    latest,
+    /// An opaque offset token, which is not necessarily numeric.
+    offset: []const u8,
+    sequence_number: i64,
+    /// Unix milliseconds.
+    enqueued_time: i64,
+};
+
+/// Starting position for reading events from a partition.
+///
+/// Slices are borrowed and must outlive the position.
+pub const EventPosition = struct {
+    location: StartLocation = .latest,
+    /// Include the event at `location` rather than starting after it. Ignored
+    /// for `earliest` and `latest`, which have no event to include.
+    is_inclusive: bool = false,
+
+    /// Start from the beginning of the partition.
+    pub fn earliest() EventPosition {
+        return .{ .location = .earliest };
+    }
+
+    /// Start from the end of the partition (new events only).
+    pub fn latest() EventPosition {
+        return .{ .location = .latest };
+    }
+
+    /// Start from a specific offset.
+    pub fn fromOffset(offset: []const u8, inclusive: bool) EventPosition {
+        return .{ .location = .{ .offset = offset }, .is_inclusive = inclusive };
+    }
+
+    /// Start from a specific sequence number.
+    pub fn fromSequenceNumber(seq: i64, inclusive: bool) EventPosition {
+        return .{ .location = .{ .sequence_number = seq }, .is_inclusive = inclusive };
+    }
+
+    /// Start from a specific enqueued time (Unix ms).
+    pub fn fromEnqueuedTime(time: i64) EventPosition {
+        return .{ .location = .{ .enqueued_time = time } };
+    }
+
+    /// Render the AMQP filter expression for this position.
+    ///
+    /// A default-constructed position renders as `@latest` rather than
+    /// failing, matching Go's `getStartExpression` and Rust's
+    /// `StartPosition::start_expression`.
+    pub fn toFilterExpression(self: EventPosition, allocator: std.mem.Allocator) ![]u8 {
+        const op: []const u8 = if (self.is_inclusive) ">=" else ">";
+        return switch (self.location) {
+            // Go and Rust both emit `>` for these two regardless of
+            // inclusivity, because `-1` and `@latest` are sentinels that
+            // already sit outside the event range.
+            .earliest => allocator.dupe(u8, "amqp.annotation.x-opt-offset > '-1'"),
+            .latest => allocator.dupe(u8, "amqp.annotation.x-opt-offset > '@latest'"),
+            .offset => |offset| std.fmt.allocPrint(
+                allocator,
+                "amqp.annotation.x-opt-offset {s} '{s}'",
+                .{ op, offset },
+            ),
+            .sequence_number => |seq| std.fmt.allocPrint(
+                allocator,
+                "amqp.annotation.x-opt-sequence-number {s} '{d}'",
+                .{ op, seq },
+            ),
+            .enqueued_time => |time| std.fmt.allocPrint(
+                allocator,
+                "amqp.annotation.x-opt-enqueued-time {s} '{d}'",
+                .{ op, time },
+            ),
+        };
+    }
+};
+
+/// Per-partition starting positions, used when a partition has no checkpoint.
+///
+/// Partition ids are copied; every other slice is borrowed.
+pub const StartPositions = struct {
+    per_partition: std.StringArrayHashMapUnmanaged(EventPosition) = .empty,
+    /// Used for any partition absent from `per_partition`.
+    default: EventPosition = .{},
+
+    pub fn deinit(self: *StartPositions, allocator: std.mem.Allocator) void {
+        for (self.per_partition.keys()) |key| allocator.free(key);
+        self.per_partition.deinit(allocator);
+    }
+
+    pub fn put(
+        self: *StartPositions,
+        allocator: std.mem.Allocator,
+        partition_id: []const u8,
+        position: EventPosition,
+    ) !void {
+        const owned_id = try allocator.dupe(u8, partition_id);
+        errdefer allocator.free(owned_id);
+
+        const gop = try self.per_partition.getOrPut(allocator, owned_id);
+        if (gop.found_existing) allocator.free(owned_id);
+        gop.value_ptr.* = position;
+    }
+
+    /// Resolve the position for a partition, falling back to `default`.
+    pub fn forPartition(self: StartPositions, partition_id: []const u8) EventPosition {
+        return self.per_partition.get(partition_id) orelse self.default;
+    }
+};

--- a/receiver.zig
+++ b/receiver.zig
@@ -1,0 +1,743 @@
+//! Receiving events from one Event Hubs partition.
+//!
+//! A partition is read through a single receiver link held open for the life
+//! of the client. Go (`partition_client.go`) and Rust
+//! (`consumer/event_receiver.rs`) both interpose an object like this rather
+//! than exposing a one-shot call, because the link carries the reader's
+//! position: reattaching without advancing the filter replays events that were
+//! already handed to the caller.
+
+const std = @import("std");
+const amqp = @import("azure_sdk_amqp");
+const event_data = @import("event_data.zig");
+const errors = @import("errors.zig");
+const position = @import("position.zig");
+
+const Allocator = std.mem.Allocator;
+const EventPosition = position.EventPosition;
+const ReceivedEventData = event_data.ReceivedEventData;
+
+/// Credit issued on attach when the caller expresses no preference. Go and
+/// Rust both use 300.
+pub const default_prefetch: i32 = 300;
+
+/// The largest number of events a single receive may ask for, and the ceiling
+/// on prefetch. It is the session's incoming window in Go, so asking for more
+/// would let the peer overrun it.
+pub const max_credit: u32 = 5000;
+
+/// Names the reader in the broker's error text, so a stolen link says which
+/// receiver took it.
+pub const receiver_name_property = amqp.receiver_name_property;
+
+/// The exclusive-consumer epoch. A higher level detaches every lower one.
+pub const epoch_property = amqp.epoch_property;
+
+pub const ReceiveError = error{
+    /// `count` was zero, or above `max_credit`.
+    InvalidCount,
+    /// `prefetch` was above `max_credit`.
+    PrefetchTooLarge,
+};
+
+pub const PartitionClientOptions = struct {
+    /// Where to start reading. Defaults to `latest`, as Go and Rust do, so a
+    /// client that says nothing sees only new events.
+    start_position: EventPosition = .{},
+    /// Claims exclusive ownership of the partition at this level. Absent
+    /// leaves the reader non-exclusive.
+    owner_level: ?i64 = null,
+    /// Credit issued up front. Zero takes `default_prefetch`; a negative value
+    /// disables prefetch and issues credit per receive, which is what a caller
+    /// that wants to bound its own memory use asks for.
+    prefetch: i32 = 0,
+};
+
+/// The AMQP address a partition is read from. Caller owns the result.
+pub fn consumerPathFor(
+    allocator: Allocator,
+    event_hub_name: []const u8,
+    consumer_group: []const u8,
+    partition_id: []const u8,
+) ![]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "{s}/ConsumerGroups/{s}/Partitions/{s}",
+        .{ event_hub_name, consumer_group, partition_id },
+    );
+}
+
+/// Reads events from one partition over a receiver link it keeps attached.
+pub const PartitionClient = struct {
+    allocator: Allocator,
+    receiver: *amqp.Receiver,
+    /// The selector the link was attached with, advanced past the last event
+    /// delivered so a reattach resumes rather than replaying. Owned.
+    filter_expression: []u8,
+    /// As configured, before `default_prefetch` is substituted for zero.
+    prefetch: i32,
+    owner_level: ?i64,
+    deadline_ms: i64,
+    /// Set when the broker detached the link; a stolen link reports
+    /// `amqp:link:stolen` here. Its strings belong to the receiver, so read it
+    /// before the session is torn down.
+    last_error: ?errors.EventHubsError = null,
+
+    pub const Args = struct {
+        /// `{hub}/ConsumerGroups/{group}/Partitions/{id}`.
+        source_address: []const u8,
+        /// Identifies this reader to the broker.
+        instance_id: []const u8,
+        deadline_ms: i64,
+        /// Attach with this selector instead of rendering
+        /// `options.start_position`. Used to resume from a position that was
+        /// already reduced to an expression.
+        filter_expression: ?[]const u8 = null,
+    };
+
+    /// Attach the receiver link and start reading.
+    ///
+    /// Initialise in place rather than assigning the result: nothing here
+    /// points into the client, but `close` detaches a link the session also
+    /// tracks, so the two must not disagree about lifetime.
+    pub fn open(
+        self: *PartitionClient,
+        allocator: Allocator,
+        session: *amqp.Session,
+        args: Args,
+        options: PartitionClientOptions,
+    ) !void {
+        if (options.prefetch > @as(i32, @intCast(max_credit))) return ReceiveError.PrefetchTooLarge;
+
+        const filter = if (args.filter_expression) |expression|
+            try allocator.dupe(u8, expression)
+        else
+            try options.start_position.toFilterExpression(allocator);
+        errdefer allocator.free(filter);
+
+        const name = try std.fmt.allocPrint(
+            allocator,
+            "{s}-receiver-{s}",
+            .{ args.source_address, args.instance_id },
+        );
+        defer allocator.free(name);
+
+        var properties: [2]amqp.MapEntry = undefined;
+        var property_count: usize = 1;
+        properties[0] = .{
+            .key = .{ .symbol = receiver_name_property },
+            .value = .{ .string = args.instance_id },
+        };
+        if (options.owner_level) |level| {
+            properties[1] = .{
+                .key = .{ .symbol = epoch_property },
+                .value = .{ .long = level },
+            };
+            property_count = 2;
+        }
+
+        const filters = [_]amqp.performative.Filter{amqp.performative.Filter.selector(filter)};
+
+        const receiver = try amqp.openReceiver(session, .{
+            .name = name,
+            .source_address = args.source_address,
+            // Go sets the target to the instance id, which is what makes the
+            // reader identifiable in a stolen-link message.
+            .target_address = args.instance_id,
+            .filters = &filters,
+            .properties = properties[0..property_count],
+            .desired_capabilities = &.{amqp.georeplication_capability},
+            .prefetch = prefetchCredit(options.prefetch),
+        }, args.deadline_ms);
+
+        self.* = .{
+            .allocator = allocator,
+            .receiver = receiver,
+            .filter_expression = filter,
+            .prefetch = options.prefetch,
+            .owner_level = options.owner_level,
+            .deadline_ms = args.deadline_ms,
+        };
+    }
+
+    /// Release the client. The link belongs to the session, which detaches it.
+    pub fn deinit(self: *PartitionClient) void {
+        self.allocator.free(self.filter_expression);
+        self.filter_expression = &.{};
+    }
+
+    /// Detach the link and release the client.
+    pub fn close(self: *PartitionClient, deadline_ms: i64) !void {
+        defer self.deinit();
+        try self.receiver.detach(deadline_ms);
+    }
+
+    /// The selector the next attach would use. Advances as events arrive.
+    pub fn filterExpression(self: *const PartitionClient) []const u8 {
+        return self.filter_expression;
+    }
+
+    /// Receive up to `count` events.
+    ///
+    /// Returns early with whatever arrived when the partition goes quiet,
+    /// which is how Go behaves when its context expires: a caller asking for a
+    /// full batch should not lose the events that did arrive. Free the result
+    /// with `freeReceivedEvents`.
+    pub fn receiveEvents(
+        self: *PartitionClient,
+        allocator: Allocator,
+        count: u32,
+    ) ![]ReceivedEventData {
+        if (count == 0 or count > max_credit) return ReceiveError.InvalidCount;
+
+        // Without prefetch the link holds no credit, so ask for exactly what
+        // this call needs on top of anything still outstanding.
+        if (self.prefetch < 0 and self.receiver.credit < count) {
+            try self.receiver.issueCredit(count - self.receiver.credit);
+        }
+
+        var events: std.ArrayList(ReceivedEventData) = .empty;
+        errdefer {
+            for (events.items) |*e| e.deinit(allocator);
+            events.deinit(allocator);
+        }
+
+        while (events.items.len < count) {
+            const delivery = self.receiver.receive(self.deadline_ms) catch |err| {
+                self.recordDetach();
+                // Events already in hand are still valid; a quiet partition is
+                // not a failure. Anything else with nothing to show is.
+                if (events.items.len > 0 and err == error.Timeout) break;
+                return err;
+            };
+
+            var decoded = try amqp.decodeMessage(allocator, delivery.payload);
+            defer decoded.deinit();
+
+            const received = try event_data.fromRawMessage(allocator, rawFrom(&decoded.message));
+            errdefer {
+                var owned = received;
+                owned.deinit(allocator);
+            }
+
+            try events.append(allocator, received);
+            try self.receiver.accept(delivery);
+        }
+
+        if (events.items.len > 0) {
+            try self.advancePast(events.items[events.items.len - 1].sequence_number);
+        }
+        return events.toOwnedSlice(allocator);
+    }
+
+    /// Move the selector past `sequence_number` so a reattach resumes.
+    fn advancePast(self: *PartitionClient, sequence_number: i64) !void {
+        const advanced = try EventPosition.fromSequenceNumber(sequence_number, false)
+            .toFilterExpression(self.allocator);
+        self.allocator.free(self.filter_expression);
+        self.filter_expression = advanced;
+    }
+
+    fn recordDetach(self: *PartitionClient) void {
+        const remote = self.receiver.detach_error orelse return;
+        self.last_error = errors.EventHubsError.fromCondition(remote.condition, remote.description);
+    }
+};
+
+/// Translate the public prefetch setting into link credit.
+fn prefetchCredit(prefetch: i32) u32 {
+    if (prefetch < 0) return 0;
+    if (prefetch == 0) return @intCast(default_prefetch);
+    return @intCast(prefetch);
+}
+
+fn rawFrom(message: *const amqp.message_codec.Message) event_data.RawMessage {
+    return .{
+        .body = switch (message.body) {
+            .data => |sections| if (sections.len == 1) sections[0] else null,
+            else => null,
+        },
+        .message_annotations = message.message_annotations,
+        .application_properties = message.application_properties,
+        .message_id = message.properties.message_id,
+        .correlation_id = message.properties.correlation_id,
+        .content_type = message.properties.content_type,
+    };
+}
+
+/// Partition clients attached on demand, one per source address.
+///
+/// A client is kept for the life of the pool so its position survives across
+/// calls: reopening per call would replay from the configured start position
+/// every time.
+pub const ReceiverPool = struct {
+    allocator: Allocator,
+    session: *amqp.Session,
+    options: PartitionClientOptions,
+    instance_id: []const u8,
+    deadline_ms: i64,
+    /// Keyed by source address. The pool owns the keys; the session owns the
+    /// links behind the clients.
+    clients: std.StringHashMapUnmanaged(*PartitionClient) = .empty,
+
+    pub const Options = struct {
+        instance_id: []const u8,
+        deadline_ms: i64,
+        client: PartitionClientOptions = .{},
+    };
+
+    pub fn init(allocator: Allocator, session: *amqp.Session, options: Options) ReceiverPool {
+        return .{
+            .allocator = allocator,
+            .session = session,
+            .options = options.client,
+            .instance_id = options.instance_id,
+            .deadline_ms = options.deadline_ms,
+        };
+    }
+
+    pub fn deinit(self: *ReceiverPool) void {
+        var it = self.clients.iterator();
+        while (it.next()) |entry| {
+            entry.value_ptr.*.deinit();
+            self.allocator.destroy(entry.value_ptr.*);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.clients.deinit(self.allocator);
+    }
+
+    /// The client for `source_address`, attaching one if this is the first
+    /// call. `filter_expression` applies only to a first attach.
+    pub fn clientFor(
+        self: *ReceiverPool,
+        source_address: []const u8,
+        filter_expression: ?[]const u8,
+    ) !*PartitionClient {
+        if (self.clients.get(source_address)) |existing| return existing;
+
+        const client = try self.allocator.create(PartitionClient);
+        errdefer self.allocator.destroy(client);
+        try client.open(self.allocator, self.session, .{
+            .source_address = source_address,
+            .instance_id = self.instance_id,
+            .deadline_ms = self.deadline_ms,
+            .filter_expression = filter_expression,
+        }, self.options);
+        errdefer client.deinit();
+
+        const key = try self.allocator.dupe(u8, source_address);
+        errdefer self.allocator.free(key);
+        try self.clients.put(self.allocator, key, client);
+        return client;
+    }
+
+    /// Read up to `count` events, attaching on first use.
+    pub fn receive(
+        self: *ReceiverPool,
+        allocator: Allocator,
+        source_address: []const u8,
+        filter_expression: ?[]const u8,
+        count: u32,
+    ) ![]ReceivedEventData {
+        const client = try self.clientFor(source_address, filter_expression);
+        return client.receiveEvents(allocator, count);
+    }
+
+    /// Why the broker detached the link for `source_address`.
+    pub fn lastError(self: *ReceiverPool, source_address: []const u8) ?errors.EventHubsError {
+        const client = self.clients.get(source_address) orelse return null;
+        return client.last_error;
+    }
+};
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const harness = amqp.test_peer;
+const driver = amqp.connection_driver;
+const Peer = harness.Peer;
+const Fixture = harness.Fixture;
+const EmittedFrames = harness.EmittedFrames;
+const MemoryTransport = amqp.MemoryTransport;
+
+const test_source = "my-hub/ConsumerGroups/$default/Partitions/0";
+const test_instance = "reader-1";
+const test_link_name = test_source ++ "-receiver-" ++ test_instance;
+
+/// Everything needed to drive a client against a scripted peer.
+///
+/// Initialised in place: the client's receiver is created by
+/// `fixture.session`, so returning this by value would leave the session
+/// pointer aimed at a dead frame.
+const Scripted = struct {
+    fixture: Fixture,
+    client: PartitionClient = undefined,
+
+    fn open(
+        self: *Scripted,
+        allocator: Allocator,
+        mem: *MemoryTransport,
+        clock: *driver.ManualClock,
+        conn: *driver.Driver,
+        options: PartitionClientOptions,
+    ) !void {
+        self.* = .{ .fixture = try Fixture.init(allocator, mem, clock, conn) };
+        errdefer self.fixture.deinit();
+        try self.client.open(allocator, &self.fixture.session, .{
+            .source_address = test_source,
+            .instance_id = test_instance,
+            .deadline_ms = 10_000,
+        }, options);
+    }
+
+    fn deinit(self: *Scripted) void {
+        self.client.deinit();
+        self.fixture.deinit();
+    }
+};
+
+/// Script the peer's side of attach for the receiver under test.
+fn scriptAttach(peer: Peer) !void {
+    try harness.scriptHandshake(peer, 512);
+    try peer.push(0, .{ .attach = .{
+        .name = test_link_name,
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+}
+
+/// Push one event as a settled single-frame transfer.
+fn pushEvent(
+    allocator: Allocator,
+    peer: Peer,
+    id: u32,
+    sequence_number: i64,
+    body: []const u8,
+) !void {
+    var annotations = [_]amqp.MapEntry{
+        .{
+            .key = .{ .symbol = event_data.sequence_number_annotation },
+            .value = .{ .long = sequence_number },
+        },
+        .{
+            .key = .{ .symbol = event_data.offset_annotation },
+            .value = .{ .string = "100" },
+        },
+    };
+    const bodies = [_][]const u8{body};
+    const payload = try amqp.encodeMessageAlloc(allocator, .{
+        .message_annotations = &annotations,
+        .body = .{ .data = &bodies },
+    });
+    defer allocator.free(payload);
+
+    const tag = [_]u8{@intCast(id)};
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = id,
+        .delivery_tag = &tag,
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, payload);
+}
+
+/// The attach the client wrote, decoded. Caller must `deinit` it.
+fn sentAttach(allocator: Allocator, mem: *MemoryTransport) !amqp.performative.Decoded {
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.attach) continue;
+        return amqp.performative.decode(allocator, body);
+    }
+    return error.NoAttach;
+}
+
+test "consumerPathFor builds the consumer group address" {
+    const allocator = testing.allocator;
+    const path = try consumerPathFor(allocator, "my-hub", "$default", "3");
+    defer allocator.free(path);
+    try testing.expectEqualStrings("my-hub/ConsumerGroups/$default/Partitions/3", path);
+}
+
+test "prefetch maps onto link credit" {
+    // Zero means "no preference", not "no credit"; only a negative value
+    // disables prefetch.
+    try testing.expectEqual(@as(u32, 300), prefetchCredit(0));
+    try testing.expectEqual(@as(u32, 50), prefetchCredit(50));
+    try testing.expectEqual(@as(u32, 0), prefetchCredit(-1));
+}
+
+test "attach carries the start position as a selector filter" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{
+        .start_position = EventPosition.earliest(),
+    });
+    defer scripted.deinit();
+
+    var attach = try sentAttach(allocator, &mem);
+    defer attach.deinit();
+
+    const filters = attach.performative.attach.source.?.filters.?;
+    try testing.expectEqual(@as(usize, 1), filters.len);
+    try testing.expectEqualStrings(amqp.performative.selector_filter_name, filters[0].name);
+    try testing.expectEqualStrings(
+        "amqp.annotation.x-opt-offset > '-1'",
+        filters[0].value.string,
+    );
+}
+
+test "attach names the reader and omits epoch without an owner level" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    var attach = try sentAttach(allocator, &mem);
+    defer attach.deinit();
+
+    const properties = attach.performative.attach.properties.?;
+    try testing.expectEqual(@as(usize, 1), properties.len);
+    try testing.expectEqualStrings(receiver_name_property, properties[0].key.symbol);
+    try testing.expectEqualStrings(test_instance, properties[0].value.string);
+    // The instance id also names the link's target, which is what makes a
+    // stolen-link error say who stole it.
+    try testing.expectEqualStrings(test_instance, attach.performative.attach.target.?.address.?);
+}
+
+test "an owner level attaches as an exclusive consumer" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{ .owner_level = 7 });
+    defer scripted.deinit();
+
+    var attach = try sentAttach(allocator, &mem);
+    defer attach.deinit();
+
+    const properties = attach.performative.attach.properties.?;
+    try testing.expectEqual(@as(usize, 2), properties.len);
+    try testing.expectEqualStrings(epoch_property, properties[1].key.symbol);
+    try testing.expectEqual(@as(i64, 7), properties[1].value.long);
+}
+
+test "receiveEvents decodes events and advances past the last one" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushEvent(allocator, peer, 0, 11, "first");
+    try pushEvent(allocator, peer, 1, 12, "second");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    const events = try scripted.client.receiveEvents(allocator, 2);
+    defer event_data.freeReceivedEvents(allocator, events);
+
+    try testing.expectEqual(@as(usize, 2), events.len);
+    try testing.expectEqualStrings("first", events[0].body());
+    try testing.expectEqualStrings("second", events[1].body());
+    try testing.expectEqual(@as(i64, 12), events[1].sequence_number);
+
+    // A reattach must resume after the last event handed out, or the caller
+    // sees it twice.
+    try testing.expectEqualStrings(
+        "amqp.annotation.x-opt-sequence-number > '12'",
+        scripted.client.filterExpression(),
+    );
+}
+
+test "a quiet partition returns the events that did arrive" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushEvent(allocator, peer, 0, 5, "only");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    // An exhausted script reads as end of stream by default, which is a
+    // broken connection rather than a quiet one. Starve it instead, and let
+    // the clock run so the deadline is what ends the wait.
+    mem.starve = true;
+    clock.auto_advance_ms = 1_000;
+
+    // Asks for more than the peer will ever send.
+    const events = try scripted.client.receiveEvents(allocator, 10);
+    defer event_data.freeReceivedEvents(allocator, events);
+
+    try testing.expectEqual(@as(usize, 1), events.len);
+    try testing.expectEqualStrings("only", events[0].body());
+}
+
+test "disabled prefetch issues credit per receive" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushEvent(allocator, peer, 0, 1, "a");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{ .prefetch = -1 });
+    defer scripted.deinit();
+
+    var attach = try sentAttach(allocator, &mem);
+    defer attach.deinit();
+    // Nothing was requested on attach, so no flow can have gone out yet.
+    try testing.expectEqual(@as(u32, 0), scripted.client.receiver.credit);
+
+    mem.clearWritten();
+    const events = try scripted.client.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, events);
+    try testing.expectEqual(@as(usize, 1), events.len);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    var flows: usize = 0;
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) == amqp.performative.descriptor.flow) flows += 1;
+    }
+    try testing.expect(flows >= 1);
+}
+
+test "receiveEvents rejects counts outside the credit window" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    try testing.expectError(
+        ReceiveError.InvalidCount,
+        scripted.client.receiveEvents(allocator, 0),
+    );
+    try testing.expectError(
+        ReceiveError.InvalidCount,
+        scripted.client.receiveEvents(allocator, max_credit + 1),
+    );
+}
+
+test "prefetch above the credit window is rejected" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try harness.scriptHandshake(peer, 512);
+
+    var fixture = try Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var client: PartitionClient = undefined;
+    try testing.expectError(ReceiveError.PrefetchTooLarge, client.open(allocator, &fixture.session, .{
+        .source_address = test_source,
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+    }, .{ .prefetch = @as(i32, @intCast(max_credit)) + 1 }));
+}
+
+test "a pool reuses one link and resumes where it left off" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushEvent(allocator, peer, 0, 20, "a");
+    try pushEvent(allocator, peer, 1, 21, "b");
+
+    var fixture = try Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var pool = ReceiverPool.init(allocator, &fixture.session, .{
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+    });
+    defer pool.deinit();
+
+    mem.clearWritten();
+    const first = try pool.receive(allocator, test_source, "amqp.annotation.x-opt-offset > '-1'", 1);
+    defer event_data.freeReceivedEvents(allocator, first);
+    try testing.expectEqual(@as(usize, 1), first.len);
+
+    // The second call passes the original filter again; the pool must ignore
+    // it and keep the position the first call advanced to.
+    const second = try pool.receive(allocator, test_source, "amqp.annotation.x-opt-offset > '-1'", 1);
+    defer event_data.freeReceivedEvents(allocator, second);
+    try testing.expectEqualStrings("b", second[0].body());
+
+    const client = try pool.clientFor(test_source, null);
+    try testing.expectEqualStrings(
+        "amqp.annotation.x-opt-sequence-number > '21'",
+        client.filterExpression(),
+    );
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    var attaches: usize = 0;
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) == amqp.performative.descriptor.attach) attaches += 1;
+    }
+    try testing.expectEqual(@as(usize, 1), attaches);
+}

--- a/root.zig
+++ b/root.zig
@@ -69,122 +69,22 @@ pub const management = @import("management.zig");
 pub const PartitionProperties = management.PartitionProperties;
 pub const EventHubProperties = management.EventHubProperties;
 
-/// Where in a partition a consumer starts reading.
-///
-/// Rust models this as a `StartLocation` enum and Go as a set of optional
-/// fields that it rejects when more than one is set. A tagged union makes the
-/// conflict unrepresentable.
-pub const StartLocation = union(enum) {
-    /// The oldest event the partition still retains.
-    earliest,
-    /// Only events enqueued after the consumer attaches. This is the default
-    /// in Go and Rust alike.
-    latest,
-    /// An opaque offset token, which is not necessarily numeric.
-    offset: []const u8,
-    sequence_number: i64,
-    /// Unix milliseconds.
-    enqueued_time: i64,
-};
+// Start positions. Kept in their own file so `receiver.zig` can use them
+// without importing this one back. Not re-exported as a namespace: `position`
+// is the natural name for a local here, and Zig forbids the shadowing.
+const start_position_types = @import("position.zig");
+pub const StartLocation = start_position_types.StartLocation;
+pub const EventPosition = start_position_types.EventPosition;
+pub const StartPositions = start_position_types.StartPositions;
 
-/// Starting position for reading events from a partition.
-///
-/// Slices are borrowed and must outlive the position.
-pub const EventPosition = struct {
-    location: StartLocation = .latest,
-    /// Include the event at `location` rather than starting after it. Ignored
-    /// for `earliest` and `latest`, which have no event to include.
-    is_inclusive: bool = false,
-
-    /// Start from the beginning of the partition.
-    pub fn earliest() EventPosition {
-        return .{ .location = .earliest };
-    }
-
-    /// Start from the end of the partition (new events only).
-    pub fn latest() EventPosition {
-        return .{ .location = .latest };
-    }
-
-    /// Start from a specific offset.
-    pub fn fromOffset(offset: []const u8, inclusive: bool) EventPosition {
-        return .{ .location = .{ .offset = offset }, .is_inclusive = inclusive };
-    }
-
-    /// Start from a specific sequence number.
-    pub fn fromSequenceNumber(seq: i64, inclusive: bool) EventPosition {
-        return .{ .location = .{ .sequence_number = seq }, .is_inclusive = inclusive };
-    }
-
-    /// Start from a specific enqueued time (Unix ms).
-    pub fn fromEnqueuedTime(time: i64) EventPosition {
-        return .{ .location = .{ .enqueued_time = time } };
-    }
-
-    /// Render the AMQP filter expression for this position.
-    ///
-    /// A default-constructed position renders as `@latest` rather than
-    /// failing, matching Go's `getStartExpression` and Rust's
-    /// `StartPosition::start_expression`.
-    pub fn toFilterExpression(self: EventPosition, allocator: std.mem.Allocator) ![]u8 {
-        const op: []const u8 = if (self.is_inclusive) ">=" else ">";
-        return switch (self.location) {
-            // Go and Rust both emit `>` for these two regardless of
-            // inclusivity, because `-1` and `@latest` are sentinels that
-            // already sit outside the event range.
-            .earliest => allocator.dupe(u8, "amqp.annotation.x-opt-offset > '-1'"),
-            .latest => allocator.dupe(u8, "amqp.annotation.x-opt-offset > '@latest'"),
-            .offset => |offset| std.fmt.allocPrint(
-                allocator,
-                "amqp.annotation.x-opt-offset {s} '{s}'",
-                .{ op, offset },
-            ),
-            .sequence_number => |seq| std.fmt.allocPrint(
-                allocator,
-                "amqp.annotation.x-opt-sequence-number {s} '{d}'",
-                .{ op, seq },
-            ),
-            .enqueued_time => |time| std.fmt.allocPrint(
-                allocator,
-                "amqp.annotation.x-opt-enqueued-time {s} '{d}'",
-                .{ op, time },
-            ),
-        };
-    }
-};
-
-/// Per-partition starting positions, used when a partition has no checkpoint.
-///
-/// Partition ids are copied; every other slice is borrowed.
-pub const StartPositions = struct {
-    per_partition: std.StringArrayHashMapUnmanaged(EventPosition) = .empty,
-    /// Used for any partition absent from `per_partition`.
-    default: EventPosition = .{},
-
-    pub fn deinit(self: *StartPositions, allocator: std.mem.Allocator) void {
-        for (self.per_partition.keys()) |key| allocator.free(key);
-        self.per_partition.deinit(allocator);
-    }
-
-    pub fn put(
-        self: *StartPositions,
-        allocator: std.mem.Allocator,
-        partition_id: []const u8,
-        position: EventPosition,
-    ) !void {
-        const owned_id = try allocator.dupe(u8, partition_id);
-        errdefer allocator.free(owned_id);
-
-        const gop = try self.per_partition.getOrPut(allocator, owned_id);
-        if (gop.found_existing) allocator.free(owned_id);
-        gop.value_ptr.* = position;
-    }
-
-    /// Resolve the position for a partition, falling back to `default`.
-    pub fn forPartition(self: StartPositions, partition_id: []const u8) EventPosition {
-        return self.per_partition.get(partition_id) orelse self.default;
-    }
-};
+pub const receiving = @import("receiver.zig");
+pub const PartitionClient = receiving.PartitionClient;
+pub const PartitionClientOptions = receiving.PartitionClientOptions;
+pub const ReceiverPool = receiving.ReceiverPool;
+pub const ReceiveError = receiving.ReceiveError;
+pub const consumerPathFor = receiving.consumerPathFor;
+pub const default_prefetch = receiving.default_prefetch;
+pub const max_credit = receiving.max_credit;
 
 // ─────────────────── AMQP Transport ──────────────────
 
@@ -236,6 +136,9 @@ pub const LinkTransport = struct {
     /// Sender links, attached on demand. Sending fails as unimplemented while
     /// this is null, which is what a metadata-only client wants.
     senders: ?*SenderPool = null,
+    /// Receiver links, attached on demand. Null leaves receiving
+    /// unimplemented, as for a producer-only or metadata-only client.
+    receivers: ?*ReceiverPool = null,
     /// The CBS token for the hub audience. Event Hubs wants it on the message
     /// as well as on the link.
     security_token: ?[]const u8 = null,
@@ -248,6 +151,7 @@ pub const LinkTransport = struct {
         return .{
             .management_client = management_client,
             .senders = options.senders,
+            .receivers = options.receivers,
             .security_token = options.security_token,
             .deadline_ms = options.deadline_ms,
             .retry = options.retry,
@@ -264,6 +168,7 @@ pub const LinkTransport = struct {
 
     pub const Options = struct {
         senders: ?*SenderPool = null,
+        receivers: ?*ReceiverPool = null,
         security_token: ?[]const u8 = null,
         deadline_ms: i64,
         retry: ?errors.RetryConfig = null,
@@ -303,13 +208,19 @@ pub const LinkTransport = struct {
         return pool.maxMessageSize(address);
     }
 
+    /// `filter` applies only to the first call for a given source: after
+    /// that the partition client holds a position advanced past everything it
+    /// has already delivered, and reapplying the original filter would replay.
     fn receiveImpl(t: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) ![]ReceivedEventData {
-        _ = t;
-        _ = allocator;
-        _ = source;
-        _ = filter;
-        _ = max_count;
-        return error.Unimplemented;
+        const self: *LinkTransport = @fieldParentPtr("transport", t);
+        const pool = self.receivers orelse return error.Unimplemented;
+        return pool.receive(allocator, source, filter, max_count);
+    }
+
+    /// Why the broker detached the receiver link for `source`.
+    pub fn lastReceiveError(self: *LinkTransport, source: []const u8) ?errors.EventHubsError {
+        const pool = self.receivers orelse return null;
+        return pool.lastError(source);
     }
 
     fn getHubPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) !EventHubProperties {
@@ -664,7 +575,14 @@ pub const ConsumerClientOptions = struct {
     fully_qualified_namespace: []const u8,
     event_hub_name: []const u8,
     consumer_group: []const u8 = "$Default",
+    /// Identifies this reader to the broker, so a stolen link names who took
+    /// it. Borrowed, and must outlive the client.
+    instance_id: ?[]const u8 = null,
 };
+
+/// Used when the caller supplies no instance id, matching the link-name
+/// suffix the producer side already uses.
+pub const default_instance_id = "eventhubs";
 
 /// Receives events from an Event Hub partition.
 pub const ConsumerClient = struct {
@@ -754,12 +672,63 @@ pub const ConsumerClient = struct {
         return self.credential.getToken(ctx);
     }
 
+    /// The AMQP address a partition is read from. Caller owns the result.
+    ///
+    /// This is an entity path, not a URL: the namespace comes from the
+    /// connection, so prefixing it here would attach to a link that does not
+    /// exist.
+    pub fn consumerPath(
+        self: *ConsumerClient,
+        allocator: std.mem.Allocator,
+        partition_id: []const u8,
+    ) ![]u8 {
+        return consumerPathFor(
+            allocator,
+            self.options.event_hub_name,
+            self.options.consumer_group,
+            partition_id,
+        );
+    }
+
+    /// The name this reader attaches under.
+    pub fn instanceId(self: *ConsumerClient) []const u8 {
+        return self.options.instance_id orelse default_instance_id;
+    }
+
+    /// Open a client that reads one partition over a link it keeps attached.
+    ///
+    /// Initialise in place; `client` must outlive neither `session` nor the
+    /// allocator. This mirrors Go's `NewPartitionClient` and is the path that
+    /// supports prefetch, owner level, and resuming without replay.
+    pub fn newPartitionClient(
+        self: *ConsumerClient,
+        client: *PartitionClient,
+        allocator: std.mem.Allocator,
+        session: *amqp.Session,
+        partition_id: []const u8,
+        deadline_ms: i64,
+        options: PartitionClientOptions,
+    ) !void {
+        const source = try self.consumerPath(allocator, partition_id);
+        defer allocator.free(source);
+
+        try client.open(allocator, session, .{
+            .source_address = source,
+            .instance_id = self.instanceId(),
+            .deadline_ms = deadline_ms,
+        }, options);
+    }
+
     /// Receive events from a specific partition.
+    ///
+    /// A one-shot convenience over the transport. Use `newPartitionClient`
+    /// when the reader needs prefetch control, an owner level, or to resume
+    /// where it left off: each call here re-applies `start_position`, and a
+    /// link-backed transport only honours it on the first call.
     ///
     /// The returned slice comes from the transport. A link-backed transport
     /// allocates it, so free it with `freeReceivedEvents`; `MockAmqpTransport`
-    /// returns
-    /// the slice a test handed it and keeps ownership.
+    /// returns the slice a test handed it and keeps ownership.
     pub fn receiveEvents(
         self: *ConsumerClient,
         allocator: std.mem.Allocator,
@@ -767,16 +736,7 @@ pub const ConsumerClient = struct {
         start_position: EventPosition,
         max_count: u32,
     ) ![]ReceivedEventData {
-        const address = try std.fmt.allocPrint(
-            allocator,
-            "{s}/{s}/ConsumerGroups/{s}/Partitions/{s}",
-            .{
-                self.options.fully_qualified_namespace,
-                self.options.event_hub_name,
-                self.options.consumer_group,
-                partition_id,
-            },
-        );
+        const address = try self.consumerPath(allocator, partition_id);
         defer allocator.free(address);
 
         const filter = try start_position.toFilterExpression(allocator);


### PR DESCRIPTION
Part of #191. Implements #205.

`ConsumerClient.receiveEvents` was a one-shot call into a transport whose `receive` returned `error.Unimplemented`, so nothing could actually read a partition. It also built the source address as `{fqns}/{hub}/ConsumerGroups/...` — the namespace comes from the connection, so that names a link that does not exist.

## `PartitionClient`

Holds one receiver link for its lifetime. The link carries the reader's position, so an object is the only shape that can resume: after each successful receive the selector is rewritten to `amqp.annotation.x-opt-sequence-number > '<last>'`, and a reattach continues rather than replaying everything the caller already saw.

Attach details follow Go's `partition_client.go`:

| | |
|---|---|
| source | `{hub}/ConsumerGroups/{group}/Partitions/{id}` |
| target | the instance id, so a stolen link names who took it |
| filter | `selector` carrying the start position |
| `com.microsoft:receiver-name` | always |
| `com.microsoft:epoch` | only with an owner level |
| capability | `com.microsoft:georeplication` |

Prefetch defaults to 300 as Go and Rust do; a negative value disables it and issues exactly the credit each receive needs; 5000 caps both prefetch and a single receive.

A receive that asks for more events than arrive returns the ones that did. Failing would discard events the caller had already been given, and a quiet partition is not an error — Go reaches the same behaviour through context expiry.

## `ReceiverPool` and the transport

The pool keeps one client per source, so it applies the caller's filter only on the first call for an address. That is what makes `LinkTransport.receiveImpl` correct across repeated calls; reopening per call would replay from the configured start position every time.

## Two moves, both to break import cycles

- `EventPosition` → `position.zig`, because `receiver.zig` needs it and `root.zig` imports the receiver.
- `fromAmqpMessage` now delegates to a codec-neutral `fromRawMessage`, because a delivery decodes to `azure_sdk_amqp`'s message type rather than uamqp's. No behaviour change; the existing tests cover it.

## Tests

132 pass. The new ones assert the selector on the attach, the reader name and target, epoch presence and absence, decoding plus the filter advance, a quiet partition returning partial results, per-receive credit with prefetch disabled, count and prefetch bounds, and a pool serving two receives over a single attach.

Mutation-verified: dropping the filter advance, always sending epoch, and never disabling prefetch each fail two tests.