### PR TITLE
amqp: move to uamqp v0.3.0 (0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 AMQP 1.0 integration for Azure SDK clients, backed by the pure Zig
 [`azure-uamqp-zig`](https://github.com/cataggar/azure-uamqp-zig) package.
 
-- Source: `sdk/core/amqp`
-- Release branch: `sdk/core_amqp`
-- Initial version: `0.1.0`
-- External dependency: `uamqp`
+- Package branch: [`sdk/amqp`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/amqp)
+- External dependency: `uamqp` ([`azure-uamqp-zig`](https://github.com/cataggar/azure-uamqp-zig)), re-exported as `azure_sdk_amqp.uamqp`
+- Version: see `build.zig.zon`
 
 `azure-uamqp-zig` supplies the AMQP type system and frame layout but owns no
 sockets and encodes no performatives. This package adds both, so a client can
@@ -38,9 +37,15 @@ defer socket.deinit();
 ## Performative codec
 
 `performative.zig` encodes and decodes `open`, `begin`, `end`, `close`, and the
-SASL performatives as described lists. Encoding is written here rather than
-delegated to `uamqp.encoder` because that encoder writes array elements of
-variable-width types without their length prefix, which no peer accepts.
+SASL performatives as described lists.
+
+Encoding was originally written here rather than delegated to `uamqp.encoder`
+because that encoder wrote array elements of variable-width types without their
+length prefix, which no peer accepts. **uamqp v0.3.0 fixed that** — it now
+emits a shared element constructor and per-element lengths, and rejects arrays
+it cannot describe (`MixedArrayElements`, `UnsupportedArrayElement`). The
+duplication is therefore no longer necessary and this codec could be folded
+into `uamqp.encoder`; that consolidation has not been done yet.
 
 ## Connection driver
 

--- a/build.zig
+++ b/build.zig
@@ -4,16 +4,20 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const uamqp_dep = b.dependency("uamqp", .{});
-    // Registered by name rather than created anonymously so dependents can
-    // reuse this exact module. Two `createModule` calls over the same source
-    // produce two modules, and therefore two incompatible copies of every
-    // type in them, which breaks any dependent that passes an `AmqpValue`
-    // across the package boundary.
-    const uamqp_mod = b.addModule("uamqp", .{
-        .root_source_file = uamqp_dep.path("src/zig/uamqp.zig"),
+    const uamqp_dep = b.dependency("uamqp", .{
         .target = target,
+        .optimize = optimize,
     });
+    // Re-export uamqp's own module instance rather than rebuilding one from
+    // its source path. Rebuilding skips the wiring uamqp's build.zig does —
+    // as of v0.3.0 it imports its own build.zig.zon so `uamqp.version` is not
+    // a second copy of the version — and it would break again on any future
+    // addition. Re-exporting also keeps a single instance: two modules over
+    // the same source produce two incompatible copies of every type in them,
+    // which breaks any dependent that passes an `AmqpValue` across the
+    // package boundary.
+    const uamqp_mod = uamqp_dep.module("uamqp");
+    b.modules.put(b.graph.arena, b.dupe("uamqp"), uamqp_mod) catch @panic("OOM");
 
     _ = b.addModule("azure_sdk_amqp", .{
         .root_source_file = b.path("root.zig"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .azure_sdk_amqp,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xe0a2f9e77f72407d,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .uamqp = .{
-            .url = "git+https://github.com/cataggar/azure-uamqp-zig#593310683d2a60da5388aa02d1e464a393a51f23",
-            .hash = "uamqp-0.1.0-lXMcaSv6AQCOX3VGEAULcjka6Retcu8O6XMRo4m4Esr4",
+            .url = "git+https://github.com/cataggar/azure-uamqp-zig#7fe05747b219fa105d3d36dcf6eaebfe15d61d0e",
+            .hash = "uamqp-0.3.0-lXMcaflQBwBNWqC7b-Ny7_0QBjy4KRDRSjxnWXznD4Zz",
         },
     },
     .paths = .{

--- a/connection.zig
+++ b/connection.zig
@@ -35,7 +35,10 @@ pub const sasl_anonymous = "ANONYMOUS";
 /// Initial response Go sends for anonymous SASL (`sasl.go:75`).
 pub const sasl_anonymous_response = "anonymous";
 
-pub const ConnectionError = error{
+/// Includes the encoder's failure modes by union rather than by restating
+/// them, so a value the encoder cannot represent surfaces as itself instead of
+/// being flattened into a transport error.
+pub const ConnectionError = perf.EncodeError || error{
     OutOfMemory,
     ConnectionFailed,
     ConnectionClosed,

--- a/message.zig
+++ b/message.zig
@@ -20,7 +20,9 @@ const descriptor = uamqp.definitions.descriptor;
 
 pub const Fields = perf.Fields;
 
-pub const EncodeError = error{OutOfMemory};
+/// Aliased to uamqp's error set rather than restated, so a new encoder
+/// failure mode cannot silently fail to compile here again.
+pub const EncodeError = encoder.EncodeError;
 
 pub const DecodeError = error{
     OutOfMemory,

--- a/performative.zig
+++ b/performative.zig
@@ -25,7 +25,9 @@ pub const SaslCode = uamqp.definitions.SaslCode;
 /// Descriptor code for `error` (§2.8.15), which uamqp omits.
 pub const error_descriptor: u64 = 0x000000000000001d;
 
-pub const EncodeError = error{OutOfMemory};
+/// Aliased to uamqp's error set rather than restated, so a new encoder
+/// failure mode cannot silently fail to compile here again.
+pub const EncodeError = encoder.EncodeError;
 
 pub const DecodeError = error{
     OutOfMemory,

--- a/performative.zig
+++ b/performative.zig
@@ -5,10 +5,12 @@
 //! order follows the OASIS AMQP 1.0 specification §2.7 and §5.3; trailing null
 //! fields are elided as §1.3 permits.
 //!
-//! Encoding is done directly rather than through `uamqp.encoder` because that
-//! encoder writes array elements of variable-width types without their length
-//! prefix, which no peer will accept. Decoding does use `uamqp.decoder`, whose
-//! array handling is correct.
+//! Compound values are encoded directly rather than through `uamqp.encoder`.
+//! That was originally necessary: the encoder wrote array elements of
+//! variable-width types without their length prefix, which no peer accepts.
+//! uamqp v0.3.0 fixed it, so this is now duplication rather than a
+//! workaround, and could be folded into `uamqp.encoder`. Decoding already
+//! uses `uamqp.decoder`.
 
 const std = @import("std");
 const uamqp = @import("uamqp");


### PR DESCRIPTION
The `uamqp` pin was 36 commits behind and predated **v0.2.0**, so this takes the v0.2.0 and v0.3.0 breaking sets together.

Pin moves to tag [`v0.3.0`](https://github.com/cataggar/azure-uamqp-zig/releases/tag/v0.3.0) — commit `7fe05747b219fa105d3d36dcf6eaebfe15d61d0e`, hash `uamqp-0.3.0-lXMcaflQBwBNWqC7b-Ny7_0QBjy4KRDRSjxnWXznD4Zz`.

## 1. Build: re-export uamqp's module instead of rebuilding it

`build.zig` re-created the uamqp module from its source path rather than using the one uamqp's own `build.zig` exports. v0.3.0 made `uamqp.version` read its `build.zig.zon` through an anonymous import that only that `build.zig` sets up, so a hand-rolled module now fails outright:

```
uamqp.zig:47:29: error: unable to load 'build.zig.zon': FileNotFound
pub const version = @import("build.zig.zon").version;
```

Now re-exports uamqp's own module instance via `b.modules.put`. This keeps the single-instance property the old comment cared about — two modules over the same source produce two incompatible copies of every type, which breaks any dependent passing an `AmqpValue` across the package boundary — and it won't break again next time uamqp adds module wiring. Dependency options now forward `target` and `optimize`, which they previously did not.

## 2. Error sets: alias uamqp's instead of restating it

`EncodeError` was restated locally as `error{OutOfMemory}` in both `message.zig` and `performative.zig`. v0.3.0 added bounds and array-shape checks, so the encoder can now also return `ValueTooLarge`, `MixedArrayElements`, and `UnsupportedArrayElement` — 7 compile errors.

Rather than re-listing them (which is what let this drift in the first place), `EncodeError` is now an alias of `uamqp.encoder.EncodeError`, and that set is unioned into `ConnectionError` — which `LinkError` already builds on. A value the encoder cannot represent now surfaces as itself instead of being flattened into a transport error.

`NestingTooDeep` (also new) is absorbed by the existing decoder `else` arm into `MalformedBody`. That is the right reading: input past uamqp's depth guard is malformed as far as this codec is concerned.

## 3. Version: 0.2.0, not 0.1.1

Widening `EncodeError`, `ConnectionError`, and `LinkError` breaks exhaustive `switch (err)`, and the re-exported `uamqp` module jumps two minor versions carrying its own breaking changes. Under the repo's 0.x rule that requires a minor bump.

## Finding: our duplicate performative encoder is no longer load-bearing

The README justified encoding performatives here rather than via `uamqp.encoder` because that encoder "writes array elements of variable-width types without their length prefix, which no peer accepts."

**v0.3.0 fixed that.** Verified by round-tripping an array of symbols through v0.3.0's encoder and decoder:

```
e0 1a 02 a3 04 "AMQP" 12 "amqp:accepted:list"
   ^array8    ^sym8 ^len          ^len
```

Shared element constructor, per-element length prefixes, `bytes_consumed` equals the full encoding. So the duplication could now be folded into `uamqp.encoder`. I have **not** done that here — it is a large change and does not belong in a dependency bump — but the README now records it instead of stating something untrue that justifies keeping the duplicate.

The README metadata block was also stale: it named a source path under `main` and a `sdk/core_amqp` release branch, neither of which exists under the branch-owned package model.

## Verification

- `zig build test --summary all` — 100/100 pass.
- `zig fmt --check .` — clean.
- `message.Message` is this package's own struct, not `uamqp.message.Message`, so v0.3.0's switch to an arena-backed message does **not** affect this package. (It does affect Event Hubs — handled in the next PR.)

Release review runs before the `azure_sdk_amqp/v0.2.0` tag is cut.