### PR TITLE
Add the Processor with balanced and greedy load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,72 @@ configured start position. For the same reason, a receive that fails partway
 through a batch returns the events that did arrive rather than discarding
 them; the next call finds the link dead and recovers it.
 
+## Distributed consumption
+
+A `Processor` spreads a hub's partitions across a fleet of consumers. Each
+processor claims what it is entitled to, opens a reader for it, and hands
+that reader to the caller; ownership lives in a `CheckpointStore`, so the
+fleet coordinates through storage rather than through each other.
+
+```zig
+var processor = consumer.newProcessor(
+    allocator,
+    &store.store,
+    opener.asOpener(),
+    .{ .load_balancing_strategy = .greedy },
+    &clock.clock,
+    prng.random(),
+);
+defer processor.deinit();
+
+while (running) {
+    try processor.runOnce();
+    while (processor.nextPartitionClient()) |partition| {
+        // read from `partition`, then `partition.updateCheckpoint(...)`
+    }
+    std.Thread.sleep(@intCast(processor.nextIntervalMs() * std.time.ns_per_ms));
+}
+```
+
+`runOnce` is one balancing cycle rather than a thread, so the caller owns
+the loop and its shutdown. `nextIntervalMs` applies Go's 0.8–1.3 jitter to
+the update interval, which keeps a fleet that started together from
+rebalancing in lockstep.
+
+Two strategies decide how fast a processor grows:
+
+- `balanced` (the default, as in Go) takes at most one partition per cycle,
+  so a fleet converges gradually and a restarting processor does not
+  stampede.
+- `greedy` takes its whole fair share at once, which is what Rust defaults
+  to and what a small, stable fleet wants.
+
+Both prefer a partition that is unowned, expired, or explicitly relinquished
+before stealing from a processor holding more than its share. The fair share
+is `partitions / owners`, plus one where the division is uneven. Selection
+among equally good candidates is random on purpose: every processor runs the
+same algorithm at the same instant, so list order would make them all race
+for the same partition.
+
+Ownership is a lease. It is renewed by re-claiming every cycle and expires
+after `partition_expiration_ms` (60s, as in Go and Rust), so a processor that
+dies is taken over rather than blocking its partitions forever. `deinit`
+relinquishes by writing an empty owner id, which the balancer treats as
+immediately available — a clean shutdown hands over in one cycle instead of
+one expiry.
+
+A reader starts where the checkpoint says, preferring offset over sequence
+number; failing that, at the per-partition start position; failing that, at
+the default. A checkpoint carrying neither offset nor sequence number is an
+error rather than a silent restart. When a geo-replicated namespace rejects
+a checkpointed offset — offsets there are per-replica and mean nothing after
+a failover — the reader restarts at earliest, inclusive: duplicates rather
+than a partition nobody can read.
+
+`InMemoryCheckpointStore` is a `CheckpointStore` held in memory, for tests
+and for running a fleet in one process. It is last-write-wins and does not
+model the etag race a real store arbitrates; `BlobCheckpointStore` does.
+
 Release branch: `sdk/eventhubs`. The package depends on `azure_sdk_core`,
 `azure_sdk_messaging_common`, `azure_sdk_storage_blobs`, `uamqp`, and `serde`
 and starts at `0.1.0`.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,6 +36,8 @@
         "position.zig",
         "receiver.zig",
         "recovery.zig",
+        "load_balancer.zig",
+        "processor.zig",
         "connection_options.zig",
         "errors.zig",
         "checkpoint.zig",

--- a/checkpoint.zig
+++ b/checkpoint.zig
@@ -95,6 +95,194 @@ pub const CheckpointStore = struct {
     }
 };
 
+/// A source of wall-clock time, so ownership expiry can be tested without
+/// sleeping.
+pub const Clock = struct {
+    nowMillisFn: *const fn (self: *Clock) i64,
+
+    pub fn nowMillis(self: *Clock) i64 {
+        return self.nowMillisFn(self);
+    }
+};
+
+/// The real clock.
+pub const SystemClock = struct {
+    clock: Clock = .{ .nowMillisFn = now },
+
+    fn now(_: *Clock) i64 {
+        return std.time.milliTimestamp();
+    }
+};
+
+/// A clock that only moves when told to.
+pub const ManualClock = struct {
+    millis: i64 = 1_000_000,
+    clock: Clock = .{ .nowMillisFn = now },
+
+    fn now(c: *Clock) i64 {
+        const self: *ManualClock = @fieldParentPtr("clock", c);
+        return self.millis;
+    }
+
+    pub fn advance(self: *ManualClock, ms: i64) void {
+        self.millis += ms;
+    }
+};
+
+/// Free an ownership record that was duplicated with `dupeOwnership`.
+pub fn freeOwned(allocator: std.mem.Allocator, ownership: PartitionOwnership) void {
+    ownership.deinit(allocator);
+}
+
+/// Copy an ownership record, substituting `owner_id`.
+pub fn dupeOwnership(
+    allocator: std.mem.Allocator,
+    source: PartitionOwnership,
+    owner_id: []const u8,
+) !PartitionOwnership {
+    var out: PartitionOwnership = .{
+        .fully_qualified_namespace = undefined,
+        .event_hub_name = undefined,
+        .consumer_group = undefined,
+        .partition_id = undefined,
+        .owner_id = undefined,
+        .last_modified_time = source.last_modified_time,
+    };
+    out.fully_qualified_namespace = try allocator.dupe(u8, source.fully_qualified_namespace);
+    errdefer allocator.free(out.fully_qualified_namespace);
+    out.event_hub_name = try allocator.dupe(u8, source.event_hub_name);
+    errdefer allocator.free(out.event_hub_name);
+    out.consumer_group = try allocator.dupe(u8, source.consumer_group);
+    errdefer allocator.free(out.consumer_group);
+    out.partition_id = try allocator.dupe(u8, source.partition_id);
+    errdefer allocator.free(out.partition_id);
+    out.owner_id = try allocator.dupe(u8, owner_id);
+    return out;
+}
+
+/// A `CheckpointStore` held entirely in memory.
+///
+/// Intended for tests and for running a processor fleet in one process. It is
+/// last-write-wins: it does not model the etag race a real store arbitrates,
+/// so two processors claiming the same partition in the same cycle both
+/// succeed rather than one losing.
+pub const InMemoryCheckpointStore = struct {
+    allocator: std.mem.Allocator,
+    ownerships: std.ArrayList(PartitionOwnership) = .empty,
+    checkpoints: std.ArrayList(Checkpoint) = .empty,
+    clock: *Clock,
+    store: CheckpointStore = .{
+        .claimOwnershipFn = claimOwnership,
+        .listOwnershipFn = listOwnership,
+        .updateCheckpointFn = updateCheckpoint,
+        .listCheckpointsFn = listCheckpoints,
+    },
+
+    pub fn deinit(self: *InMemoryCheckpointStore) void {
+        for (self.ownerships.items) |ownership| freeOwned(self.allocator, ownership);
+        self.ownerships.deinit(self.allocator);
+        for (self.checkpoints.items) |c| c.deinit(self.allocator);
+        self.checkpoints.deinit(self.allocator);
+    }
+
+    fn find(self: *InMemoryCheckpointStore, partition_id: []const u8) ?*PartitionOwnership {
+        for (self.ownerships.items) |*ownership| {
+            if (std.mem.eql(u8, ownership.partition_id, partition_id)) return ownership;
+        }
+        return null;
+    }
+
+    fn claimOwnership(
+        s: *CheckpointStore,
+        allocator: std.mem.Allocator,
+        requested: []const PartitionOwnership,
+    ) anyerror![]PartitionOwnership {
+        const self: *InMemoryCheckpointStore = @fieldParentPtr("store", s);
+        const now = @divFloor(self.clock.nowMillis(), std.time.ms_per_s);
+
+        var claimed: std.ArrayList(PartitionOwnership) = .empty;
+        errdefer {
+            for (claimed.items) |c| freeOwned(allocator, c);
+            claimed.deinit(allocator);
+        }
+
+        for (requested) |ownership| {
+            if (self.find(ownership.partition_id)) |existing| {
+                allocator.free(existing.owner_id);
+                existing.owner_id = try allocator.dupe(u8, ownership.owner_id);
+                existing.last_modified_time = now;
+            } else {
+                var stored = try dupeOwnership(allocator, ownership, ownership.owner_id);
+                stored.last_modified_time = now;
+                try self.ownerships.append(self.allocator, stored);
+            }
+            var out = try dupeOwnership(allocator, ownership, ownership.owner_id);
+            out.last_modified_time = now;
+            try claimed.append(allocator, out);
+        }
+        return claimed.toOwnedSlice(allocator);
+    }
+
+    fn listOwnership(
+        s: *CheckpointStore,
+        allocator: std.mem.Allocator,
+        _: []const u8,
+        _: []const u8,
+        _: []const u8,
+    ) anyerror![]PartitionOwnership {
+        const self: *InMemoryCheckpointStore = @fieldParentPtr("store", s);
+        const out = try allocator.alloc(PartitionOwnership, self.ownerships.items.len);
+        errdefer allocator.free(out);
+        for (out, self.ownerships.items) |*slot, stored| {
+            slot.* = try dupeOwnership(allocator, stored, stored.owner_id);
+        }
+        return out;
+    }
+
+    fn updateCheckpoint(s: *CheckpointStore, allocator: std.mem.Allocator, c: Checkpoint) anyerror!void {
+        const self: *InMemoryCheckpointStore = @fieldParentPtr("store", s);
+        _ = allocator;
+        for (self.checkpoints.items) |*existing| {
+            if (!std.mem.eql(u8, existing.partition_id, c.partition_id)) continue;
+            if (existing.offset) |offset| self.allocator.free(offset);
+            existing.offset = if (c.offset) |o| try self.allocator.dupe(u8, o) else null;
+            existing.sequence_number = c.sequence_number;
+            return;
+        }
+        try self.checkpoints.append(self.allocator, .{
+            .fully_qualified_namespace = try self.allocator.dupe(u8, c.fully_qualified_namespace),
+            .event_hub_name = try self.allocator.dupe(u8, c.event_hub_name),
+            .consumer_group = try self.allocator.dupe(u8, c.consumer_group),
+            .partition_id = try self.allocator.dupe(u8, c.partition_id),
+            .offset = if (c.offset) |o| try self.allocator.dupe(u8, o) else null,
+            .sequence_number = c.sequence_number,
+        });
+    }
+
+    fn listCheckpoints(
+        s: *CheckpointStore,
+        allocator: std.mem.Allocator,
+        _: []const u8,
+        _: []const u8,
+        _: []const u8,
+    ) anyerror![]Checkpoint {
+        const self: *InMemoryCheckpointStore = @fieldParentPtr("store", s);
+        const out = try allocator.alloc(Checkpoint, self.checkpoints.items.len);
+        errdefer allocator.free(out);
+        for (out, self.checkpoints.items) |*slot, stored| {
+            slot.* = .{
+                .fully_qualified_namespace = try allocator.dupe(u8, stored.fully_qualified_namespace),
+                .event_hub_name = try allocator.dupe(u8, stored.event_hub_name),
+                .consumer_group = try allocator.dupe(u8, stored.consumer_group),
+                .partition_id = try allocator.dupe(u8, stored.partition_id),
+                .offset = if (stored.offset) |o| try allocator.dupe(u8, o) else null,
+                .sequence_number = stored.sequence_number,
+            };
+        }
+        return out;
+    }
+};
+
 test "relinquished ownership is signalled by an empty owner id" {
     const relinquished = PartitionOwnership{
         .fully_qualified_namespace = "ns",

--- a/load_balancer.zig
+++ b/load_balancer.zig
@@ -1,0 +1,756 @@
+//! Distributed consumption: the `Processor` and its load balancer.
+//!
+//! One consumer per partition is the easy case. The hard case is a fleet of
+//! processors that has to agree on who reads what, survive members joining and
+//! leaving, and resume where the last owner stopped. Every SDK solves it the
+//! same way: ownership records in a shared store, claimed and renewed on a
+//! timer, with a balancing rule that converges on an even split.
+//!
+//! This is a port of Go's `processorLoadBalancer` (`processor_load_balancer.go`)
+//! and the start-position precedence in `processor.go`. Rust's
+//! `event_processor/processor.rs` has the same two strategies.
+//!
+//! Nothing here starts a thread. `runOnce` performs exactly one balancing
+//! cycle and the caller drives the loop, which keeps the whole algorithm
+//! testable against a fake clock and a seeded random source.
+
+const std = @import("std");
+const checkpoint_types = @import("checkpoint.zig");
+const errors = @import("errors.zig");
+const start_position_types = @import("position.zig");
+
+const Allocator = std.mem.Allocator;
+const Checkpoint = checkpoint_types.Checkpoint;
+const CheckpointStore = checkpoint_types.CheckpointStore;
+const PartitionOwnership = checkpoint_types.PartitionOwnership;
+const EventPosition = start_position_types.EventPosition;
+const StartPositions = start_position_types.StartPositions;
+
+/// How aggressively a processor claims partitions.
+pub const LoadBalancingStrategy = enum {
+    /// Claim at most one partition per cycle. Slower to converge, but a
+    /// restarting fleet does not thrash.
+    balanced,
+    /// Claim up to the fair share in a single cycle.
+    greedy,
+};
+
+/// Go's defaults. Rust uses a 30s interval and greedy; Go's are the more
+/// conservative pair and the ones the issue asks for.
+pub const default_update_interval_ms: i64 = 10_000;
+pub const default_partition_expiration_ms: i64 = 60_000;
+
+/// Jitter bounds applied to the loop interval, matching Go's retry jitter.
+pub const jitter_min = 0.8;
+pub const jitter_max = 1.3;
+
+pub const ProcessorOptions = struct {
+    load_balancing_strategy: LoadBalancingStrategy = .balanced,
+    /// How often ownership is re-evaluated and renewed.
+    update_interval_ms: i64 = default_update_interval_ms,
+    /// How long an unrenewed ownership stays valid. Must comfortably exceed
+    /// the update interval or a live owner expires between its own renewals.
+    partition_expiration_ms: i64 = default_partition_expiration_ms,
+    /// Where to start a partition that has no checkpoint.
+    start_positions: StartPositions = .{},
+    prefetch: i32 = 0,
+};
+
+/// Wall clock, injected so the expiry rules can be tested without waiting.
+/// A `Clock` over the system clock.
+pub const Clock = checkpoint_types.Clock;
+pub const SystemClock = checkpoint_types.SystemClock;
+
+/// Identifies the consumer group this processor balances within.
+pub const OwnershipDetails = struct {
+    fully_qualified_namespace: []const u8,
+    event_hub_name: []const u8,
+    consumer_group: []const u8,
+    /// This processor's identity, written into every ownership it claims.
+    client_id: []const u8,
+};
+
+/// The empty owner id a departing processor writes to release a partition.
+pub const relinquished_owner_id = "";
+
+/// What one balancing cycle decided, before anything is written.
+///
+/// Kept separate from the claim so the decision can be asserted directly:
+/// the claim's result depends on what the store accepts, which is a different
+/// question from what the algorithm asked for.
+pub const Plan = struct {
+    allocator: Allocator,
+    /// Ownerships to claim or renew this cycle.
+    requested: []PartitionOwnership,
+    /// What this processor already held, before the cycle.
+    held: usize,
+    /// The fair share this processor is allowed.
+    max_allowed: usize,
+    /// Whether the cycle decided to reach for more.
+    claim_more: bool,
+
+    pub fn deinit(self: *Plan) void {
+        for (self.requested) |ownership| freeOwned(self.allocator, ownership);
+        self.allocator.free(self.requested);
+    }
+
+    /// Whether `partition_id` is in the plan.
+    pub fn includes(self: Plan, partition_id: []const u8) bool {
+        for (self.requested) |ownership| {
+            if (std.mem.eql(u8, ownership.partition_id, partition_id)) return true;
+        }
+        return false;
+    }
+};
+
+const freeOwned = checkpoint_types.freeOwned;
+const dupeOwnership = checkpoint_types.dupeOwnership;
+
+/// Decides which partitions this processor should own.
+///
+/// Not thread safe, and not meant to be: one processor runs one balancer.
+pub const LoadBalancer = struct {
+    allocator: Allocator,
+    store: *CheckpointStore,
+    details: OwnershipDetails,
+    strategy: LoadBalancingStrategy = .balanced,
+    partition_expiration_ms: i64 = default_partition_expiration_ms,
+    clock: *Clock,
+    random: std.Random,
+
+    /// Work out what to claim this cycle, without claiming it.
+    pub fn plan(self: *LoadBalancer, partition_ids: []const []const u8) !Plan {
+        const existing = try self.store.listOwnership(
+            self.allocator,
+            self.details.fully_qualified_namespace,
+            self.details.event_hub_name,
+            self.details.consumer_group,
+        );
+        defer checkpoint_types.freeOwnerships(self.allocator, existing);
+
+        return self.planFrom(partition_ids, existing);
+    }
+
+    /// The algorithm proper, over an already-listed ownership set.
+    pub fn planFrom(
+        self: *LoadBalancer,
+        partition_ids: []const []const u8,
+        existing: []const PartitionOwnership,
+    ) !Plan {
+        const now = self.clock.nowMillis();
+
+        var seen: std.StringHashMapUnmanaged(void) = .empty;
+        defer seen.deinit(self.allocator);
+
+        // Owner id -> how many live partitions it holds. Every owner counts,
+        // including this one, because the fair share is per participant.
+        var by_owner: std.StringHashMapUnmanaged(usize) = .empty;
+        defer by_owner.deinit(self.allocator);
+        try by_owner.put(self.allocator, self.details.client_id, 0);
+
+        var available: std.ArrayList(PartitionOwnership) = .empty;
+        defer available.deinit(self.allocator);
+        var mine: std.ArrayList(PartitionOwnership) = .empty;
+        defer mine.deinit(self.allocator);
+        var others: std.ArrayList(PartitionOwnership) = .empty;
+        defer others.deinit(self.allocator);
+
+        for (existing) |ownership| {
+            try seen.put(self.allocator, ownership.partition_id, {});
+
+            // Expired first: a record whose owner stopped renewing is free
+            // regardless of whose name is on it.
+            const last_modified = ownership.last_modified_time orelse 0;
+            if (now - last_modified * std.time.ms_per_s > self.partition_expiration_ms) {
+                try available.append(self.allocator, ownership);
+                continue;
+            }
+            if (ownership.isRelinquished()) {
+                try available.append(self.allocator, ownership);
+                continue;
+            }
+
+            const gop = try by_owner.getOrPut(self.allocator, ownership.owner_id);
+            gop.value_ptr.* = if (gop.found_existing) gop.value_ptr.* + 1 else 1;
+
+            if (std.mem.eql(u8, ownership.owner_id, self.details.client_id)) {
+                try mine.append(self.allocator, ownership);
+            } else {
+                try others.append(self.allocator, ownership);
+            }
+        }
+
+        // Partitions nobody has ever owned have no record at all.
+        for (partition_ids) |id| {
+            if (seen.contains(id)) continue;
+            try available.append(self.allocator, .{
+                .fully_qualified_namespace = self.details.fully_qualified_namespace,
+                .event_hub_name = self.details.event_hub_name,
+                .consumer_group = self.details.consumer_group,
+                .partition_id = id,
+                .owner_id = self.details.client_id,
+            });
+        }
+
+        const owners = by_owner.count();
+        const min_required = partition_ids.len / owners;
+        const allow_extra = partition_ids.len % owners > 0;
+        var max_allowed = min_required;
+        // An extra partition is only allowed once the minimum is met.
+        // Otherwise a processor that is still below its share would defend a
+        // surplus it has no claim to.
+        if (allow_extra and mine.items.len >= min_required) max_allowed += 1;
+
+        // Only an owner *above* the fair share is worth stealing from.
+        var above_max: std.ArrayList(PartitionOwnership) = .empty;
+        defer above_max.deinit(self.allocator);
+        var owner_it = by_owner.iterator();
+        while (owner_it.next()) |entry| {
+            if (std.mem.eql(u8, entry.key_ptr.*, self.details.client_id)) continue;
+            if (entry.value_ptr.* <= max_allowed) continue;
+            for (others.items) |ownership| {
+                if (std.mem.eql(u8, ownership.owner_id, entry.key_ptr.*)) {
+                    try above_max.append(self.allocator, ownership);
+                }
+            }
+        }
+
+        var claim_more = true;
+        if (mine.items.len >= max_allowed) {
+            // Exactly right, or too many and expecting to be stolen from.
+            claim_more = false;
+        } else if (allow_extra and mine.items.len == max_allowed - 1) {
+            // One under, in the uneven case. Worth one more only if there is
+            // something to take that nobody is entitled to.
+            claim_more = available.items.len > 0 or above_max.items.len > 0;
+        }
+
+        var requested: std.ArrayList(PartitionOwnership) = .empty;
+        errdefer {
+            for (requested.items) |ownership| freeOwned(self.allocator, ownership);
+            requested.deinit(self.allocator);
+        }
+
+        // Renewing what is already held is the whole of the steady state:
+        // ownership expires unless it is re-claimed every cycle.
+        for (mine.items) |ownership| {
+            try requested.append(self.allocator, try dupeOwnership(
+                self.allocator,
+                ownership,
+                self.details.client_id,
+            ));
+        }
+
+        if (claim_more) {
+            const room = max_allowed - mine.items.len;
+            switch (self.strategy) {
+                .greedy => {
+                    // Free partitions first; stealing is a last resort even
+                    // when greedy.
+                    try self.takeRandom(&requested, available.items, room);
+                    if (requested.items.len < max_allowed) {
+                        try self.takeRandom(
+                            &requested,
+                            above_max.items,
+                            max_allowed - requested.items.len,
+                        );
+                    }
+                },
+                .balanced => {
+                    const pool = if (available.items.len > 0)
+                        available.items
+                    else
+                        above_max.items;
+                    try self.takeRandom(&requested, pool, @min(1, room));
+                },
+            }
+        }
+
+        return .{
+            .allocator = self.allocator,
+            .requested = try requested.toOwnedSlice(self.allocator),
+            .held = mine.items.len,
+            .max_allowed = max_allowed,
+            .claim_more = claim_more,
+        };
+    }
+
+    /// Take up to `count` from `pool`, at random and without repeats.
+    ///
+    /// Random because every processor runs the same algorithm at the same
+    /// moment: picking in list order would have them all reach for the same
+    /// partition and all but one lose the race, every cycle.
+    fn takeRandom(
+        self: *LoadBalancer,
+        out: *std.ArrayList(PartitionOwnership),
+        pool: []const PartitionOwnership,
+        count: usize,
+    ) !void {
+        if (count == 0 or pool.len == 0) return;
+
+        const indices = try self.allocator.alloc(usize, pool.len);
+        defer self.allocator.free(indices);
+        for (indices, 0..) |*index, i| index.* = i;
+        self.random.shuffle(usize, indices);
+
+        for (indices[0..@min(count, pool.len)]) |index| {
+            try out.append(self.allocator, try dupeOwnership(
+                self.allocator,
+                pool[index],
+                self.details.client_id,
+            ));
+        }
+    }
+
+    /// Plan and then claim, returning what the store accepted.
+    ///
+    /// Free the result with `freeOwnerships`. A partition lost to another
+    /// processor is simply absent, not an error.
+    pub fn loadBalance(
+        self: *LoadBalancer,
+        partition_ids: []const []const u8,
+    ) ![]PartitionOwnership {
+        var decided = try self.plan(partition_ids);
+        defer decided.deinit();
+        return self.store.claimOwnership(self.allocator, decided.requested);
+    }
+
+    /// Write an empty owner id for each partition, freeing it immediately.
+    ///
+    /// Without this a departing processor's partitions sit idle until they
+    /// expire, which is a minute of nobody reading them.
+    pub fn relinquish(self: *LoadBalancer, partition_ids: []const []const u8) !void {
+        if (partition_ids.len == 0) return;
+
+        const releases = try self.allocator.alloc(PartitionOwnership, partition_ids.len);
+        defer self.allocator.free(releases);
+
+        for (releases, partition_ids) |*release, id| {
+            release.* = .{
+                .fully_qualified_namespace = self.details.fully_qualified_namespace,
+                .event_hub_name = self.details.event_hub_name,
+                .consumer_group = self.details.consumer_group,
+                .partition_id = id,
+                .owner_id = relinquished_owner_id,
+            };
+        }
+
+        const claimed = try self.store.claimOwnership(self.allocator, releases);
+        checkpoint_types.freeOwnerships(self.allocator, claimed);
+    }
+
+    /// The next cycle's delay, jittered so a fleet does not synchronise.
+    pub fn nextIntervalMs(self: *LoadBalancer, update_interval_ms: i64) i64 {
+        const factor = jitter_min + self.random.float(f64) * (jitter_max - jitter_min);
+        const jittered: f64 = @as(f64, @floatFromInt(update_interval_ms)) * factor;
+        return @intFromFloat(jittered);
+    }
+};
+
+/// Where a partition should start reading.
+///
+/// Go's precedence, exactly: a checkpoint wins over everything, preferring
+/// offset to sequence number; then a per-partition configured position; then
+/// the default. A checkpoint that carries neither offset nor sequence number
+/// is corrupt and is reported rather than silently ignored, because starting
+/// over would replay the partition.
+pub const StartPositionError = error{InvalidCheckpoint};
+
+pub fn resolveStartPosition(
+    positions: StartPositions,
+    partition_id: []const u8,
+    stored: ?Checkpoint,
+) StartPositionError!EventPosition {
+    const found = stored orelse return positions.forPartition(partition_id);
+
+    if (found.offset) |offset| return EventPosition.fromOffset(offset, false);
+    if (found.sequence_number) |sequence| return EventPosition.fromSequenceNumber(sequence, false);
+    return StartPositionError.InvalidCheckpoint;
+}
+
+/// The position to fall back to when a namespace rejects a checkpointed
+/// offset.
+///
+/// A geo-replicated namespace has no meaningful integer offsets: they are
+/// per-replica, so one carried over from before a failover names nothing.
+/// Go restarts such a partition at earliest, inclusive, which replays rather
+/// than skips — duplicates being the acceptable failure here.
+pub const geo_replication_fallback = EventPosition{
+    .location = .earliest,
+    .is_inclusive = true,
+};
+
+/// The error a partition opener returns when the namespace refused the
+/// checkpointed offset. The processor turns it into the earliest-inclusive
+/// restart rather than giving up on the partition.
+pub const GeoReplicationOffsetRejected = error.GeoReplicationOffsetRejected;
+
+/// Whether an AMQP error condition says the namespace refused the offset.
+///
+/// Go keys this off the condition rather than a stable error code, because
+/// the condition is fatal for retry purposes and so has no code of its own.
+pub fn isGeoReplicationOffsetError(amqp_condition: ?[]const u8) bool {
+    const c = amqp_condition orelse return false;
+    return std.mem.eql(u8, c, geo_replication_condition);
+}
+
+/// The condition Event Hubs returns for an offset a replicated namespace
+/// cannot interpret.
+pub const geo_replication_condition = errors.condition.georeplication_invalid_offset;
+
+// ─────────────────────────── Tests ───────────────────────────
+
+const testing = std.testing;
+
+/// An in-memory `CheckpointStore` with last-write-wins claiming.
+///
+/// Enough to converge two processors, which is what the balancing rules are
+/// actually about; the blob store's etag races are its own tests' business.
+const TestClock = checkpoint_types.ManualClock;
+const MemoryStore = checkpoint_types.InMemoryCheckpointStore;
+
+const test_details = OwnershipDetails{
+    .fully_qualified_namespace = "ns.servicebus.windows.net",
+    .event_hub_name = "my-hub",
+    .consumer_group = "$Default",
+    .client_id = "processor-a",
+};
+
+const eight_partitions = [_][]const u8{ "0", "1", "2", "3", "4", "5", "6", "7" };
+
+fn ownedCount(store: *MemoryStore, owner_id: []const u8) usize {
+    var count: usize = 0;
+    for (store.ownerships.items) |ownership| {
+        if (std.mem.eql(u8, ownership.owner_id, owner_id)) count += 1;
+    }
+    return count;
+}
+
+test "greedy claims the whole fair share in one cycle" {
+    const allocator = testing.allocator;
+    var clock = TestClock{};
+    var store = MemoryStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+
+    var prng = std.Random.DefaultPrng.init(1);
+    var balancer = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = test_details,
+        .strategy = .greedy,
+        .clock = &clock.clock,
+        .random = prng.random(),
+    };
+
+    const claimed = try balancer.loadBalance(&eight_partitions);
+    defer checkpoint_types.freeOwnerships(allocator, claimed);
+
+    // Sole processor: the fair share is everything.
+    try testing.expectEqual(@as(usize, 8), claimed.len);
+}
+
+test "balanced claims one partition per cycle" {
+    const allocator = testing.allocator;
+    var clock = TestClock{};
+    var store = MemoryStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+
+    var prng = std.Random.DefaultPrng.init(1);
+    var balancer = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = test_details,
+        .strategy = .balanced,
+        .clock = &clock.clock,
+        .random = prng.random(),
+    };
+
+    for (1..5) |cycle| {
+        const claimed = try balancer.loadBalance(&eight_partitions);
+        defer checkpoint_types.freeOwnerships(allocator, claimed);
+        // One more each time, on top of everything already held: a renewal is
+        // a claim, so the total is the cycle number.
+        try testing.expectEqual(cycle, claimed.len);
+    }
+}
+
+/// Run two processors to convergence and report the split.
+fn converge(
+    allocator: Allocator,
+    strategy: LoadBalancingStrategy,
+    cycles: usize,
+) ![2]usize {
+    var clock = TestClock{};
+    var store = MemoryStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+
+    var prng_a = std.Random.DefaultPrng.init(7);
+    var prng_b = std.Random.DefaultPrng.init(11);
+
+    var a = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = test_details,
+        .strategy = strategy,
+        .clock = &clock.clock,
+        .random = prng_a.random(),
+    };
+    var details_b = test_details;
+    details_b.client_id = "processor-b";
+    var b = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = details_b,
+        .strategy = strategy,
+        .clock = &clock.clock,
+        .random = prng_b.random(),
+    };
+
+    for (0..cycles) |_| {
+        for ([_]*LoadBalancer{ &a, &b }) |balancer| {
+            const claimed = try balancer.loadBalance(&eight_partitions);
+            checkpoint_types.freeOwnerships(allocator, claimed);
+        }
+        // Well inside the expiration, so nothing is reclaimed as stale.
+        clock.advance(1_000);
+    }
+
+    return .{
+        ownedCount(&store, "processor-a"),
+        ownedCount(&store, "processor-b"),
+    };
+}
+
+test "two greedy processors converge on a four-four split" {
+    const split = try converge(testing.allocator, .greedy, 6);
+    try testing.expectEqual(@as(usize, 4), split[0]);
+    try testing.expectEqual(@as(usize, 4), split[1]);
+}
+
+test "two balanced processors converge on a four-four split" {
+    // Balanced takes one partition per cycle, so it needs more of them.
+    const split = try converge(testing.allocator, .balanced, 12);
+    try testing.expectEqual(@as(usize, 4), split[0]);
+    try testing.expectEqual(@as(usize, 4), split[1]);
+}
+
+test "an expired ownership is reclaimed and a live one is not" {
+    const allocator = testing.allocator;
+    var clock = TestClock{};
+    var store = MemoryStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+
+    const partitions = [_][]const u8{ "0", "1" };
+    const now_s = @divFloor(clock.millis, std.time.ms_per_s);
+    try store.ownerships.append(allocator, try dupeOwnership(allocator, .{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "0",
+        .owner_id = "processor-b",
+        // Stopped renewing two minutes ago.
+        .last_modified_time = now_s - 120,
+    }, "processor-b"));
+    try store.ownerships.append(allocator, try dupeOwnership(allocator, .{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "1",
+        .owner_id = "processor-b",
+        .last_modified_time = now_s,
+    }, "processor-b"));
+
+    var prng = std.Random.DefaultPrng.init(3);
+    var balancer = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = test_details,
+        .strategy = .greedy,
+        .clock = &clock.clock,
+        .random = prng.random(),
+    };
+
+    var decided = try balancer.plan(&partitions);
+    defer decided.deinit();
+
+    // Partition 0's owner is gone; partition 1's is alive and holds exactly
+    // its fair share, so taking it would only start a tug of war.
+    try testing.expect(decided.includes("0"));
+    try testing.expect(!decided.includes("1"));
+}
+
+test "a relinquished partition is available immediately" {
+    const allocator = testing.allocator;
+    var clock = TestClock{};
+    var store = MemoryStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+
+    const partitions = [_][]const u8{ "0", "1" };
+    const now_s = @divFloor(clock.millis, std.time.ms_per_s);
+    try store.ownerships.append(allocator, try dupeOwnership(allocator, .{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "0",
+        .owner_id = relinquished_owner_id,
+        // Freshly written, so only the empty owner id makes it available.
+        .last_modified_time = now_s,
+    }, relinquished_owner_id));
+
+    var prng = std.Random.DefaultPrng.init(5);
+    var balancer = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = test_details,
+        .strategy = .greedy,
+        .clock = &clock.clock,
+        .random = prng.random(),
+    };
+
+    var decided = try balancer.plan(&partitions);
+    defer decided.deinit();
+    try testing.expect(decided.includes("0"));
+}
+
+test "relinquishing hands the partition to the other processor" {
+    const allocator = testing.allocator;
+    var clock = TestClock{};
+    var store = MemoryStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+
+    const partitions = [_][]const u8{"0"};
+    var prng_a = std.Random.DefaultPrng.init(2);
+    var a = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = test_details,
+        .strategy = .greedy,
+        .clock = &clock.clock,
+        .random = prng_a.random(),
+    };
+    const first = try a.loadBalance(&partitions);
+    checkpoint_types.freeOwnerships(allocator, first);
+    try testing.expectEqual(@as(usize, 1), ownedCount(&store, "processor-a"));
+
+    try a.relinquish(&partitions);
+
+    var details_b = test_details;
+    details_b.client_id = "processor-b";
+    var prng_b = std.Random.DefaultPrng.init(4);
+    var b = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = details_b,
+        .strategy = .greedy,
+        .clock = &clock.clock,
+        .random = prng_b.random(),
+    };
+
+    // Without the relinquish this would wait out the full expiration, which
+    // is a minute of nobody reading the partition.
+    const second = try b.loadBalance(&partitions);
+    checkpoint_types.freeOwnerships(allocator, second);
+    try testing.expectEqual(@as(usize, 1), ownedCount(&store, "processor-b"));
+}
+
+test "a checkpoint beats the configured start position" {
+    const allocator = testing.allocator;
+    var positions = StartPositions{ .default = EventPosition.latest() };
+    defer positions.deinit(allocator);
+    try positions.put(allocator, "0", EventPosition.earliest());
+
+    const from_offset = try resolveStartPosition(positions, "0", .{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .offset = "12345",
+    });
+    try testing.expectEqualStrings("12345", from_offset.location.offset);
+    try testing.expect(!from_offset.is_inclusive);
+
+    // Offset wins over sequence number when a checkpoint carries both: it is
+    // the more precise of the two.
+    const both = try resolveStartPosition(positions, "0", .{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .offset = "999",
+        .sequence_number = 42,
+    });
+    try testing.expectEqualStrings("999", both.location.offset);
+
+    const from_sequence = try resolveStartPosition(positions, "0", .{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+        .sequence_number = 42,
+    });
+    try testing.expectEqual(@as(i64, 42), from_sequence.location.sequence_number);
+}
+
+test "the per-partition position beats the default" {
+    const allocator = testing.allocator;
+    var positions = StartPositions{ .default = EventPosition.latest() };
+    defer positions.deinit(allocator);
+    try positions.put(allocator, "0", EventPosition.earliest());
+
+    const configured = try resolveStartPosition(positions, "0", null);
+    try testing.expectEqual(start_position_types.StartLocation.earliest, configured.location);
+
+    const fallback = try resolveStartPosition(positions, "1", null);
+    try testing.expectEqual(start_position_types.StartLocation.latest, fallback.location);
+}
+
+test "a checkpoint with neither offset nor sequence number is rejected" {
+    // Silently starting over would replay the whole partition, which is worse
+    // than telling the caller their store is corrupt.
+    try testing.expectError(StartPositionError.InvalidCheckpoint, resolveStartPosition(.{}, "0", .{
+        .fully_qualified_namespace = "ns",
+        .event_hub_name = "hub",
+        .consumer_group = "$Default",
+        .partition_id = "0",
+    }));
+}
+
+test "a geo-replication offset rejection falls back to inclusive earliest" {
+    try testing.expect(isGeoReplicationOffsetError(geo_replication_condition));
+    try testing.expect(!isGeoReplicationOffsetError(null));
+    try testing.expectEqual(start_position_types.StartLocation.earliest, geo_replication_fallback.location);
+    // Inclusive, so the event the offset named is replayed rather than lost.
+    try testing.expect(geo_replication_fallback.is_inclusive);
+
+    try testing.expect(!isGeoReplicationOffsetError("amqp:link:detach-forced"));
+}
+
+test "the loop interval is jittered within Go's bounds" {
+    const allocator = testing.allocator;
+    var clock = TestClock{};
+    var store = MemoryStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+
+    var prng = std.Random.DefaultPrng.init(9);
+    var balancer = LoadBalancer{
+        .allocator = allocator,
+        .store = &store.store,
+        .details = test_details,
+        .clock = &clock.clock,
+        .random = prng.random(),
+    };
+
+    // A fleet that all restarted together would otherwise balance in
+    // lockstep, and every cycle would be a race nobody needs to run.
+    var saw_below: bool = false;
+    var saw_above: bool = false;
+    for (0..200) |_| {
+        const interval = balancer.nextIntervalMs(10_000);
+        try testing.expect(interval >= 8_000);
+        try testing.expect(interval <= 13_000);
+        if (interval < 10_000) saw_below = true;
+        if (interval > 10_000) saw_above = true;
+    }
+    try testing.expect(saw_below);
+    try testing.expect(saw_above);
+}

--- a/processor.zig
+++ b/processor.zig
@@ -1,0 +1,686 @@
+//! The `Processor`: distributed consumption over a fleet.
+//!
+//! One balancing cycle claims what this processor is entitled to, opens a
+//! reader for anything newly claimed, and closes anything lost. The caller
+//! drives the loop, so there is no thread here and nothing to shut down
+//! except the readers themselves.
+//!
+//! Ported from Go's `Processor` (`processor.go`), minus its goroutine
+//! plumbing: `runOnce` is the body of Go's `Run` loop, and
+//! `nextPartitionClient` is `NextPartitionClient`.
+
+const std = @import("std");
+const checkpoint_types = @import("checkpoint.zig");
+const errors = @import("errors.zig");
+const event_data = @import("event_data.zig");
+const balancing = @import("load_balancer.zig");
+const receiving = @import("receiver.zig");
+const start_position_types = @import("position.zig");
+
+const Allocator = std.mem.Allocator;
+const Checkpoint = checkpoint_types.Checkpoint;
+const CheckpointStore = checkpoint_types.CheckpointStore;
+const EventPosition = start_position_types.EventPosition;
+const LoadBalancer = balancing.LoadBalancer;
+const OwnershipDetails = balancing.OwnershipDetails;
+const PartitionClient = receiving.PartitionClient;
+const PartitionClientOptions = receiving.PartitionClientOptions;
+const ProcessorOptions = balancing.ProcessorOptions;
+const ReceivedEventData = event_data.ReceivedEventData;
+
+/// Opens and closes partition readers on the processor's behalf.
+///
+/// A vtable rather than a `ConsumerClient` for the same reason recovery uses
+/// one: `root.zig` imports this file, so this file cannot import `root.zig`.
+/// It also lets the balancing loop be tested without an AMQP peer.
+pub const PartitionOpener = struct {
+    partitionIdsFn: *const fn (self: *PartitionOpener, allocator: Allocator) anyerror![][]const u8,
+    openFn: *const fn (
+        self: *PartitionOpener,
+        allocator: Allocator,
+        partition_id: []const u8,
+        position: EventPosition,
+        options: PartitionClientOptions,
+    ) anyerror!*PartitionClient,
+    closeFn: *const fn (self: *PartitionOpener, client: *PartitionClient) void,
+
+    /// The hub's partition ids. Caller owns the slice and its strings.
+    pub fn partitionIds(self: *PartitionOpener, allocator: Allocator) ![][]const u8 {
+        return self.partitionIdsFn(self, allocator);
+    }
+
+    pub fn open(
+        self: *PartitionOpener,
+        allocator: Allocator,
+        partition_id: []const u8,
+        position: EventPosition,
+        options: PartitionClientOptions,
+    ) !*PartitionClient {
+        return self.openFn(self, allocator, partition_id, position, options);
+    }
+
+    pub fn close(self: *PartitionOpener, client: *PartitionClient) void {
+        self.closeFn(self, client);
+    }
+};
+
+pub fn freePartitionIds(allocator: Allocator, ids: [][]const u8) void {
+    for (ids) |id| allocator.free(id);
+    allocator.free(ids);
+}
+
+/// A reader for one claimed partition, plus the checkpointing that goes with
+/// it.
+pub const ProcessorPartitionClient = struct {
+    allocator: Allocator,
+    /// Owned: the ownership record it came from does not outlive the cycle.
+    partition_id: []u8,
+    client: *PartitionClient,
+    store: *CheckpointStore,
+    details: OwnershipDetails,
+    opener: *PartitionOpener,
+    /// Set when the broker says another processor took the partition. The
+    /// processor releases rather than retries: the whole point of an owner
+    /// level is that the newer reader wins.
+    ownership_lost: bool = false,
+
+    pub fn partitionId(self: *const ProcessorPartitionClient) []const u8 {
+        return self.partition_id;
+    }
+
+    /// Receive up to `count` events. Free the result with
+    /// `freeReceivedEvents`.
+    pub fn receiveEvents(
+        self: *ProcessorPartitionClient,
+        allocator: Allocator,
+        count: u32,
+    ) ![]ReceivedEventData {
+        return self.client.receiveEvents(allocator, count) catch |err| {
+            if (self.client.last_error) |info| {
+                if (info.code == .ownership_lost) self.ownership_lost = true;
+            }
+            return err;
+        };
+    }
+
+    /// Record `event` as processed, so a later owner resumes after it.
+    pub fn updateCheckpoint(
+        self: *ProcessorPartitionClient,
+        allocator: Allocator,
+        event: ReceivedEventData,
+    ) !void {
+        return self.store.updateCheckpoint(allocator, .{
+            .fully_qualified_namespace = self.details.fully_qualified_namespace,
+            .event_hub_name = self.details.event_hub_name,
+            .consumer_group = self.details.consumer_group,
+            .partition_id = self.partition_id,
+            .offset = event.offset,
+            .sequence_number = event.sequence_number,
+        });
+    }
+
+    pub fn close(self: *ProcessorPartitionClient) void {
+        self.opener.close(self.client);
+        self.allocator.free(self.partition_id);
+    }
+};
+
+pub const Processor = struct {
+    allocator: Allocator,
+    store: *CheckpointStore,
+    opener: *PartitionOpener,
+    details: OwnershipDetails,
+    options: ProcessorOptions = .{},
+    balancer: LoadBalancer,
+    /// Readers keyed by partition id. The key is the client's owned id, so
+    /// the map borrows and the client frees.
+    clients: std.StringArrayHashMapUnmanaged(*ProcessorPartitionClient) = .empty,
+    /// Newly opened readers waiting to be handed out.
+    pending: std.ArrayList(*ProcessorPartitionClient) = .empty,
+    deadline_ms: i64 = 60_000,
+
+    pub fn init(
+        allocator: Allocator,
+        store: *CheckpointStore,
+        opener: *PartitionOpener,
+        details: OwnershipDetails,
+        options: ProcessorOptions,
+        clock: *balancing.Clock,
+        random: std.Random,
+    ) Processor {
+        return .{
+            .allocator = allocator,
+            .store = store,
+            .opener = opener,
+            .details = details,
+            .options = options,
+            .balancer = .{
+                .allocator = allocator,
+                .store = store,
+                .details = details,
+                .strategy = options.load_balancing_strategy,
+                .partition_expiration_ms = options.partition_expiration_ms,
+                .clock = clock,
+                .random = random,
+            },
+        };
+    }
+
+    /// Close every reader and drop the ownership records.
+    ///
+    /// Relinquishing is best effort: a processor whose store has gone away
+    /// still has to stop cleanly, and the records expire on their own.
+    pub fn deinit(self: *Processor) void {
+        var held: std.ArrayList([]const u8) = .empty;
+        defer held.deinit(self.allocator);
+        for (self.clients.keys()) |id| held.append(self.allocator, id) catch {};
+        self.balancer.relinquish(held.items) catch {};
+
+        for (self.clients.values()) |client| {
+            client.close();
+            self.allocator.destroy(client);
+        }
+        self.clients.deinit(self.allocator);
+        self.pending.deinit(self.allocator);
+    }
+
+    /// One balancing cycle: claim, renew, open, and release.
+    pub fn runOnce(self: *Processor) !void {
+        const partition_ids = try self.opener.partitionIds(self.allocator);
+        defer freePartitionIds(self.allocator, partition_ids);
+
+        const claimed = try self.balancer.loadBalance(partition_ids);
+        defer checkpoint_types.freeOwnerships(self.allocator, claimed);
+
+        try self.releaseUnclaimed(claimed);
+
+        const checkpoints = try self.store.listCheckpoints(
+            self.allocator,
+            self.details.fully_qualified_namespace,
+            self.details.event_hub_name,
+            self.details.consumer_group,
+        );
+        defer checkpoint_types.freeCheckpoints(self.allocator, checkpoints);
+
+        for (claimed) |ownership| {
+            if (self.clients.contains(ownership.partition_id)) continue;
+            try self.openPartition(ownership.partition_id, checkpoints);
+        }
+    }
+
+    /// Close readers for partitions this cycle did not keep.
+    ///
+    /// Also covers a reader that reported ownership lost: it is no longer in
+    /// the claim, and holding the link open would keep stealing the partition
+    /// back from whoever took it.
+    fn releaseUnclaimed(self: *Processor, claimed: []const checkpoint_types.PartitionOwnership) !void {
+        var dropped: std.ArrayList([]const u8) = .empty;
+        defer dropped.deinit(self.allocator);
+
+        for (self.clients.keys(), self.clients.values()) |id, client| {
+            var kept = false;
+            for (claimed) |ownership| {
+                if (std.mem.eql(u8, ownership.partition_id, id)) {
+                    kept = true;
+                    break;
+                }
+            }
+            if (kept and !client.ownership_lost) continue;
+            try dropped.append(self.allocator, id);
+        }
+
+        for (dropped.items) |id| self.releasePartition(id);
+    }
+
+    fn releasePartition(self: *Processor, partition_id: []const u8) void {
+        const client = self.clients.get(partition_id) orelse return;
+
+        var i: usize = 0;
+        while (i < self.pending.items.len) {
+            if (self.pending.items[i] == client) {
+                _ = self.pending.orderedRemove(i);
+                continue;
+            }
+            i += 1;
+        }
+        _ = self.clients.orderedRemove(partition_id);
+        client.close();
+        self.allocator.destroy(client);
+    }
+
+    fn openPartition(self: *Processor, partition_id: []const u8, checkpoints: []const Checkpoint) !void {
+        var stored: ?Checkpoint = null;
+        for (checkpoints) |c| {
+            if (std.mem.eql(u8, c.partition_id, partition_id)) stored = c;
+        }
+
+        const position = try balancing.resolveStartPosition(
+            self.options.start_positions,
+            partition_id,
+            stored,
+        );
+
+        const options: PartitionClientOptions = .{ .prefetch = self.options.prefetch };
+        const client = blk: {
+            break :blk self.opener.open(self.allocator, partition_id, position, options) catch |err| {
+                // A replicated namespace cannot interpret an offset carried
+                // over from before a failover. Go restarts at earliest,
+                // inclusive: duplicates, rather than a partition nobody can
+                // read at all.
+                if (err != error.GeoReplicationOffsetRejected) return err;
+                break :blk try self.opener.open(
+                    self.allocator,
+                    partition_id,
+                    balancing.geo_replication_fallback,
+                    options,
+                );
+            };
+        };
+
+        const owned_id = try self.allocator.dupe(u8, partition_id);
+        errdefer self.allocator.free(owned_id);
+
+        const wrapper = try self.allocator.create(ProcessorPartitionClient);
+        errdefer self.allocator.destroy(wrapper);
+        wrapper.* = .{
+            .allocator = self.allocator,
+            .partition_id = owned_id,
+            .client = client,
+            .store = self.store,
+            .details = self.details,
+            .opener = self.opener,
+        };
+
+        try self.clients.put(self.allocator, owned_id, wrapper);
+        errdefer _ = self.clients.orderedRemove(owned_id);
+        try self.pending.append(self.allocator, wrapper);
+    }
+
+    /// The next newly claimed partition, or null when there is none.
+    ///
+    /// The processor keeps owning the reader: it has to close it when the
+    /// partition is lost, which the caller cannot know about.
+    pub fn nextPartitionClient(self: *Processor) ?*ProcessorPartitionClient {
+        if (self.pending.items.len == 0) return null;
+        return self.pending.orderedRemove(0);
+    }
+
+    /// Partitions this processor currently reads.
+    pub fn ownedPartitions(self: *const Processor) []const []const u8 {
+        return self.clients.keys();
+    }
+
+    /// The next cycle's delay, jittered.
+    pub fn nextIntervalMs(self: *Processor) i64 {
+        return self.balancer.nextIntervalMs(self.options.update_interval_ms);
+    }
+};
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+const InMemoryCheckpointStore = checkpoint_types.InMemoryCheckpointStore;
+const ManualClock = checkpoint_types.ManualClock;
+
+/// A `PartitionOpener` that records what it was asked for instead of
+/// attaching a link.
+///
+/// The `PartitionClient` it hands back is never read from: the processor only
+/// stores it and passes it back to `close`. That is exactly the surface the
+/// balancing loop uses, so a fake is enough to test the loop without a peer.
+const FakeOpener = struct {
+    allocator: Allocator,
+    partitions: []const []const u8,
+    /// Every position the processor asked to open at, in order.
+    opened: std.ArrayList(Opened) = .empty,
+    closed: usize = 0,
+    /// Reject an offset once, as a geo-replicated namespace does.
+    reject_offsets: bool = false,
+    opener: PartitionOpener = .{
+        .partitionIdsFn = partitionIds,
+        .openFn = open,
+        .closeFn = close,
+    },
+
+    const Opened = struct {
+        partition_id: []u8,
+        position: EventPosition,
+        /// An owned copy: the position's offset is borrowed from the
+        /// checkpoint list, which the cycle frees before the test looks.
+        offset: ?[]u8,
+    };
+
+    fn deinit(self: *FakeOpener) void {
+        for (self.opened.items) |o| {
+            self.allocator.free(o.partition_id);
+            if (o.offset) |offset| self.allocator.free(offset);
+        }
+        self.opened.deinit(self.allocator);
+    }
+
+    fn positionFor(self: *FakeOpener, partition_id: []const u8) ?EventPosition {
+        var found: ?EventPosition = null;
+        for (self.opened.items) |o| {
+            if (std.mem.eql(u8, o.partition_id, partition_id)) found = o.position;
+        }
+        return found;
+    }
+
+    fn partitionIds(o: *PartitionOpener, allocator: Allocator) anyerror![][]const u8 {
+        const self: *FakeOpener = @fieldParentPtr("opener", o);
+        const ids = try allocator.alloc([]const u8, self.partitions.len);
+        errdefer allocator.free(ids);
+        for (ids, self.partitions) |*slot, id| slot.* = try allocator.dupe(u8, id);
+        return ids;
+    }
+
+    fn open(
+        o: *PartitionOpener,
+        allocator: Allocator,
+        partition_id: []const u8,
+        position: EventPosition,
+        _: PartitionClientOptions,
+    ) anyerror!*PartitionClient {
+        const self: *FakeOpener = @fieldParentPtr("opener", o);
+        const id = try self.allocator.dupe(u8, partition_id);
+        const offset = switch (position.location) {
+            .offset => |token| try self.allocator.dupe(u8, token),
+            else => null,
+        };
+        // No errdefer: the record outlives a rejected open, which is the
+        // whole point of recording it.
+        self.opened.append(self.allocator, .{
+            .partition_id = id,
+            .position = position,
+            .offset = offset,
+        }) catch |err| {
+            self.allocator.free(id);
+            if (offset) |token| self.allocator.free(token);
+            return err;
+        };
+
+        if (self.reject_offsets and position.location == .offset) {
+            return error.GeoReplicationOffsetRejected;
+        }
+
+        const client = try allocator.create(PartitionClient);
+        client.* = .{
+            .allocator = allocator,
+            .receiver = undefined,
+            .filter_expression = &.{},
+            .prefetch = 0,
+            .owner_level = null,
+            .deadline_ms = 0,
+        };
+        return client;
+    }
+
+    fn close(o: *PartitionOpener, client: *PartitionClient) void {
+        const self: *FakeOpener = @fieldParentPtr("opener", o);
+        self.closed += 1;
+        client.allocator.destroy(client);
+    }
+};
+
+const test_details = OwnershipDetails{
+    .fully_qualified_namespace = "ns.servicebus.windows.net",
+    .event_hub_name = "my-hub",
+    .consumer_group = "$Default",
+    .client_id = "processor-a",
+};
+
+test "a cycle opens a reader for every partition it claims, exactly once" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{ "0", "1" } };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(7);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), processor.ownedPartitions().len);
+    try testing.expectEqual(@as(usize, 2), opener.opened.items.len);
+
+    // Renewal must not reopen: the link is already attached, and dropping it
+    // every ten seconds would replay from the last checkpoint each time.
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), opener.opened.items.len);
+    try testing.expectEqual(@as(usize, 0), opener.closed);
+}
+
+test "each claimed partition is handed out once" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{ "0", "1" } };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(3);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+
+    var seen: usize = 0;
+    while (processor.nextPartitionClient()) |client| : (seen += 1) {
+        try testing.expect(client.partitionId().len > 0);
+    }
+    try testing.expectEqual(@as(usize, 2), seen);
+    // A second drain yields nothing: the reader is already the caller's.
+    try testing.expect(processor.nextPartitionClient() == null);
+}
+
+test "a reader that lost ownership is closed rather than reused" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{"0"} };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(11);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const first = processor.nextPartitionClient().?;
+
+    // Set directly rather than through `receiveEvents`, which would need a
+    // live link. The flag is what the receive path sets on `amqp:link:stolen`.
+    first.ownership_lost = true;
+
+    try processor.runOnce();
+
+    // The link is gone, so the reader must be too. Go drops the client and
+    // lets the next cycle decide; because the store still says the partition
+    // is ours, that means a fresh reader rather than the dead one.
+    try testing.expectEqual(@as(usize, 1), opener.closed);
+    try testing.expectEqual(@as(usize, 2), opener.opened.items.len);
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+
+    const second = processor.nextPartitionClient().?;
+    try testing.expect(!second.ownership_lost);
+}
+
+test "a partition claimed by another processor is released" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{"0"} };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(19);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+
+    const stolen = [_]checkpoint_types.PartitionOwnership{.{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "0",
+        .owner_id = "processor-b",
+    }};
+    const taken = try store.store.claimOwnership(allocator, &stolen);
+    checkpoint_types.freeOwnerships(allocator, taken);
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+    try testing.expectEqual(@as(usize, 1), opener.closed);
+}
+
+test "a rejected offset reopens at earliest, inclusive" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    try store.store.updateCheckpoint(allocator, .{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "0",
+        .offset = "12345",
+    });
+
+    var opener = FakeOpener{
+        .allocator = allocator,
+        .partitions = &.{"0"},
+        .reject_offsets = true,
+    };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(5);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+
+    try testing.expectEqual(@as(usize, 2), opener.opened.items.len);
+    try testing.expectEqualStrings("12345", opener.opened.items[0].offset.?);
+    const retried = opener.opened.items[1].position;
+    try testing.expectEqual(start_position_types.StartLocation.earliest, retried.location);
+    try testing.expect(retried.is_inclusive);
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+}
+
+test "the checkpoint decides where a reader starts" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    try store.store.updateCheckpoint(allocator, .{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "1",
+        .sequence_number = 99,
+    });
+
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{ "0", "1" } };
+    defer opener.deinit();
+
+    var positions = start_position_types.StartPositions{
+        .default = EventPosition.earliest(),
+    };
+    defer positions.deinit(allocator);
+
+    var random = std.Random.DefaultPrng.init(13);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy, .start_positions = positions },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+
+    // The checkpointed partition resumes after event 99; the other falls
+    // through to the configured default.
+    const resumed = opener.positionFor("1").?;
+    try testing.expectEqual(@as(i64, 99), resumed.location.sequence_number);
+    try testing.expect(!resumed.is_inclusive);
+    try testing.expectEqual(
+        start_position_types.StartLocation.earliest,
+        opener.positionFor("0").?.location,
+    );
+}
+
+test "shutdown relinquishes every partition it held" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{ "0", "1" } };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(17);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), processor.ownedPartitions().len);
+    processor.deinit();
+
+    try testing.expectEqual(@as(usize, 2), opener.closed);
+    for (store.ownerships.items) |ownership| {
+        try testing.expect(ownership.isRelinquished());
+    }
+}

--- a/root.zig
+++ b/root.zig
@@ -86,6 +86,24 @@ pub const TlsSettings = connection_options.TlsSettings;
 pub const WebSocketHook = connection_options.WebSocketHook;
 pub const AmqpConnectionFactory = connection_options.AmqpConnectionFactory;
 
+// The processor. Named for the file: `processor` reads better as a local.
+pub const processing = @import("processor.zig");
+pub const Processor = processing.Processor;
+pub const ProcessorPartitionClient = processing.ProcessorPartitionClient;
+pub const PartitionOpener = processing.PartitionOpener;
+pub const freePartitionIds = processing.freePartitionIds;
+
+// Load balancing. Named for the file: `balancer` reads better as a local.
+pub const load_balancing = @import("load_balancer.zig");
+pub const LoadBalancer = load_balancing.LoadBalancer;
+pub const LoadBalancingStrategy = load_balancing.LoadBalancingStrategy;
+pub const ProcessorOptions = load_balancing.ProcessorOptions;
+pub const OwnershipDetails = load_balancing.OwnershipDetails;
+pub const resolveStartPosition = load_balancing.resolveStartPosition;
+pub const isGeoReplicationOffsetError = load_balancing.isGeoReplicationOffsetError;
+pub const geo_replication_fallback = load_balancing.geo_replication_fallback;
+pub const relinquished_owner_id = load_balancing.relinquished_owner_id;
+
 pub const recovery = @import("recovery.zig");
 pub const RecoverableConnection = recovery.RecoverableConnection;
 pub const ConnectionFactory = recovery.ConnectionFactory;
@@ -847,6 +865,37 @@ pub const ConsumerClient = struct {
         }, options);
     }
 
+    /// A `PartitionOpener` over this client and one session.
+    ///
+    /// This is what a `Processor` reads through: it knows partition ids and
+    /// how to attach a reader, which is everything the balancing loop needs
+    /// from a connection.
+    pub fn partitionOpener(
+        self: *ConsumerClient,
+        session: *amqp.Session,
+        deadline_ms: i64,
+    ) ConsumerPartitionOpener {
+        return .{ .client = self, .session = session, .deadline_ms = deadline_ms };
+    }
+
+    /// Build a processor that reads this hub through `opener`.
+    pub fn newProcessor(
+        self: *ConsumerClient,
+        allocator: std.mem.Allocator,
+        store: *CheckpointStore,
+        opener: *PartitionOpener,
+        options: ProcessorOptions,
+        clock: *load_balancing.Clock,
+        random: std.Random,
+    ) Processor {
+        return Processor.init(allocator, store, opener, .{
+            .fully_qualified_namespace = self.options.fully_qualified_namespace,
+            .event_hub_name = self.options.event_hub_name,
+            .consumer_group = self.options.consumer_group,
+            .client_id = self.instanceId(),
+        }, options, clock, random);
+    }
+
     /// Receive events from a specific partition.
     ///
     /// A one-shot convenience over the transport. Use `newPartitionClient`
@@ -887,7 +936,98 @@ pub const ConsumerClient = struct {
     }
 };
 
+/// A `PartitionOpener` backed by a `ConsumerClient` and one session.
+pub const ConsumerPartitionOpener = struct {
+    client: *ConsumerClient,
+    session: *amqp.Session,
+    deadline_ms: i64,
+    opener: PartitionOpener = .{
+        .partitionIdsFn = partitionIds,
+        .openFn = openPartition,
+        .closeFn = closePartition,
+    },
+
+    pub fn asOpener(self: *ConsumerPartitionOpener) *PartitionOpener {
+        return &self.opener;
+    }
+
+    fn partitionIds(o: *PartitionOpener, allocator: std.mem.Allocator) anyerror![][]const u8 {
+        const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
+        var props = try self.client.getEventHubProperties(allocator);
+        defer props.deinit();
+
+        const ids = try allocator.alloc([]const u8, props.partition_ids.len);
+        errdefer allocator.free(ids);
+        var filled: usize = 0;
+        errdefer for (ids[0..filled]) |id| allocator.free(id);
+        for (ids, props.partition_ids) |*slot, id| {
+            slot.* = try allocator.dupe(u8, id);
+            filled += 1;
+        }
+        return ids;
+    }
+
+    fn openPartition(
+        o: *PartitionOpener,
+        allocator: std.mem.Allocator,
+        partition_id: []const u8,
+        position: EventPosition,
+        options: PartitionClientOptions,
+    ) anyerror!*PartitionClient {
+        const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
+
+        const client = try allocator.create(PartitionClient);
+        errdefer allocator.destroy(client);
+
+        var with_position = options;
+        with_position.start_position = position;
+        self.client.newPartitionClient(
+            client,
+            allocator,
+            self.session,
+            partition_id,
+            self.deadline_ms,
+            with_position,
+        ) catch |err| {
+            // A replicated namespace refuses an offset carried over from
+            // before a failover. Say so in the error so the processor can
+            // restart the partition rather than abandon it.
+            if (err == error.LinkDetached and self.sawGeoReplicationRejection()) {
+                return error.GeoReplicationOffsetRejected;
+            }
+            return err;
+        };
+        return client;
+    }
+
+    /// Whether the attach that just failed was refused for a geo-replicated
+    /// offset. The link never attached, so the condition is only readable
+    /// from the detached receiver the session still holds.
+    fn sawGeoReplicationRejection(self: *ConsumerPartitionOpener) bool {
+        for (self.session.receivers.items) |receiver| {
+            const remote = receiver.detach_error orelse continue;
+            if (load_balancing.isGeoReplicationOffsetError(remote.condition)) return true;
+        }
+        return false;
+    }
+
+    fn closePartition(o: *PartitionOpener, client: *PartitionClient) void {
+        const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
+        client.close(self.deadline_ms) catch {};
+        client.deinit();
+        client.allocator.destroy(client);
+    }
+};
+
 // ─────────────────────── Tests ───────────────────────
+
+// Zig only analyses a file it is told to. Re-exporting a type is not
+// telling it: the decl is lazy, so the file's tests silently do not exist.
+test {
+    _ = @import("load_balancer.zig");
+    _ = @import("processor.zig");
+    _ = ConsumerPartitionOpener;
+}
 
 test "EventData init" {
     const allocator = std.testing.allocator;


### PR DESCRIPTION
Closes #208.

Distributed consumption was entirely absent: `CheckpointStore` existed but nothing consumed it, so partitions could only be read by naming them.

`Processor` claims its share every cycle, opens a reader for anything newly claimed, and closes anything lost. `runOnce` is one cycle rather than a thread, so the caller keeps its own loop and shutdown; `nextIntervalMs` applies Go's 0.8–1.3 jitter.

The load balancer ports Go's `processor_load_balancer.go`. Balanced takes one partition per cycle, greedy takes its whole fair share, and both prefer unowned, expired, or relinquished partitions before stealing from a processor above its share. Selection among equal candidates is random on purpose: every processor runs the same algorithm at the same instant.

Ownership is a lease renewed by re-claiming each cycle; `deinit` relinquishes with an empty owner id so a clean shutdown hands over in one cycle rather than one expiry.

Start position resolves checkpoint → per-partition → default, preferring offset over sequence number. A checkpoint with neither is an error. A geo-replicated namespace rejecting a checkpointed offset gets earliest-inclusive.

The in-memory store the balancer tests used is now public as `InMemoryCheckpointStore`, alongside `Clock`, `SystemClock`, and `ManualClock`.

165 tests pass. Five mutations were checked and each was caught by exactly one test: ignoring the ownership-lost flag, dropping the geo fallback, not relinquishing on shutdown, removing the uneven-division guard on the fair share, and letting balanced claim more than one partition.

A paired `main` PR registers `load_balancer.zig` and `processor.zig` in `eng/packages.zig`.