### PR TITLE
Settle a received batch in one disposition (0.4.0)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_eventhubs,
-    .version = "0.3.1",
+    .version = "0.4.0",
     .fingerprint = 0xcb7772a1125a8d42,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#8377f9283ab3ddcc6073c36638e07ebaf313f771",
-            .hash = "azure_sdk_amqp-0.3.0-fUByfx7GBABEuMVKZdI2Dvu7x9civfpA9x52iqWA0KPF",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#12ee60bac9ca2233b4a0083309fd167b3a9f261c",
+            .hash = "azure_sdk_amqp-0.4.0-fUByf1kMBQCZMc-pdQEvU4BRbv-OwCRZh_jfdsf5gVyG",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/receiver.zig
+++ b/receiver.zig
@@ -215,30 +215,40 @@ pub const PartitionClient = struct {
         while (events.items.len < count) {
             const delivery = self.receiver.receive(self.deadline_ms) catch |err| {
                 self.recordDetach();
-                // Events already in hand arrived and were accepted, so dropping
-                // them here would lose them outright. Hand back the short batch
-                // and let the next call surface the failure: the link is dead,
-                // so that call fails immediately with nothing to lose.
+                // Events already in hand arrived, so dropping them here would
+                // lose them outright. Hand back the short batch and let the
+                // next call surface the failure: the link is dead, so that
+                // call fails immediately with nothing to lose.
                 if (events.items.len > 0) break;
                 return err;
             };
 
-            var decoded = try amqp.decodeMessage(allocator, delivery.payload);
-            defer decoded.deinit();
+            const received = blk: {
+                var decoded = try amqp.decodeMessage(allocator, delivery.payload);
+                defer decoded.deinit();
+                break :blk try event_data.fromRawMessage(allocator, rawFrom(&decoded.message));
+            };
 
-            const received = try event_data.fromRawMessage(allocator, rawFrom(&decoded.message));
-            errdefer {
-                var owned = received;
-                owned.deinit(allocator);
-            }
-
-            try events.append(allocator, received);
+            // Capacity for `count` was reserved up front and the loop runs
+            // only while short of it, so this cannot fail. That matters
+            // beyond the allocation it saves: it leaves no point at which
+            // the event is owned by both this frame and `events`, which is
+            // what would otherwise let a later failure in this iteration
+            // free it twice.
+            events.appendAssumeCapacity(received);
             try settling.add(delivery);
         }
 
-        // Anything decoded but not settled here is redelivered rather than
-        // lost, so failing before the flush errs in the safe direction.
-        try settling.flush();
+        // Settling tells the peer these will not be asked for again. It is
+        // advisory here: an unsettled delivery is redelivered, and a consumer
+        // resumes from the sequence number rather than from AMQP settlement.
+        // So events that did arrive are never worth discarding merely to
+        // report that the disposition did not land — least of all on the
+        // break above, where the link that would carry it is the one that
+        // just failed.
+        settling.flush() catch |err| {
+            if (events.items.len == 0) return err;
+        };
 
         if (events.items.len > 0) {
             try self.advancePast(events.items[events.items.len - 1].sequence_number);
@@ -763,6 +773,73 @@ test "a quiet partition returns the events that did arrive" {
 
     try testing.expectEqual(@as(usize, 1), events.len);
     try testing.expectEqualStrings("only", events[0].body());
+}
+
+test "a broken connection still hands back the events that arrived" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushEvent(allocator, peer, 0, 1, "first");
+    try pushEvent(allocator, peer, 1, 2, "second");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    // A reset connection stops carrying traffic in both directions, so the
+    // disposition that settles the batch cannot go out either. Asking for
+    // more than the script holds runs the read failure and the failed
+    // settlement together, which is what a consumer sees when a broker
+    // recycles a node mid-batch.
+    mem.fail_write = true;
+
+    const events = try scripted.client.receiveEvents(allocator, 10);
+    defer event_data.freeReceivedEvents(allocator, events);
+
+    // Settling is advisory: unsettled deliveries are redelivered, and the
+    // consumer resumes from the sequence number. Reporting the failed
+    // disposition instead would throw away two events that did arrive.
+    try testing.expectEqual(@as(usize, 2), events.len);
+    try testing.expectEqualStrings("first", events[0].body());
+    try testing.expectEqualStrings("second", events[1].body());
+}
+
+test "a failed settlement mid-batch frees each event exactly once" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    // The gap at 2 is what another link on the session leaves behind. It
+    // makes `SettleBatch.add` close the open run mid-loop, so the settle
+    // write — and its failure — land inside the loop rather than after it.
+    try pushEvent(allocator, peer, 0, 1, "first");
+    try pushEvent(allocator, peer, 1, 2, "second");
+    try pushEvent(allocator, peer, 3, 3, "third");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    mem.fail_write = true;
+
+    // Whatever comes back, the point is that nothing is freed twice and
+    // nothing leaks: `testing.allocator` fails the test either way.
+    const events = scripted.client.receiveEvents(allocator, 3) catch |err| {
+        try testing.expectEqual(anyerror.WriteFailed, err);
+        return;
+    };
+    event_data.freeReceivedEvents(allocator, events);
 }
 
 test "disabled prefetch issues credit per receive" {

--- a/receiver.zig
+++ b/receiver.zig
@@ -236,19 +236,21 @@ pub const PartitionClient = struct {
             // what would otherwise let a later failure in this iteration
             // free it twice.
             events.appendAssumeCapacity(received);
-            try settling.add(delivery);
+            // `add` is not merely bookkeeping: it puts the open run on the
+            // wire whenever a delivery id is not the one after the last,
+            // which is whenever another link on the session took an id in
+            // between. So it fails for the same reasons the flush below
+            // does, and is swallowed for the same reason — see there.
+            settling.add(delivery) catch {};
         }
 
         // Settling tells the peer these will not be asked for again. It is
         // advisory here: an unsettled delivery is redelivered, and a consumer
         // resumes from the sequence number rather than from AMQP settlement.
-        // So events that did arrive are never worth discarding merely to
-        // report that the disposition did not land — least of all on the
-        // break above, where the link that would carry it is the one that
-        // just failed.
-        settling.flush() catch |err| {
-            if (events.items.len == 0) return err;
-        };
+        // So a settle write that does not land is never worth the events that
+        // did arrive — least of all on the break above, where the link that
+        // would carry it is the one that just failed.
+        settling.flush() catch {};
 
         if (events.items.len > 0) {
             try self.advancePast(events.items[events.items.len - 1].sequence_number);
@@ -810,7 +812,7 @@ test "a broken connection still hands back the events that arrived" {
     try testing.expectEqualStrings("second", events[1].body());
 }
 
-test "a failed settlement mid-batch frees each event exactly once" {
+test "a settle write failing mid-batch costs no events either" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -833,13 +835,15 @@ test "a failed settlement mid-batch frees each event exactly once" {
 
     mem.fail_write = true;
 
-    // Whatever comes back, the point is that nothing is freed twice and
-    // nothing leaks: `testing.allocator` fails the test either way.
-    const events = scripted.client.receiveEvents(allocator, 3) catch |err| {
-        try testing.expectEqual(anyerror.WriteFailed, err);
-        return;
-    };
-    event_data.freeReceivedEvents(allocator, events);
+    const events = try scripted.client.receiveEvents(allocator, 3);
+    defer event_data.freeReceivedEvents(allocator, events);
+
+    // The gap makes the settle write happen inside the loop rather than
+    // after it, which is the other place it can fail. It must cost the
+    // caller no more there than it does at the end.
+    try testing.expectEqual(@as(usize, 3), events.len);
+    try testing.expectEqualStrings("first", events[0].body());
+    try testing.expectEqualStrings("third", events[2].body());
 }
 
 test "disabled prefetch issues credit per receive" {

--- a/receiver.zig
+++ b/receiver.zig
@@ -197,10 +197,20 @@ pub const PartitionClient = struct {
         }
 
         var events: std.ArrayList(ReceivedEventData) = .empty;
+        // `count` is exactly how many will be appended on the success path, and
+        // a `ReceivedEventData` is large enough that regrowing a 300-deep
+        // prefetch means repeatedly copying tens of kilobytes.
+        try events.ensureTotalCapacityPrecise(allocator, count);
         errdefer {
             for (events.items) |*e| e.deinit(allocator);
             events.deinit(allocator);
         }
+
+        // One disposition per message meant a frame on the wire per event; a
+        // full prefetch window cost hundreds of round trips of bookkeeping.
+        // `SettleBatch` coalesces the ids into runs and only breaks a run
+        // where another link on the session took an id in between.
+        var settling = amqp.SettleBatch.init(self.receiver, .accepted);
 
         while (events.items.len < count) {
             const delivery = self.receiver.receive(self.deadline_ms) catch |err| {
@@ -223,8 +233,12 @@ pub const PartitionClient = struct {
             }
 
             try events.append(allocator, received);
-            try self.receiver.accept(delivery);
+            try settling.add(delivery);
         }
+
+        // Anything decoded but not settled here is redelivered rather than
+        // lost, so failing before the flush errs in the safe direction.
+        try settling.flush();
 
         if (events.items.len > 0) {
             try self.advancePast(events.items[events.items.len - 1].sequence_number);
@@ -665,6 +679,60 @@ test "receiveEvents decodes events and advances past the last one" {
         "amqp.annotation.x-opt-sequence-number > '12'",
         scripted.client.filterExpression(),
     );
+}
+
+test "receiveEvents settles a whole batch in one disposition" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+
+    const batch = 32;
+    var i: u32 = 0;
+    while (i < batch) : (i += 1) {
+        try pushEvent(allocator, peer, i, @as(i64, i) + 1, "event");
+    }
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    mem.clearWritten();
+    const events = try scripted.client.receiveEvents(allocator, batch);
+    defer event_data.freeReceivedEvents(allocator, events);
+    try testing.expectEqual(@as(usize, batch), events.len);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+
+    var dispositions: usize = 0;
+    var covered_first: ?u32 = null;
+    var covered_last: ?u32 = null;
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.disposition) continue;
+        dispositions += 1;
+        var decoded = try amqp.performative.decode(allocator, body);
+        defer decoded.deinit();
+        const d = decoded.performative.disposition;
+        try testing.expectEqual(amqp.performative.Role.receiver, d.role);
+        try testing.expect(d.settled);
+        try testing.expectEqual(amqp.performative.DeliveryState.accepted, d.state.?);
+        covered_first = d.first;
+        covered_last = d.last orelse d.first;
+    }
+
+    // Settling one at a time put a frame on the wire per event, so a 300-deep
+    // prefetch cost 300 round trips of nothing but bookkeeping. AMQP 1.0
+    // §2.6.10 lets one disposition cover a contiguous `first..last` run, which
+    // is what every other client does.
+    try testing.expectEqual(@as(usize, 1), dispositions);
+    try testing.expectEqual(@as(u32, 0), covered_first.?);
+    try testing.expectEqual(@as(u32, batch - 1), covered_last.?);
 }
 
 test "a quiet partition returns the events that did arrive" {


### PR DESCRIPTION
Audit item 2.1, the Event Hubs half. Supersedes the pin-only #316, which was merged but never tagged.

## One disposition instead of 300

`receiveEvents` called `receiver.accept(delivery)` as it decoded each event, so draining a prefetch window put **a disposition frame on the wire per event**. At the default 300-deep prefetch that is 300 frames saying nothing but "got it". It now accumulates into `amqp.SettleBatch` and flushes once.

The batch matters rather than a bare `settleRange` call because **delivery ids belong to the session, not the link**. A partition client shares its session with CBS and `$management`, so the ids it is handed have gaps in them — and a range spanning a gap would settle another link's delivery, silently and as `accepted`. `SettleBatch` breaks the run at every gap.

Nothing reaches the wire until the flush, so failing before it leaves those deliveries unsettled and the peer redelivers them. That is the same direction the existing short-batch path already errs in.

## Also

`events.ensureTotalCapacityPrecise(count)` — `count` is exactly how many land on the success path, and a `ReceivedEventData` is large enough that regrowing a 300-deep window means repeatedly copying tens of kilobytes.

## azure_sdk_amqp 0.3.0 → 0.4.0

Carries the range disposition API plus the sender work:

- a multi-frame send went from **88 allocations to 24** (reused frame scratch, budget measured twice per delivery instead of once per chunk);
- that scratch is sized by the message rather than by the peer's advertised `max-frame-size` — a peer omitting the field means `2^32-1`, which had a five-byte message asking for 4 GiB;
- from 0.3.0: a received body is copied once instead of three times, and a prefetch queue drains in amortised O(1) bounded by the live backlog.

## Validation

`test_peer`-driven test asserts a 32-event `receiveEvents` emits **exactly one** disposition covering `0..31`, checking `role`, `settled` and `state` on it. **Verified to find 32 before the change.**

Offline benchmarks unchanged, as expected — they measure encode and decode, not the link:

| case | avg | allocs/op | B/op |
| --- | ---: | ---: | ---: |
| `toAmqpMessage` | 110 ns | 3.00 | 608 |
| `batch.tryAdd x1000` | 303 µs | 5010.00 | 838158 |
| `encodeBatchTransfer x1000` | 413 µs | 5011.00 | 928188 |
| `fromAmqpMessage` | 180 ns | 9.00 | 371 |

**167/167** pass. `zig fmt --check .` clean.