### PR TITLE
Add benchmarks to azure_sdk_eventhubs publish_paths

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -474,6 +474,7 @@ pub const all = [_]Package{
             "checkpoint_store_blob",
             "examples",
             "live_tests",
+            "benchmarks",
             "README.md",
             "LICENSE.txt",
         },


### PR DESCRIPTION
Companion to #311, which adds a `benchmarks/` directory to `sdk/eventhubs` and lists it in the branch manifest's `.paths`.

`eng/package_branch_tool.zig:97` requires `publish_paths` and `manifest.paths` to be an **exact set match**, so without this the next `azure_sdk_eventhubs` release fails `validate-tree` with `ManifestPathMismatch`.

## Verified in both directions

```
git archive origin/perf/eventhubs-benchmarks | tar -x -C /tmp/eh-tree
zig run eng/package_branch_tool.zig -- validate-tree azure_sdk_eventhubs /tmp/eh-tree
```

- before this change: `error: ManifestPathMismatch`, exit 1
- after this change: exit 0

## Why CI does not catch this

`zig build package-check` passes either way — it validates the registry against itself. The manifest comparison in `eng/package_tool.zig:195` is gated on `entry.ownership == .main_owned` **and** needs a `workspace_path`, and no entry sets one, because `main` owns no package source. So nothing on `main` compares the registry to a branch tree; only the release script does, at release time.

This is the same class of drift that #303 fixed. Landing it alongside #311 keeps the two in step.