### PR TITLE
Bound the receiver's ready queue, not just its drain cost

### DIFF
--- a/link.zig
+++ b/link.zig
@@ -683,6 +683,33 @@ pub const Receiver = struct {
         self.credit -|= 1;
     }
 
+    /// Drop the entries the cursor has already passed.
+    ///
+    /// The cursor alone would let `ready` grow without bound: it only shrinks
+    /// when the caller happens to consume the exact last queued delivery, and
+    /// a receiver that stays even one delivery behind — an app pumping the
+    /// session itself, or two links on one session consumed in turn — never
+    /// hits that. Compacting once the consumed run reaches half the array
+    /// bounds it by the live backlog while still moving each entry at most
+    /// once per two `receive` calls, so draining stays amortised O(1).
+    fn compactReady(self: *Receiver) void {
+        if (self.ready_head == self.ready.items.len) {
+            self.ready.clearRetainingCapacity();
+            self.ready_head = 0;
+            return;
+        }
+        if (self.ready_head * 2 < self.ready.items.len) return;
+
+        const live = self.ready.items.len - self.ready_head;
+        std.mem.copyForwards(
+            Delivery,
+            self.ready.items[0..live],
+            self.ready.items[self.ready_head..],
+        );
+        self.ready.shrinkRetainingCapacity(live);
+        self.ready_head = 0;
+    }
+
     /// Free the delivery handed out by the previous `receive`, whose "valid
     /// until the next `receive`" window has just closed.
     fn releaseCurrent(self: *Receiver) void {
@@ -775,10 +802,7 @@ pub const Receiver = struct {
 
         const delivery = self.ready.items[self.ready_head];
         self.ready_head += 1;
-        if (self.ready_head == self.ready.items.len) {
-            self.ready.clearRetainingCapacity();
-            self.ready_head = 0;
-        }
+        self.compactReady();
 
         // Only now that a replacement is in hand, so a `receive` that fails or
         // times out leaves the previously returned delivery readable, as it
@@ -1551,14 +1575,75 @@ test "receive hands out the queued buffer rather than copying it" {
     try testing.expectEqual(receiver.ready.items[0].payload.ptr, first.payload.ptr);
     try testing.expectEqual(receiver.ready.items[0].tag.ptr, first.tag.ptr);
 
+    // The second receive puts the consumed run at half the array, so the live
+    // tail is shifted down and the cursor resets.
     _ = try receiver.receive(10_000);
-    try testing.expectEqual(@as(usize, 2), receiver.ready_head);
+    try testing.expectEqual(@as(usize, 0), receiver.ready_head);
+    try testing.expectEqual(@as(usize, 1), receiver.ready.items.len);
 
     const last = try receiver.receive(10_000);
     try testing.expectEqual(@as(u32, 2), last.id);
     // Fully drained, so the queue resets rather than growing without bound.
     try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
     try testing.expectEqual(@as(usize, 0), receiver.ready_head);
+}
+
+test "a partially drained queue stays bounded by the backlog" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    const count = 400;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = i,
+            .delivery_tag = "t",
+            .message_format = 0,
+            .settled = true,
+            .more = false,
+        }, "event");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        .prefetch = 512,
+    }, 10_000);
+
+    while (receiver.ready.items.len < count) _ = try fixture.session.pump(10_000);
+
+    // Consume all but one. A cursor that only reset on an exactly empty queue
+    // would still be holding all 400 entries, 399 of them dead, and would go
+    // on accruing them for the life of the link.
+    i = 0;
+    while (i < count - 1) : (i += 1) {
+        const delivery = try receiver.receive(10_000);
+        try testing.expectEqual(i, delivery.id);
+    }
+
+    const backlog = receiver.ready.items.len - receiver.ready_head;
+    try testing.expectEqual(@as(usize, 1), backlog);
+    try testing.expect(receiver.ready.items.len <= 2 * backlog);
+
+    const last = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, count - 1), last.id);
 }
 
 test "draining an already queued backlog allocates nothing" {


### PR DESCRIPTION
Found by the pre-release review of #314, **before the 0.3.0 tag was cut**. This is the release-review gate doing its job — the tag would have been immutable.

## The regression

#314 replaced `ready.orderedRemove(0)` with a head cursor so that draining a deep prefetch window is no longer quadratic. But the array itself then only shrank in one case: when the caller consumed the *exact* last queued delivery.

Any receiver that stays even one delivery behind never hits that, so consumed entries accumulated for the life of the link — `ready.items.len` tracked *total deliveries ever received* rather than the backlog. `orderedRemove(0)` at least kept it bounded by peak lag, so #314 turned bounded memory into unbounded: ~40 bytes per delivery forever, plus the repeated grow-and-copy of an ever larger array.

The entries below the cursor also held dangling `payload`/`tag` pointers, already freed by `releaseCurrent`. Nothing reads them today (the only accesses are `ready.items[ready_head]` and `ready.items[ready_head..]`), so it is not a correctness bug, but a growing run of stale pointers is a poor thing to leave for the next person to iterate that array.

## Why it is not theoretical

The exposed case is precisely the one the cursor exists to serve. A plain `receive` loop *cannot* build a deep queue: it pumps only while the queue is empty, and `Session.pump` applies one transfer per frame, so it always consumes the last entry and always resets. The queue only gets deep when frames are pumped from elsewhere:

- an app driving the public `Session.pump` itself;
- two links on one session consumed in turn — the CBS-plus-events shape `link.zig` already calls out in its own comments.

Reproduced by the reviewer at 400 iterations of "pump two, receive one": `ready.items.len=800`, `ready_head=400`, `capacity=1057`, for a live backlog of 400.

## The fix

`compactReady` shifts the live tail down once the consumed run reaches half the array. Each entry moves at most once per two `receive` calls, so draining stays **amortised O(1)**, and the array is bounded by **twice the live backlog**.

## Validation

- New test `a partially drained queue stays bounded by the backlog`: queues 400, consumes 399, asserts the array is within 2x the backlog of 1. **Verified to fail without the compaction branch.**
- The `receive hands out the queued buffer rather than copying it` test now also pins the cursor reset at the halfway point, and likewise fails without compaction.
- `zig build test --summary all` — **104/104** pass. `zig fmt --check` clean.

No version change: 0.3.0 is not tagged yet, so this is part of it.

## Also verified by the review, no action needed

Recorded because it is non-obvious: ownership is sound on every path under an injected-allocation-failure sweep (no leaks, double frees, or invalid frees); `ready.items[ready_head..]` in `deinit` is always in bounds and exactly the set still owned by `ready`; the fast-path guard is behaviourally identical to 0.2.0 including the `MessageTooLarge` boundary, because `partial_id == null` implies `partial.items.len == 0` on every path; and the "valid until the next `receive`" contract holds on the error and timeout paths.