### PR TITLE
Cut allocations and copies out of the batch encode path

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,9 +490,10 @@ zig build bench -Doptimize=ReleaseFast
 ```
 
 Offline benchmarks for the encode and decode paths — building an AMQP message
-from an `EventData`, filling an `EventDataBatch`, and converting a received
-AMQP message back. Nothing touches the network, so a result is attributable to
-a code change rather than to service latency.
+from an `EventData`, filling an `EventDataBatch`, laying that batch out as a
+transfer payload, and converting a received AMQP message back. Nothing touches
+the network, so a result is attributable to a code change rather than to
+service latency.
 
 Prefer `allocs/op` and `B/op` as the regression signal: they are stable across
 machines, while wall-clock timings move on shared or virtualised hosts. The

--- a/batch.zig
+++ b/batch.zig
@@ -144,11 +144,7 @@ pub const EventDataBatch = struct {
     }
 };
 
-/// Wrapping a payload in a data section costs a described-type constructor, the
-/// descriptor, and a binary length prefix. Go's `calcActualSizeForPayload`
-/// uses the same constants.
-fn dataSectionSize(payload_len: usize) usize {
-    const vbin8_overhead = 5;
-    const vbin32_overhead = 8;
-    return if (payload_len < 256) vbin8_overhead + payload_len else vbin32_overhead + payload_len;
-}
+/// Shared with the encoder rather than restated here, so a batch cannot report
+/// as fitting and then encode to something larger because only one of the two
+/// was changed.
+const dataSectionSize = event_data.dataSectionSize;

--- a/benchmarks/main.zig
+++ b/benchmarks/main.zig
@@ -59,6 +59,23 @@ fn benchBatchAdd1000(allocator: std.mem.Allocator) !void {
     try addToBatch(allocator, 1000);
 }
 
+/// Laying a full batch out on the wire: the envelope followed by one data
+/// section per event. This is what a `sendEventBatch` pays on top of the
+/// per-event `tryAdd` cost, and it is the only place a single allocation
+/// spans the whole batch.
+fn benchEncodeBatchTransfer(allocator: std.mem.Allocator) !void {
+    var batch = try eh.EventDataBatch.init(.{});
+    defer batch.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        _ = try batch.tryAdd(allocator, makeEvent());
+    }
+
+    const payload = try eh.sending.encodeBatchTransfer(allocator, batch);
+    allocator.free(payload);
+}
+
 /// The annotations Event Hubs stamps on every received event, plus a few
 /// application properties, so the decode path does representative work.
 var annotations = [_]uamqp.MapEntry{
@@ -107,6 +124,7 @@ pub fn main(init: std.process.Init) !void {
         .{ "batch.tryAdd x1", 10_000, benchBatchAdd1 },
         .{ "batch.tryAdd x100", 200, benchBatchAdd100 },
         .{ "batch.tryAdd x1000", 20, benchBatchAdd1000 },
+        .{ "encodeBatchTransfer x1000", 20, benchEncodeBatchTransfer },
         .{ "fromAmqpMessage", 10_000, benchFromAmqpMessage },
     };
 

--- a/event_data.zig
+++ b/event_data.zig
@@ -487,9 +487,11 @@ fn encodeMessageSections(
         try encodeSection(&buffer, uamqp.definitions.descriptor.footer, .{ .map = entries });
     }
 
-    const encoded = try allocator.dupe(u8, buffer.written());
-    buffer.deinit();
-    return encoded;
+    // `toOwnedSlice` shrinks the buffer's own allocation to the written length
+    // and hands it over. Duplicating `written()` instead would allocate a
+    // second full-size buffer and copy every byte into it, on the per-event
+    // path of every batch.
+    return buffer.toOwnedSlice();
 }
 
 /// Append one data section per payload to an already encoded prefix.
@@ -503,17 +505,41 @@ pub fn encodeDataSections(
     prefix: []const u8,
     payloads: []const []u8,
 ) ![]u8 {
-    var buffer = uamqp.encoder.Buffer.initDynamic(allocator);
-    errdefer buffer.deinit();
+    // The exact size is plain arithmetic here — `dataSectionSize` is the same
+    // constant-overhead formula batching already charges per event — so the
+    // whole concatenation is one allocation. Growing a dynamic buffer instead
+    // costs a doubling series of reallocations across a batch that may reach
+    // the 1 MiB message limit, and then a full copy of the result.
+    var total: usize = prefix.len;
+    for (payloads) |payload| total += dataSectionSize(payload.len);
 
+    const bytes = try allocator.alloc(u8, total);
+    errdefer allocator.free(bytes);
+
+    var buffer = uamqp.encoder.Buffer.initFixed(bytes);
     try buffer.writeAll(prefix);
     for (payloads) |payload| {
         try encodeSection(&buffer, uamqp.definitions.descriptor.data, .{ .binary = payload });
     }
 
-    const encoded = try allocator.dupe(u8, buffer.written());
-    buffer.deinit();
-    return encoded;
+    // `dataSectionSize` is exact, so this holds; shrinking rather than
+    // asserting means a future disagreement returns correct bytes instead of a
+    // buffer with a garbage tail.
+    if (buffer.pos != total) return try allocator.realloc(bytes, buffer.pos);
+    return bytes;
+}
+
+/// Encoded size of the data section wrapping a payload of `payload_len` bytes:
+/// a described-type constructor, the descriptor, and a binary length prefix.
+/// Go's `calcActualSizeForPayload` uses the same constants.
+///
+/// Batching charges this per event without encoding anything, so it has to
+/// agree with what `encodeDataSections` writes; sharing one function rather
+/// than restating the constants is what keeps them from drifting apart.
+pub fn dataSectionSize(payload_len: usize) usize {
+    const vbin8_overhead = 5;
+    const vbin32_overhead = 8;
+    return if (payload_len < 256) vbin8_overhead + payload_len else vbin32_overhead + payload_len;
 }
 
 fn encodeSection(buffer: *uamqp.encoder.Buffer, code: u64, value: AmqpValue) !void {
@@ -1096,6 +1122,62 @@ test "encodeMessageEnvelope drops the body" {
 
     try std.testing.expect(envelope.len < full.len);
     try std.testing.expectEqualSlices(u8, envelope, full[0..envelope.len]);
+}
+
+test "dataSectionSize matches what encodeDataSections writes" {
+    const allocator = std.testing.allocator;
+
+    // `encodeDataSections` allocates exactly `dataSectionSize` per payload and
+    // encodes into a fixed buffer, so a disagreement would truncate the wire
+    // payload. The vbin8/vbin32 boundary is where the two would drift first.
+    const lengths = [_]usize{ 0, 1, 254, 255, 256, 257, 1024 };
+
+    for (lengths) |len| {
+        const payload = try allocator.alloc(u8, len);
+        defer allocator.free(payload);
+        @memset(payload, 0x5a);
+
+        const payloads = [_][]u8{payload};
+        const encoded = try encodeDataSections(allocator, "", &payloads);
+        defer allocator.free(encoded);
+
+        try std.testing.expectEqual(dataSectionSize(len), encoded.len);
+
+        var result = try uamqp.decoder.decode(allocator, encoded);
+        defer result.value.deinit(allocator);
+        try std.testing.expectEqual(
+            uamqp.definitions.descriptor.data,
+            result.value.described.descriptor.ulong,
+        );
+        try std.testing.expectEqualSlices(u8, payload, result.value.described.value.binary);
+        try std.testing.expectEqual(encoded.len, result.bytes_consumed);
+    }
+}
+
+test "encodeDataSections keeps the prefix and appends one section per payload" {
+    const allocator = std.testing.allocator;
+
+    var first = [_]u8{ 1, 2, 3 };
+    var second = [_]u8{ 4, 5 };
+    const payloads = [_][]u8{ &first, &second };
+
+    const encoded = try encodeDataSections(allocator, "PREFIX", &payloads);
+    defer allocator.free(encoded);
+
+    try std.testing.expectEqualSlices(u8, "PREFIX", encoded[0..6]);
+    try std.testing.expectEqual(
+        6 + dataSectionSize(first.len) + dataSectionSize(second.len),
+        encoded.len,
+    );
+
+    var offset: usize = 6;
+    for ([_][]const u8{ &first, &second }) |expected| {
+        var result = try uamqp.decoder.decode(allocator, encoded[offset..]);
+        defer result.value.deinit(allocator);
+        try std.testing.expectEqualSlices(u8, expected, result.value.described.value.binary);
+        offset += result.bytes_consumed;
+    }
+    try std.testing.expectEqual(encoded.len, offset);
 }
 
 test "trailing null fields are omitted from composite sections" {


### PR DESCRIPTION
P2.2 of the performance plan, measured against the baseline #311 established. Two changes, both on the path every batched send takes.

## What changed

**`encodeMessageSections` returned `dupe(buffer.written())`** — allocating a second full-size buffer and copying every byte into it, once per event. uamqp v0.3.0 added `Buffer.toOwnedSlice`, which shrinks the buffer's own allocation to the written length and transfers ownership, so the copy and the extra allocation both go away.

**`encodeDataSections` grew a dynamic buffer** while concatenating the envelope and every event's data section, then duped the result. For a batch approaching the 1 MiB limit that is a doubling series of reallocations plus a full copy of the payload. The exact size is plain arithmetic here — `dataSectionSize` is the same constant-overhead formula batching already charges per event — so it now sizes first and encodes into one exactly sized fixed buffer.

That made `dataSectionSize` load-bearing for **correctness**, not just for the size estimate: if it disagreed with the encoder the payload would be silently truncated. So it moves next to the encoder and `batch.zig` aliases it, rather than the two restating the same constants in different files, and two new tests pin the agreement across the vbin8/vbin32 boundary where they would drift first. `encodeDataSections` had no direct test coverage at all before this.

Also benchmarks `encodeBatchTransfer`, which is the one hot path #311 left unmeasured.

## Results

Best-of-3 minimum, `-Doptimize=ReleaseFast`. Allocation counts are exact and identical across runs.

| case | base | new | | allocs/op | | B/op |
| --- | ---: | ---: | --- | ---: | --- | ---: |
| `toAmqpMessage` | 110 ns | 110 ns | | 3.00 → 3.00 | | 608 → 608 |
| `batch.tryAdd x1` | 450 ns | **440 ns** | | 9.00 → **8.00** | | 1123 → **1038** |
| `batch.tryAdd x100` | 31.5 µs | **29.5 µs** | | 606 → **506** | | 91010 → **82510** |
| `batch.tryAdd x1000` | 343 µs | **305 µs** | | 6010 → **5010** | | 923158 → **838158** |
| `encodeBatchTransfer x1000` | 457 µs | **421 µs** | | 6022.75 → **5011** | | 1242500 → **928188** |

Isolating the transfer encode from the `tryAdd` cost it includes, that step goes from **12.75 allocations and 319 KB of churn to 1 allocation and 90 KB** — the payload itself, allocated once. It previously allocated 3.5× the bytes it produced.

## An approach that was tried and rejected

A full exact-size two-pass rewrite of `encodeMessageSections` reached 4009 allocs/op at x1000 — better than the 5010 here — but was **~30% slower**. `encodedSize` walks the value tree, and `encode` then recomputes every compound body size again internally, so the sizing pass costs more than the memcpy it removes. Sizing first only pays where the size is arithmetic rather than a tree walk, which is why it is used in `encodeDataSections` and not here. Worth recording so it is not re-attempted.

## Validation

- `zig build test --summary all` — **166/166** pass (2 new)
- `zig fmt --check` clean
- Wire format unchanged; the existing exact-byte section-order and envelope-prefix tests still pass