### PR TITLE
Register the Event Hubs receiver sources

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -459,6 +459,8 @@ pub const all = [_]Package{
             "event_data.zig",
             "batch.zig",
             "sender.zig",
+            "position.zig",
+            "receiver.zig",
             "errors.zig",
             "checkpoint.zig",
             "checkpoint_store.zig",


### PR DESCRIPTION
Paired with #285, which adds `position.zig` and `receiver.zig` on `sdk/eventhubs`.

A new published file needs an entry in both the branch's `build.zig.zon` `.paths` (done in #285) and `publish_paths` here. Without this the tarball omits both files and the package does not build for a consumer.

`zig build package-check`: all packages valid.