### PR TITLE
Add link and connection recovery to Event Hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,39 @@ call `attempt.resetAttempts` to take one more immediate try after recovering a
 link. Both the `Sleeper` and the jitter source are injected, so tests can
 exercise the whole schedule without spending the time it describes.
 
+## Recovery
+
+A long-lived producer or consumer outlives the links it runs on. Brokers
+recycle links during upgrades and rebalances, and a connection can drop
+outright. `RecoverableConnection` rebuilds whatever the failure says is
+broken and `runWithRecovery` re-runs the operation on top of it:
+
+- `link` — reattach that one link. The connection and every other link stay
+  up. The first link failure of an operation takes one immediate retry
+  before the normal backoff, since a reattach is cheap and usually enough.
+- `connection` — rebuild the connection, its session, and every link.
+- `fatal` — surface it. `amqp:link:stolen` lands here, so a displaced
+  consumer stops rather than stealing its partition back.
+
+The connection is opened lazily through a `ConnectionFactory`, so nothing
+dials until the first operation runs. An `Authorizer` puts a CBS token on
+each generation *before* any link attaches: a rebuilt connection carries no
+claims, and a link attaching without one is refused with
+`unauthorized-access`, which is fatal.
+
+Recovery is idempotent across concurrent failures. `ensureOpen` returns the
+generation the caller is working against, and `recoverConnection` ignores a
+request naming a generation that is already gone — otherwise two operations
+failing on the same dead connection would rebuild it twice and the second
+rebuild would discard the first's healthy connection.
+
+Reattached receivers resume where they left off. The pool remembers each
+partition's selector when it drops a client, so a reattach continues past
+the last sequence number handed to the caller instead of replaying from the
+configured start position. For the same reason, a receive that fails partway
+through a batch returns the events that did arrive rather than discarding
+them; the next call finds the link dead and recovers it.
+
 Release branch: `sdk/eventhubs`. The package depends on `azure_sdk_core`,
 `azure_sdk_messaging_common`, `azure_sdk_storage_blobs`, `uamqp`, and `serde`
 and starts at `0.1.0`.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.1.0-I5lGdlJ7CgCiJaJDvHH7ukhtln4baXBvqfvrDGCOhiVD",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#e91e345f852b2a9b8ac33c0a494d82deace30f38",
-            .hash = "azure_sdk_amqp-0.1.0-fUByf3l2BADNnCWXU2h6TZCgZmAmaXNfmjOr0yTHE4JR",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#f86daf8c68a9cce393250e93d15f24d03711bc4f",
+            .hash = "azure_sdk_amqp-0.1.0-fUByf_qKBABdtcHT_R-h5O0Nw-2ZQgAf83vKGZTk7xZf",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
@@ -35,6 +35,7 @@
         "sender.zig",
         "position.zig",
         "receiver.zig",
+        "recovery.zig",
         "errors.zig",
         "checkpoint.zig",
         "checkpoint_store.zig",

--- a/receiver.zig
+++ b/receiver.zig
@@ -205,9 +205,11 @@ pub const PartitionClient = struct {
         while (events.items.len < count) {
             const delivery = self.receiver.receive(self.deadline_ms) catch |err| {
                 self.recordDetach();
-                // Events already in hand are still valid; a quiet partition is
-                // not a failure. Anything else with nothing to show is.
-                if (events.items.len > 0 and err == error.Timeout) break;
+                // Events already in hand arrived and were accepted, so dropping
+                // them here would lose them outright. Hand back the short batch
+                // and let the next call surface the failure: the link is dead,
+                // so that call fails immediately with nothing to lose.
+                if (events.items.len > 0) break;
                 return err;
             };
 
@@ -279,6 +281,10 @@ pub const ReceiverPool = struct {
     /// Keyed by source address. The pool owns the keys; the session owns the
     /// links behind the clients.
     clients: std.StringHashMapUnmanaged(*PartitionClient) = .empty,
+    /// The selector each dropped client had reached, kept so a reattach
+    /// resumes instead of replaying from the configured start position. Keys
+    /// and values are both owned.
+    positions: std.StringHashMapUnmanaged([]u8) = .empty,
 
     pub const Options = struct {
         instance_id: []const u8,
@@ -297,17 +303,76 @@ pub const ReceiverPool = struct {
     }
 
     pub fn deinit(self: *ReceiverPool) void {
-        var it = self.clients.iterator();
-        while (it.next()) |entry| {
-            entry.value_ptr.*.deinit();
-            self.allocator.destroy(entry.value_ptr.*);
-            self.allocator.free(entry.key_ptr.*);
-        }
+        self.dropAll(false);
         self.clients.deinit(self.allocator);
+
+        var positions = self.positions.iterator();
+        while (positions.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.positions.deinit(self.allocator);
+    }
+
+    /// Detach the client for `source_address` and forget it, remembering where
+    /// it had read to.
+    ///
+    /// `detach` is false when the session is already gone: writing a detach
+    /// into a dead connection would fail, and the link died with the session
+    /// regardless.
+    pub fn drop(self: *ReceiverPool, source_address: []const u8, detach: bool) void {
+        const entry = self.clients.fetchRemove(source_address) orelse return;
+        const client = entry.value;
+
+        // Remembered before the client is torn down, so the reattach resumes
+        // rather than replaying everything already delivered.
+        self.remember(entry.key, client.filterExpression()) catch {};
+
+        if (detach) self.session.closeReceiver(client.receiver, self.deadline_ms);
+        client.deinit();
+        self.allocator.destroy(client);
+        self.allocator.free(entry.key);
+    }
+
+    /// Forget every client, remembering where each had read to.
+    pub fn dropAll(self: *ReceiverPool, detach: bool) void {
+        var addresses: std.ArrayList([]const u8) = .empty;
+        defer addresses.deinit(self.allocator);
+
+        var it = self.clients.keyIterator();
+        while (it.next()) |key| addresses.append(self.allocator, key.*) catch return;
+        for (addresses.items) |address| self.drop(address, detach);
+    }
+
+    /// Point the pool at a rebuilt session.
+    ///
+    /// The old session took its links with it, so they are forgotten rather
+    /// than detached; the remembered positions survive so the reattached
+    /// clients resume.
+    pub fn rebind(self: *ReceiverPool, session: *amqp.Session) void {
+        self.dropAll(false);
+        self.session = session;
+    }
+
+    fn remember(self: *ReceiverPool, source_address: []const u8, expression: []const u8) !void {
+        const owned = try self.allocator.dupe(u8, expression);
+        errdefer self.allocator.free(owned);
+
+        const gop = try self.positions.getOrPut(self.allocator, source_address);
+        if (gop.found_existing) {
+            self.allocator.free(gop.value_ptr.*);
+        } else {
+            gop.key_ptr.* = self.allocator.dupe(u8, source_address) catch |err| {
+                _ = self.positions.remove(source_address);
+                return err;
+            };
+        }
+        gop.value_ptr.* = owned;
     }
 
     /// The client for `source_address`, attaching one if this is the first
-    /// call. `filter_expression` applies only to a first attach.
+    /// call. `filter_expression` applies only to a first attach, and is
+    /// ignored once the pool has remembered a position for the address.
     pub fn clientFor(
         self: *ReceiverPool,
         source_address: []const u8,
@@ -315,13 +380,20 @@ pub const ReceiverPool = struct {
     ) !*PartitionClient {
         if (self.clients.get(source_address)) |existing| return existing;
 
+        // A remembered position wins: reapplying the original filter after a
+        // recovery would replay every event already delivered.
+        const resume_from: ?[]const u8 = if (self.positions.get(source_address)) |remembered|
+            remembered
+        else
+            filter_expression;
+
         const client = try self.allocator.create(PartitionClient);
         errdefer self.allocator.destroy(client);
         try client.open(self.allocator, self.session, .{
             .source_address = source_address,
             .instance_id = self.instance_id,
             .deadline_ms = self.deadline_ms,
-            .filter_expression = filter_expression,
+            .filter_expression = resume_from,
         }, self.options);
         errdefer client.deinit();
 
@@ -347,6 +419,19 @@ pub const ReceiverPool = struct {
     pub fn lastError(self: *ReceiverPool, source_address: []const u8) ?errors.EventHubsError {
         const client = self.clients.get(source_address) orelse return null;
         return client.last_error;
+    }
+
+    /// Describe why the receive from `source_address` failed, so the retrier
+    /// can classify it.
+    pub fn recordFailure(
+        self: *ReceiverPool,
+        source_address: []const u8,
+        attempt: *errors.Attempt,
+    ) void {
+        const client = self.clients.get(source_address) orelse return;
+        const detached = client.receiver.detach_error orelse return;
+        attempt.condition = detached.condition;
+        attempt.description = detached.description;
     }
 };
 

--- a/recovery.zig
+++ b/recovery.zig
@@ -689,7 +689,11 @@ test "a connection failure rebuilds and re-authorises before reattaching" {
     // which is fatal and would end the retry.
     try testing.expectEqual(@as(usize, 2), authorizer.calls);
     try testing.expectEqual(@as(usize, 2), authorizer.sessions.items.len);
-    try testing.expect(authorizer.sessions.items[0] != authorizer.sessions.items[1]);
+    // The claim has to land on the session the links will actually attach on.
+    // Comparing the two recorded pointers would not show that: the first
+    // session is freed before the second is allocated, so the allocator is
+    // free to hand back the same address, and on Windows it does.
+    try testing.expectEqual(try connection.session(), authorizer.sessions.items[1]);
 }
 
 test "a stale recovery request does not rebuild a second time" {

--- a/recovery.zig
+++ b/recovery.zig
@@ -1,0 +1,928 @@
+//! Link and connection recovery.
+//!
+//! Event Hubs detaches links routinely, during service upgrades and partition
+//! moves, so a client that treats a detach as terminal dies on the first
+//! ordinary fault. Go recovers through a `LinkRetrier` that classifies the
+//! failure and rebuilds only what the classification demands
+//! (`internal/links_recover.go`); Rust does the same with reconnect scopes
+//! (`common/recoverable/connection.rs`). This is that machinery.
+
+const std = @import("std");
+const amqp = @import("azure_sdk_amqp");
+const errors = @import("errors.zig");
+const sending = @import("sender.zig");
+const receiving = @import("receiver.zig");
+
+const Allocator = std.mem.Allocator;
+const SenderPool = sending.SenderPool;
+const ReceiverPool = receiving.ReceiverPool;
+const PartitionClientOptions = receiving.PartitionClientOptions;
+
+/// The AMQP plumbing one connection generation owns.
+///
+/// `context` is opaque to this file and belongs to the factory that produced
+/// it, which is also the only thing that knows how to take it apart.
+pub const Plumbing = struct {
+    context: *anyopaque,
+    session: *amqp.Session,
+    management: *amqp.Management,
+};
+
+/// Builds and tears down the AMQP plumbing behind a connection.
+///
+/// A vtable rather than a concrete type because recovery has to be exercised
+/// against a scripted peer, and because #207 will add custom endpoints and
+/// WebSockets without this file needing to know.
+pub const ConnectionFactory = struct {
+    openFn: *const fn (self: *ConnectionFactory, deadline_ms: i64) anyerror!Plumbing,
+    closeFn: *const fn (self: *ConnectionFactory, plumbing: Plumbing) void,
+
+    pub fn open(self: *ConnectionFactory, deadline_ms: i64) !Plumbing {
+        return self.openFn(self, deadline_ms);
+    }
+
+    pub fn close(self: *ConnectionFactory, plumbing: Plumbing) void {
+        self.closeFn(self, plumbing);
+    }
+};
+
+/// Puts a CBS token for an audience.
+///
+/// A rebuilt connection carries no claims, so every link must be
+/// re-authorised before it reattaches or the broker refuses the attach with
+/// `unauthorized-access` — which is classified fatal, turning a recoverable
+/// fault into a terminal one.
+pub const Authorizer = struct {
+    authorizeFn: *const fn (
+        self: *Authorizer,
+        session: *amqp.Session,
+        deadline_ms: i64,
+    ) anyerror!void,
+
+    pub fn authorize(self: *Authorizer, session: *amqp.Session, deadline_ms: i64) !void {
+        return self.authorizeFn(self, session, deadline_ms);
+    }
+};
+
+pub const RecoveryError = error{
+    /// The connection was closed by the caller and cannot be reopened.
+    ConnectionClosedPermanently,
+};
+
+/// An AMQP connection that can be rebuilt underneath its links.
+///
+/// `generation` is the connection identity Go calls `connID`. A caller reads
+/// it before an operation and hands it back when asking for recovery; a
+/// mismatch means someone else already rebuilt, so the request is a no-op.
+/// That is what makes concurrent failures recover once rather than once per
+/// waiter.
+pub const RecoverableConnection = struct {
+    allocator: Allocator,
+    factory: *ConnectionFactory,
+    /// Null skips re-authorisation, which is what a test peer or an emulator
+    /// with authentication disabled wants.
+    authorizer: ?*Authorizer,
+    deadline_ms: i64,
+    sender_options: SenderPool.Options,
+    receiver_options: ReceiverPool.Options,
+
+    generation: u64 = 0,
+    plumbing: ?Plumbing = null,
+    senders: SenderPool = undefined,
+    receivers: ReceiverPool = undefined,
+    closed: bool = false,
+    /// The pools outlive any one generation, because a receiver's position
+    /// has to survive the rebuild that lost its link.
+    pools_ready: bool = false,
+    /// Counts completed rebuilds, so a test can prove a stale request did not
+    /// cause a second one.
+    recoveries: u64 = 0,
+    link_recoveries: u64 = 0,
+    /// Counts CBS authorisations, so a test can prove a rebuild re-authorised
+    /// before reattaching.
+    authorizations: u64 = 0,
+    /// A copy of the most recent failure's condition and description.
+    ///
+    /// The originals belong to the link that failed, which recovery is about
+    /// to free; the retrier reads them after the attempt returns, and the
+    /// outcome hands them to the caller after that. Only the connection
+    /// outlives both, so the copy lives here.
+    condition_buf: [128]u8 = undefined,
+    condition_len: usize = 0,
+    description_buf: [512]u8 = undefined,
+    description_len: usize = 0,
+
+    pub const Options = struct {
+        factory: *ConnectionFactory,
+        authorizer: ?*Authorizer = null,
+        deadline_ms: i64,
+        /// Identifies this reader to the broker on receiver links.
+        instance_id: []const u8 = "eventhubs",
+        /// Distinguishes this client's sender links from any others.
+        link_id: []const u8 = "eventhubs",
+        partition_client: PartitionClientOptions = .{},
+    };
+
+    pub fn init(allocator: Allocator, options: Options) RecoverableConnection {
+        return .{
+            .allocator = allocator,
+            .factory = options.factory,
+            .authorizer = options.authorizer,
+            .deadline_ms = options.deadline_ms,
+            .sender_options = .{
+                .deadline_ms = options.deadline_ms,
+                .link_id = options.link_id,
+            },
+            .receiver_options = .{
+                .instance_id = options.instance_id,
+                .deadline_ms = options.deadline_ms,
+                .client = options.partition_client,
+            },
+        };
+    }
+
+    pub fn deinit(self: *RecoverableConnection) void {
+        self.teardown();
+        if (self.pools_ready) {
+            self.senders.deinit();
+            self.receivers.deinit();
+            self.pools_ready = false;
+        }
+        self.closed = true;
+    }
+
+    /// Open the connection if it is not already open.
+    ///
+    /// Returns the generation the caller is now working against; pass it back
+    /// to `recoverConnection` if the operation fails.
+    pub fn ensureOpen(self: *RecoverableConnection) !u64 {
+        if (self.closed) return RecoveryError.ConnectionClosedPermanently;
+        if (self.plumbing != null) return self.generation;
+
+        const plumbing = try self.factory.open(self.deadline_ms);
+        errdefer self.factory.close(plumbing);
+
+        // Before the pools, not after: a link that attaches without a claim is
+        // refused with a condition classified fatal, so the recovery would
+        // report as unrecoverable.
+        if (self.authorizer) |authorizer| {
+            try authorizer.authorize(plumbing.session, self.deadline_ms);
+            self.authorizations += 1;
+        }
+
+        self.plumbing = plumbing;
+        if (self.pools_ready) {
+            // Rebound, not rebuilt: a fresh `ReceiverPool` would drop the
+            // remembered positions and every reattached client would replay
+            // from the configured start position.
+            self.senders.rebind(plumbing.session);
+            self.receivers.rebind(plumbing.session);
+        } else {
+            self.senders = SenderPool.init(self.allocator, plumbing.session, self.sender_options);
+            self.receivers = ReceiverPool.init(self.allocator, plumbing.session, self.receiver_options);
+            self.pools_ready = true;
+        }
+        return self.generation;
+    }
+
+    pub fn session(self: *RecoverableConnection) !*amqp.Session {
+        _ = try self.ensureOpen();
+        return self.plumbing.?.session;
+    }
+
+    pub fn managementClient(self: *RecoverableConnection) !*amqp.Management {
+        _ = try self.ensureOpen();
+        return self.plumbing.?.management;
+    }
+
+    pub fn senderPool(self: *RecoverableConnection) !*SenderPool {
+        _ = try self.ensureOpen();
+        return &self.senders;
+    }
+
+    pub fn receiverPool(self: *RecoverableConnection) !*ReceiverPool {
+        _ = try self.ensureOpen();
+        return &self.receivers;
+    }
+
+    /// Detach the links for `address` so the next use reattaches them.
+    ///
+    /// Both pools are asked because the address alone does not say which side
+    /// failed, and dropping a link that was never attached is free.
+    pub fn recoverLink(self: *RecoverableConnection, address: []const u8) void {
+        if (self.plumbing == null) return;
+        self.senders.drop(address, true);
+        self.receivers.drop(address, true);
+        self.link_recoveries += 1;
+    }
+
+    /// Rebuild the connection, unless someone already did.
+    ///
+    /// `their_generation` is what the caller read from `ensureOpen`. If the
+    /// current generation has moved past it, the connection the caller failed
+    /// on no longer exists and rebuilding again would throw away a healthy
+    /// one — Go makes exactly this check in `Namespace.Recover`.
+    pub fn recoverConnection(self: *RecoverableConnection, their_generation: u64) !void {
+        if (self.closed) return RecoveryError.ConnectionClosedPermanently;
+        if (their_generation != self.generation) return;
+
+        self.teardown();
+        self.generation += 1;
+        self.recoveries += 1;
+
+        _ = try self.ensureOpen();
+    }
+
+    /// Whether the connection currently has plumbing behind it.
+    pub fn isOpen(self: *const RecoverableConnection) bool {
+        return self.plumbing != null;
+    }
+
+    /// Copy the failure out of the link that produced it and repoint
+    /// `attempt` at the copy.
+    ///
+    /// Without this, recovering the link frees the strings the retrier is
+    /// about to classify, and the outcome the caller inspects points at freed
+    /// memory. Truncation is fine: these are diagnostics, and an AMQP
+    /// condition is a short symbol.
+    pub fn captureFailure(self: *RecoverableConnection, attempt: *errors.Attempt) void {
+        self.condition_len = copyInto(&self.condition_buf, attempt.condition);
+        self.description_len = copyInto(&self.description_buf, attempt.description);
+        attempt.condition = if (attempt.condition != null) self.condition_buf[0..self.condition_len] else null;
+        attempt.description = if (attempt.description != null) self.description_buf[0..self.description_len] else null;
+    }
+
+    fn teardown(self: *RecoverableConnection) void {
+        const plumbing = self.plumbing orelse return;
+        if (self.pools_ready) {
+            // Forgotten rather than detached: the links belong to a session
+            // that is about to stop existing, so a detach would be written
+            // into a connection that is already gone.
+            self.senders.dropAll(false);
+            self.receivers.dropAll(false);
+        }
+        self.plumbing = null;
+        self.factory.close(plumbing);
+    }
+};
+
+/// Run an operation, recovering whatever its failures say is broken.
+///
+/// `op` is a pointer to a struct with a
+/// `pub fn call(self: @TypeOf(op), attempt: *errors.Attempt) anyerror!Result`
+/// method, the same shape `errors.retry` takes. It should set
+/// `attempt.condition` when the broker named one, since that is what decides
+/// whether a link, the connection, or nothing gets rebuilt.
+///
+/// `address` names the link the operation uses, so a link-level failure can be
+/// narrowed to it. Null recovers nothing at link level, which is what a
+/// connection-wide operation wants.
+pub fn runWithRecovery(
+    comptime Result: type,
+    connection: *RecoverableConnection,
+    address: ?[]const u8,
+    op: anytype,
+    config: errors.RetryConfig,
+) errors.Outcome(Result) {
+    var runner = Runner(Result, @TypeOf(op)){
+        .connection = connection,
+        .address = address,
+        .op = op,
+    };
+    return errors.retry(Result, &runner, config);
+}
+
+fn copyInto(buffer: []u8, value: ?[]const u8) usize {
+    const bytes = value orelse return 0;
+    const n = @min(bytes.len, buffer.len);
+    @memcpy(buffer[0..n], bytes[0..n]);
+    return n;
+}
+
+fn Runner(comptime Result: type, comptime Op: type) type {
+    return struct {
+        connection: *RecoverableConnection,
+        address: ?[]const u8,
+        op: Op,
+        /// Go does one immediate retry for an asynchronous detach before
+        /// backing off, because the error may describe a link that has already
+        /// been replaced. Once only, or a link that keeps failing never backs
+        /// off at all.
+        did_quick_retry: bool = false,
+
+        pub fn call(self: *@This(), attempt: *errors.Attempt) anyerror!Result {
+            const generation = try self.connection.ensureOpen();
+
+            const result = self.op.call(attempt) catch |err| {
+                // Before anything is torn down: the condition belongs to the
+                // link that failed.
+                self.connection.captureFailure(attempt);
+
+                const kind = if (attempt.condition) |c|
+                    errors.recoveryKindForCondition(c)
+                else
+                    // An error with no condition left the connection in an
+                    // unknown state, which is Go's fallthrough too.
+                    .connection;
+
+                // Never for a fatal failure: `amqp:link:stolen` means another
+                // consumer legitimately owns the partition, and reattaching
+                // would steal it straight back.
+                if (kind == .fatal) return err;
+
+                if (attempt.index == 0 and !self.did_quick_retry and kind == .link) {
+                    self.did_quick_retry = true;
+                    attempt.resetAttempts();
+                }
+
+                switch (kind) {
+                    .none => {},
+                    .link => if (self.address) |address| self.connection.recoverLink(address),
+                    .connection => {
+                        // Drop this operation's link too. Go does the same:
+                        // the link cannot outlive the connection it was
+                        // attached to.
+                        if (self.address) |address| self.connection.recoverLink(address);
+                        try self.connection.recoverConnection(generation);
+                    },
+                    .fatal => unreachable,
+                }
+
+                // The original error, not the recovery's success: returning
+                // null here would end the retry loop as though the operation
+                // had worked.
+                return err;
+            };
+            return result;
+        }
+    };
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const harness = amqp.test_peer;
+const driver = amqp.connection_driver;
+const Peer = harness.Peer;
+const MemoryTransport = amqp.MemoryTransport;
+const event_data = @import("event_data.zig");
+const batching = @import("batch.zig");
+
+/// One connection generation: its own transport, driver, and session.
+///
+/// Heap-allocated because the session holds a pointer to the driver and the
+/// links hold pointers to the session, so moving any of it invalidates the
+/// rest.
+const Generation = struct {
+    allocator: Allocator,
+    mem: *MemoryTransport,
+    clock: *driver.ManualClock,
+    conn: *driver.Driver,
+    session: *amqp.Session,
+    /// Never used by these tests; management recovery is covered by the
+    /// metadata operations, which already run under the retry schedule.
+    management: *amqp.Management,
+
+    fn deinit(self: *Generation) void {
+        self.session.deinit();
+        self.allocator.destroy(self.session);
+        self.conn.deinit();
+        self.allocator.destroy(self.conn);
+        self.allocator.destroy(self.management);
+        self.mem.deinit();
+        self.allocator.destroy(self.mem);
+        self.allocator.destroy(self.clock);
+        self.allocator.destroy(self);
+    }
+};
+
+/// Hands out one pre-scripted generation per open.
+///
+/// A connection rebuild needs a genuinely new transport, so the script for
+/// each generation is written by the test before anything opens.
+const ScriptedFactory = struct {
+    allocator: Allocator,
+    scripts: []const *const fn (Allocator, Peer) anyerror!void,
+    opened: usize = 0,
+    live: std.ArrayList(*Generation) = .empty,
+    factory: ConnectionFactory = .{ .openFn = open, .closeFn = close },
+
+    fn deinit(self: *ScriptedFactory) void {
+        for (self.live.items) |generation| generation.deinit();
+        self.live.deinit(self.allocator);
+    }
+
+    fn open(f: *ConnectionFactory, deadline_ms: i64) anyerror!Plumbing {
+        const self: *ScriptedFactory = @fieldParentPtr("factory", f);
+        if (self.opened >= self.scripts.len) return error.NoMoreConnections;
+
+        const generation = try self.allocator.create(Generation);
+        errdefer self.allocator.destroy(generation);
+
+        const mem = try self.allocator.create(MemoryTransport);
+        mem.* = MemoryTransport.init(self.allocator);
+        const clock = try self.allocator.create(driver.ManualClock);
+        clock.* = .{};
+        const management = try self.allocator.create(amqp.Management);
+
+        try self.scripts[self.opened](self.allocator, .{ .allocator = self.allocator, .mem = mem });
+        self.opened += 1;
+
+        const conn = try self.allocator.create(driver.Driver);
+        conn.* = try driver.Driver.init(self.allocator, mem.transport(), clock.clock(), harness.driver_options);
+        try conn.open(deadline_ms);
+
+        const session = try self.allocator.create(amqp.Session);
+        session.* = try amqp.Session.begin(self.allocator, conn, 0, .{
+            .incoming_window = 100,
+            .outgoing_window = 100,
+        }, deadline_ms);
+
+        generation.* = .{
+            .allocator = self.allocator,
+            .mem = mem,
+            .clock = clock,
+            .conn = conn,
+            .session = session,
+            .management = management,
+        };
+        try self.live.append(self.allocator, generation);
+        return .{
+            .context = generation,
+            .session = session,
+            .management = management,
+        };
+    }
+
+    fn close(f: *ConnectionFactory, plumbing: Plumbing) void {
+        const self: *ScriptedFactory = @fieldParentPtr("factory", f);
+        const generation: *Generation = @ptrCast(@alignCast(plumbing.context));
+        for (self.live.items, 0..) |item, i| {
+            if (item != generation) continue;
+            _ = self.live.orderedRemove(i);
+            generation.deinit();
+            return;
+        }
+    }
+
+    /// The generation currently serving, for asserting on emitted frames.
+    fn current(self: *ScriptedFactory) *Generation {
+        return self.live.items[self.live.items.len - 1];
+    }
+};
+
+const CountingAuthorizer = struct {
+    calls: usize = 0,
+    /// Set to record the ordering question that matters: a claim put after a
+    /// link attaches is a claim the broker never saw.
+    sessions: std.ArrayList(*amqp.Session) = .empty,
+    allocator: Allocator,
+    authorizer: Authorizer = .{ .authorizeFn = authorize },
+
+    fn deinit(self: *CountingAuthorizer) void {
+        self.sessions.deinit(self.allocator);
+    }
+
+    fn authorize(a: *Authorizer, session: *amqp.Session, deadline_ms: i64) anyerror!void {
+        _ = deadline_ms;
+        const self: *CountingAuthorizer = @fieldParentPtr("authorizer", a);
+        self.calls += 1;
+        try self.sessions.append(self.allocator, session);
+    }
+};
+
+const test_target = "my-hub";
+const test_sender_link = test_target ++ "-sender-eventhubs";
+
+fn scriptHandshakeOnly(allocator: Allocator, peer: Peer) anyerror!void {
+    _ = allocator;
+    try harness.scriptHandshake(peer, 512);
+}
+
+/// Attach the sender, grant credit, then detach it with a link-level
+/// condition, which is what an ordinary Event Hubs link recycle looks like.
+fn scriptSenderThenDetach(allocator: Allocator, peer: Peer) anyerror!void {
+    _ = allocator;
+    try harness.scriptHandshake(peer, 512);
+    try scriptSenderAttach(peer, 0);
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{ .condition = "amqp:link:detach-forced", .description = "recycling" },
+    } });
+    // The reattach after recovery, on a fresh handle, then an accepted send.
+    // Delivery id 1: the session counted the first, failed delivery.
+    try scriptSenderAttach(peer, 1);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 1,
+        .last = 1,
+        .settled = true,
+        .state = .accepted,
+    } });
+}
+
+/// Attach the sender, grant credit, then drop the whole connection.
+fn scriptSenderThenConnectionLoss(allocator: Allocator, peer: Peer) anyerror!void {
+    _ = allocator;
+    try harness.scriptHandshake(peer, 512);
+    try scriptSenderAttach(peer, 0);
+    try peer.push(0, .{ .close = .{
+        .err = .{ .condition = "amqp:connection:forced", .description = "node shutting down" },
+    } });
+}
+
+/// A fresh connection that attaches the sender and accepts one delivery.
+fn scriptSenderThenAccept(allocator: Allocator, peer: Peer) anyerror!void {
+    _ = allocator;
+    try harness.scriptHandshake(peer, 512);
+    try scriptSenderAttach(peer, 0);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+}
+
+fn scriptSenderAttach(peer: Peer, handle: u32) !void {
+    try peer.push(0, .{ .attach = .{
+        .name = test_sender_link,
+        .handle = handle,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = handle,
+        .delivery_count = 0,
+        .link_credit = 10,
+    } });
+}
+
+fn testRetryConfig(sleeper: *errors.Sleeper, random: std.Random) errors.RetryConfig {
+    return .{
+        .options = .{ .max_retries = 3, .retry_delay_ns = 0, .max_retry_delay_ns = 0 },
+        .sleeper = sleeper,
+        .random = random,
+    };
+}
+
+fn noSleep(_: *errors.Sleeper, _: u64) errors.SleepError!void {}
+
+fn oneEventBatch(allocator: Allocator) !batching.EventDataBatch {
+    var batch = try batching.EventDataBatch.init(.{});
+    errdefer batch.deinit(allocator);
+    var event = event_data.EventData.init("hello");
+    defer event.deinit(allocator);
+    _ = try batch.tryAdd(allocator, event);
+    return batch;
+}
+
+test "a detached link is reattached and the send succeeds" {
+    const allocator = testing.allocator;
+    var factory = ScriptedFactory{
+        .allocator = allocator,
+        .scripts = &.{&scriptSenderThenDetach},
+    };
+    defer factory.deinit();
+
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+
+    var sleeper = errors.Sleeper{ .sleepFn = noSleep };
+    var prng = std.Random.DefaultPrng.init(0);
+
+    var batch = try oneEventBatch(allocator);
+    defer batch.deinit(allocator);
+
+    const Op = struct {
+        connection: *RecoverableConnection,
+        allocator: Allocator,
+        batch: batching.EventDataBatch,
+
+        pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror!void {
+            const pool = try op.connection.senderPool();
+            return pool.send(op.allocator, test_target, op.batch) catch |err| {
+                pool.recordFailure(test_target, attempt);
+                return err;
+            };
+        }
+    };
+    var op = Op{ .connection = &connection, .allocator = allocator, .batch = batch };
+
+    const outcome = runWithRecovery(
+        void,
+        &connection,
+        test_target,
+        &op,
+        testRetryConfig(&sleeper, prng.random()),
+    );
+    try testing.expect(outcome == .ok);
+
+    // A link-level failure must not cost the connection.
+    try testing.expectEqual(@as(u64, 1), connection.link_recoveries);
+    try testing.expectEqual(@as(u64, 0), connection.recoveries);
+    try testing.expectEqual(@as(u64, 0), connection.generation);
+}
+
+test "a connection failure rebuilds and re-authorises before reattaching" {
+    const allocator = testing.allocator;
+    var factory = ScriptedFactory{
+        .allocator = allocator,
+        .scripts = &.{ &scriptSenderThenConnectionLoss, &scriptSenderThenAccept },
+    };
+    defer factory.deinit();
+
+    var authorizer = CountingAuthorizer{ .allocator = allocator };
+    defer authorizer.deinit();
+
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .authorizer = &authorizer.authorizer,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+
+    var sleeper = errors.Sleeper{ .sleepFn = noSleep };
+    var prng = std.Random.DefaultPrng.init(0);
+
+    var batch = try oneEventBatch(allocator);
+    defer batch.deinit(allocator);
+
+    const Op = struct {
+        connection: *RecoverableConnection,
+        allocator: Allocator,
+        batch: batching.EventDataBatch,
+
+        pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror!void {
+            const pool = try op.connection.senderPool();
+            return pool.send(op.allocator, test_target, op.batch) catch |err| {
+                pool.recordFailure(test_target, attempt);
+                return err;
+            };
+        }
+    };
+    var op = Op{ .connection = &connection, .allocator = allocator, .batch = batch };
+
+    const outcome = runWithRecovery(
+        void,
+        &connection,
+        test_target,
+        &op,
+        testRetryConfig(&sleeper, prng.random()),
+    );
+    try testing.expect(outcome == .ok);
+
+    try testing.expectEqual(@as(u64, 1), connection.recoveries);
+    try testing.expectEqual(@as(u64, 1), connection.generation);
+
+    // Twice: once per connection. A rebuilt connection carries no claims, so
+    // a link attaching on it without one is refused as unauthorized-access,
+    // which is fatal and would end the retry.
+    try testing.expectEqual(@as(usize, 2), authorizer.calls);
+    try testing.expectEqual(@as(usize, 2), authorizer.sessions.items.len);
+    try testing.expect(authorizer.sessions.items[0] != authorizer.sessions.items[1]);
+}
+
+test "a stale recovery request does not rebuild a second time" {
+    const allocator = testing.allocator;
+    var factory = ScriptedFactory{
+        .allocator = allocator,
+        .scripts = &.{ &scriptHandshakeOnly, &scriptHandshakeOnly },
+    };
+    defer factory.deinit();
+
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+
+    // Two callers read the same generation before either fails.
+    const first = try connection.ensureOpen();
+    const second = try connection.ensureOpen();
+    try testing.expectEqual(first, second);
+
+    try connection.recoverConnection(first);
+    try testing.expectEqual(@as(u64, 1), connection.recoveries);
+
+    // The second caller's connection no longer exists. Rebuilding again would
+    // throw away the healthy one the first caller just made — and there is no
+    // third script, so a second rebuild fails outright.
+    try connection.recoverConnection(second);
+    try testing.expectEqual(@as(u64, 1), connection.recoveries);
+    try testing.expectEqual(@as(u64, 1), connection.generation);
+}
+
+test "a closed connection refuses to reopen" {
+    const allocator = testing.allocator;
+    var factory = ScriptedFactory{
+        .allocator = allocator,
+        .scripts = &.{&scriptHandshakeOnly},
+    };
+    defer factory.deinit();
+
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    _ = try connection.ensureOpen();
+    connection.deinit();
+
+    try testing.expectError(RecoveryError.ConnectionClosedPermanently, connection.ensureOpen());
+    try testing.expectError(RecoveryError.ConnectionClosedPermanently, connection.recoverConnection(0));
+}
+
+const test_source = "my-hub/ConsumerGroups/$default/Partitions/0";
+const test_receiver_link = test_source ++ "-receiver-eventhubs";
+
+fn scriptReceiverAttach(peer: Peer, handle: u32) !void {
+    try peer.push(0, .{ .attach = .{
+        .name = test_receiver_link,
+        .handle = handle,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+}
+
+fn pushEvent(allocator: Allocator, peer: Peer, handle: u32, id: u32, sequence_number: i64, body: []const u8) !void {
+    var annotations = [_]amqp.MapEntry{.{
+        .key = .{ .symbol = event_data.sequence_number_annotation },
+        .value = .{ .long = sequence_number },
+    }};
+    const bodies = [_][]const u8{body};
+    const payload = try amqp.encodeMessageAlloc(allocator, .{
+        .message_annotations = &annotations,
+        .body = .{ .data = &bodies },
+    });
+    defer allocator.free(payload);
+
+    const tag = [_]u8{@intCast(id)};
+    try peer.pushTransfer(0, .{
+        .handle = handle,
+        .delivery_id = id,
+        .delivery_tag = &tag,
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, payload);
+}
+
+/// One event, then the link is taken by another consumer.
+fn scriptReceiverThenStolen(allocator: Allocator, peer: Peer) anyerror!void {
+    try harness.scriptHandshake(peer, 512);
+    try scriptReceiverAttach(peer, 0);
+    try pushEvent(allocator, peer, 0, 0, 30, "before");
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{ .condition = "amqp:link:stolen", .description = "another receiver attached" },
+    } });
+}
+
+/// One event, an ordinary link recycle, then the reattach delivers more.
+fn scriptReceiverThenDetach(allocator: Allocator, peer: Peer) anyerror!void {
+    try harness.scriptHandshake(peer, 512);
+    try scriptReceiverAttach(peer, 0);
+    try pushEvent(allocator, peer, 0, 0, 40, "first");
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{ .condition = "amqp:link:detach-forced", .description = "recycling" },
+    } });
+    try scriptReceiverAttach(peer, 1);
+    try pushEvent(allocator, peer, 1, 1, 41, "second");
+    try pushEvent(allocator, peer, 1, 2, 42, "third");
+}
+
+const ReceiveOp = struct {
+    connection: *RecoverableConnection,
+    allocator: Allocator,
+    count: u32,
+
+    pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror![]event_data.ReceivedEventData {
+        const pool = try op.connection.receiverPool();
+        return pool.receive(op.allocator, test_source, null, op.count) catch |err| {
+            pool.recordFailure(test_source, attempt);
+            return err;
+        };
+    }
+};
+
+/// Every selector expression the client attached with, in order.
+fn attachedFilters(allocator: Allocator, mem: *MemoryTransport) ![][]const u8 {
+    var frames = try harness.EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.attach) continue;
+        var decoded = try amqp.performative.decode(allocator, body);
+        defer decoded.deinit();
+        const source = decoded.performative.attach.source orelse continue;
+        const filters = source.filters orelse continue;
+        if (filters.len == 0) continue;
+        try out.append(allocator, try allocator.dupe(u8, filters[0].value.string));
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn freeFilters(allocator: Allocator, filters: [][]const u8) void {
+    for (filters) |f| allocator.free(f);
+    allocator.free(filters);
+}
+
+test "a stolen receiver link surfaces ownership lost and is not reattached" {
+    const allocator = testing.allocator;
+    var factory = ScriptedFactory{
+        .allocator = allocator,
+        .scripts = &.{&scriptReceiverThenStolen},
+    };
+    defer factory.deinit();
+
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+
+    var sleeper = errors.Sleeper{ .sleepFn = noSleep };
+    var prng = std.Random.DefaultPrng.init(0);
+
+    var op = ReceiveOp{ .connection = &connection, .allocator = allocator, .count = 2 };
+    const config = testRetryConfig(&sleeper, prng.random());
+
+    const first = runWithRecovery([]event_data.ReceivedEventData, &connection, test_source, &op, config);
+    try testing.expect(first == .ok);
+    event_data.freeReceivedEvents(allocator, first.ok);
+
+    const second = runWithRecovery([]event_data.ReceivedEventData, &connection, test_source, &op, config);
+    try testing.expect(second == .failed);
+    // The partition belongs to someone else now. Reattaching would steal it
+    // straight back, and the displaced consumer would never learn to stop.
+    try testing.expectEqual(errors.ErrorCode.ownership_lost, second.failed.info.code);
+    try testing.expectEqualStrings("amqp:link:stolen", second.failed.info.amqp_condition.?);
+    try testing.expectEqual(@as(u32, 1), second.failed.attempts);
+    try testing.expectEqual(@as(u64, 0), connection.link_recoveries);
+    try testing.expectEqual(@as(u64, 0), connection.recoveries);
+
+    const filters = try attachedFilters(allocator, factory.current().mem);
+    defer freeFilters(allocator, filters);
+    try testing.expectEqual(@as(usize, 1), filters.len);
+}
+
+test "a reattached receiver resumes from the last sequence number" {
+    const allocator = testing.allocator;
+    var factory = ScriptedFactory{
+        .allocator = allocator,
+        .scripts = &.{&scriptReceiverThenDetach},
+    };
+    defer factory.deinit();
+
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+
+    var sleeper = errors.Sleeper{ .sleepFn = noSleep };
+    var prng = std.Random.DefaultPrng.init(0);
+
+    var op = ReceiveOp{ .connection = &connection, .allocator = allocator, .count = 2 };
+    const config = testRetryConfig(&sleeper, prng.random());
+
+    // The link dies halfway through the batch. The one event that did arrive
+    // is still handed back rather than dropped on the floor.
+    const first = runWithRecovery([]event_data.ReceivedEventData, &connection, test_source, &op, config);
+    try testing.expect(first == .ok);
+    defer event_data.freeReceivedEvents(allocator, first.ok);
+    try testing.expectEqual(@as(usize, 1), first.ok.len);
+    try testing.expectEqualStrings("first", first.ok[0].body());
+
+    const second = runWithRecovery([]event_data.ReceivedEventData, &connection, test_source, &op, config);
+    try testing.expect(second == .ok);
+    defer event_data.freeReceivedEvents(allocator, second.ok);
+    try testing.expectEqual(@as(usize, 2), second.ok.len);
+    try testing.expectEqualStrings("second", second.ok[0].body());
+    try testing.expectEqualStrings("third", second.ok[1].body());
+    // A link-level fault: the connection itself was never rebuilt.
+    try testing.expectEqual(@as(u64, 1), connection.link_recoveries);
+    try testing.expectEqual(@as(u64, 0), connection.recoveries);
+
+    const filters = try attachedFilters(allocator, factory.current().mem);
+    defer freeFilters(allocator, filters);
+    try testing.expectEqual(@as(usize, 2), filters.len);
+    try testing.expectEqualStrings("amqp.annotation.x-opt-offset > '@latest'", filters[0]);
+    // Reattaching with the original filter would replay event 40, which the
+    // caller has already been given.
+    try testing.expectEqualStrings("amqp.annotation.x-opt-sequence-number > '40'", filters[1]);
+}

--- a/root.zig
+++ b/root.zig
@@ -77,6 +77,14 @@ pub const StartLocation = start_position_types.StartLocation;
 pub const EventPosition = start_position_types.EventPosition;
 pub const StartPositions = start_position_types.StartPositions;
 
+pub const recovery = @import("recovery.zig");
+pub const RecoverableConnection = recovery.RecoverableConnection;
+pub const ConnectionFactory = recovery.ConnectionFactory;
+pub const Plumbing = recovery.Plumbing;
+pub const Authorizer = recovery.Authorizer;
+pub const RecoveryError = recovery.RecoveryError;
+pub const runWithRecovery = recovery.runWithRecovery;
+
 pub const receiving = @import("receiver.zig");
 pub const PartitionClient = receiving.PartitionClient;
 pub const PartitionClientOptions = receiving.PartitionClientOptions;
@@ -132,13 +140,18 @@ pub const AmqpTransport = struct {
 /// client and session rather than opening them, because the connection and its
 /// CBS authorisation outlive any single operation and are owned by the caller.
 pub const LinkTransport = struct {
-    management_client: *amqp.Management,
+    /// Set when the caller manages the connection itself. Null when
+    /// `connection` provides it, since a rebuild replaces the client.
+    management_client: ?*amqp.Management = null,
     /// Sender links, attached on demand. Sending fails as unimplemented while
     /// this is null, which is what a metadata-only client wants.
     senders: ?*SenderPool = null,
     /// Receiver links, attached on demand. Null leaves receiving
     /// unimplemented, as for a producer-only or metadata-only client.
     receivers: ?*ReceiverPool = null,
+    /// When set, the transport owns neither the links nor the connection:
+    /// both come from here and are rebuilt when an operation says they broke.
+    connection: ?*RecoverableConnection = null,
     /// The CBS token for the hub audience. Event Hubs wants it on the message
     /// as well as on the link.
     security_token: ?[]const u8 = null,
@@ -148,10 +161,31 @@ pub const LinkTransport = struct {
     transport: AmqpTransport,
 
     pub fn init(management_client: *amqp.Management, options: Options) LinkTransport {
+        var self = initEmpty(options);
+        self.management_client = management_client;
+        self.senders = options.senders;
+        self.receivers = options.receivers;
+        return self;
+    }
+
+    /// Build a transport that recovers its own links and connection.
+    ///
+    /// Every operation runs under the retry schedule, because recovery is
+    /// pointless without one: rebuilding and then not retrying just returns
+    /// the original failure.
+    pub fn initRecoverable(
+        connection: *RecoverableConnection,
+        retry_config: errors.RetryConfig,
+        options: Options,
+    ) LinkTransport {
+        var self = initEmpty(options);
+        self.connection = connection;
+        self.retry = retry_config;
+        return self;
+    }
+
+    fn initEmpty(options: Options) LinkTransport {
         return .{
-            .management_client = management_client,
-            .senders = options.senders,
-            .receivers = options.receivers,
             .security_token = options.security_token,
             .deadline_ms = options.deadline_ms,
             .retry = options.retry,
@@ -181,17 +215,45 @@ pub const LinkTransport = struct {
     /// The broker's status and description for the most recent failed
     /// metadata operation, which a Zig error cannot carry.
     pub fn lastError(self: *LinkTransport) ?amqp.ManagementStatusError {
-        return self.management_client.last_error;
+        const client = self.managementClient() catch return null;
+        return client.last_error;
+    }
+
+    /// The management client to use, from the recoverable connection when
+    /// there is one.
+    fn managementClient(self: *LinkTransport) !*amqp.Management {
+        if (self.connection) |conn| return conn.managementClient();
+        return self.management_client orelse error.Unimplemented;
+    }
+
+    fn senderPool(self: *LinkTransport) !*SenderPool {
+        if (self.connection) |conn| return conn.senderPool();
+        return self.senders orelse error.Unimplemented;
+    }
+
+    fn receiverPool(self: *LinkTransport) !*ReceiverPool {
+        if (self.connection) |conn| return conn.receiverPool();
+        return self.receivers orelse error.Unimplemented;
     }
 
     /// Why the broker refused the most recent send.
     pub fn lastSendError(self: *LinkTransport) ?errors.EventHubsError {
-        const pool = self.senders orelse return null;
+        const pool = self.senderPool() catch return null;
         return pool.lastError();
     }
 
     fn sendBatchImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) !void {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
+
+        if (self.connection) |conn| {
+            const config = self.retry orelse return error.Unimplemented;
+            var op = SendOp{ .connection = conn, .allocator = allocator, .target = target, .batch = batch };
+            return switch (recovery.runWithRecovery(void, conn, target, &op, config)) {
+                .ok => {},
+                .failed => |failure| failure.err,
+            };
+        }
+
         const pool = self.senders orelse return error.Unimplemented;
         if (self.retry) |config| {
             return switch (pool.sendWithRetry(allocator, target, batch, config)) {
@@ -202,9 +264,46 @@ pub const LinkTransport = struct {
         return pool.send(allocator, target, batch);
     }
 
+    /// One send attempt against whichever sender pool the connection has now.
+    ///
+    /// The pool is fetched inside `call` rather than captured, because a
+    /// recovery between attempts replaces the links behind it.
+    const SendOp = struct {
+        connection: *RecoverableConnection,
+        allocator: std.mem.Allocator,
+        target: []const u8,
+        batch: EventDataBatch,
+
+        pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror!void {
+            const pool = try op.connection.senderPool();
+            return pool.send(op.allocator, op.target, op.batch) catch |err| {
+                pool.recordFailure(op.target, attempt);
+                return err;
+            };
+        }
+    };
+
+    /// One receive attempt against whichever receiver pool the connection has
+    /// now.
+    const ReceiveOp = struct {
+        connection: *RecoverableConnection,
+        allocator: std.mem.Allocator,
+        source: []const u8,
+        filter: ?[]const u8,
+        max_count: u32,
+
+        pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror![]ReceivedEventData {
+            const pool = try op.connection.receiverPool();
+            return pool.receive(op.allocator, op.source, op.filter, op.max_count) catch |err| {
+                pool.recordFailure(op.source, attempt);
+                return err;
+            };
+        }
+    };
+
     fn maxMessageSizeImpl(t: *AmqpTransport, address: []const u8) !?u64 {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
-        const pool = self.senders orelse return null;
+        const pool = self.senderPool() catch return null;
         return pool.maxMessageSize(address);
     }
 
@@ -213,13 +312,29 @@ pub const LinkTransport = struct {
     /// has already delivered, and reapplying the original filter would replay.
     fn receiveImpl(t: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) ![]ReceivedEventData {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
+
+        if (self.connection) |conn| {
+            const config = self.retry orelse return error.Unimplemented;
+            var op = ReceiveOp{
+                .connection = conn,
+                .allocator = allocator,
+                .source = source,
+                .filter = filter,
+                .max_count = max_count,
+            };
+            return switch (recovery.runWithRecovery([]ReceivedEventData, conn, source, &op, config)) {
+                .ok => |events| events,
+                .failed => |failure| failure.err,
+            };
+        }
+
         const pool = self.receivers orelse return error.Unimplemented;
         return pool.receive(allocator, source, filter, max_count);
     }
 
     /// Why the broker detached the receiver link for `source`.
     pub fn lastReceiveError(self: *LinkTransport, source: []const u8) ?errors.EventHubsError {
-        const pool = self.receivers orelse return null;
+        const pool = self.receiverPool() catch return null;
         return pool.lastError(source);
     }
 
@@ -228,7 +343,7 @@ pub const LinkTransport = struct {
         if (self.retry) |config| {
             return switch (management.getEventHubPropertiesWithRetry(
                 allocator,
-                self.management_client,
+                try self.managementClient(),
                 hub_name,
                 self.security_token,
                 self.deadline_ms,
@@ -240,7 +355,7 @@ pub const LinkTransport = struct {
         }
         return management.getEventHubProperties(
             allocator,
-            self.management_client,
+            try self.managementClient(),
             hub_name,
             self.security_token,
             self.deadline_ms,
@@ -252,7 +367,7 @@ pub const LinkTransport = struct {
         if (self.retry) |config| {
             return switch (management.getPartitionPropertiesWithRetry(
                 allocator,
-                self.management_client,
+                try self.managementClient(),
                 hub_name,
                 partition_id,
                 self.security_token,
@@ -265,7 +380,7 @@ pub const LinkTransport = struct {
         }
         return management.getPartitionProperties(
             allocator,
-            self.management_client,
+            try self.managementClient(),
             hub_name,
             partition_id,
             self.security_token,

--- a/sender.zig
+++ b/sender.zig
@@ -108,6 +108,42 @@ pub const SenderPool = struct {
         return sender;
     }
 
+    /// Detach the sender for `address` and forget it, so the next send
+    /// reattaches.
+    ///
+    /// `detach` is false when the session is already gone: writing a detach
+    /// into a dead connection would fail, and the link died with the session
+    /// regardless.
+    pub fn drop(self: *SenderPool, address: []const u8, detach: bool) void {
+        for (self.entries.items, 0..) |entry, i| {
+            if (!std.mem.eql(u8, entry.address, address)) continue;
+            if (detach) self.session.closeSender(entry.sender, self.deadline_ms);
+            self.allocator.free(entry.address);
+            _ = self.entries.orderedRemove(i);
+            self.last_rejection = null;
+            return;
+        }
+    }
+
+    /// Forget every sender.
+    pub fn dropAll(self: *SenderPool, detach: bool) void {
+        for (self.entries.items) |entry| {
+            if (detach) self.session.closeSender(entry.sender, self.deadline_ms);
+            self.allocator.free(entry.address);
+        }
+        self.entries.clearRetainingCapacity();
+        self.last_rejection = null;
+    }
+
+    /// Point the pool at a rebuilt session.
+    ///
+    /// The old session took its senders with it, so they are forgotten rather
+    /// than detached; detaching would write into a connection that is gone.
+    pub fn rebind(self: *SenderPool, session: *amqp.Session) void {
+        self.dropAll(false);
+        self.session = session;
+    }
+
     /// The largest transfer the broker will take on `address`, or null when it
     /// advertised no limit.
     pub fn maxMessageSize(self: *SenderPool, address: []const u8) !?u64 {
@@ -187,6 +223,22 @@ pub const SenderPool = struct {
         const rejection = self.last_rejection orelse return;
         attempt.condition = rejection.condition;
         attempt.description = rejection.description;
+    }
+
+    /// Describe why the send to `address` failed, so the retrier can classify
+    /// it.
+    ///
+    /// A rejection wins over a detach: the broker refused this specific
+    /// delivery, which is more precise than "the link went away".
+    pub fn recordFailure(self: *const SenderPool, address: []const u8, attempt: *errors.Attempt) void {
+        if (self.last_rejection != null) return self.recordCondition(attempt);
+        for (self.entries.items) |entry| {
+            if (!std.mem.eql(u8, entry.address, address)) continue;
+            const detached = entry.sender.detach_error orelse return;
+            attempt.condition = detached.condition;
+            attempt.description = detached.description;
+            return;
+        }
     }
 };
 


### PR DESCRIPTION
Closes #206.

A long-lived producer or consumer outlives the links it runs on. Brokers recycle links during upgrades and rebalances, and connections drop. Until now any of that surfaced to the caller as a hard failure.

`RecoverableConnection` owns the connection, its session, the management client, and both link pools, and rebuilds whatever the failure names as broken. `runWithRecovery` re-runs the operation on the rebuilt plumbing, following Go's `LinkRetrier`:

- `link` reattaches one link, after a single immediate retry
- `connection` rebuilds everything
- `fatal` is surfaced, so a consumer displaced with `amqp:link:stolen` stops instead of stealing its partition back

Also here:

- `recoverConnection` ignores a request naming a generation that is already gone, so two operations failing on the same dead connection rebuild it once — the port of `Namespace.Recover`'s connID check.
- Authorization runs before any link attaches. A rebuilt connection carries no CBS claims, and a link attaching without one is refused with `unauthorized-access`, which is fatal.
- `ReceiverPool` remembers each partition's selector when it drops a client, so a reattach resumes past the last sequence number the caller was given. Pools are rebound rather than rebuilt across a connection rebuild so that memory survives.
- A receive that fails partway through a batch now returns the events that did arrive. The old behaviour discarded them, which lost events; the next call finds the link dead and recovers it.
- Failures are copied onto the connection before recovery runs, because `Attempt.condition` borrows from the link that failed and recovering it frees the strings before the retrier classifies them.

138 tests. The generation check, the pre-attach authorization, and the position memory are each mutation-verified.