### PR TITLE
Reconcile the registry and catalog with the package branches

### DIFF
--- a/doc/package-catalog.md
+++ b/doc/package-catalog.md
@@ -16,15 +16,15 @@ its source lives at the root of the named branch.
 | `azure_sdk_storage_common` | Branch | — | [`sdk/storage_common`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/storage_common) | `azure_sdk_core` |
 | `azure_sdk_storage_blobs` | Branch | — | [`sdk/storage_blobs`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/storage_blobs) | `azure_sdk_core`, `azure_sdk_storage_common` |
 | `azure_sdk_storage_queues` | Branch | — | [`sdk/storage_queues`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/storage_queues) | `azure_sdk_core`, `azure_sdk_storage_common` |
-| `azure_sdk_storage_files_shares` | Branch | — | [`sdk/storage_files_shares`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/storage_files_shares) | `azure_sdk_core`, `azure_sdk_storage_common` |
-| `azure_sdk_storage_files_datalake` | Branch | — | [`sdk/storage_files_datalake`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/storage_files_datalake) | `azure_sdk_core`, `azure_sdk_storage_common`, `azure_sdk_storage_blobs` |
+| `azure_sdk_storage_files_shares` | Branch | — | [`sdk/storage_files_shares`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/storage_files_shares) | `azure_sdk_core` |
+| `azure_sdk_storage_files_datalake` | Branch | — | [`sdk/storage_files_datalake`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/storage_files_datalake) | `azure_sdk_core` |
 | `azure_sdk_keyvault` | Branch | — | [`sdk/keyvault`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/keyvault) | `azure_sdk_core` |
 | `azure_sdk_data_tables` | Branch | — | [`sdk/data_tables`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/data_tables) | `azure_sdk_core` |
 | `azure_sdk_data_cosmos` | Branch | — | [`sdk/data_cosmos`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/data_cosmos) | `azure_sdk_core` |
 | `azure_sdk_data_appconfiguration` | Branch | — | [`sdk/data_appconfiguration`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/data_appconfiguration) | `azure_sdk_core` |
 | `azure_sdk_attestation` | Branch | — | [`sdk/attestation`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/attestation) | `azure_sdk_core` |
 | `azure_sdk_messaging_common` | Branch | — | [`sdk/messaging_common`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/messaging_common) | `azure_sdk_core` |
-| `azure_sdk_eventhubs` | Branch | — | [`sdk/eventhubs`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/eventhubs) | `azure_sdk_core`, `azure_sdk_messaging_common`, `azure_sdk_storage_blobs` |
+| `azure_sdk_eventhubs` | Branch | — | [`sdk/eventhubs`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/eventhubs) | `azure_sdk_core`, `azure_sdk_messaging_common`, `azure_sdk_storage_blobs`, `azure_sdk_amqp` |
 | `azure_sdk_servicebus` | Branch | — | [`sdk/servicebus`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/servicebus) | `azure_sdk_core`, `azure_sdk_messaging_common` |
 | `azure_sdk_kusto` | Branch | — | [`sdk/kusto`](https://github.com/cataggar/azure-sdk-for-zig/tree/sdk/kusto) | `azure_sdk_core`, `azure_sdk_storage_common`, `azure_sdk_storage_blobs`, `azure_sdk_storage_queues` |
 

--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -450,7 +450,7 @@ pub const all = [_]Package{
             "azure_sdk_storage_blobs",
             "azure_sdk_amqp",
         },
-        .external_dependencies = &.{ "uamqp", "serde" },
+        .external_dependencies = &.{"serde"},
         .examples_command = "zig build examples",
         .live_test_command = "zig build live-test",
         .publish_paths = &.{


### PR DESCRIPTION
`azure_sdk_eventhubs` declared `uamqp` as an external dependency, but its branch manifest does not pin it — uamqp arrives transitively through `azure_sdk_amqp`. `eng/package_branch_tool.zig` requires the manifest's dependency key set to match `dependencies ++ external_dependencies` exactly, so the declaration made the package **unreleasable**:

```
$ ./scripts/package-branch-release.sh verify azure_sdk_eventhubs
error: ManifestDependencyMismatch
```

This blocks the `azure_sdk_eventhubs/v0.2.0` release (#302).

### Why `package-check` did not catch it

`zig build package-check` validates the registry against itself. The manifest comparison in `eng/package_tool.zig` is guarded by `if (entry.ownership != .main_owned) continue;` and needs a `workspace_path` — and no entry sets one, because `main` owns no package source. So nothing on `main` compares the registry to the branch manifests; only the release script does, at release time.

### Changes

- `eng/packages.zig`: drop `"uamqp"` from `azure_sdk_eventhubs.external_dependencies`.
- `doc/package-catalog.md`: fix three dependency columns that had drifted from the registry. `azure_sdk_storage_files_shares` and `azure_sdk_storage_files_datalake` claimed storage dependencies they do not have; `azure_sdk_eventhubs` was missing `azure_sdk_amqp`. The catalog check only asserts each package name appears somewhere in the file, so these columns are unvalidated.

### Verification

Extracted all 22 package branches with `git archive` and ran `validate-tree` against each. Before: `azure_sdk_eventhubs` and `azure_sdk_data_tables` failed. After: only `azure_sdk_data_tables`.

Also: `zig fmt --check`, `zig build package-check`, `zig build package-history-check`.

### Pre-existing issue left alone

`azure_sdk_data_tables.publish_paths` is a 6-entry stub (`.gitignore`, `build.zig`, `build.zig.zon`, `root.zig`, `README.md`, `LICENSE.txt`) while the branch carries ~35 files including `client.zig`, `entity_codec.zig`, `sas.zig` and `service_client.zig`. It fails `validate-tree` with `ManifestPathMismatch`, so that package is also unreleasable, and a `publish` would ship a package missing nearly all of its source. Deciding which of `examples`, `live_tests`, `integration_tests` and `scripts` belong in a published package is a judgement call, so it is left for a separate change.