### PR TITLE
Honor AZURE_TOKEN_CREDENTIALS and drop the default IMDS probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,29 @@ Identity remains part of `azure_sdk_core` and is available through
 | `AzureCliCredential` | `az account get-access-token` |
 | `WorkloadIdentityCredential` | Kubernetes OIDC federation |
 | `ChainedTokenCredential` | First successful credential |
-| `DefaultAzureCredential` | Environment, workload identity, managed identity, then Azure CLI |
+| `DefaultAzureCredential` | A chain selected by `AZURE_TOKEN_CREDENTIALS` |
+
+### `AZURE_TOKEN_CREDENTIALS`
+
+`DefaultAzureCredential` builds its chain from `AZURE_TOKEN_CREDENTIALS`.
+
+| Value | Chain |
+| --- | --- |
+| unset | `EnvironmentCredential`, `WorkloadIdentityCredential`, `AzureCliCredential`, `AzureDeveloperCliCredential` |
+| `prod` | `EnvironmentCredential`, `WorkloadIdentityCredential`, `ManagedIdentityCredential` |
+| `dev` | `AzureCliCredential`, `AzureDeveloperCliCredential` |
+| a credential name | just that credential |
+
+Values are matched ignoring ASCII case and surrounding whitespace; any other
+value fails with `error.UnknownTokenCredentialSelection`. A selected credential
+whose configuration is absent is left out of the chain, and a selection that
+leaves the chain empty fails with `error.NoCredentialConfigured`.
+
+`ManagedIdentityCredential` probes the Instance Metadata Service at
+`169.254.169.254`, which is unroutable outside Azure and stalls every token
+request until the connection times out. It is therefore never in the default
+chain. Set `AZURE_TOKEN_CREDENTIALS=prod` on deployed services, or name the
+credential directly, to use it.
 
 ## Related packages
 

--- a/identity/azure_developer_cli.zig
+++ b/identity/azure_developer_cli.zig
@@ -13,12 +13,14 @@ const Context = core.context.Context;
 /// Parses JSON response fields: `token`, `expiresOn`.
 pub const AzureDeveloperCliCredential = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     tenant_id: ?[]const u8 = null,
     credential: TokenCredential,
 
-    pub fn init(allocator: std.mem.Allocator) AzureDeveloperCliCredential {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io) AzureDeveloperCliCredential {
         return .{
             .allocator = allocator,
+            .io = io,
             .credential = .{ .getTokenFn = &getTokenImpl },
         };
     }
@@ -40,7 +42,7 @@ pub const AzureDeveloperCliCredential = struct {
         else
             return error.NoScopesProvided;
 
-        const result = try runCommand(allocator, scope, self.tenant_id);
+        const result = try runCommand(allocator, self.io, scope, self.tenant_id);
         defer allocator.free(result);
 
         return parseAzdResponse(allocator, result);
@@ -143,8 +145,13 @@ fn parseRfc3339Unix(value: []const u8) !i64 {
 }
 
 /// Run the azd auth token command and capture stdout.
-fn runCommand(allocator: std.mem.Allocator, scope: []const u8, tenant_id: ?[]const u8) ![]u8 {
-    var argv_buf: [8][]const u8 = undefined;
+fn runCommand(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    scope: []const u8,
+    tenant_id: ?[]const u8,
+) ![]u8 {
+    var argv_buf: [9][]const u8 = undefined;
     var argc: usize = 0;
 
     argv_buf[argc] = "azd";
@@ -169,23 +176,20 @@ fn runCommand(allocator: std.mem.Allocator, scope: []const u8, tenant_id: ?[]con
         argc += 1;
     }
 
-    var child = std.process.Child.init(argv_buf[0..argc], allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    const result = try std.process.run(allocator, io, .{
+        .argv = argv_buf[0..argc],
+        .stdout_limit = .limited(1024 * 1024),
+        .stderr_limit = .limited(1024 * 1024),
+    });
+    defer allocator.free(result.stderr);
+    errdefer allocator.free(result.stdout);
 
-    try child.spawn();
+    switch (result.term) {
+        .exited => |code| if (code != 0) return error.AzdCliNotAvailable,
+        else => return error.AzdCliNotAvailable,
+    }
 
-    var stdout_buf: std.ArrayList(u8) = .empty;
-    defer stdout_buf.deinit(allocator);
-    var stderr_buf: std.ArrayList(u8) = .empty;
-    defer stderr_buf.deinit(allocator);
-
-    try child.collectOutput(allocator, &stdout_buf, &stderr_buf, 1024 * 1024);
-    const term = try child.wait();
-
-    if (term.Exited != 0) return error.AzdCliNotAvailable;
-
-    return stdout_buf.toOwnedSlice(allocator);
+    return result.stdout;
 }
 
 test "parseAzdResponse" {

--- a/identity/default_azure_credential.zig
+++ b/identity/default_azure_credential.zig
@@ -49,24 +49,120 @@ pub const ChainedTokenCredential = struct {
     }
 };
 
+/// A credential that `DefaultAzureCredential` can place in its chain.
+pub const CredentialKind = enum {
+    environment,
+    workload_identity,
+    managed_identity,
+    azure_cli,
+    azure_developer_cli,
+};
+
+/// Chain selection requested through the `AZURE_TOKEN_CREDENTIALS`
+/// environment variable.
+///
+/// `ManagedIdentityCredential` probes the Instance Metadata Service at
+/// `169.254.169.254`, which is unroutable outside Azure and stalls every token
+/// request until the connection times out. It is therefore excluded from the
+/// default chain and only used when `AZURE_TOKEN_CREDENTIALS` selects it,
+/// either directly or through the `prod` category.
+pub const TokenCredentialSelection = enum {
+    /// `AZURE_TOKEN_CREDENTIALS` unset: every credential except the IMDS probe.
+    default,
+    /// `prod`: deployed-service credentials.
+    prod,
+    /// `dev`: developer-tool credentials.
+    dev,
+    environment_credential,
+    workload_identity_credential,
+    managed_identity_credential,
+    azure_cli_credential,
+    azure_developer_cli_credential,
+
+    pub const env_var = "AZURE_TOKEN_CREDENTIALS";
+
+    pub const ParseError = error{UnknownTokenCredentialSelection};
+
+    const Alias = struct { name: []const u8, selection: TokenCredentialSelection };
+
+    const aliases = [_]Alias{
+        .{ .name = "prod", .selection = .prod },
+        .{ .name = "dev", .selection = .dev },
+        .{ .name = "EnvironmentCredential", .selection = .environment_credential },
+        .{ .name = "WorkloadIdentityCredential", .selection = .workload_identity_credential },
+        .{ .name = "ManagedIdentityCredential", .selection = .managed_identity_credential },
+        .{ .name = "AzureCliCredential", .selection = .azure_cli_credential },
+        .{ .name = "AzureDeveloperCliCredential", .selection = .azure_developer_cli_credential },
+    };
+
+    /// Parses an `AZURE_TOKEN_CREDENTIALS` value. Matching ignores ASCII case
+    /// and surrounding whitespace; an empty value means `.default`.
+    pub fn parse(raw: []const u8) ParseError!TokenCredentialSelection {
+        const value = std.mem.trim(u8, raw, " \t\r\n");
+        if (value.len == 0) return .default;
+        for (aliases) |alias| {
+            if (std.ascii.eqlIgnoreCase(value, alias.name)) return alias.selection;
+        }
+        return error.UnknownTokenCredentialSelection;
+    }
+
+    pub fn fromEnv(env: anytype) ParseError!TokenCredentialSelection {
+        return parse(envGet(env, env_var) orelse return .default);
+    }
+
+    /// Whether `kind` belongs in the chain for this selection.
+    pub fn includes(self: TokenCredentialSelection, kind: CredentialKind) bool {
+        return switch (self) {
+            .default => kind != .managed_identity,
+            .prod => switch (kind) {
+                .environment, .workload_identity, .managed_identity => true,
+                .azure_cli, .azure_developer_cli => false,
+            },
+            .dev => switch (kind) {
+                .azure_cli, .azure_developer_cli => true,
+                .environment, .workload_identity, .managed_identity => false,
+            },
+            .environment_credential => kind == .environment,
+            .workload_identity_credential => kind == .workload_identity,
+            .managed_identity_credential => kind == .managed_identity,
+            .azure_cli_credential => kind == .azure_cli,
+            .azure_developer_cli_credential => kind == .azure_developer_cli,
+        };
+    }
+};
+
 /// Pre-configured credential chain matching Azure's DefaultAzureCredential.
 ///
-/// Chain order:
-///   1. EnvironmentCredential
-///   2. WorkloadIdentityCredential  (if AZURE_FEDERATED_TOKEN_FILE set)
-///   3. ManagedIdentityCredential
-///   4. AzureCliCredential
+/// The chain is selected by `AZURE_TOKEN_CREDENTIALS`:
+///
+///   unset  EnvironmentCredential, WorkloadIdentityCredential,
+///          AzureCliCredential, AzureDeveloperCliCredential
+///   prod   EnvironmentCredential, WorkloadIdentityCredential,
+///          ManagedIdentityCredential
+///   dev    AzureCliCredential, AzureDeveloperCliCredential
+///   a credential name  only that credential
+///
+/// `WorkloadIdentityCredential` still requires `AZURE_TENANT_ID`,
+/// `AZURE_CLIENT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`, and
+/// `EnvironmentCredential` still requires its own variables; a selected
+/// credential that is not configured is left out of the chain.
+///
+/// `ManagedIdentityCredential` is never in the default chain because its IMDS
+/// probe stalls outside Azure. Set `AZURE_TOKEN_CREDENTIALS=prod` on deployed
+/// services, or name the credential directly, to use it.
 pub const DefaultAzureCredential = struct {
     allocator: std.mem.Allocator,
     state: *State,
 
     const State = struct {
         chain: ChainedTokenCredential,
+        selection: TokenCredentialSelection,
         env_cred: ?@import("environment.zig").EnvironmentCredential = null,
         wi_cred: ?@import("workload_identity.zig").WorkloadIdentityCredential = null,
         mi_cred: @import("managed_identity.zig").ManagedIdentityCredential,
         mi_client_id: ?[]u8 = null,
         cli_cred: @import("azure_cli.zig").AzureCliCredential,
+        azd_cred: @import("azure_developer_cli.zig").AzureDeveloperCliCredential,
         sources_buf: [5]ChainedTokenCredential.Source = undefined,
     };
 
@@ -76,11 +172,31 @@ pub const DefaultAzureCredential = struct {
         transport: *core.http.HttpTransport,
         env: anytype,
     ) !DefaultAzureCredential {
+        return initWithSelection(
+            allocator,
+            io,
+            transport,
+            env,
+            try TokenCredentialSelection.fromEnv(env),
+        );
+    }
+
+    /// Builds the chain for an explicit selection, ignoring
+    /// `AZURE_TOKEN_CREDENTIALS`.
+    pub fn initWithSelection(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        transport: *core.http.HttpTransport,
+        env: anytype,
+        requested: TokenCredentialSelection,
+    ) !DefaultAzureCredential {
         const state = try allocator.create(State);
         state.* = .{
             .chain = undefined,
+            .selection = requested,
             .mi_cred = @import("managed_identity.zig").ManagedIdentityCredential.init(allocator, transport),
             .cli_cred = @import("azure_cli.zig").AzureCliCredential.init(allocator, io),
+            .azd_cred = @import("azure_developer_cli.zig").AzureDeveloperCliCredential.init(allocator, io),
         };
         errdefer {
             if (state.env_cred) |*credential| credential.deinit();
@@ -89,35 +205,41 @@ pub const DefaultAzureCredential = struct {
             allocator.destroy(state);
         }
 
-        if (envGet(env, "AZURE_CLIENT_ID")) |client_id| {
-            state.mi_client_id = try allocator.dupe(u8, client_id);
-            state.mi_cred.withClientId(state.mi_client_id.?);
+        if (requested.includes(.managed_identity)) {
+            if (envGet(env, "AZURE_CLIENT_ID")) |client_id| {
+                state.mi_client_id = try allocator.dupe(u8, client_id);
+                state.mi_cred.withClientId(state.mi_client_id.?);
+            }
         }
 
-        // 1. EnvironmentCredential (may fail if env vars absent).
-        state.env_cred = @import("environment.zig").EnvironmentCredential.init(
-            allocator,
-            transport,
-            env,
-        ) catch |err| switch (err) {
-            error.EnvironmentNotConfigured => null,
-            else => return err,
-        };
-
-        // 2. WorkloadIdentityCredential (if federated token file is configured).
-        const wi_tenant = envGet(env, "AZURE_TENANT_ID");
-        const wi_client = envGet(env, "AZURE_CLIENT_ID");
-        const wi_file = envGet(env, "AZURE_FEDERATED_TOKEN_FILE");
-        if (wi_tenant != null and wi_client != null and wi_file != null) {
-            state.wi_cred = try @import("workload_identity.zig").WorkloadIdentityCredential.init(
+        // EnvironmentCredential (may fail if env vars absent).
+        if (requested.includes(.environment)) {
+            state.env_cred = @import("environment.zig").EnvironmentCredential.init(
                 allocator,
                 transport,
-                wi_tenant.?,
-                wi_client.?,
-                wi_file.?,
-            );
-            if (envGet(env, "AZURE_AUTHORITY_HOST")) |authority_host| {
-                try state.wi_cred.?.setAuthorityHost(authority_host);
+                env,
+            ) catch |err| switch (err) {
+                error.EnvironmentNotConfigured => null,
+                else => return err,
+            };
+        }
+
+        // WorkloadIdentityCredential (if federated token file is configured).
+        if (requested.includes(.workload_identity)) {
+            const wi_tenant = envGet(env, "AZURE_TENANT_ID");
+            const wi_client = envGet(env, "AZURE_CLIENT_ID");
+            const wi_file = envGet(env, "AZURE_FEDERATED_TOKEN_FILE");
+            if (wi_tenant != null and wi_client != null and wi_file != null) {
+                state.wi_cred = try @import("workload_identity.zig").WorkloadIdentityCredential.init(
+                    allocator,
+                    transport,
+                    wi_tenant.?,
+                    wi_client.?,
+                    wi_file.?,
+                );
+                if (envGet(env, "AZURE_AUTHORITY_HOST")) |authority_host| {
+                    try state.wi_cred.?.setAuthorityHost(authority_host);
+                }
             }
         }
 
@@ -131,13 +253,32 @@ pub const DefaultAzureCredential = struct {
             state.sources_buf[n] = .{ .name = "WorkloadIdentityCredential", .cred = state.wi_cred.?.asCredential() };
             n += 1;
         }
-        state.sources_buf[n] = .{ .name = "ManagedIdentityCredential", .cred = state.mi_cred.asCredential() };
-        n += 1;
-        state.sources_buf[n] = .{ .name = "AzureCliCredential", .cred = state.cli_cred.asCredential() };
-        n += 1;
+        if (requested.includes(.managed_identity)) {
+            state.sources_buf[n] = .{ .name = "ManagedIdentityCredential", .cred = state.mi_cred.asCredential() };
+            n += 1;
+        }
+        if (requested.includes(.azure_cli)) {
+            state.sources_buf[n] = .{ .name = "AzureCliCredential", .cred = state.cli_cred.asCredential() };
+            n += 1;
+        }
+        if (requested.includes(.azure_developer_cli)) {
+            state.sources_buf[n] = .{ .name = "AzureDeveloperCliCredential", .cred = state.azd_cred.asCredential() };
+            n += 1;
+        }
+        if (n == 0) return error.NoCredentialConfigured;
         state.chain = ChainedTokenCredential.init(state.sources_buf[0..n]);
 
         return .{ .allocator = allocator, .state = state };
+    }
+
+    /// The `AZURE_TOKEN_CREDENTIALS` selection this chain was built from.
+    pub fn selection(self: *const DefaultAzureCredential) TokenCredentialSelection {
+        return self.state.selection;
+    }
+
+    /// Names of the credentials in the chain, in order.
+    pub fn chainSources(self: *const DefaultAzureCredential) []const ChainedTokenCredential.Source {
+        return self.state.chain.sources;
     }
 
     pub fn asCredential(self: *DefaultAzureCredential) *TokenCredential {
@@ -152,6 +293,43 @@ pub const DefaultAzureCredential = struct {
         self.* = undefined;
     }
 };
+
+const TestEnv = struct {
+    allocator: std.mem.Allocator,
+    map: std.StringHashMap([]const u8),
+
+    fn init(alloc: std.mem.Allocator) TestEnv {
+        return .{
+            .allocator = alloc,
+            .map = std.StringHashMap([]const u8).init(alloc),
+        };
+    }
+
+    fn put(self: *TestEnv, key: []const u8, value: []const u8) !void {
+        try self.map.put(key, try self.allocator.dupe(u8, value));
+    }
+
+    pub fn get(self: TestEnv, key: []const u8) ?[]const u8 {
+        return self.map.get(key);
+    }
+
+    fn deinit(self: *TestEnv) void {
+        var iterator = self.map.valueIterator();
+        while (iterator.next()) |value| self.allocator.free(value.*);
+        self.map.deinit();
+    }
+};
+
+fn expectChain(
+    credential: *const DefaultAzureCredential,
+    expected: []const []const u8,
+) !void {
+    const sources = credential.chainSources();
+    try std.testing.expectEqual(expected.len, sources.len);
+    for (expected, sources) |name, source| {
+        try std.testing.expectEqualStrings(name, source.name);
+    }
+}
 
 test "ChainedTokenCredential uses first success" {
     const allocator = std.testing.allocator;
@@ -188,26 +366,26 @@ test "DefaultAzureCredential remains valid after return and move" {
     );
     defer mock.deinit();
 
-    const EmptyEnv = struct {
-        pub fn get(_: @This(), _: []const u8) ?[]const u8 {
-            return null;
-        }
-    };
+    var env = TestEnv.init(allocator);
+    defer env.deinit();
+    try env.put("AZURE_TOKEN_CREDENTIALS", "ManagedIdentityCredential");
+
     const Factory = struct {
         fn create(
             alloc: std.mem.Allocator,
             transport: *core.http.HttpTransport,
+            test_env: TestEnv,
         ) !DefaultAzureCredential {
             return DefaultAzureCredential.init(
                 alloc,
                 std.testing.io,
                 transport,
-                EmptyEnv{},
+                test_env,
             );
         }
     };
 
-    var returned = try Factory.create(allocator, mock.asTransport());
+    var returned = try Factory.create(allocator, mock.asTransport(), env);
     var moved = returned;
     returned = undefined;
     defer moved.deinit();
@@ -227,32 +405,6 @@ test "DefaultAzureCredential owns environment credential values" {
     );
     defer mock.deinit();
 
-    const TestEnv = struct {
-        allocator: std.mem.Allocator,
-        map: std.StringHashMap([]const u8),
-
-        fn init(alloc: std.mem.Allocator) @This() {
-            return .{
-                .allocator = alloc,
-                .map = std.StringHashMap([]const u8).init(alloc),
-            };
-        }
-
-        fn put(self: *@This(), key: []const u8, value: []const u8) !void {
-            try self.map.put(key, try self.allocator.dupe(u8, value));
-        }
-
-        pub fn get(self: @This(), key: []const u8) ?[]const u8 {
-            return self.map.get(key);
-        }
-
-        fn deinit(self: *@This()) void {
-            var iterator = self.map.valueIterator();
-            while (iterator.next()) |value| self.allocator.free(value.*);
-            self.map.deinit();
-        }
-    };
-
     var env = TestEnv.init(allocator);
     var env_owned = true;
     defer if (env_owned) env.deinit();
@@ -271,7 +423,6 @@ test "DefaultAzureCredential owns environment credential values" {
     );
     defer credential.deinit();
     try std.testing.expect(credential.state.env_cred.?.tenant_id.ptr != original_tenant_ptr);
-    try std.testing.expectEqualStrings("client", credential.state.mi_cred.client_id.?);
     try std.testing.expectEqualStrings(
         "https://login.microsoftonline.us",
         credential.state.wi_cred.?.authority_host,
@@ -285,4 +436,155 @@ test "DefaultAzureCredential owns environment credential values" {
     );
     defer allocator.free(token.token);
     try std.testing.expectEqualStrings("environment-token", token.token);
+}
+
+test "TokenCredentialSelection parses AZURE_TOKEN_CREDENTIALS values" {
+    const Selection = TokenCredentialSelection;
+    try std.testing.expectEqual(Selection.default, try Selection.parse(""));
+    try std.testing.expectEqual(Selection.default, try Selection.parse("  \t"));
+    try std.testing.expectEqual(Selection.prod, try Selection.parse("prod"));
+    try std.testing.expectEqual(Selection.prod, try Selection.parse(" PROD\n"));
+    try std.testing.expectEqual(Selection.dev, try Selection.parse("Dev"));
+    try std.testing.expectEqual(
+        Selection.managed_identity_credential,
+        try Selection.parse("managedidentitycredential"),
+    );
+    try std.testing.expectEqual(
+        Selection.azure_developer_cli_credential,
+        try Selection.parse("AzureDeveloperCliCredential"),
+    );
+    try std.testing.expectError(
+        error.UnknownTokenCredentialSelection,
+        Selection.parse("AzurePowerShellCredential"),
+    );
+}
+
+test "DefaultAzureCredential omits managed identity by default" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    var env = TestEnv.init(allocator);
+    defer env.deinit();
+
+    var credential = try DefaultAzureCredential.init(
+        allocator,
+        std.testing.io,
+        mock.asTransport(),
+        env,
+    );
+    defer credential.deinit();
+
+    try std.testing.expectEqual(TokenCredentialSelection.default, credential.selection());
+    try expectChain(&credential, &.{ "AzureCliCredential", "AzureDeveloperCliCredential" });
+    try std.testing.expectEqual(@as(?[]const u8, null), credential.state.mi_cred.client_id);
+}
+
+test "DefaultAzureCredential prod selection enables managed identity" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    var env = TestEnv.init(allocator);
+    defer env.deinit();
+    try env.put("AZURE_TOKEN_CREDENTIALS", "prod");
+    try env.put("AZURE_TENANT_ID", "tenant");
+    try env.put("AZURE_CLIENT_ID", "client");
+    try env.put("AZURE_CLIENT_SECRET", "secret");
+    try env.put("AZURE_FEDERATED_TOKEN_FILE", "/tmp/federated-token");
+
+    var credential = try DefaultAzureCredential.init(
+        allocator,
+        std.testing.io,
+        mock.asTransport(),
+        env,
+    );
+    defer credential.deinit();
+
+    try expectChain(&credential, &.{
+        "EnvironmentCredential",
+        "WorkloadIdentityCredential",
+        "ManagedIdentityCredential",
+    });
+    try std.testing.expectEqualStrings("client", credential.state.mi_cred.client_id.?);
+}
+
+test "DefaultAzureCredential dev selection uses developer tools only" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    var env = TestEnv.init(allocator);
+    defer env.deinit();
+    try env.put("AZURE_TOKEN_CREDENTIALS", "dev");
+    try env.put("AZURE_TENANT_ID", "tenant");
+    try env.put("AZURE_CLIENT_ID", "client");
+    try env.put("AZURE_CLIENT_SECRET", "secret");
+
+    var credential = try DefaultAzureCredential.init(
+        allocator,
+        std.testing.io,
+        mock.asTransport(),
+        env,
+    );
+    defer credential.deinit();
+
+    try expectChain(&credential, &.{ "AzureCliCredential", "AzureDeveloperCliCredential" });
+}
+
+test "DefaultAzureCredential honors a named credential" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    var env = TestEnv.init(allocator);
+    defer env.deinit();
+    try env.put("AZURE_TOKEN_CREDENTIALS", "AzureCliCredential");
+    try env.put("AZURE_TENANT_ID", "tenant");
+    try env.put("AZURE_CLIENT_ID", "client");
+    try env.put("AZURE_CLIENT_SECRET", "secret");
+
+    var credential = try DefaultAzureCredential.init(
+        allocator,
+        std.testing.io,
+        mock.asTransport(),
+        env,
+    );
+    defer credential.deinit();
+
+    try expectChain(&credential, &.{"AzureCliCredential"});
+}
+
+test "DefaultAzureCredential rejects an unknown selection" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    var env = TestEnv.init(allocator);
+    defer env.deinit();
+    try env.put("AZURE_TOKEN_CREDENTIALS", "NotACredential");
+
+    try std.testing.expectError(error.UnknownTokenCredentialSelection, DefaultAzureCredential.init(
+        allocator,
+        std.testing.io,
+        mock.asTransport(),
+        env,
+    ));
+}
+
+test "DefaultAzureCredential rejects a selection with no configured credential" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+
+    var env = TestEnv.init(allocator);
+    defer env.deinit();
+    try env.put("AZURE_TOKEN_CREDENTIALS", "WorkloadIdentityCredential");
+
+    try std.testing.expectError(error.NoCredentialConfigured, DefaultAzureCredential.init(
+        allocator,
+        std.testing.io,
+        mock.asTransport(),
+        env,
+    ));
 }

--- a/identity/root.zig
+++ b/identity/root.zig
@@ -31,6 +31,8 @@ pub const AzurePipelinesCredential = azure_pipelines.AzurePipelinesCredential;
 pub const WorkloadIdentityCredential = workload_identity.WorkloadIdentityCredential;
 pub const ChainedTokenCredential = default_azure_credential.ChainedTokenCredential;
 pub const DefaultAzureCredential = default_azure_credential.DefaultAzureCredential;
+pub const TokenCredentialSelection = default_azure_credential.TokenCredentialSelection;
+pub const CredentialKind = default_azure_credential.CredentialKind;
 
 test {
     @import("std").testing.refAllDecls(@This());


### PR DESCRIPTION
Closes #297.

## Problem

`DefaultAzureCredential` always placed `ManagedIdentityCredential` in its chain.
That credential probes IMDS at `http://169.254.169.254`, which is unroutable
outside Azure, so every token acquisition on a developer machine stalled until
the connect timed out before falling through to the Azure CLI.

## Change

The chain is now selected by `AZURE_TOKEN_CREDENTIALS`, matching the
[.NET/Java/Python/JS behavior](https://learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains?tabs=dac#use-a-specific-credential)
tracked upstream in Azure/azure-sdk-for-rust#3072.

| `AZURE_TOKEN_CREDENTIALS` | Chain |
| --- | --- |
| unset | `EnvironmentCredential`, `WorkloadIdentityCredential`, `AzureCliCredential`, `AzureDeveloperCliCredential` |
| `prod` | `EnvironmentCredential`, `WorkloadIdentityCredential`, `ManagedIdentityCredential` |
| `dev` | `AzureCliCredential`, `AzureDeveloperCliCredential` |
| a credential name | just that credential |

- Values match ignoring ASCII case and surrounding whitespace; an empty value
  means the default.
- Any other value fails with `error.UnknownTokenCredentialSelection`.
- A selected credential whose configuration is absent is left out of the chain;
  a selection that leaves the chain empty fails with
  `error.NoCredentialConfigured`.
- Credentials excluded by the selection are no longer constructed, so the
  managed identity client id is only read when that credential is in the chain.
- New public API: `identity.TokenCredentialSelection`, `identity.CredentialKind`,
  `DefaultAzureCredential.initWithSelection`, `.selection()`, `.chainSources()`.

IMDS is still fully supported — it is opt-in via `AZURE_TOKEN_CREDENTIALS=prod`
(the natural setting for a deployed service) or by naming
`ManagedIdentityCredential` directly.

## Incidental fix

`AzureDeveloperCliCredential` joins the chain for the first time, which exposed
that its `runCommand` still used the removed `std.process.Child.init` API and
never compiled under Zig 0.16. It is ported to `std.process.run` to match
`AzureCliCredential`; this adds a `std.Io` parameter to its `init`.

## Behavior change

`DefaultAzureCredential` no longer contacts IMDS unless asked to. Deployed
services relying on managed identity must set `AZURE_TOKEN_CREDENTIALS=prod`.

## Validation

```
zig fmt --check .   # clean
zig build           # ok
zig build test --summary all   # 165/165 pass
```