### PR TITLE
Publish the Event Hubs processor sources

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -462,6 +462,8 @@ pub const all = [_]Package{
             "position.zig",
             "receiver.zig",
             "recovery.zig",
+            "load_balancer.zig",
+            "processor.zig",
             "connection_options.zig",
             "errors.zig",
             "checkpoint.zig",


### PR DESCRIPTION
Registers `load_balancer.zig` and `processor.zig`, added on `sdk/eventhubs` by #292.

A file missing from `publish_paths` is absent from the published tarball, which makes the package unbuildable for a consumer even though the branch itself builds.