### PR TITLE
Restore the experimental and unofficial README warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Azure SDK for Zig
 
+> **⚠️ Experimental and unofficial** — This project is built with AI assistance
+> (GitHub Copilot). It was ported from the
+> [Azure SDK for C++](https://github.com/Azure/azure-sdk-for-cpp) as a starting
+> point, with all C/C++ dependencies replaced by pure Zig equivalents.
+> This is not an official Microsoft or Azure SDK.
+
 Idiomatic Azure client libraries for Zig 0.16.0 and later.
 
 ## SDK Packages


### PR DESCRIPTION
Restores the top-of-README notice that this project is experimental,
AI-assisted, unofficial, and was ported from the
[Azure SDK for C++](https://github.com/Azure/azure-sdk-for-cpp) with all
C/C++ dependencies replaced by pure Zig equivalents.

## Where it went

- #111 (`8c55fd769`) replaced the full notice with a short
  "Experimental and unofficial" line, dropping the C++ provenance.
- `b1bb6eaa1` ("Consolidate Kusto and prepare package branch reset",
  pushed directly to `main`) removed the remaining line.

## Change

```diff
 # Azure SDK for Zig

+> **⚠️ Experimental and unofficial** — This project is built with AI assistance
+> (GitHub Copilot). It was ported from the
+> [Azure SDK for C++](https://github.com/Azure/azure-sdk-for-cpp) as a starting
+> point, with all C/C++ dependencies replaced by pure Zig equivalents.
+> This is not an official Microsoft or Azure SDK.
+
 Idiomatic Azure client libraries for Zig 0.16.0 and later.
```

Documentation-only change; no code, build, or package registry impact.