### PR TITLE
Close a settle run at the delivery id wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ defer allocator.free(bytes);
   the delivery already owns rather than copying it into scratch storage, so a
   received body is copied once rather than three times
 - settlement: accepted, rejected, and released outcomes, with a rejection
-  surfacing the peer's error condition
+  surfacing the peer's error condition, one delivery at a time or a whole
+  contiguous run in a single disposition
 - the Event Hubs link properties the Go and Rust clients send —
   `com.microsoft:receiver-name`, `com.microsoft:epoch`, and the
   `apache.org:selector-filter:string` filter used to pick a starting offset
@@ -136,6 +137,24 @@ try receiver.accept(delivery);
 `delivery` stays valid until the next `receive` returns, so copy anything you
 need to keep. Prefetched deliveries queue up and are drained with a cursor
 rather than by shifting the queue, which keeps a deep prefetch window linear.
+
+Settling one delivery at a time costs a frame per message, which at a 300-deep
+prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`
+range instead, and `SettleBatch` builds those runs safely — delivery ids belong
+to the session rather than to the link, so anything else sharing the session
+leaves gaps that a range must not span:
+
+```zig
+var settling = amqp.SettleBatch.init(receiver, .accepted);
+var i: usize = 0;
+while (i < 300) : (i += 1) {
+    try settling.add(try receiver.receive(deadline_ms));
+}
+try settling.flush();
+```
+
+Nothing reaches the wire until `flush`, so abandoning a batch leaves its
+deliveries unsettled and the peer redelivers them.
 
 A handle in an inbound frame is scoped to the peer that sent it, so links are
 looked up by the handle the peer chose, never by our own. A session holding both

--- a/link.zig
+++ b/link.zig
@@ -968,7 +968,13 @@ pub const SettleBatch = struct {
 
     pub fn addId(self: *SettleBatch, id: u32) LinkError!void {
         if (self.first) |_| {
-            if (id == self.last +% 1) {
+            // A delivery id is a serial number (Â§2.8.3), so 0 really does
+            // follow 0xffffffff — but a range written that way reads as
+            // `first > last` to anything comparing the two numerically, which
+            // includes this library's own `Sender.applyDisposition`. Rather
+            // than emit a form only a strict serial-number implementation can
+            // read, close the run at the wrap and start a new one.
+            if (self.last != std.math.maxInt(u32) and id == self.last + 1) {
                 self.last = id;
                 return;
             }
@@ -2084,6 +2090,37 @@ test "a batch does not settle across a gap in delivery ids" {
     try testing.expectEqual([2]u32{ 3, 5 }, ranges[0]);
     try testing.expectEqual([2]u32{ 8, 9 }, ranges[1]);
     try testing.expectEqual([2]u32{ 11, 11 }, ranges[2]);
+}
+
+test "a batch does not settle across the delivery id wrap" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+
+    const max = std.math.maxInt(u32);
+    const ids = [_]u32{ max - 2, max - 1, max, 0, 1 };
+    var driver: Driver = undefined;
+    var fixture: Fixture = undefined;
+    const receiver = try scriptedReceiver(allocator, &mem, &clock, &driver, &fixture, &ids);
+    defer driver.deinit();
+    defer fixture.deinit();
+
+    mem.clearWritten();
+    var batch = SettleBatch.init(receiver, .accepted);
+    for (ids) |_| try batch.add(try receiver.receive(10_000));
+    try batch.flush();
+
+    const ranges = try settledRanges(allocator, mem.written());
+    defer allocator.free(ranges);
+
+    // Treating these five as one run would put `first = 0xfffffffd,
+    // last = 1` on the wire: legal under serial-number arithmetic, and
+    // unreadable to every peer that just compares the two.
+    try testing.expectEqual(@as(usize, 2), ranges.len);
+    try testing.expectEqual([2]u32{ max - 2, max }, ranges[0]);
+    try testing.expectEqual([2]u32{ 0, 1 }, ranges[1]);
+    for (ranges) |r| try testing.expect(r[0] <= r[1]);
 }
 
 test "flushing an empty batch says nothing" {


### PR DESCRIPTION
The release review of #319 found this. Graded **Low** and explicitly not a blocker — closing it anyway, because the tag it would ship in is immutable and the fix is three lines.

## The problem

A `SettleBatch` run spanning `0xFFFFFFFF → 0` was emitted as a single range: `first = 0xFFFFFFFD, last = 1`.

That form is spec-legal. A delivery id is a `sequence-no`, i.e. an RFC 1982 serial number (AMQP 1.0 §2.8.3), so the range is unambiguous under serial comparison. But it is a form **this library itself cannot read**: `Sender.applyDisposition` (`link.zig:415`) tests `if (id < first or id > last) return` — plain numeric comparison. A peer doing the same sees an empty range and redelivers, or rejects the field.

`+%` was and remains the correct adjacency test — it never merges non-adjacent ids and never splits adjacent ones. The problem was only what `flush` then put on the wire. The run is now closed at the wrap.

Reaching this needs ~2^32 deliveries on one session, and the failure direction is redelivery rather than over-settlement, which is why it was graded low.

## Also

Documents `SettleBatch` in the README, which described the settlement surface but stopped at `receiver.accept(delivery)`.

## Validation

New test feeds ids `{max-2, max-1, max, 0, 1}` and asserts **two** ranges — `{max-2, max}` and `{0, 1}` — plus `first <= last` on every emitted range. **Verified to fail against the previous implementation**, which produced one range.

**110/110** pass. `zig fmt --check .` clean.

Everything else in the v0.3.0..v0.4.0 review came back clean, including: no false merges or splits in `SettleBatch`; no double-settle on any flush-failure path (verified with `fail_write` injection); `settle` emits byte-identical frames to v0.3.0; nothing in `Receiver` depends on settlement having happened; all new tests discriminate; `.paths` complete; `0.4.0` is the correct bump.