### PR TITLE
Let a sender give up on the deliveries still in flight

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ Deliveries settle in the order they were sent, and the ring holding them is
 allocated once at attach, so a silent peer costs a fixed amount of memory rather
 than a growing one.
 
+`abandonInFlight` is the way out of a pipeline that failed partway. Waiting is
+what just failed, so the caller cannot wait the remaining deliveries out, and a
+sender still holding unsettled ones refuses every later blocking send — without
+it a single timed-out pipeline would wedge the link for good. The abandoned
+verdicts are lost and any disposition that arrives for them is ignored, so
+resending an abandoned delivery the broker went on to accept publishes it
+twice.
+
 ### Session flow control
 
 Session ids count transfer *frames*, not deliveries (§2.5.6). Every frame of a

--- a/link.zig
+++ b/link.zig
@@ -501,23 +501,29 @@ pub const Sender = struct {
         return &self.in_flight[(self.in_flight_head + i) % self.in_flight.len];
     }
 
-    /// How many deliveries are written but not yet settled.
     /// Give up on every delivery still in flight, emptying the window.
     ///
-    /// Their verdicts are lost. The peer may still settle those ids, and those
-    /// dispositions are then ignored, so this is at-least-once: a caller that
-    /// abandons a delivery the broker went on to accept and then resends it
-    /// has published it twice.
+    /// Their verdicts are lost — including any the peer has already sent but
+    /// the caller has not collected, since `awaitSettlement` retires strictly
+    /// in send order and a peer may settle out of it. The peer may also settle
+    /// those ids later, and those dispositions are then ignored. So this is
+    /// at-least-once: a caller that abandons a delivery the broker went on to
+    /// accept and then resends it has published it twice.
     ///
     /// This is the way out of a pipelined send that failed partway. A sender
     /// still holding unsettled deliveries refuses every later blocking send
     /// with `error.DeliveriesInFlight`, so without it a single timed-out
     /// pipeline would wedge the link for good — the caller cannot wait the
     /// deliveries out, because waiting is what just failed.
+    ///
+    /// The `Settlement` from the last `awaitSettlement` stays valid: this is
+    /// not an `awaitSettlement`, so it does not disturb the rejection the
+    /// sender is holding for the caller to read.
     pub fn abandonInFlight(self: *Sender) void {
         while (self.in_flight_len > 0) self.discardOldest();
     }
 
+    /// How many deliveries are written but not yet settled.
     pub fn inFlight(self: *const Sender) usize {
         return self.in_flight_len;
     }
@@ -2366,12 +2372,12 @@ test "abandoning the window frees a rejection and lets blocking sends resume" {
     const peer = Peer{ .allocator = allocator, .mem = &mem };
 
     try scriptSenderAttach(peer, 10);
-    // One verdict for three deliveries, and it carries an allocated
-    // description so the abandon has memory to release.
+    // One verdict covering all three, so the two the caller never collects are
+    // each left holding an allocated rejection for the abandon to release.
     try peer.push(0, .{ .disposition = .{
         .role = .receiver,
         .first = 0,
-        .last = 0,
+        .last = 2,
         .settled = true,
         .state = .{ .rejected = .{
             .condition = "amqp:resource-limit-exceeded",
@@ -2413,6 +2419,11 @@ test "abandoning the window frees a rejection and lets blocking sends resume" {
 
     sender.abandonInFlight();
     try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    // Abandoning is not a settlement, so the verdict already handed out is
+    // still readable — its contract says it lives until the next
+    // `awaitSettlement`, and this was not one.
+    try testing.expectEqualStrings("slow down", first.rejection.?.description.?);
 
     // And now it goes through, with the peer settling id 3 as it would.
     try sender.sendBytes("d", 10_000);

--- a/link.zig
+++ b/link.zig
@@ -502,6 +502,22 @@ pub const Sender = struct {
     }
 
     /// How many deliveries are written but not yet settled.
+    /// Give up on every delivery still in flight, emptying the window.
+    ///
+    /// Their verdicts are lost. The peer may still settle those ids, and those
+    /// dispositions are then ignored, so this is at-least-once: a caller that
+    /// abandons a delivery the broker went on to accept and then resends it
+    /// has published it twice.
+    ///
+    /// This is the way out of a pipelined send that failed partway. A sender
+    /// still holding unsettled deliveries refuses every later blocking send
+    /// with `error.DeliveriesInFlight`, so without it a single timed-out
+    /// pipeline would wedge the link for good — the caller cannot wait the
+    /// deliveries out, because waiting is what just failed.
+    pub fn abandonInFlight(self: *Sender) void {
+        while (self.in_flight_len > 0) self.discardOldest();
+    }
+
     pub fn inFlight(self: *const Sender) usize {
         return self.in_flight_len;
     }
@@ -2337,6 +2353,114 @@ test "a sender waits for the peer to reopen the window instead of sending past i
     }
     try testing.expectEqual(@as(usize, 1), transfers);
     try testing.expectEqual(@as(u32, 3), fixture.session.remote_incoming_window);
+}
+
+test "abandoning the window frees a rejection and lets blocking sends resume" {
+    // Waiting is what fails when a pipeline fails, so a caller cannot wait the
+    // deliveries out. Without a way to drop them the sender refuses every
+    // later blocking send and the link is finished.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 10);
+    // One verdict for three deliveries, and it carries an allocated
+    // description so the abandon has memory to release.
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .{ .rejected = .{
+            .condition = "amqp:resource-limit-exceeded",
+            .description = "slow down",
+        } },
+    } });
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 3,
+        .last = 3,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+        .max_in_flight = 4,
+    }, 10_000);
+
+    _ = try sender.sendBytesAsync("a", .{}, 10_000);
+    _ = try sender.sendBytesAsync("b", .{}, 10_000);
+    _ = try sender.sendBytesAsync("c", .{}, 10_000);
+    try testing.expectEqual(@as(usize, 3), sender.inFlight());
+
+    // The first comes back refused, which parks an allocated rejection on its
+    // entry; the other two are never answered.
+    const first = try sender.awaitSettlement(10_000);
+    try testing.expectEqual(Outcome.rejected, first.outcome);
+    try testing.expectEqual(@as(usize, 2), sender.inFlight());
+
+    // A blocking send is refused while they are outstanding.
+    try testing.expectError(error.DeliveriesInFlight, sender.sendBytes("d", 10_000));
+
+    sender.abandonInFlight();
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    // And now it goes through, with the peer settling id 3 as it would.
+    try sender.sendBytes("d", 10_000);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+}
+
+test "abandoning an unanswered window leaks nothing" {
+    // The entries hold duplicated rejection text, so dropping them has to
+    // release it rather than just moving the cursors.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 10);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 1,
+        .settled = true,
+        .state = .{ .rejected = .{
+            .condition = "amqp:internal-error",
+            .description = "a description long enough to be worth freeing",
+        } },
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+        .max_in_flight = 4,
+    }, 10_000);
+
+    _ = try sender.sendBytesAsync("a", .{}, 10_000);
+    _ = try sender.sendBytesAsync("b", .{}, 10_000);
+
+    // Pump the refusal onto both entries without retiring either.
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 2), sender.inFlight());
+
+    // testing.allocator reports anything left behind.
+    sender.abandonInFlight();
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
 }
 
 test "one disposition settles every delivery a pipelining sender put on the wire" {


### PR DESCRIPTION
Found while building the pipelined Event Hubs send on top of #323.

A pipelined send that fails partway leaves unsettled deliveries in the window, and `sendBytes` refuses to run while any are there — it cannot tell whose verdict it is reading otherwise. There was no way out of that state: the only means of emptying the window was to wait for the verdicts, and waiting is exactly what had just failed. So one timed-out pipeline wedged the link for every later blocking send.

That is not hypothetical for the caller I am writing: `ProducerClient.sendBatches` sends pipelined and, on failure, resends the unaccepted remainder through the retrying blocking path. Which is precisely the sequence that could not work.

`abandonInFlight` drops the window, releasing the rejection text an entry may be holding. The abandoned verdicts are lost and any disposition that later names those ids is ignored, so it is at-least-once — resending a delivery the broker had in fact accepted publishes it twice. The retry path already makes that bargain.

134 tests. Two new:

| mutation | caught by |
| --- | --- |
| move the cursors without freeing | the leak test, 4 allocations |
| make it a no-op | both |

No version change.