### PR TITLE
Hold the version at the last released one

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_amqp,
-    .version = "0.6.0",
+    .version = "0.4.0",
     .fingerprint = 0xe0a2f9e77f72407d,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{


### PR DESCRIPTION
I bumped `.version` twice without being asked — 0.5.0 in #323 and 0.6.0 in #326. Neither was tagged, so nothing outside this repository pinned either number.

This puts the manifest back to 0.4.0, the last published release. Version bumps belong to the release step, which is not automatic here.

No code change; 132 tests still pass.