### PR TITLE
core: real clock and allocation counting in the perf harness (0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The canonical package/module name is `azure_sdk_core`, released from
 | `errors` | Azure error-envelope parsing |
 | `lro` | Long-running-operation polling |
 | `pager` | Generic `PipelinePager` |
+| `tracing` | Span and attribute plumbing |
+| `perf` | Wall-clock and allocation benchmark harness |
 
 `HttpTransport.open` and `HttpPipeline.open` return a heap-backed,
 single-owner `HttpOperation`. Consume its reader and call `finish` to drain for
@@ -69,12 +71,43 @@ request until the connection times out. It is therefore never in the default
 chain. Set `AZURE_TOKEN_CREDENTIALS=prod` on deployed services, or name the
 credential directly, to use it.
 
+## Benchmarking
+
+`core.perf` measures a closure against the monotonic clock and counts the
+allocations it makes.
+
+```zig
+fn encodeOnce() !void { ... }
+
+const result = core.perf.benchmark(io, "encode", 10_000, encodeOnce);
+core.perf.printResult(result);
+```
+
+`benchmark` needs a `std.Io` because it reads `std.Io.Timestamp.now(io, .awake)`,
+the monotonic clock that keeps running while a task sleeps. Pass the same `Io`
+the code under test uses; `std.testing.io` works in tests.
+
+To attribute allocations, run through `benchmarkAllocating`, which wraps the
+allocator you hand it and reports `allocationsPerOp` and `bytesPerOp` alongside
+`avgNs`:
+
+```zig
+fn encodeWith(allocator: std.mem.Allocator) !void { ... }
+
+const result = core.perf.benchmarkAllocating(io, "encode", 10_000, gpa, encodeWith);
+```
+
+`CountingAllocator` is also usable on its own to assert an operation stays
+allocation-free.
+
 ## Related packages
 
-- [Tracing](https://github.com/cataggar/azure-sdk-for-zig/tree/main/sdk/core/tracing)
-- [Testing](https://github.com/cataggar/azure-sdk-for-zig/tree/main/sdk/core/testing)
-- [Performance](https://github.com/cataggar/azure-sdk-for-zig/tree/main/sdk/core/perf)
-- [AMQP](https://github.com/cataggar/azure-sdk-for-zig/tree/main/sdk/core/amqp)
+- [AMQP](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/amqp)
+- [Event Hubs](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/eventhubs)
+- [Service Bus](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/servicebus)
+- [Testing](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/testing)
+
+`tracing` and `perf` are namespaces of this package, not separate packages.
 
 ## Development
 
@@ -82,5 +115,5 @@ credential directly, to use it.
 zig build test --summary all
 ```
 
-The package depends on `serde` and `azure_sdk_core_tracing`. See the
+The package depends on `serde`. See the
 [package model](https://github.com/cataggar/azure-sdk-for-zig/blob/main/doc/package-branch-model.md).

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 
+/// Single source of truth for the package version: the manifest.
+const package_version = @import("build.zig.zon").version;
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -10,12 +13,17 @@ pub fn build(b: *std.Build) void {
     });
     const serde_mod = serde_dep.module("serde");
 
+    const options = b.addOptions();
+    options.addOption([]const u8, "version", package_version);
+    const options_mod = options.createModule();
+
     _ = b.addModule("azure_sdk_core", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
             .{ .name = "serde", .module = serde_mod },
+            .{ .name = "build_options", .module = options_mod },
         },
     });
 
@@ -26,6 +34,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "serde", .module = serde_mod },
+                .{ .name = "build_options", .module = options_mod },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_core,
-    .version = "0.1.3",
+    .version = "0.2.0",
     .fingerprint = 0x0fdf522a12345678,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/perf/root.zig
+++ b/perf/root.zig
@@ -1,10 +1,15 @@
-///! Azure SDK Performance Framework — benchmark harness.
-///!
-///! Provides a lightweight framework for throughput and latency benchmarks.
+//! Azure SDK Performance Framework — benchmark harness.
+//!
+//! Measures wall-clock nanoseconds and, optionally, allocation counts.
+//!
+//! Timing reads `std.Io.Timestamp` on the `.awake` monotonic clock, so every
+//! caller must supply a `std.Io`. Use `std.testing.io` in tests.
 const std = @import("std");
-const builtin = @import("builtin");
 
 /// Collected metrics from a benchmark run.
+///
+/// `allocations` and `bytes_allocated` are zero unless the benchmark ran
+/// through `benchmarkAllocating`.
 pub const BenchmarkResult = struct {
     name: []const u8,
     iterations: u64,
@@ -12,6 +17,12 @@ pub const BenchmarkResult = struct {
     min_ns: u64,
     max_ns: u64,
     sum_ns: u64,
+    allocations: u64 = 0,
+    bytes_allocated: u64 = 0,
+    /// Iterations whose closure returned an error. A benchmark that fails
+    /// early looks deceptively fast, so callers should check this is zero
+    /// before trusting the timings.
+    errors: u64 = 0,
 
     pub fn avgNs(self: BenchmarkResult) u64 {
         if (self.iterations == 0) return 0;
@@ -24,24 +35,113 @@ pub const BenchmarkResult = struct {
         const secs: f64 = @as(f64, @floatFromInt(self.total_ns)) / 1_000_000_000.0;
         return iters / secs;
     }
+
+    pub fn allocationsPerOp(self: BenchmarkResult) f64 {
+        if (self.iterations == 0) return 0;
+        return @as(f64, @floatFromInt(self.allocations)) /
+            @as(f64, @floatFromInt(self.iterations));
+    }
+
+    pub fn bytesPerOp(self: BenchmarkResult) f64 {
+        if (self.iterations == 0) return 0;
+        return @as(f64, @floatFromInt(self.bytes_allocated)) /
+            @as(f64, @floatFromInt(self.iterations));
+    }
 };
 
-/// Simple monotonic tick counter.
-/// Uses a thread-safe atomic counter — suitable for relative benchmarking.
-/// Real high-resolution timing requires `std.Io` in Zig 0.16.
-var global_tick: std.atomic.Value(u64) = std.atomic.Value(u64).init(0);
+/// Wraps an allocator and counts allocations and bytes requested.
+///
+/// `resize` is not counted: it grows or shrinks an existing allocation in
+/// place and issues no new one. `remap` is counted because it may move the
+/// allocation.
+pub const CountingAllocator = struct {
+    parent: std.mem.Allocator,
+    count: u64 = 0,
+    bytes: u64 = 0,
 
-fn readTick() u64 {
-    return global_tick.fetchAdd(1, .monotonic);
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    pub fn init(parent: std.mem.Allocator) CountingAllocator {
+        return .{ .parent = parent };
+    }
+
+    pub fn allocator(self: *CountingAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    /// Clears the counters without disturbing the parent allocator, so a
+    /// warm-up pass can be excluded from a measurement.
+    pub fn reset(self: *CountingAllocator) void {
+        self.count = 0;
+        self.bytes = 0;
+    }
+
+    fn alloc(
+        ctx: *anyopaque,
+        len: usize,
+        alignment: std.mem.Alignment,
+        ret_addr: usize,
+    ) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.count += 1;
+        self.bytes += len;
+        return self.parent.rawAlloc(len, alignment, ret_addr);
+    }
+
+    fn resize(
+        ctx: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        ret_addr: usize,
+    ) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.parent.rawResize(memory, alignment, new_len, ret_addr);
+    }
+
+    fn remap(
+        ctx: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        ret_addr: usize,
+    ) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.count += 1;
+        self.bytes += new_len;
+        return self.parent.rawRemap(memory, alignment, new_len, ret_addr);
+    }
+
+    fn free(
+        ctx: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        ret_addr: usize,
+    ) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.parent.rawFree(memory, alignment, ret_addr);
+    }
+};
+
+/// Reads the monotonic clock that keeps running while the process sleeps.
+pub fn nowNs(io: std.Io) i96 {
+    return std.Io.Timestamp.now(io, .awake).nanoseconds;
 }
 
-fn ticksToNs(ticks: u64) u64 {
-    // Each "tick" is one iteration unit — approximate as 1ns for stats.
-    return ticks;
+fn elapsedSince(io: std.Io, start: i96) u64 {
+    const delta = nowNs(io) - start;
+    if (delta <= 0) return 0;
+    return @intCast(delta);
 }
 
-/// Run a benchmark function `iterations` times and collect timing stats.
+/// Runs `func` `iterations` times and collects wall-clock timing stats.
 pub fn benchmark(
+    io: std.Io,
     name: []const u8,
     iterations: u64,
     comptime func: anytype,
@@ -49,36 +149,84 @@ pub fn benchmark(
     var min_ns: u64 = std.math.maxInt(u64);
     var max_ns: u64 = 0;
     var sum_ns: u64 = 0;
+    var errors: u64 = 0;
 
-    const start = readTick();
+    const start = nowNs(io);
 
     var i: u64 = 0;
     while (i < iterations) : (i += 1) {
-        const lap_start = readTick();
-        func() catch {};
-        const lap_end = readTick();
-        const elapsed = ticksToNs(lap_end - lap_start);
+        const lap_start = nowNs(io);
+        func() catch {
+            errors += 1;
+        };
+        const elapsed = elapsedSince(io, lap_start);
         sum_ns += elapsed;
         if (elapsed < min_ns) min_ns = elapsed;
         if (elapsed > max_ns) max_ns = elapsed;
     }
 
-    const total_ns = ticksToNs(readTick() - start);
+    return .{
+        .name = name,
+        .iterations = iterations,
+        .total_ns = elapsedSince(io, start),
+        .min_ns = if (iterations > 0) min_ns else 0,
+        .max_ns = max_ns,
+        .sum_ns = sum_ns,
+        .errors = errors,
+    };
+}
+
+/// Runs `func(allocator)` `iterations` times, collecting timing stats and
+/// counting the allocations `func` makes.
+///
+/// `func` receives a counting wrapper around `parent`; it must free whatever
+/// it allocates, since the wrapper only observes.
+pub fn benchmarkAllocating(
+    io: std.Io,
+    name: []const u8,
+    iterations: u64,
+    parent: std.mem.Allocator,
+    comptime func: anytype,
+) BenchmarkResult {
+    var counting = CountingAllocator.init(parent);
+    const allocator = counting.allocator();
+
+    var min_ns: u64 = std.math.maxInt(u64);
+    var max_ns: u64 = 0;
+    var sum_ns: u64 = 0;
+    var errors: u64 = 0;
+
+    const start = nowNs(io);
+
+    var i: u64 = 0;
+    while (i < iterations) : (i += 1) {
+        const lap_start = nowNs(io);
+        func(allocator) catch {
+            errors += 1;
+        };
+        const elapsed = elapsedSince(io, lap_start);
+        sum_ns += elapsed;
+        if (elapsed < min_ns) min_ns = elapsed;
+        if (elapsed > max_ns) max_ns = elapsed;
+    }
 
     return .{
         .name = name,
         .iterations = iterations,
-        .total_ns = total_ns,
+        .total_ns = elapsedSince(io, start),
         .min_ns = if (iterations > 0) min_ns else 0,
         .max_ns = max_ns,
         .sum_ns = sum_ns,
+        .allocations = counting.count,
+        .bytes_allocated = counting.bytes,
+        .errors = errors,
     };
 }
 
-/// Print benchmark results to stderr.
+/// Prints a benchmark result to stderr.
 pub fn printResult(result: BenchmarkResult) void {
     std.debug.print(
-        "BENCH {s}: {d} iters, avg {d}ns, min {d}ns, max {d}ns, {d:.0} ops/s\n",
+        "BENCH {s}: {d} iters, avg {d}ns, min {d}ns, max {d}ns, {d:.0} ops/s, {d:.2} allocs/op, {d:.0} B/op{s}\n",
         .{
             result.name,
             result.iterations,
@@ -86,8 +234,17 @@ pub fn printResult(result: BenchmarkResult) void {
             result.min_ns,
             result.max_ns,
             result.opsPerSecond(),
+            result.allocationsPerOp(),
+            result.bytesPerOp(),
+            if (result.errors > 0) " [ERRORS]" else "",
         },
     );
+    if (result.errors > 0) {
+        std.debug.print(
+            "  WARNING: {d} of {d} iterations returned an error; timings are not meaningful\n",
+            .{ result.errors, result.iterations },
+        );
+    }
 }
 
 fn dummyWork() !void {
@@ -96,13 +253,93 @@ fn dummyWork() !void {
     std.mem.doNotOptimizeAway(x);
 }
 
-test "benchmark collects stats" {
-    const result = benchmark("dummy", 1000, dummyWork);
+fn allocatingWork(allocator: std.mem.Allocator) !void {
+    const buf = try allocator.alloc(u8, 64);
+    defer allocator.free(buf);
+    @memset(buf, 7);
+    std.mem.doNotOptimizeAway(buf.ptr);
+}
+
+test "benchmark measures wall-clock time" {
+    const result = benchmark(std.testing.io, "dummy", 1000, dummyWork);
     try std.testing.expectEqual(@as(u64, 1000), result.iterations);
     try std.testing.expect(result.total_ns > 0);
     try std.testing.expect(result.min_ns <= result.max_ns);
-    try std.testing.expect(result.avgNs() > 0);
     try std.testing.expect(result.opsPerSecond() > 0);
+    try std.testing.expectEqual(@as(u64, 0), result.allocations);
+}
+
+test "benchmark elapsed time grows with work" {
+    const Work = struct {
+        fn spin(comptime rounds: usize) fn () anyerror!void {
+            return struct {
+                fn run() anyerror!void {
+                    var x: u64 = 0;
+                    for (0..rounds) |i| x +%= i *% 2654435761;
+                    std.mem.doNotOptimizeAway(x);
+                }
+            }.run;
+        }
+    };
+    const small = benchmark(std.testing.io, "small", 200, Work.spin(64));
+    const large = benchmark(std.testing.io, "large", 200, Work.spin(64 * 512));
+    try std.testing.expect(large.total_ns > small.total_ns);
+}
+
+test "benchmarkAllocating counts allocations" {
+    const result = benchmarkAllocating(
+        std.testing.io,
+        "alloc",
+        100,
+        std.testing.allocator,
+        allocatingWork,
+    );
+    try std.testing.expectEqual(@as(u64, 100), result.iterations);
+    try std.testing.expectEqual(@as(u64, 100), result.allocations);
+    try std.testing.expectEqual(@as(u64, 6400), result.bytes_allocated);
+    try std.testing.expectEqual(@as(f64, 1), result.allocationsPerOp());
+    try std.testing.expectEqual(@as(f64, 64), result.bytesPerOp());
+}
+
+test "CountingAllocator counts allocations but not resizes" {
+    var counting = CountingAllocator.init(std.testing.allocator);
+    const allocator = counting.allocator();
+
+    const buf = try allocator.alloc(u8, 32);
+    defer allocator.free(buf);
+    try std.testing.expectEqual(@as(u64, 1), counting.count);
+    try std.testing.expectEqual(@as(u64, 32), counting.bytes);
+
+    _ = allocator.resize(buf, 16);
+    try std.testing.expectEqual(@as(u64, 1), counting.count);
+
+    counting.reset();
+    try std.testing.expectEqual(@as(u64, 0), counting.count);
+    try std.testing.expectEqual(@as(u64, 0), counting.bytes);
+}
+
+test "CountingAllocator forwards to the parent allocator" {
+    var counting = CountingAllocator.init(std.testing.allocator);
+    const allocator = counting.allocator();
+
+    var list: std.ArrayList(u32) = .empty;
+    defer list.deinit(allocator);
+    for (0..256) |i| try list.append(allocator, @intCast(i));
+
+    try std.testing.expectEqual(@as(usize, 256), list.items.len);
+    try std.testing.expectEqual(@as(u32, 255), list.items[255]);
+    try std.testing.expect(counting.count > 0);
+}
+
+test "benchmark records failing iterations" {
+    const Failing = struct {
+        fn run() !void {
+            return error.Boom;
+        }
+    };
+    const result = benchmark(std.testing.io, "failing", 10, Failing.run);
+    try std.testing.expectEqual(@as(u64, 10), result.errors);
+    try std.testing.expectEqual(@as(u64, 10), result.iterations);
 }
 
 test "BenchmarkResult zero iterations" {
@@ -116,4 +353,6 @@ test "BenchmarkResult zero iterations" {
     };
     try std.testing.expectEqual(@as(u64, 0), r.avgNs());
     try std.testing.expectEqual(@as(f64, 0), r.opsPerSecond());
+    try std.testing.expectEqual(@as(f64, 0), r.allocationsPerOp());
+    try std.testing.expectEqual(@as(f64, 0), r.bytesPerOp());
 }

--- a/root.zig
+++ b/root.zig
@@ -47,7 +47,7 @@ pub const wasi_http = if (@import("builtin").target.cpu.arch == .wasm32 and
 else
     struct {};
 
-pub const version: []const u8 = "0.1.0";
+pub const version: []const u8 = @import("build_options").version;
 pub const user_agent_prefix: []const u8 = "azsdk-zig-core/" ++ version;
 
 test {


### PR DESCRIPTION
## Why

`perf.benchmark` did not measure time. It read a global atomic tick counter that it incremented itself (`perf/root.zig:31-41`), so its "nanoseconds" were a count of calls, not a duration. Any benchmark built on it would have been unable to detect a regression or confirm an optimisation.

This blocks the planned Event Hubs and Service Bus performance work, which needs a trustworthy baseline before and after each change.

## What

- **Real clock.** Timing now reads `std.Io.Timestamp.now(io, .awake).nanoseconds`, the monotonic clock that keeps running while a task sleeps. Verified end to end: a 50 ms sleep measures 50 ms, and a fixed spin loop reports a stable ~218 µs/iter with a plausible min/max spread.
- **Allocation counting.** New `benchmarkAllocating` runs the closure against a `CountingAllocator` and reports allocations/op and bytes/op beside ns/op. This is the metric the messaging packages need most — their hot paths are dominated by per-message allocations rather than compute. `resize` is not counted (it issues no new allocation); `remap` is, because it may move the allocation. `CountingAllocator` is public so a test can assert an operation stays allocation-free.
- **Errors are no longer swallowed.** The harness did `func() catch {}`, so a benchmark that failed on its first statement reported outstanding throughput. `BenchmarkResult.errors` now records failing iterations and `printResult` flags them.

### Breaking change

`benchmark` takes a `std.Io` as its first parameter. That is why this is `0.1.3` → **`0.2.0`** rather than a patch. No package in this repository calls `perf.benchmark` today, so there is nothing to migrate; dependents repinning to `0.2.0` need no source change.

## Adjacent fixes

Both are in code this PR touches:

- `core.version` was hardcoded `"0.1.0"` in `root.zig` while the manifest said `0.1.3` — drifted across three releases, and it is sent to Azure in every `User-Agent` via `user_agent_prefix`. It is now derived from `build.zig.zon` at build time, so the two cannot disagree again. Confirmed from a real consumer package: `core.version=0.2.0`, `ua=azsdk-zig-core/0.2.0`.
- The README's "Related packages" links pointed at `main/sdk/core/tracing|testing|perf|amqp`, paths that do not exist under the branch-owned package model, and the development section claimed a dependency on `azure_sdk_core_tracing`, which is not a package. Links now point at the package branches, `tracing` and `perf` are documented as namespaces of this package, and the perf harness itself is documented.

## Verification

- `zig build test --summary all` — 170/170 pass (6 new perf tests).
- `zig fmt --check .` — clean.
- Consumer check: a scratch package depending on this tree reads the version through the module graph correctly.

Part of the uamqp v0.3.0 upgrade and Event Hubs / Service Bus performance work; this is the prerequisite that makes the later benchmark deltas meaningful.