### PR TITLE
azure_sdk_storage_common 0.2.0: move to azure_sdk_core 0.2.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .azure_sdk_storage_common,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xf1bdfbd9782b3a27,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
     },
     .paths = .{


### PR DESCRIPTION
Dependency pin update only; no source change.

Every package in the `azure_sdk_eventhubs` dependency closure has to move to core 0.2.0 together. Zig resolves a package pinned at two different commits as two distinct module instances, so a mixed graph fails to compile with errors like:

```
expected type '*credentials.token.TokenCredential', found '*credentials.token.TokenCredential'
```

`storage_common` is the root of the storage half of that closure (`storage_blobs` depends on it), so it moves first. Order is: **storage_common → storage_blobs → messaging_common → eventhubs**.

`storage_common` uses none of the three APIs core 0.2.0 broke — `perf.benchmark` (gained a leading `std.Io`), `AzureDeveloperCliCredential.init` (same), and `DefaultAzureCredential.init` (error set grew, managed identity left the default chain). So this is a pin update only; the minor bump signals the new core requirement rather than a local API change, matching how `azure_sdk_amqp` and `azure_sdk_eventhubs` were versioned for their breaking dependency bumps.

Three commits had also accumulated since `v0.1.0` without a release (#140, #233, #265) — all core re-pins or CI changes; they ship here.

12/12 tests pass, `zig fmt --check` clean.