### PR TITLE
Add offline encode/decode benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,3 +482,19 @@ resources you do not mind polluting.
 ```bash
 zig build test --summary all
 ```
+
+## Benchmarks
+
+```bash
+zig build bench -Doptimize=ReleaseFast
+```
+
+Offline benchmarks for the encode and decode paths — building an AMQP message
+from an `EventData`, filling an `EventDataBatch`, and converting a received
+AMQP message back. Nothing touches the network, so a result is attributable to
+a code change rather than to service latency.
+
+Prefer `allocs/op` and `B/op` as the regression signal: they are stable across
+machines, while wall-clock timings move on shared or virtualised hosts. The
+benchmarks are built (but not run) by `zig build test`, so a signature change
+cannot silently rot them.

--- a/benchmarks/main.zig
+++ b/benchmarks/main.zig
@@ -1,0 +1,122 @@
+//! Offline benchmarks for the Event Hubs encode and decode paths.
+//!
+//! Nothing here touches the network. Every benchmark measures pure CPU and
+//! allocation cost, so a result is reproducible and a regression is
+//! attributable to a specific code change rather than to service latency.
+//!
+//! Run with:
+//!   zig build bench -Doptimize=ReleaseFast
+//!
+//! Allocation counts are the primary signal. Wall-clock numbers on a shared or
+//! virtualised host move between runs; `allocs/op` and `B/op` do not, so treat
+//! those as the regression gate and the timings as advisory.
+//!
+//! Everything is driven through the package's public API, so these measure
+//! what a consumer actually pays.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const core = @import("azure_sdk_core");
+const eh = @import("azure_sdk_eventhubs");
+const uamqp = @import("uamqp");
+
+const perf = core.perf;
+
+/// Representative telemetry event: a small JSON body plus a content type.
+const small_body = "{\"device\":\"sensor-01\",\"temp\":21.5,\"ts\":1730000000}";
+
+fn makeEvent() eh.EventData {
+    var event = eh.EventData.init(small_body);
+    event.content_type = "application/json";
+    return event;
+}
+
+fn benchToAmqpMessage(allocator: std.mem.Allocator) !void {
+    const event = makeEvent();
+    var message = try event.toAmqpMessage(allocator);
+    eh.freeAmqpMessage(allocator, &message);
+}
+
+fn addToBatch(allocator: std.mem.Allocator, count: usize) !void {
+    var batch = try eh.EventDataBatch.init(.{});
+    defer batch.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        _ = try batch.tryAdd(allocator, makeEvent());
+    }
+}
+
+fn benchBatchAdd1(allocator: std.mem.Allocator) !void {
+    try addToBatch(allocator, 1);
+}
+
+fn benchBatchAdd100(allocator: std.mem.Allocator) !void {
+    try addToBatch(allocator, 100);
+}
+
+fn benchBatchAdd1000(allocator: std.mem.Allocator) !void {
+    try addToBatch(allocator, 1000);
+}
+
+/// The annotations Event Hubs stamps on every received event, plus a few
+/// application properties, so the decode path does representative work.
+var annotations = [_]uamqp.MapEntry{
+    .{ .key = .{ .symbol = "x-opt-sequence-number" }, .value = .{ .long = 4242 } },
+    .{ .key = .{ .symbol = "x-opt-offset" }, .value = .{ .string = "98765" } },
+    .{ .key = .{ .symbol = "x-opt-partition-key" }, .value = .{ .string = "device-01" } },
+};
+
+var properties = [_]uamqp.MapEntry{
+    .{ .key = .{ .string = "tenant" }, .value = .{ .string = "contoso" } },
+    .{ .key = .{ .string = "retries" }, .value = .{ .long = 3 } },
+    .{ .key = .{ .string = "enabled" }, .value = .{ .boolean = true } },
+};
+
+/// Receive-side decode. The message is built once and borrowed, so this
+/// measures only the conversion a consumer pays per event.
+var receive_message: uamqp.message.Message = undefined;
+
+fn benchFromAmqpMessage(allocator: std.mem.Allocator) !void {
+    var received = try eh.fromAmqpMessage(allocator, &receive_message);
+    received.deinit(allocator);
+}
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+
+    receive_message = uamqp.message.Message.init(allocator);
+    defer receive_message.deinit();
+    try receive_message.addBodyData(small_body);
+    receive_message.message_annotations = &annotations;
+    receive_message.application_properties = &properties;
+    receive_message.properties = .{ .content_type = "application/json" };
+
+    std.debug.print("Event Hubs benchmarks (mode: {s})\n", .{@tagName(builtin.mode)});
+    if (builtin.mode == .Debug) {
+        std.debug.print(
+            "  NOTE: Debug build. Re-run with -Doptimize=ReleaseFast for timings that\n" ++
+                "  mean anything; allocation counts are valid in either mode.\n",
+            .{},
+        );
+    }
+
+    const cases = .{
+        .{ "toAmqpMessage", 10_000, benchToAmqpMessage },
+        .{ "batch.tryAdd x1", 10_000, benchBatchAdd1 },
+        .{ "batch.tryAdd x100", 200, benchBatchAdd100 },
+        .{ "batch.tryAdd x1000", 20, benchBatchAdd1000 },
+        .{ "fromAmqpMessage", 10_000, benchFromAmqpMessage },
+    };
+
+    inline for (cases) |case| {
+        perf.printResult(perf.benchmarkAllocating(
+            io,
+            case[0],
+            case[1],
+            allocator,
+            case[2],
+        ));
+    }
+}

--- a/build.zig
+++ b/build.zig
@@ -140,4 +140,27 @@ pub fn build(b: *std.Build) void {
     );
     live_test_step.dependOn(&b.addRunArtifact(live_tests).step);
     test_step.dependOn(&live_tests.step);
+
+    // Offline encode/decode benchmarks. Build them with the tests so a
+    // signature change cannot silently rot them, but only run them on demand:
+    // they are far too slow for every `zig build test`.
+    const benchmarks = b.addExecutable(.{
+        .name = "eventhubs-bench",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("benchmarks/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = core_mod },
+                .{ .name = "azure_sdk_eventhubs", .module = sdk_mod },
+                .{ .name = "uamqp", .module = uamqp_mod },
+            },
+        }),
+    });
+    const bench_step = b.step(
+        "bench",
+        "Run Event Hubs encode/decode benchmarks (use -Doptimize=ReleaseFast)",
+    );
+    bench_step.dependOn(&b.addRunArtifact(benchmarks).step);
+    test_step.dependOn(&benchmarks.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -46,6 +46,7 @@
         "checkpoint_store_blob",
         "examples",
         "live_tests",
+        "benchmarks",
         "README.md",
         "LICENSE.txt",
     },


### PR DESCRIPTION
Phase 2 of the performance plan changes the Event Hubs hot paths, and there is currently no way to tell whether a change helps. Core 0.2.0 brought a real monotonic clock and an allocation-counting harness, and Event Hubs is now on it (0.3.0), so the benchmarks can finally be wired up.

Five cases, all offline: `toAmqpMessage`, `EventDataBatch.tryAdd` at 1, 100, and 1000 events, and `fromAmqpMessage`. Everything is driven through the package's public API, so the numbers are what a consumer actually pays — the benchmark widens no surface. Nothing touches the network, so a delta is attributable to a code change rather than to service latency.

`bench` is a separate step because the benchmarks are far too slow for every `zig build test`, but they are added to `test_step` as a compile dependency so a signature change cannot silently rot them.

## Baseline at this commit

`zig build bench -Doptimize=ReleaseFast`

| case | avg | allocs/op | B/op |
| --- | ---: | ---: | ---: |
| `toAmqpMessage` | 127 ns | 3.00 | 608 |
| `batch.tryAdd x1` | 531 ns | 9.00 | 1123 |
| `batch.tryAdd x100` | 39.4 µs | 606.00 | 91010 |
| `batch.tryAdd x1000` | 533 µs | 6010.00 | 923158 |
| `fromAmqpMessage` | 292 ns | 9.00 | 371 |

Two things the baseline already confirms from the audit:

- Adding an event to a batch costs **~6 allocations that survive the add** (606 for 100, 6010 for 1000), on top of the 3 that `toAmqpMessage` alone pays. That is the double envelope encode plus the `dupe(buffer.written())` pattern.
- The receive-side conversion costs **9 allocations for a 49-byte body**.

Treat `allocs/op` and `B/op` as the regression gate. They are stable across machines; wall-clock timings move on shared or virtualised hosts.

## Note for the next release

`benchmarks` is added to `.paths`, so `publish_paths` for `azure_sdk_eventhubs` in `eng/packages.zig` on `main` must gain it too, or `validate-tree` will fail at release time. Filed as a companion PR against `main`.

## Validation

- `zig build test --summary all` — 164/164 pass
- `zig fmt --check` clean
- `zig build bench` runs in both Debug and ReleaseFast