### PR TITLE
azure_sdk_messaging_common 0.2.0: move to azure_sdk_core 0.2.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .azure_sdk_messaging_common,
-    .version = "0.1.1",
+    .version = "0.2.0",
     .fingerprint = 0x3e14ae944a664962,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
     },
     .paths = .{


### PR DESCRIPTION
Dependency pin update only; no source change.

Part of moving the whole `azure_sdk_eventhubs` dependency closure to core 0.2.0 at once. Zig resolves a package pinned at two different commits as two distinct module instances, so a mixed graph fails to compile with errors like:

```
expected type '*credentials.token.TokenCredential', found '*credentials.token.TokenCredential'
```

Order is: **storage_common (#307) → storage_blobs → messaging_common → eventhubs**. This one is independent of the storage chain, so it can land in parallel.

`messaging_common` uses none of the three APIs core 0.2.0 broke — `perf.benchmark` (gained a leading `std.Io`), `AzureDeveloperCliCredential.init` (same), and `DefaultAzureCredential.init` (error set grew, managed identity left the default chain). The minor bump signals the new core requirement rather than a local API change.

26/26 tests pass, `zig fmt --check` clean.