### PR TITLE
Publish the Event Hubs examples and live tests

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -451,6 +451,8 @@ pub const all = [_]Package{
             "azure_sdk_amqp",
         },
         .external_dependencies = &.{ "uamqp", "serde" },
+        .examples_command = "zig build examples",
+        .live_test_command = "zig build live-test",
         .publish_paths = &.{
             ".gitignore",
             "build.zig",
@@ -470,6 +472,8 @@ pub const all = [_]Package{
             "checkpoint_store.zig",
             "management.zig",
             "checkpoint_store_blob",
+            "examples",
+            "live_tests",
             "README.md",
             "LICENSE.txt",
         },


### PR DESCRIPTION
Registry half of #294.

The eventhubs package branch now ships six examples and four live tests.
Two things have to change on `main` for that to mean anything:

- `examples_command` and `live_test_command`, because the package branch
  workflow is *generated* from this registry — without them the branch keeps
  regenerating the `echo "No examples configured"` placeholders.
- `"examples"` and `"live_tests"` in `publish_paths`, because a directory
  absent from that list is absent from the published tarball. This has bitten
  the AMQP package before, where four source files were silently missing.

`zig build package-check` reports 22 packages valid; `zig build test` passes.