### PR TITLE
Move to azure_sdk_amqp 0.3.0 (0.3.1)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_eventhubs,
-    .version = "0.3.0",
+    .version = "0.3.1",
     .fingerprint = 0xcb7772a1125a8d42,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#ba0cff592398e19e81137dbf2c20832192b2d071",
-            .hash = "azure_sdk_amqp-0.2.0-fUByf1aQBADz7Rj7zQP39Pa-z_izpONFJlM2ZfvPJDSK",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#8377f9283ab3ddcc6073c36638e07ebaf313f771",
+            .hash = "azure_sdk_amqp-0.3.0-fUByfx7GBABEuMVKZdI2Dvu7x9civfpA9x52iqWA0KPF",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",


### PR DESCRIPTION
Picks up the receive-path work from #314 and #315:

- a received body is copied **once instead of three times** — single-frame deliveries skip the reassembly buffer, and `receive` hands out the buffer the delivery already owns instead of copying it into scratch storage;
- a prefetching consumer drains its queue in **amortised O(1)** instead of shifting the whole queue on every `receive`, with the queue bounded by the live backlog rather than by every delivery it has ever seen.

That matters here specifically because Event Hubs runs the default **300-deep prefetch** (`receiver.zig`), which is exactly the shape that was quadratic to drain.

## Pin-only

Nothing in this package touches the `Receiver` fields whose types changed. `Delivery` — the receive contract Event Hubs actually uses — is unchanged.

`zig build test --summary all` — **166/166** pass.

## Benchmarks unchanged, as expected

The offline suite measures the encode and decode paths, not the AMQP link, so the receive improvement does not show up in it. Recorded here to confirm no regression:

| case | avg | allocs/op | B/op |
| --- | ---: | ---: | ---: |
| `toAmqpMessage` | 110 ns | 3.00 | 608 |
| `batch.tryAdd x1` | 430 ns | 8.00 | 1038 |
| `batch.tryAdd x100` | 29.4 µs | 506.00 | 82510 |
| `batch.tryAdd x1000` | 307 µs | 5010.00 | 838158 |
| `encodeBatchTransfer x1000` | 426 µs | 5011.00 | 928188 |
| `fromAmqpMessage` | 180 ns | 9.00 | 371 |

Measuring the link path end-to-end needs a `test_peer`-driven benchmark; the deterministic tests added in #314/#315 cover it instead.