### PR TITLE
azure_sdk_storage_blobs 0.1.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_storage_blobs,
-    .version = "0.1.0",
+    .version = "0.1.1",
     .fingerprint = 0xd9bbf92976469923,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{


### PR DESCRIPTION
Version bump only; no source change.

Five commits landed since `azure_sdk_storage_blobs/v0.1.0` without a release — the generated XML BlobClient (#123), a core re-pin (#127), convenience helpers (#147, #190), the blob metadata send/read fix (#211), and the CI change to install Zig via ghr (#264).

`azure_sdk_eventhubs` pins `547a1f889` from the middle of that range, but no release tag protects it, so the Event Hubs release is blocked:

```
$ ./scripts/package-branch-release.sh verify azure_sdk_eventhubs
azure_sdk_storage_blobs: dependency commit is not protected by a package release tag
```

`scripts/package-branch-release.sh:112-118` requires a remote `refs/tags/<pkg>/v*` to point directly at every pinned dependency commit. The tag cannot just be added to the pinned commit: `v0.1.0` is already taken by an earlier commit, and the manifest here still claimed `0.1.0`.

Releasing at the branch tip means Event Hubs will repin one commit forward of what it pins today, picking up #264 (CI only, no source change).

`azure_sdk_core` stays pinned at 0.1.3. 46/46 tests pass, `zig fmt --check` clean.