### PR TITLE
Register recovery.zig in azure_sdk_eventhubs publish paths

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -461,6 +461,7 @@ pub const all = [_]Package{
             "sender.zig",
             "position.zig",
             "receiver.zig",
+            "recovery.zig",
             "errors.zig",
             "checkpoint.zig",
             "checkpoint_store.zig",


### PR DESCRIPTION
Pairs with #288. A published file missing from `publish_paths` is absent from the tarball, so the package would not build as a dependency.