### PR TITLE
azure_sdk_messaging_common 0.1.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_messaging_common,
-    .version = "0.1.0",
+    .version = "0.1.1",
     .fingerprint = 0x3e14ae944a664962,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{


### PR DESCRIPTION
Version bump only; no source change.

Two commits landed since `azure_sdk_messaging_common/v0.1.0` without a release — SAS token generation and emulator connection string parsing (#221), and the CI change to install Zig via ghr (#262).

`azure_sdk_eventhubs` pins this branch's tip commit directly, but no release tag protects it, so the Event Hubs release is blocked:

```
$ ./scripts/package-branch-release.sh verify azure_sdk_eventhubs
azure_sdk_messaging_common: dependency commit is not protected by a package release tag
```

`scripts/package-branch-release.sh:112-118` requires a remote `refs/tags/<pkg>/v*` to point directly at every pinned dependency commit. The tag cannot just be added to the pinned commit: `v0.1.0` is already taken by an earlier commit, and the manifest here still claimed `0.1.0`.

`azure_sdk_core` stays pinned at 0.1.3. 26/26 tests pass, `zig fmt --check` clean.