### PR TITLE
azure_sdk_eventhubs: add examples and live tests

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: zig build test --summary all
       - name: Build examples
         shell: bash
-        run: echo "No examples configured"
+        run: zig build examples
       - name: Compile live tests
         shell: bash
-        run: echo "No live tests configured"
+        run: zig build live-test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,51 @@ Azure Event Hubs clients:
 
 - `ProducerClient`
 - `ConsumerClient`
+- `Processor`
 - [`checkpoint_store_blob`](checkpoint_store_blob/README.md)
+
+## Connecting
+
+`HubConnection` is the whole transport stack in one value: the dialler, the
+retry schedule, CBS authorisation, and a connection that rebuilds itself. It
+is what turns a client into one that reaches the network.
+
+```zig
+var hub: HubConnection = undefined;
+hub.open(.{
+    .allocator = allocator,
+    .io = io,
+    .fully_qualified_namespace = "ns.servicebus.windows.net",
+});
+defer hub.deinit();
+
+var producer = try ProducerClient.fromConnectionString(
+    allocator,
+    connection_string,
+    "my-hub",
+    hub.asTransport(),
+);
+defer producer.close();
+
+// Late-bound because a connection-string client owns the credential it
+// parses, and that credential does not exist until the client is built.
+const audience = try producer.entityAudience(allocator);
+defer allocator.free(audience);
+try hub.bind(&producer.credential, audience);
+```
+
+Initialise it in place. It holds interior pointers — the authorizer points at
+the credential, the transport at the connection — so a copy would dangle.
+
+Nothing dials until the first operation runs, and `Options` carries the
+`ConnectionOptions` described below along with the container id, link id,
+consumer instance id, per-operation deadline, and retry jitter seed.
+
+`CbsAuthorizer` is the piece that satisfies `recovery.Authorizer`: before any
+link attaches on a connection generation, it opens `$cbs`, puts the client's
+token for the audience, and tears the link down again. It is opened per
+authorisation on purpose — the link is only needed for the round trip, and
+holding it across a rebuild would leave it pointing at a dead session.
 
 ## Authentication
 
@@ -381,9 +425,57 @@ than a partition nobody can read.
 and for running a fleet in one process. It is last-write-wins and does not
 model the etag race a real store arbitrates; `BlobCheckpointStore` does.
 
+Expiry is measured against a `Clock`. `SystemClock` reads wall time — not
+monotonic, because a lease is compared against a `last_modified_time` written
+by another process, possibly on another machine, so the two have to share an
+epoch. `ManualClock` moves only when told to, which is what lets the expiry
+and hand-over paths be tested without spending 60 seconds.
+
 Release branch: `sdk/eventhubs`. The package depends on `azure_sdk_core`,
 `azure_sdk_messaging_common`, `azure_sdk_storage_blobs`, `uamqp`, and `serde`
 and starts at `0.1.0`.
+
+## Examples
+
+```bash
+zig build examples
+```
+
+Each builds to `zig-out/bin/` and reads its configuration from the
+environment and its arguments:
+
+| Example | What it shows |
+| --- | --- |
+| `eventhubs-send-events` | Producing with `DefaultAzureCredential` |
+| `eventhubs-connection-string` | Producing with a connection string |
+| `eventhubs-batch-producer` | Filling batches to the link's real ceiling |
+| `eventhubs-consume-partition` | Reading one partition from earliest |
+| `eventhubs-properties` | Hub and per-partition watermarks |
+| `eventhubs-processor` | A `Processor` over `BlobCheckpointStore` |
+
+## Live tests
+
+```bash
+zig build live-test
+```
+
+Every test skips when the environment is not configured, so this is safe to
+run anywhere and runs in CI on every change. Opt in with
+`AZURE_EVENTHUBS_LIVE_TESTS=1`; any other value is an error rather than a
+silent skip.
+
+| Variable | Required | Meaning |
+| --- | --- | --- |
+| `AZURE_EVENTHUBS_LIVE_TESTS` | yes | Set to `1` to opt in |
+| `AZURE_EVENTHUBS_CONNECTION_STRING` | yes | Namespace connection string |
+| `AZURE_EVENTHUBS_HUB_NAME` | unless the connection string has an `EntityPath` | The hub |
+| `AZURE_EVENTHUBS_CONSUMER_GROUP` | no | Defaults to `$Default` |
+| `AZURE_EVENTHUBS_STORAGE_ENDPOINT` | checkpoint test only | Blob service endpoint |
+| `AZURE_EVENTHUBS_STORAGE_CONTAINER` | checkpoint test only | Existing container |
+| `AZURE_TOKEN` | checkpoint test only | Bearer token for `https://storage.azure.com` |
+
+The tests publish events and write checkpoint blobs, so point them at
+resources you do not mind polluting.
 
 ## Development
 

--- a/build.zig
+++ b/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *std.Build) void {
     blobs_mod.addImport("azure_sdk_core", core_mod);
     blobs_mod.addImport("serde", serde_mod);
 
-    _ = b.addModule("azure_sdk_eventhubs", .{
+    const sdk_mod = b.addModule("azure_sdk_eventhubs", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .imports = &.{
@@ -83,4 +83,61 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run Event Hubs tests");
     test_step.dependOn(&b.addRunArtifact(eventhubs_tests).step);
     test_step.dependOn(&b.addRunArtifact(checkpoint_store_tests).step);
+
+    const examples_step = b.step("examples", "Compile all Event Hubs examples");
+    const example_sources = [_]struct {
+        name: []const u8,
+        source: []const u8,
+    }{
+        .{ .name = "eventhubs-send-events", .source = "examples/send_events.zig" },
+        .{
+            .name = "eventhubs-connection-string",
+            .source = "examples/connection_string_auth.zig",
+        },
+        .{ .name = "eventhubs-batch-producer", .source = "examples/batch_producer.zig" },
+        .{
+            .name = "eventhubs-consume-partition",
+            .source = "examples/consume_partition.zig",
+        },
+        .{ .name = "eventhubs-properties", .source = "examples/hub_properties.zig" },
+        .{ .name = "eventhubs-processor", .source = "examples/processor.zig" },
+    };
+    for (example_sources) |example| {
+        const executable = b.addExecutable(.{
+            .name = example.name,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(example.source),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "azure_sdk_core", .module = core_mod },
+                    .{ .name = "azure_sdk_storage_blobs", .module = blobs_mod },
+                    .{ .name = "azure_sdk_eventhubs", .module = sdk_mod },
+                },
+            }),
+        });
+        examples_step.dependOn(&b.addInstallArtifact(executable, .{}).step);
+        // Examples are API surface: a signature change that breaks one is a
+        // break for every caller, so they build with the tests.
+        test_step.dependOn(&executable.step);
+    }
+
+    const live_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("live_tests/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = core_mod },
+                .{ .name = "azure_sdk_storage_blobs", .module = blobs_mod },
+                .{ .name = "azure_sdk_eventhubs", .module = sdk_mod },
+            },
+        }),
+    });
+    const live_test_step = b.step(
+        "live-test",
+        "Run Event Hubs live tests; every test skips when unconfigured",
+    );
+    live_test_step.dependOn(&b.addRunArtifact(live_tests).step);
+    test_step.dependOn(&live_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -44,6 +44,8 @@
         "checkpoint_store.zig",
         "management.zig",
         "checkpoint_store_blob",
+        "examples",
+        "live_tests",
         "README.md",
         "LICENSE.txt",
     },

--- a/checkpoint.zig
+++ b/checkpoint.zig
@@ -106,11 +106,18 @@ pub const Clock = struct {
 };
 
 /// The real clock.
+///
+/// Wall time rather than monotonic: ownership expiry compares against a
+/// `last_modified_time` written by another process, possibly on another
+/// machine, so the two have to share an epoch.
 pub const SystemClock = struct {
+    io: std.Io,
     clock: Clock = .{ .nowMillisFn = now },
 
-    fn now(_: *Clock) i64 {
-        return std.time.milliTimestamp();
+    fn now(c: *Clock) i64 {
+        const self: *SystemClock = @fieldParentPtr("clock", c);
+        const timestamp = std.Io.Timestamp.now(self.io, .real);
+        return @intCast(@divTrunc(timestamp.nanoseconds, std.time.ns_per_ms));
     }
 };
 

--- a/examples/batch_producer.zig
+++ b/examples/batch_producer.zig
@@ -1,0 +1,88 @@
+//! Fill batches to the link's real maximum and send each as it fills.
+//!
+//! Usage:
+//!   EVENTHUB_CONNECTION_STRING=... ./zig-out/bin/eventhubs-batch-producer <hub> <count>
+//!
+//! `tryAdd` returns false rather than failing when an event would not fit, so
+//! the caller sends what it has and starts a new batch. The ceiling comes
+//! from the sender link's negotiated `max-message-size`, which is why
+//! `createBatch` is a client method rather than a free function.
+
+const std = @import("std");
+const eh = @import("azure_sdk_eventhubs");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+
+    var args = try init.minimal.args.iterateAllocator(allocator);
+    defer args.deinit();
+    _ = args.next();
+    const hub_name = args.next() orelse return error.MissingEventHubName;
+    const count_text = args.next() orelse "1000";
+    const count = try std.fmt.parseInt(usize, count_text, 10);
+
+    const connection_string = init.environ_map.get("EVENTHUB_CONNECTION_STRING") orelse
+        return error.MissingConnectionString;
+    const properties = try eh.ConnectionStringProperties.parse(connection_string);
+
+    var hub: eh.HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = init.io,
+        .fully_qualified_namespace = properties.fully_qualified_namespace,
+        .container_id = "eventhubs-batch-producer",
+    });
+    defer hub.deinit();
+
+    var producer = try eh.ProducerClient.fromConnectionString(
+        allocator,
+        connection_string,
+        hub_name,
+        hub.asTransport(),
+    );
+    defer producer.close();
+
+    const audience = try producer.entityAudience(allocator);
+    defer allocator.free(audience);
+    try hub.bind(&producer.credential, audience);
+
+    var stdout_file = std.Io.File.stdout();
+    var buffer: [256]u8 = undefined;
+    var stdout = stdout_file.writer(init.io, &buffer);
+    const out = &stdout.interface;
+    defer out.flush() catch {};
+
+    // A partition key routes related events to one partition without naming
+    // it, so a rebalance cannot split an ordered stream.
+    var batch = try producer.createBatch(allocator, .{ .partition_key = "orders" });
+    var sent: usize = 0;
+    var batches: usize = 0;
+
+    var i: usize = 0;
+    while (i < count) {
+        var body_buf: [128]u8 = undefined;
+        const body = try std.fmt.bufPrint(&body_buf, "order {d}", .{i});
+
+        if (try batch.tryAdd(allocator, eh.EventData.init(body))) {
+            i += 1;
+            continue;
+        }
+
+        // Full. Send it, then retry this event against a fresh batch.
+        if (batch.count() == 0) return error.EventTooLarge;
+        try producer.sendBatch(allocator, batch);
+        sent += batch.count();
+        batches += 1;
+        batch.deinit(allocator);
+        batch = try producer.createBatch(allocator, .{ .partition_key = "orders" });
+    }
+
+    defer batch.deinit(allocator);
+    if (batch.count() > 0) {
+        try producer.sendBatch(allocator, batch);
+        sent += batch.count();
+        batches += 1;
+    }
+
+    try out.print("sent {d} events in {d} batches\n", .{ sent, batches });
+}

--- a/examples/connection_string_auth.zig
+++ b/examples/connection_string_auth.zig
@@ -1,0 +1,54 @@
+//! Send events using a connection string rather than Azure Active Directory.
+//!
+//! Usage:
+//!   EVENTHUB_CONNECTION_STRING="Endpoint=sb://...;SharedAccessKeyName=...;SharedAccessKey=..." \
+//!   ./zig-out/bin/eventhubs-connection-string [hub]
+//!
+//! The hub name is optional when the connection string carries an
+//! `EntityPath`.
+
+const std = @import("std");
+const eh = @import("azure_sdk_eventhubs");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+
+    var args = try init.minimal.args.iterateAllocator(allocator);
+    defer args.deinit();
+    _ = args.next();
+    const hub_name = args.next();
+
+    // The connection string must outlive the client: the namespace, hub name,
+    // and key are all borrowed from it rather than copied.
+    const connection_string = init.environ_map.get("EVENTHUB_CONNECTION_STRING") orelse
+        return error.MissingConnectionString;
+
+    const properties = try eh.ConnectionStringProperties.parse(connection_string);
+
+    var hub: eh.HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = init.io,
+        .fully_qualified_namespace = properties.fully_qualified_namespace,
+        .container_id = "eventhubs-connection-string",
+    });
+    defer hub.deinit();
+
+    var producer = try eh.ProducerClient.fromConnectionString(
+        allocator,
+        connection_string,
+        hub_name,
+        hub.asTransport(),
+    );
+    defer producer.close();
+
+    const audience = try producer.entityAudience(allocator);
+    defer allocator.free(audience);
+    try hub.bind(&producer.credential, audience);
+
+    var batch = try producer.createBatch(allocator, .{});
+    defer batch.deinit(allocator);
+    _ = try batch.tryAdd(allocator, eh.EventData.init("hello from a connection string"));
+
+    try producer.sendBatch(allocator, batch);
+}

--- a/examples/consume_partition.zig
+++ b/examples/consume_partition.zig
@@ -1,0 +1,68 @@
+//! Read events from one partition.
+//!
+//! Usage:
+//!   EVENTHUB_CONNECTION_STRING=... ./zig-out/bin/eventhubs-consume-partition <hub> <partition>
+//!
+//! This reads a single partition by name. To spread a hub's partitions across
+//! a fleet of consumers, use a `Processor` instead — see
+//! `examples/processor.zig`.
+
+const std = @import("std");
+const eh = @import("azure_sdk_eventhubs");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+
+    var args = try init.minimal.args.iterateAllocator(allocator);
+    defer args.deinit();
+    _ = args.next();
+    const hub_name = args.next() orelse return error.MissingEventHubName;
+    const partition_id = args.next() orelse "0";
+
+    const connection_string = init.environ_map.get("EVENTHUB_CONNECTION_STRING") orelse
+        return error.MissingConnectionString;
+    const properties = try eh.ConnectionStringProperties.parse(connection_string);
+
+    var hub: eh.HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = init.io,
+        .fully_qualified_namespace = properties.fully_qualified_namespace,
+        .container_id = "eventhubs-consume-partition",
+        .instance_id = "example-reader",
+    });
+    defer hub.deinit();
+
+    var consumer = try eh.ConsumerClient.fromConnectionString(
+        allocator,
+        connection_string,
+        hub_name,
+        hub.asTransport(),
+    );
+    defer consumer.close();
+
+    const audience = try consumer.entityAudience(allocator);
+    defer allocator.free(audience);
+    try hub.bind(&consumer.credential, audience);
+
+    var stdout_file = std.Io.File.stdout();
+    var buffer: [4096]u8 = undefined;
+    var stdout = stdout_file.writer(init.io, &buffer);
+    const out = &stdout.interface;
+    defer out.flush() catch {};
+
+    // Earliest replays the partition from the start; the default is latest,
+    // which shows only events enqueued after the link attaches.
+    const events = try consumer.receiveEvents(
+        allocator,
+        partition_id,
+        eh.EventPosition.earliest(),
+        20,
+    );
+    defer eh.freeReceivedEvents(allocator, events);
+
+    for (events) |event| {
+        try out.print("[{d}] {s}\n", .{ event.sequence_number, event.body() });
+    }
+    try out.print("→ {d} event(s) from partition {s}\n", .{ events.len, partition_id });
+}

--- a/examples/hub_properties.zig
+++ b/examples/hub_properties.zig
@@ -1,0 +1,75 @@
+//! Read a hub's metadata and each partition's high and low watermarks.
+//!
+//! Usage:
+//!   EVENTHUB_CONNECTION_STRING=... ./zig-out/bin/eventhubs-properties <hub>
+//!
+//! Both operations run over the `$management` link rather than a data link,
+//! so neither sends nor receives events.
+
+const std = @import("std");
+const eh = @import("azure_sdk_eventhubs");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+
+    var args = try init.minimal.args.iterateAllocator(allocator);
+    defer args.deinit();
+    _ = args.next();
+    const hub_name = args.next() orelse return error.MissingEventHubName;
+
+    const connection_string = init.environ_map.get("EVENTHUB_CONNECTION_STRING") orelse
+        return error.MissingConnectionString;
+    const properties = try eh.ConnectionStringProperties.parse(connection_string);
+
+    var hub: eh.HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = init.io,
+        .fully_qualified_namespace = properties.fully_qualified_namespace,
+        .container_id = "eventhubs-properties",
+    });
+    defer hub.deinit();
+
+    var consumer = try eh.ConsumerClient.fromConnectionString(
+        allocator,
+        connection_string,
+        hub_name,
+        hub.asTransport(),
+    );
+    defer consumer.close();
+
+    const audience = try consumer.entityAudience(allocator);
+    defer allocator.free(audience);
+    try hub.bind(&consumer.credential, audience);
+
+    var stdout_file = std.Io.File.stdout();
+    var buffer: [4096]u8 = undefined;
+    var stdout = stdout_file.writer(init.io, &buffer);
+    const out = &stdout.interface;
+    defer out.flush() catch {};
+
+    var hub_properties = try consumer.getEventHubProperties(allocator);
+    defer hub_properties.deinit();
+
+    try out.print("{s}: {d} partition(s), geo-replication {s}\n", .{
+        hub_properties.name,
+        hub_properties.partition_ids.len,
+        if (hub_properties.geo_replication_enabled) "on" else "off",
+    });
+
+    for (hub_properties.partition_ids) |partition_id| {
+        var partition = try consumer.getPartitionProperties(allocator, partition_id);
+        defer partition.deinit();
+
+        if (partition.is_empty) {
+            try out.print("  partition {s}: empty\n", .{partition_id});
+            continue;
+        }
+        try out.print("  partition {s}: sequence {d}..{d}, offset {s}\n", .{
+            partition_id,
+            partition.beginning_sequence_number,
+            partition.last_enqueued_sequence_number,
+            partition.last_enqueued_offset orelse "?",
+        });
+    }
+}

--- a/examples/processor.zig
+++ b/examples/processor.zig
@@ -1,0 +1,126 @@
+//! Run a `Processor` over a hub, checkpointing to Azure Blob Storage.
+//!
+//! Usage:
+//!   EVENTHUB_CONNECTION_STRING=... AZURE_TOKEN=$(az account get-access-token \
+//!       --resource https://storage.azure.com --query accessToken -o tsv) \
+//!   ./zig-out/bin/eventhubs-processor <hub> <storage-endpoint> <container>
+//!
+//! Every processor in a fleet runs this same loop. They coordinate only
+//! through the checkpoint store, so starting another copy of this program
+//! against the same container takes over half the partitions.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const blobs = @import("azure_sdk_storage_blobs");
+const eh = @import("azure_sdk_eventhubs");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+
+    var args = try init.minimal.args.iterateAllocator(allocator);
+    defer args.deinit();
+    _ = args.next();
+    const hub_name = args.next() orelse return error.MissingEventHubName;
+    const storage_endpoint = args.next() orelse return error.MissingStorageEndpoint;
+    const container_name = args.next() orelse return error.MissingContainerName;
+
+    const connection_string = init.environ_map.get("EVENTHUB_CONNECTION_STRING") orelse
+        return error.MissingConnectionString;
+    const properties = try eh.ConnectionStringProperties.parse(connection_string);
+
+    // ── Checkpoint store ──────────────────────────────────────────────
+    var http = core.http.StdHttpTransport.init(allocator, init.io);
+    defer http.deinit();
+
+    var storage_credential = core.env_token.EnvTokenCredential.init(
+        allocator,
+        init.environ_map.get("AZURE_TOKEN") orelse return error.MissingAzureToken,
+    );
+
+    var container = try blobs.BlobContainerClient.init(allocator, .{
+        .credential = storage_credential.asCredential(),
+        .transport = http.asTransport(),
+        .endpoint = storage_endpoint,
+        .container_name = container_name,
+    });
+    defer container.deinit();
+
+    var store = eh.checkpoint_store_blob.BlobCheckpointStore.init(&container);
+
+    // ── Event Hubs ────────────────────────────────────────────────────
+    var hub: eh.HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = init.io,
+        .fully_qualified_namespace = properties.fully_qualified_namespace,
+        .container_id = "eventhubs-processor",
+    });
+    defer hub.deinit();
+
+    var consumer = try eh.ConsumerClient.fromConnectionString(
+        allocator,
+        connection_string,
+        hub_name,
+        hub.asTransport(),
+    );
+    defer consumer.close();
+
+    const audience = try consumer.entityAudience(allocator);
+    defer allocator.free(audience);
+    try hub.bind(&consumer.credential, audience);
+
+    var opener = consumer.partitionOpener(&hub.connection, 60_000);
+    var clock = eh.load_balancing.SystemClock{ .io = init.io };
+    var prng = std.Random.DefaultPrng.init(@bitCast(clock.clock.nowMillis()));
+
+    var processor = consumer.newProcessor(
+        allocator,
+        store.asCheckpointStore(),
+        opener.asOpener(),
+        .{ .load_balancing_strategy = .balanced },
+        &clock.clock,
+        prng.random(),
+    );
+    // Relinquishes every partition it holds, so the rest of the fleet takes
+    // over in one cycle rather than waiting out the expiry.
+    defer processor.deinit();
+
+    var stdout_file = std.Io.File.stdout();
+    var buffer: [4096]u8 = undefined;
+    var stdout = stdout_file.writer(init.io, &buffer);
+    const out = &stdout.interface;
+    defer out.flush() catch {};
+
+    // `runOnce` is one balancing cycle, not a thread: the loop, and its
+    // shutdown, stay with the caller.
+    for (0..10) |_| {
+        try processor.runOnce();
+
+        while (processor.nextPartitionClient()) |partition| {
+            const events = partition.receiveEvents(allocator, 100) catch |err| {
+                try out.print("partition {s}: {t}\n", .{ partition.partitionId(), err });
+                continue;
+            };
+            defer eh.freeReceivedEvents(allocator, events);
+
+            for (events) |event| {
+                try out.print("[{s}/{d}] {s}\n", .{
+                    partition.partitionId(),
+                    event.sequence_number,
+                    event.body(),
+                });
+            }
+            // Checkpoint the last event of the batch: a later owner resumes
+            // after it rather than replaying the whole partition.
+            if (events.len > 0) {
+                try partition.updateCheckpoint(allocator, events[events.len - 1]);
+            }
+        }
+
+        try out.flush();
+        try init.io.sleep(
+            .{ .nanoseconds = @intCast(processor.nextIntervalMs() * std.time.ns_per_ms) },
+            .awake,
+        );
+    }
+}

--- a/examples/send_events.zig
+++ b/examples/send_events.zig
@@ -1,0 +1,77 @@
+//! Send events to an Event Hub with Azure Active Directory credentials.
+//!
+//! Usage:
+//!   zig build examples
+//!   ./zig-out/bin/eventhubs-send-events <namespace> <hub>
+//!
+//! e.g. <namespace> = my-namespace.servicebus.windows.net
+//!
+//! Authentication uses `DefaultAzureCredential`, so an `az login` session,
+//! a managed identity, or the usual `AZURE_*` environment variables all work.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const eh = @import("azure_sdk_eventhubs");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+
+    var args = try init.minimal.args.iterateAllocator(allocator);
+    defer args.deinit();
+    _ = args.next();
+    const namespace = args.next() orelse return error.MissingNamespace;
+    const hub_name = args.next() orelse return error.MissingEventHubName;
+
+    var transport = core.http.StdHttpTransport.init(allocator, init.io);
+    defer transport.deinit();
+
+    var credential = try core.identity.DefaultAzureCredential.init(
+        allocator,
+        init.io,
+        transport.asTransport(),
+        init.environ_map,
+    );
+    defer credential.deinit();
+
+    // Nothing dials until the first operation: the connection is opened
+    // lazily and rebuilt underneath the client if it drops.
+    var hub: eh.HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = init.io,
+        .fully_qualified_namespace = namespace,
+        .container_id = "eventhubs-send-events",
+    });
+    defer hub.deinit();
+
+    var producer = eh.ProducerClient.init(.{
+        .fully_qualified_namespace = namespace,
+        .event_hub_name = hub_name,
+    }, credential.asCredential(), hub.asTransport());
+    defer producer.close();
+
+    // The authorizer needs the client's credential, and the client needed
+    // the transport, so binding is the last step rather than part of `open`.
+    const audience = try producer.entityAudience(allocator);
+    defer allocator.free(audience);
+    try hub.bind(&producer.credential, audience);
+
+    var batch = try producer.createBatch(allocator, .{});
+    defer batch.deinit(allocator);
+
+    for (0..5) |i| {
+        var body_buf: [64]u8 = undefined;
+        const body = try std.fmt.bufPrint(&body_buf, "event {d}", .{i});
+        if (!try batch.tryAdd(allocator, eh.EventData.init(body))) {
+            return error.BatchFull;
+        }
+    }
+
+    try producer.sendBatch(allocator, batch);
+
+    var stdout_file = std.Io.File.stdout();
+    var buffer: [256]u8 = undefined;
+    var stdout = stdout_file.writer(init.io, &buffer);
+    defer stdout.interface.flush() catch {};
+    try stdout.interface.print("sent {d} events to {s}\n", .{ batch.count(), hub_name });
+}

--- a/live_tests/main.zig
+++ b/live_tests/main.zig
@@ -1,0 +1,374 @@
+//! Destructive, explicit opt-in Azure Event Hubs live coverage.
+//!
+//! Every test skips when the environment is not configured, so this compiles
+//! and runs in CI without any Azure resources. Configure it with:
+//!
+//! - `AZURE_EVENTHUBS_LIVE_TESTS=1` — opt in. Without it every test skips,
+//!   and any other value is an error rather than a silent skip.
+//! - `AZURE_EVENTHUBS_CONNECTION_STRING` — namespace connection string, with
+//!   or without an `EntityPath`.
+//! - `AZURE_EVENTHUBS_HUB_NAME` — the hub, required when the connection
+//!   string carries no `EntityPath`.
+//! - `AZURE_EVENTHUBS_CONSUMER_GROUP` — optional, defaults to `$Default`.
+//! - `AZURE_EVENTHUBS_STORAGE_ENDPOINT`, `AZURE_EVENTHUBS_STORAGE_CONTAINER`,
+//!   and `AZURE_TOKEN` — optional; only the checkpoint-store test needs them,
+//!   and it skips without all three.
+//!
+//! These tests publish to the hub and write checkpoint blobs, so point them
+//! at resources you do not mind polluting.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const blobs = @import("azure_sdk_storage_blobs");
+const eh = @import("azure_sdk_eventhubs");
+
+const testing = std.testing;
+
+const Config = struct {
+    connection_string: []const u8,
+    hub_name: ?[]const u8,
+    consumer_group: []const u8,
+    storage: ?Storage,
+
+    const Storage = struct {
+        endpoint: []const u8,
+        container: []const u8,
+        token: []const u8,
+    };
+
+    /// Null means "not configured", which the caller turns into a skip. A
+    /// malformed opt-in is an error: silently skipping a run someone asked
+    /// for is worse than failing it.
+    fn fromEnvironment(env: *const std.process.Environ.Map) !?Config {
+        const enabled = nonEmpty(env.get("AZURE_EVENTHUBS_LIVE_TESTS")) orelse
+            return null;
+        if (!std.mem.eql(u8, enabled, "1"))
+            return error.InvalidEventHubsLiveTestOptIn;
+        const connection_string = nonEmpty(
+            env.get("AZURE_EVENTHUBS_CONNECTION_STRING"),
+        ) orelse return error.EventHubsConnectionStringRequired;
+        const hub_name = nonEmpty(env.get("AZURE_EVENTHUBS_HUB_NAME"));
+        // Fail here rather than at the first operation: the hub name decides
+        // every address the tests build.
+        const parsed = try eh.ConnectionStringProperties.parse(connection_string);
+        if (hub_name == null and parsed.entity_path == null)
+            return error.EventHubsHubNameRequired;
+        return .{
+            .connection_string = connection_string,
+            .hub_name = hub_name,
+            .consumer_group = nonEmpty(
+                env.get("AZURE_EVENTHUBS_CONSUMER_GROUP"),
+            ) orelse "$Default",
+            .storage = storageFrom(env),
+        };
+    }
+
+    fn storageFrom(env: *const std.process.Environ.Map) ?Storage {
+        return .{
+            .endpoint = nonEmpty(env.get("AZURE_EVENTHUBS_STORAGE_ENDPOINT")) orelse
+                return null,
+            .container = nonEmpty(env.get("AZURE_EVENTHUBS_STORAGE_CONTAINER")) orelse
+                return null,
+            .token = nonEmpty(env.get("AZURE_TOKEN")) orelse return null,
+        };
+    }
+
+    fn hub(self: Config) ![]const u8 {
+        if (self.hub_name) |name| return name;
+        const parsed = try eh.ConnectionStringProperties.parse(self.connection_string);
+        return parsed.entity_path.?;
+    }
+
+    fn namespace(self: Config) ![]const u8 {
+        const parsed = try eh.ConnectionStringProperties.parse(self.connection_string);
+        return parsed.fully_qualified_namespace;
+    }
+};
+
+fn nonEmpty(value: ?[]const u8) ?[]const u8 {
+    const v = value orelse return null;
+    return if (v.len == 0) null else v;
+}
+
+/// One authorised connection to a hub, plus a producer over it.
+///
+/// Heap-allocated and initialised in place because it holds interior
+/// pointers: the CBS authorizer points at the producer's credential, and the
+/// transport at the connection. Copying it by value would leave both dangling.
+const LiveSession = struct {
+    allocator: std.mem.Allocator,
+    hub: eh.HubConnection,
+    producer: eh.ProducerClient,
+    audience: []u8,
+
+    fn create(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        config: Config,
+    ) !*LiveSession {
+        const self = try allocator.create(LiveSession);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+
+        self.hub.open(.{
+            .allocator = allocator,
+            .io = io,
+            .fully_qualified_namespace = try config.namespace(),
+            .container_id = "azure-sdk-for-zig-live",
+        });
+        errdefer self.hub.deinit();
+
+        self.producer = try eh.ProducerClient.fromConnectionString(
+            allocator,
+            config.connection_string,
+            config.hub_name,
+            self.hub.asTransport(),
+        );
+        errdefer self.producer.deinit();
+
+        self.audience = try self.producer.entityAudience(allocator);
+        errdefer allocator.free(self.audience);
+        try self.hub.bind(&self.producer.credential, self.audience);
+        return self;
+    }
+
+    /// A consumer sharing this session's connection and claim.
+    ///
+    /// The connection is already authorised for the hub, so this only needs
+    /// its own client state; the receiver links attach over the same session.
+    fn consumer(self: *LiveSession, config: Config) !eh.ConsumerClient {
+        var client = try eh.ConsumerClient.fromConnectionString(
+            self.allocator,
+            config.connection_string,
+            config.hub_name,
+            self.hub.asTransport(),
+        );
+        client.options.consumer_group = config.consumer_group;
+        return client;
+    }
+
+    fn deinit(self: *LiveSession) void {
+        self.allocator.free(self.audience);
+        self.producer.deinit();
+        self.hub.deinit();
+        self.allocator.destroy(self);
+    }
+};
+
+test "live: a batch sent to a partition is read back from it" {
+    const allocator = testing.allocator;
+    var env = try std.process.Environ.createMap(std.testing.environ, allocator);
+    defer env.deinit();
+    const config = (try Config.fromEnvironment(&env)) orelse
+        return error.SkipZigTest;
+
+    const session = try LiveSession.create(allocator, std.testing.io, config);
+    defer session.deinit();
+
+    // Address one partition explicitly. Without a partition id the service
+    // picks, and the events could land anywhere, so the read would be racy.
+    var properties = try session.producer.getEventHubProperties(allocator);
+    defer properties.deinit();
+    try testing.expect(properties.partition_ids.len > 0);
+    const partition_id = properties.partition_ids[0];
+
+    // The watermark before the send is where the read resumes from, so it
+    // sees exactly what this test wrote rather than the whole partition.
+    var before = try session.producer.getPartitionProperties(allocator, partition_id);
+    defer before.deinit();
+
+    var batch = try session.producer.createBatch(allocator, .{
+        .partition_id = partition_id,
+    });
+    defer batch.deinit(allocator);
+    try testing.expect(try batch.tryAdd(allocator, eh.EventData.init("live-test-one")));
+    try testing.expect(try batch.tryAdd(allocator, eh.EventData.init("live-test-two")));
+    try testing.expectEqual(@as(usize, 2), batch.count());
+    try session.producer.sendBatch(allocator, batch);
+
+    var after = try session.producer.getPartitionProperties(allocator, partition_id);
+    defer after.deinit();
+    try testing.expectEqual(
+        before.last_enqueued_sequence_number + 2,
+        after.last_enqueued_sequence_number,
+    );
+
+    var consumer = try session.consumer(config);
+    defer consumer.deinit();
+
+    const events = try consumer.receiveEvents(
+        allocator,
+        partition_id,
+        eh.EventPosition.fromSequenceNumber(before.last_enqueued_sequence_number, false),
+        2,
+    );
+    defer eh.freeReceivedEvents(allocator, events);
+
+    try testing.expectEqual(@as(usize, 2), events.len);
+    try testing.expectEqualStrings("live-test-one", events[0].body());
+    try testing.expectEqualStrings("live-test-two", events[1].body());
+}
+
+test "live: hub and partition properties describe the same hub" {
+    const allocator = testing.allocator;
+    var env = try std.process.Environ.createMap(std.testing.environ, allocator);
+    defer env.deinit();
+    const config = (try Config.fromEnvironment(&env)) orelse
+        return error.SkipZigTest;
+
+    const session = try LiveSession.create(allocator, std.testing.io, config);
+    defer session.deinit();
+
+    var properties = try session.producer.getEventHubProperties(allocator);
+    defer properties.deinit();
+
+    try testing.expectEqualStrings(try config.hub(), properties.name);
+    try testing.expect(properties.partition_ids.len > 0);
+
+    for (properties.partition_ids) |partition_id| {
+        var partition = try session.producer.getPartitionProperties(
+            allocator,
+            partition_id,
+        );
+        defer partition.deinit();
+
+        try testing.expectEqualStrings(partition_id, partition.id);
+        try testing.expectEqualStrings(properties.name, partition.event_hub_name);
+        // An empty partition reports a last sequence number one below the
+        // first, so this holds either way.
+        try testing.expect(
+            partition.last_enqueued_sequence_number >=
+                partition.beginning_sequence_number - 1,
+        );
+    }
+}
+
+test "live: a checkpoint written to blob storage is listed back" {
+    const allocator = testing.allocator;
+    var env = try std.process.Environ.createMap(std.testing.environ, allocator);
+    defer env.deinit();
+    const config = (try Config.fromEnvironment(&env)) orelse
+        return error.SkipZigTest;
+    const storage = config.storage orelse return error.SkipZigTest;
+
+    var http = core.http.StdHttpTransport.init(allocator, std.testing.io);
+    defer http.deinit();
+
+    var credential = core.env_token.EnvTokenCredential.init(allocator, storage.token);
+    var container = try blobs.BlobContainerClient.init(allocator, .{
+        .credential = credential.asCredential(),
+        .transport = http.asTransport(),
+        .endpoint = storage.endpoint,
+        .container_name = storage.container,
+    });
+    defer container.deinit();
+
+    var blob_store = eh.checkpoint_store_blob.BlobCheckpointStore.init(&container);
+    const store = blob_store.asCheckpointStore();
+
+    const namespace = try config.namespace();
+    const hub_name = try config.hub();
+    // Its own consumer group, so this cannot disturb the ownership a real
+    // fleet holds in the same container.
+    const consumer_group = "azure-sdk-for-zig-live";
+
+    try store.updateCheckpoint(allocator, .{
+        .fully_qualified_namespace = namespace,
+        .event_hub_name = hub_name,
+        .consumer_group = consumer_group,
+        .partition_id = "0",
+        .sequence_number = 42,
+        .offset = "42",
+    });
+
+    const checkpoints = try store.listCheckpoints(
+        allocator,
+        namespace,
+        hub_name,
+        consumer_group,
+    );
+    defer eh.freeCheckpoints(allocator, checkpoints);
+
+    var found = false;
+    for (checkpoints) |checkpoint| {
+        if (!std.mem.eql(u8, checkpoint.partition_id, "0")) continue;
+        found = true;
+        try testing.expectEqual(@as(?i64, 42), checkpoint.sequence_number);
+        try testing.expectEqualStrings("42", checkpoint.offset.?);
+    }
+    try testing.expect(found);
+
+    // Ownership round-trips through the same container, and the store must
+    // report back what it stamped rather than what we asked for.
+    const claimed = try store.claimOwnership(allocator, &.{.{
+        .fully_qualified_namespace = namespace,
+        .event_hub_name = hub_name,
+        .consumer_group = consumer_group,
+        .partition_id = "0",
+        .owner_id = "live-test",
+    }});
+    defer eh.freeOwnerships(allocator, claimed);
+    try testing.expectEqual(@as(usize, 1), claimed.len);
+    try testing.expectEqualStrings("live-test", claimed[0].owner_id);
+    try testing.expect(claimed[0].etag != null);
+    try testing.expect(claimed[0].last_modified_time != null);
+}
+
+test "live: a lone processor claims every partition" {
+    const allocator = testing.allocator;
+    var env = try std.process.Environ.createMap(std.testing.environ, allocator);
+    defer env.deinit();
+    const config = (try Config.fromEnvironment(&env)) orelse
+        return error.SkipZigTest;
+
+    const session = try LiveSession.create(allocator, std.testing.io, config);
+    defer session.deinit();
+
+    var properties = try session.producer.getEventHubProperties(allocator);
+    defer properties.deinit();
+
+    var consumer = try session.consumer(config);
+    defer consumer.deinit();
+
+    // In memory rather than blob-backed: this asserts the balancing loop
+    // against a real hub, not the store, and it must not disturb the
+    // ownership a real fleet holds in a shared container.
+    var clock = eh.SystemClock{ .io = std.testing.io };
+    var store = eh.InMemoryCheckpointStore{
+        .allocator = allocator,
+        .clock = &clock.clock,
+    };
+    defer store.deinit();
+
+    var opener = consumer.partitionOpener(&session.hub.connection, 60_000);
+    var prng = std.Random.DefaultPrng.init(@bitCast(clock.clock.nowMillis()));
+
+    var processor = consumer.newProcessor(
+        allocator,
+        &store.store,
+        opener.asOpener(),
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        prng.random(),
+    );
+    // Relinquishes every claim, so a rerun starts from a clean slate.
+    defer processor.deinit();
+
+    // Greedy takes its whole fair share in one cycle, and alone that is
+    // every partition.
+    try processor.runOnce();
+    try testing.expectEqual(
+        properties.partition_ids.len,
+        processor.ownedPartitions().len,
+    );
+
+    var handed_out: usize = 0;
+    while (processor.nextPartitionClient()) |partition| : (handed_out += 1) {
+        try testing.expect(partition.partitionId().len > 0);
+        // A partition with nothing in it returns an empty slice rather than
+        // blocking until the deadline.
+        const events = try partition.receiveEvents(allocator, 1);
+        defer eh.freeReceivedEvents(allocator, events);
+    }
+    try testing.expectEqual(properties.partition_ids.len, handed_out);
+}

--- a/root.zig
+++ b/root.zig
@@ -16,6 +16,10 @@ pub const PartitionOwnership = checkpoint.PartitionOwnership;
 pub const CheckpointStore = checkpoint.CheckpointStore;
 pub const freeCheckpoints = checkpoint.freeCheckpoints;
 pub const freeOwnerships = checkpoint.freeOwnerships;
+pub const InMemoryCheckpointStore = checkpoint.InMemoryCheckpointStore;
+pub const Clock = checkpoint.Clock;
+pub const SystemClock = checkpoint.SystemClock;
+pub const ManualClock = checkpoint.ManualClock;
 pub const checkpoint_store_blob = @import("checkpoint_store.zig");
 
 pub const AmqpValue = event_data.AmqpValue;
@@ -872,10 +876,10 @@ pub const ConsumerClient = struct {
     /// from a connection.
     pub fn partitionOpener(
         self: *ConsumerClient,
-        session: *amqp.Session,
+        connection: *recovery.RecoverableConnection,
         deadline_ms: i64,
     ) ConsumerPartitionOpener {
-        return .{ .client = self, .session = session, .deadline_ms = deadline_ms };
+        return .{ .client = self, .connection = connection, .deadline_ms = deadline_ms };
     }
 
     /// Build a processor that reads this hub through `opener`.
@@ -939,7 +943,10 @@ pub const ConsumerClient = struct {
 /// A `PartitionOpener` backed by a `ConsumerClient` and one session.
 pub const ConsumerPartitionOpener = struct {
     client: *ConsumerClient,
-    session: *amqp.Session,
+    /// The session is resolved per open rather than held: a recovered
+    /// connection has a new one, and a link attached to the old session would
+    /// be attached to nothing.
+    connection: *recovery.RecoverableConnection,
     deadline_ms: i64,
     opener: PartitionOpener = .{
         .partitionIdsFn = partitionIds,
@@ -979,12 +986,13 @@ pub const ConsumerPartitionOpener = struct {
         const client = try allocator.create(PartitionClient);
         errdefer allocator.destroy(client);
 
+        const session = try self.connection.session();
         var with_position = options;
         with_position.start_position = position;
         self.client.newPartitionClient(
             client,
             allocator,
-            self.session,
+            session,
             partition_id,
             self.deadline_ms,
             with_position,
@@ -992,7 +1000,7 @@ pub const ConsumerPartitionOpener = struct {
             // A replicated namespace refuses an offset carried over from
             // before a failover. Say so in the error so the processor can
             // restart the partition rather than abandon it.
-            if (err == error.LinkDetached and self.sawGeoReplicationRejection()) {
+            if (err == error.LinkDetached and sawGeoReplicationRejection(session)) {
                 return error.GeoReplicationOffsetRejected;
             }
             return err;
@@ -1003,8 +1011,8 @@ pub const ConsumerPartitionOpener = struct {
     /// Whether the attach that just failed was refused for a geo-replicated
     /// offset. The link never attached, so the condition is only readable
     /// from the detached receiver the session still holds.
-    fn sawGeoReplicationRejection(self: *ConsumerPartitionOpener) bool {
-        for (self.session.receivers.items) |receiver| {
+    fn sawGeoReplicationRejection(session: *amqp.Session) bool {
+        for (session.receivers.items) |receiver| {
             const remote = receiver.detach_error orelse continue;
             if (load_balancing.isGeoReplicationOffsetError(remote.condition)) return true;
         }
@@ -1019,6 +1027,150 @@ pub const ConsumerPartitionOpener = struct {
     }
 };
 
+// ─────────────────────── Connecting ───────────────────────
+
+/// Puts the client's CBS token on a session before any link attaches.
+///
+/// A rebuilt connection carries no claims, so recovery re-authorises through
+/// this before reattaching. The `$cbs` link pair is opened and torn down per
+/// authorisation: it is only needed for the round trip, and holding it across
+/// a rebuild would leave a link pointing at a dead session.
+pub const CbsAuthorizer = struct {
+    allocator: std.mem.Allocator,
+    /// The credential to sign with. Bound after the client is built, because
+    /// a connection-string client owns the credential it creates.
+    credential: ?*Credential = null,
+    /// `amqps://{fqns}/{hub}`. Owned when `bind` copied it.
+    audience: ?[]u8 = null,
+    link_id: []const u8 = "eventhubs",
+    ctx: core.context.Context = .none,
+    authorizer: recovery.Authorizer = .{ .authorizeFn = authorize },
+
+    pub fn bind(self: *CbsAuthorizer, credential: *Credential, audience: []const u8) !void {
+        const owned = try self.allocator.dupe(u8, audience);
+        if (self.audience) |old| self.allocator.free(old);
+        self.audience = owned;
+        self.credential = credential;
+    }
+
+    pub fn deinit(self: *CbsAuthorizer) void {
+        if (self.audience) |audience| self.allocator.free(audience);
+        self.audience = null;
+    }
+
+    pub fn asAuthorizer(self: *CbsAuthorizer) *recovery.Authorizer {
+        return &self.authorizer;
+    }
+
+    fn authorize(a: *recovery.Authorizer, session: *amqp.Session, deadline_ms: i64) anyerror!void {
+        const self: *CbsAuthorizer = @fieldParentPtr("authorizer", a);
+        const credential = self.credential orelse return error.CredentialNotBound;
+        const audience = self.audience orelse return error.CredentialNotBound;
+
+        var token = try credential.getToken(self.ctx);
+        defer token.deinit();
+
+        const client = try amqp.Cbs.open(session, .{ .link_id = self.link_id }, deadline_ms);
+        defer client.deinit();
+
+        try client.putToken(audience, .{
+            .token = token.token,
+            .expires_on_ms = token.expires_on * std.time.ms_per_s,
+            .kind = switch (credential.*) {
+                .token => .jwt,
+                .sas => .sas,
+            },
+            .refreshable = credential.isRefreshable(),
+        }, deadline_ms);
+        client.close(deadline_ms) catch {};
+    }
+};
+
+/// Everything a client needs to reach a namespace, assembled.
+///
+/// The pieces are individually usable — this only saves a caller from wiring
+/// a factory, an authorizer, a recoverable connection, and a transport by
+/// hand. It holds interior pointers, so initialise it in place and never copy
+/// it after `open`.
+pub const HubConnection = struct {
+    allocator: std.mem.Allocator,
+    sleeper: errors.IoSleeper,
+    prng: std.Random.DefaultPrng,
+    factory: connection_options.AmqpConnectionFactory,
+    authorizer: CbsAuthorizer,
+    connection: recovery.RecoverableConnection,
+    transport: LinkTransport,
+
+    pub const Options = struct {
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        fully_qualified_namespace: []const u8,
+        /// Identifies this connection to the service. Go uses a GUID.
+        container_id: []const u8 = "azure-sdk-for-zig",
+        /// Distinguishes this client's links from any other on the connection.
+        link_id: []const u8 = "eventhubs",
+        /// Identifies this reader to the broker, and is what a stolen-link
+        /// message names.
+        instance_id: []const u8 = default_instance_id,
+        connection: ConnectionOptions = .{},
+        partition_client: PartitionClientOptions = .{},
+        /// How long any one operation may take, including its recovery.
+        deadline_ms: i64 = 60_000,
+        /// Seed for the retry jitter.
+        seed: u64 = 0,
+    };
+
+    /// Initialise in place. Nothing dials until the first operation runs.
+    pub fn open(self: *HubConnection, options: Options) void {
+        self.* = .{
+            .allocator = options.allocator,
+            .sleeper = errors.IoSleeper.init(options.io),
+            .prng = std.Random.DefaultPrng.init(options.seed),
+            .factory = .{
+                .allocator = options.allocator,
+                .io = options.io,
+                .fully_qualified_namespace = options.fully_qualified_namespace,
+                .container_id = options.container_id,
+                .options = options.connection,
+            },
+            .authorizer = .{ .allocator = options.allocator },
+            .connection = undefined,
+            .transport = undefined,
+        };
+        self.connection = recovery.RecoverableConnection.init(options.allocator, .{
+            .factory = &self.factory.factory,
+            .authorizer = self.authorizer.asAuthorizer(),
+            .deadline_ms = options.deadline_ms,
+            .instance_id = options.instance_id,
+            .link_id = options.link_id,
+            .partition_client = options.partition_client,
+        });
+        self.transport = LinkTransport.initRecoverable(
+            &self.connection,
+            options.connection.retryConfig(&self.sleeper.sleeper, self.prng.random()),
+            .{ .deadline_ms = options.deadline_ms },
+        );
+    }
+
+    /// Point the authorizer at the client's credential.
+    ///
+    /// Separate from `open` because a connection-string client owns the
+    /// credential it parses, so the credential does not exist until after the
+    /// client is built, and the client needs this transport to be built.
+    pub fn bind(self: *HubConnection, credential: *Credential, audience: []const u8) !void {
+        return self.authorizer.bind(credential, audience);
+    }
+
+    pub fn asTransport(self: *HubConnection) *AmqpTransport {
+        return self.transport.asTransport();
+    }
+
+    pub fn deinit(self: *HubConnection) void {
+        self.connection.deinit();
+        self.authorizer.deinit();
+    }
+};
+
 // ─────────────────────── Tests ───────────────────────
 
 // Zig only analyses a file it is told to. Re-exporting a type is not
@@ -1027,6 +1179,40 @@ test {
     _ = @import("load_balancer.zig");
     _ = @import("processor.zig");
     _ = ConsumerPartitionOpener;
+}
+
+test "a hub connection wires itself up without dialling" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    defer threaded.deinit();
+
+    var hub: HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = threaded.io(),
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .container_id = "test",
+    });
+    defer hub.deinit();
+
+    // Nothing has dialled, so there is no plumbing and no claim yet.
+    try std.testing.expect(hub.connection.plumbing == null);
+    try std.testing.expect(hub.authorizer.credential == null);
+
+    var credential = Credential{ .sas = undefined };
+    try hub.bind(&credential, "amqps://ns.servicebus.windows.net/hub");
+    try std.testing.expectEqualStrings(
+        "amqps://ns.servicebus.windows.net/hub",
+        hub.authorizer.audience.?,
+    );
+
+    // Binding twice replaces rather than leaks: recovery rebinds after a
+    // credential is swapped.
+    try hub.bind(&credential, "amqps://ns.servicebus.windows.net/other");
+    try std.testing.expectEqualStrings(
+        "amqps://ns.servicebus.windows.net/other",
+        hub.authorizer.audience.?,
+    );
 }
 
 test "EventData init" {


### PR DESCRIPTION
Fixes #209. Part of #191 — this is the last child issue.

## Connecting was impossible

Nothing in the package implemented `recovery.Authorizer`, so a rebuilt
connection carried no CBS claim and every link attach was refused with
`unauthorized-access`, which is fatal. No example could reach the network.

- **`CbsAuthorizer`** opens `$cbs`, puts the client's token for the
  audience, and tears the link down again. Per authorisation on purpose:
  the link is only needed for the round trip, and holding it across a
  rebuild would leave it pointing at a dead session.
- **`HubConnection`** assembles the dialler, retry schedule, authorizer,
  recoverable connection, and transport into one value. `open` initialises
  in place — it holds interior pointers, so a copy would dangle — and
  nothing dials until the first operation. `bind` is separate because a
  connection-string client owns the credential it parses, so the credential
  does not exist until after the client is built, and the client needs the
  transport.

## Two bugs this uncovered

`ConsumerPartitionOpener` held a fixed `*amqp.Session`. A recovered
connection has a *new* session, so after any connection-level recovery it
attached readers to nothing. It now holds the `*RecoverableConnection` and
resolves the session per open.

`SystemClock` called `std.time.milliTimestamp`, which does not exist in Zig
0.16. It was introduced in #292 and never analysed, so it compiled. It now
takes an `std.Io` and reads `std.Io.Timestamp.now(io, .real)` — wall time
rather than monotonic, because ownership expiry compares against a
`last_modified_time` written by another machine and the two must share an
epoch.

## Examples

`zig build examples` builds and installs six binaries:

| Example | What it shows |
| --- | --- |
| `eventhubs-send-events` | Producing with `DefaultAzureCredential` |
| `eventhubs-connection-string` | Producing with a connection string |
| `eventhubs-batch-producer` | Filling batches to the link's real ceiling |
| `eventhubs-consume-partition` | Reading one partition from earliest |
| `eventhubs-properties` | Hub and per-partition watermarks |
| `eventhubs-processor` | A `Processor` over `BlobCheckpointStore` |

They also build under `zig build test`: an example is API surface, so a
signature change that breaks one is a break for every caller.

## Live tests

Four tests, all skipping when unconfigured, so they compile *and run* in CI
with no Azure resources:

- a batch sent to a pinned partition is read back from it, resuming from
  the watermark taken before the send so the read is not racy;
- hub and partition properties agree on the hub name for every partition;
- a checkpoint and an ownership claim round-trip through blob storage,
  under their own consumer group so a real fleet's leases are untouched;
- a lone greedy processor claims every partition in one cycle.

Opt in with `AZURE_EVENTHUBS_LIVE_TESTS=1`; any other value is an error
rather than a silent skip, because skipping a run someone asked for is
worse than failing it. The README documents every variable.

## CI

Both placeholder steps are gone — `zig build examples` and
`zig build live-test`. The paired registry change is #295.

## Verification

`zig build test --summary all` — 166 tests pass, six examples compile, live
tests compile. `zig build live-test` — 4 skipped, 0 failed.
