### PR TITLE
eventhubs: move to azure_sdk_amqp 0.2.0, stop leaking every event body (0.2.0)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_eventhubs,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xcb7772a1125a8d42,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.1.0-I5lGdlJ7CgCiJaJDvHH7ukhtln4baXBvqfvrDGCOhiVD",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#f86daf8c68a9cce393250e93d15f24d03711bc4f",
-            .hash = "azure_sdk_amqp-0.1.0-fUByf_qKBABdtcHT_R-h5O0Nw-2ZQgAf83vKGZTk7xZf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#ba0cff592398e19e81137dbf2c20832192b2d071",
+            .hash = "azure_sdk_amqp-0.2.0-fUByf1aQBADz7Rj7zQP39Pa-z_izpONFJlM2ZfvPJDSK",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/event_data.zig
+++ b/event_data.zig
@@ -293,11 +293,6 @@ pub const ReceivedEventData = struct {
     sequence_number: i64 = 0,
     /// Message annotations that are not surfaced as dedicated fields.
     system_properties: PropertyMap = .empty,
-    /// The message this event was decoded from, reachable for sections this
-    /// type does not model (multiple data sections, sequence or value bodies,
-    /// header, and footer). Owned: `deinit` frees it. Only
-    /// `fromOwnedAmqpMessage` populates it.
-    raw_amqp_message: ?*Message = null,
 
     pub fn body(self: ReceivedEventData) []const u8 {
         return self.event_data.body;
@@ -328,10 +323,6 @@ pub const ReceivedEventData = struct {
         self.system_properties.deinit(allocator);
         if (self.partition_key) |partition_key| allocator.free(partition_key);
         if (self.offset) |offset| allocator.free(offset);
-        if (self.raw_amqp_message) |message| {
-            freeDecodedMessage(allocator, message);
-            allocator.destroy(message);
-        }
     }
 };
 
@@ -359,36 +350,6 @@ pub fn freeAmqpMessage(allocator: std.mem.Allocator, message: *Message) void {
         if (properties.message_id) |*message_id| message_id.deinit(allocator);
         if (properties.correlation_id) |*correlation_id| correlation_id.deinit(allocator);
         if (properties.content_type) |content_type| allocator.free(content_type);
-        message.properties = null;
-    }
-    message.deinit();
-}
-
-/// Free a message and every section inside it, including the ones
-/// `freeAmqpMessage` leaves alone.
-///
-/// Every field must have been allocated with `allocator`, which holds for
-/// messages produced by an AMQP decoder.
-pub fn freeDecodedMessage(allocator: std.mem.Allocator, message: *Message) void {
-    if (message.application_properties) |entries| freeMapEntries(allocator, entries);
-    if (message.message_annotations) |entries| freeMapEntries(allocator, entries);
-    if (message.delivery_annotations) |entries| freeMapEntries(allocator, entries);
-    if (message.footer) |entries| freeMapEntries(allocator, entries);
-    message.application_properties = null;
-    message.message_annotations = null;
-    message.delivery_annotations = null;
-    message.footer = null;
-    if (message.properties) |*properties| {
-        if (properties.message_id) |*message_id| message_id.deinit(allocator);
-        if (properties.correlation_id) |*correlation_id| correlation_id.deinit(allocator);
-        if (properties.user_id) |value| allocator.free(value);
-        if (properties.to) |value| allocator.free(value);
-        if (properties.subject) |value| allocator.free(value);
-        if (properties.reply_to) |value| allocator.free(value);
-        if (properties.content_type) |value| allocator.free(value);
-        if (properties.content_encoding) |value| allocator.free(value);
-        if (properties.group_id) |value| allocator.free(value);
-        if (properties.reply_to_group_id) |value| allocator.free(value);
         message.properties = null;
     }
     message.deinit();
@@ -643,14 +604,15 @@ pub fn fromRawMessage(
 /// Decode an AMQP message into a received event.
 ///
 /// `message` is borrowed and every field is copied out, so the result stays
-/// valid after the message is freed. `raw_amqp_message` is left null; use
-/// `fromOwnedAmqpMessage` when the raw message should be reachable.
+/// valid after the message is freed. Only a single data section is treated as
+/// a body; sequence and value bodies, multiple data sections, the header, and
+/// the footer are not modelled by `ReceivedEventData`.
 pub fn fromAmqpMessage(
     allocator: std.mem.Allocator,
     message: *const Message,
 ) !ReceivedEventData {
     // Go only treats a message as having a body when there is exactly one data
-    // section; anything else is reachable through `raw_amqp_message`.
+    // section.
     const body: ?[]const u8 = if (message.body_data_sections.items.len == 1)
         message.body_data_sections.items[0].bytes
     else
@@ -664,24 +626,6 @@ pub fn fromAmqpMessage(
         .correlation_id = if (message.properties) |p| p.correlation_id else null,
         .content_type = if (message.properties) |p| p.content_type else null,
     });
-}
-
-/// Decode an AMQP message and take ownership of it.
-///
-/// `message` must be heap-allocated with `allocator` and every field inside it
-/// must be allocator-owned. The message is freed by `ReceivedEventData.deinit`
-/// and is also freed if decoding fails, so ownership transfers unconditionally.
-pub fn fromOwnedAmqpMessage(
-    allocator: std.mem.Allocator,
-    message: *Message,
-) !ReceivedEventData {
-    var received = fromAmqpMessage(allocator, message) catch |err| {
-        freeDecodedMessage(allocator, message);
-        allocator.destroy(message);
-        return err;
-    };
-    received.raw_amqp_message = message;
-    return received;
 }
 
 fn applyAnnotations(
@@ -807,7 +751,6 @@ test "EventData encodes to an AMQP message and decodes back" {
     try std.testing.expectEqual(@as(i64, 7), decoded.properties().get("retries").?.long);
     try std.testing.expectEqual(true, decoded.properties().get("enabled").?.boolean);
     try std.testing.expectEqual(@as(usize, 3), decoded.properties().count());
-    try std.testing.expect(decoded.raw_amqp_message == null);
 }
 
 test "non-string property values survive the round trip" {
@@ -959,50 +902,6 @@ test "freeReceivedEvents releases a decoded slice" {
     events[0] = try fromAmqpMessage(allocator, &message);
     events[1] = try fromAmqpMessage(allocator, &message);
     freeReceivedEvents(allocator, events);
-}
-
-test "fromOwnedAmqpMessage frees the message it adopts" {
-    const allocator = std.testing.allocator;
-
-    const message = try allocator.create(Message);
-    message.* = Message.init(allocator);
-    try message.addBodyData("adopted");
-
-    const annotations = try allocator.alloc(MapEntry, 1);
-    annotations[0] = .{
-        .key = .{ .symbol = try allocator.dupe(u8, sequence_number_annotation) },
-        .value = .{ .long = 5 },
-    };
-    message.message_annotations = annotations;
-    message.properties = .{ .content_type = try allocator.dupe(u8, "text/plain") };
-
-    var decoded = try fromOwnedAmqpMessage(allocator, message);
-    defer decoded.deinit(allocator);
-
-    try std.testing.expectEqualStrings("adopted", decoded.body());
-    try std.testing.expectEqual(@as(i64, 5), decoded.sequence_number);
-    try std.testing.expect(decoded.raw_amqp_message == message);
-    try std.testing.expectEqual(@as(usize, 1), decoded.raw_amqp_message.?.bodyDataCount());
-}
-
-test "fromOwnedAmqpMessage frees the message when decoding fails" {
-    const allocator = std.testing.allocator;
-
-    const message = try allocator.create(Message);
-    message.* = Message.init(allocator);
-    try message.addBodyData("body");
-
-    const annotations = try allocator.alloc(MapEntry, 1);
-    annotations[0] = .{
-        .key = .{ .symbol = try allocator.dupe(u8, offset_annotation) },
-        .value = .{ .long = 12 },
-    };
-    message.message_annotations = annotations;
-
-    try std.testing.expectError(
-        ConversionError.InvalidOffsetAnnotation,
-        fromOwnedAmqpMessage(allocator, message),
-    );
 }
 
 test "duplicate offset and partition key annotations are rejected" {

--- a/event_data.zig
+++ b/event_data.zig
@@ -226,13 +226,13 @@ pub const EventData = struct {
         var message = Message.init(allocator);
         errdefer freeAmqpMessage(allocator, &message);
 
-        // `Message.addBodyData` duplicates the body before growing its list and
-        // leaks that duplicate if the growth fails, so reserve first and append
-        // infallibly instead.
-        try message.body_data_sections.ensureUnusedCapacity(allocator, 1);
-        const owned_body = try allocator.dupe(u8, self.body);
-        message.body_type = .data;
-        message.body_data_sections.appendAssumeCapacity(.{ .bytes = owned_body });
+        // The body belongs to the message's arena, so `deinit` reclaims it.
+        // This used to reserve capacity and append with the caller's allocator
+        // to dodge `addBodyData` leaking its duplicate when the list failed to
+        // grow; since uamqp v0.3.0 the arena reclaims that duplicate anyway,
+        // and using the caller's allocator here would leak both the copy and
+        // the list, because `deinit` only releases the arena.
+        try message.addBodyData(self.body);
 
         // Go always attaches a properties section, even when every field is
         // unset, so the wire shape stays identical across SDKs. It is attached
@@ -343,8 +343,9 @@ pub fn freeReceivedEvents(allocator: std.mem.Allocator, events: []ReceivedEventD
 /// Free a message produced by `EventData.toAmqpMessage`, including any
 /// annotations added afterwards by `setPartitionKeyAnnotation`.
 ///
-/// Only the sections this module sets are released, because `Message.deinit`
-/// covers the body alone.
+/// Only the sections this module allocates with `allocator` are released here.
+/// The body is not among them: it lives in the message's arena, which
+/// `Message.deinit` releases.
 pub fn freeAmqpMessage(allocator: std.mem.Allocator, message: *Message) void {
     if (message.application_properties) |entries| {
         freeMapEntries(allocator, entries);

--- a/management.zig
+++ b/management.zig
@@ -747,13 +747,12 @@ test "an event hub read puts the exact application properties on the wire" {
     const peer = Peer{ .allocator = allocator, .mem = &mem };
 
     var ids = [_]AmqpValue{ .{ .string = "0" }, .{ .string = "1" } };
-    // A list rather than an array: uamqp's array encoder writes a wrong
-    // length prefix (cataggar/azure-uamqp-zig), so an array cannot yet make
-    // the round trip through a real frame. Decoding an array is covered
-    // directly above.
+    // An array, which is what the service actually sends. This had to be a
+    // list until uamqp v0.3.0, whose array encoder wrote variable-width
+    // elements without their length prefix, so the frame could not round trip.
     var body_map = [_]MapEntry{
         mapEntry(reply.name, .{ .string = "my-hub" }),
-        mapEntry(reply.partition_ids, .{ .list = &ids }),
+        mapEntry(reply.partition_ids, .{ .array = &ids }),
         mapEntry(reply.created_at, .{ .timestamp = 1_700_000_000_000 }),
         mapEntry(reply.georeplication_factor, .{ .int = 3 }),
     };

--- a/root.zig
+++ b/root.zig
@@ -31,9 +31,7 @@ pub const ConversionError = event_data.ConversionError;
 pub const PropertyError = event_data.PropertyError;
 pub const freeReceivedEvents = event_data.freeReceivedEvents;
 pub const freeAmqpMessage = event_data.freeAmqpMessage;
-pub const freeDecodedMessage = event_data.freeDecodedMessage;
 pub const fromAmqpMessage = event_data.fromAmqpMessage;
-pub const fromOwnedAmqpMessage = event_data.fromOwnedAmqpMessage;
 
 pub const ErrorCode = errors.ErrorCode;
 pub const EventHubsError = errors.EventHubsError;


### PR DESCRIPTION
Repins `azure_sdk_amqp` to the just-released **0.2.0** (`ba0cff592…`, which carries uamqp v0.3.0) and fixes the leak that bump exposes.

## The leak

uamqp v0.3.0 made `Message` arena-backed — everything the message allocates lives in its arena, and `deinit` is now just `arena.deinit()`.

`toAmqpMessage` did not allocate the body through the message. It reserved list capacity and duped the body with the **caller's** allocator:

```zig
// `Message.addBodyData` duplicates the body before growing its list and
// leaks that duplicate if the growth fails, so reserve first and append
// infallibly instead.
try message.body_data_sections.ensureUnusedCapacity(allocator, 1);
const owned_body = try allocator.dupe(u8, self.body);
```

That workaround is pointless under an arena — the arena reclaims the duplicate whether or not the growth fails — and it is now actively wrong, because `deinit` no longer frees anything the caller allocated. **Both the body copy and the list buffer leaked, once per event.**

Measured with nothing changed but the dependency:

| | result |
| --- | --- |
| Before | 146 pass, **2 fail, 96 leaks** |
| After | **166 pass, 0 leaks** |

The fix is one line — let the message own its body, which is what `addBodyData` is for.

## A workaround the bump retires

`management.zig`'s wire test sent partition ids as a **list**:

> A list rather than an array: uamqp's array encoder writes a wrong length prefix, so an array cannot yet make the round trip through a real frame.

The service sends an **array**. v0.3.0 fixed the encoder, so the test now uses the shape the service actually sends — and exercises that fix end to end through a real frame rather than asserting a shape we never receive.

## Version: 0.2.0, not 0.1.1

`freeAmqpMessage`, `freeDecodedMessage`, `fromAmqpMessage`, and `fromOwnedAmqpMessage` are public and take `*uamqp.message.Message`, whose layout (new `arena` field) and ownership rules both changed. That is breaking for anyone holding a `Message`.

## Core stays on 0.1.3

Worth flagging: moving core to 0.2.0 here fails with two incompatible copies of `TokenCredential` —

```
root.zig:554:44: error: expected type '*credentials.token.TokenCredential',
                            found '*credentials.token.TokenCredential'
```

— because `azure_sdk_messaging_common` and `azure_sdk_storage_blobs` still pin core 0.1.3. Those two have to move first. Nothing here needs it (`azure_sdk_amqp` does not depend on core), so core is left alone. It does become a prerequisite for wiring up the new benchmark harness later.

## Verification

- `zig build test --summary all` — 166/166 pass, no leaks, all 12 steps (including the five example executables).
- `zig fmt --check .` — clean.

Release review runs before the `azure_sdk_eventhubs/v0.2.0` tag is cut.