### PR TITLE
azure_sdk_eventhubs 0.3.0: move to azure_sdk_core 0.2.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,20 +1,20 @@
 .{
     .name = .azure_sdk_eventhubs,
-    .version = "0.2.0",
+    .version = "0.3.0",
     .fingerprint = 0xcb7772a1125a8d42,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
         .azure_sdk_messaging_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#719f1c06742d308bb7d8353dc23b78b323043b5d",
-            .hash = "azure_sdk_messaging_common-0.1.1-YklmSkWIAAA5cHQJWgEGchFkD8J5iIA1wUMce-N7UrcY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#381b11a05c271b66d6496f9fc3aa9c1633a3c5aa",
+            .hash = "azure_sdk_messaging_common-0.2.0-YklmSkWIAADy4QHeNJAVUdRq-xKFeRx75G1TjE5lMeHR",
         },
         .azure_sdk_storage_blobs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#a7ef1bbd7e4743f2bd0bdb5a6c71595d9761909d",
-            .hash = "azure_sdk_storage_blobs-0.1.1-I5lGdlJ7CgASx12BmHwoTmejC0hO_9d40sUmvwm3e_9g",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3beb8819585cb1663975446d1fc6b68ca56e16ef",
+            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_amqp = .{
             .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#ba0cff592398e19e81137dbf2c20832192b2d071",

--- a/examples/send_events.zig
+++ b/examples/send_events.zig
@@ -6,8 +6,11 @@
 //!
 //! e.g. <namespace> = my-namespace.servicebus.windows.net
 //!
-//! Authentication uses `DefaultAzureCredential`, so an `az login` session,
-//! a managed identity, or the usual `AZURE_*` environment variables all work.
+//! Authentication uses `DefaultAzureCredential`, so an `az login` session or
+//! the usual `AZURE_*` environment variables work out of the box. Managed
+//! identity is not in the default chain, because its IMDS probe stalls
+//! outside Azure; set `AZURE_TOKEN_CREDENTIALS=prod` on a deployed service to
+//! enable it.
 
 const std = @import("std");
 const core = @import("azure_sdk_core");


### PR DESCRIPTION
Completes moving the `azure_sdk_eventhubs` dependency closure to core 0.2.0.

Zig resolves a package pinned at two different commits as two distinct module instances, so all four pins had to land together — doing eventhubs alone would have failed with:

```
expected type '*credentials.token.TokenCredential', found '*credentials.token.TokenCredential'
```

| dependency | before | after |
| --- | --- | --- |
| `azure_sdk_core` | 0.1.3 | **0.2.0** `1d73a90ee` |
| `azure_sdk_messaging_common` | 0.1.1 | **0.2.0** `381b11a05` (#308) |
| `azure_sdk_storage_blobs` | 0.1.1 | **0.2.0** `3beb88195` (#309) |
| `azure_sdk_amqp` | 0.2.0 | 0.2.0 (unchanged) |

Release order was storage_common (#307) → storage_blobs (#309) → messaging_common (#308) → this.

### Behavior change worth calling out

Core 0.2.0 removes managed identity from the `DefaultAzureCredential` chain, because the IMDS probe stalls outside Azure. The `send_events` example promised the opposite — *"an `az login` session, a managed identity, or the usual `AZURE_*` environment variables all work"* — which is now wrong in a way that would strand someone on a VM or AKS pod with no obvious cause. It now points at `AZURE_TOKEN_CREDENTIALS=prod`.

Minor bump rather than patch: the required core version changed, and a consumer sharing core types with this package must move in step.

164/164 tests pass, `zig fmt --check` clean.