### PR TITLE
Overlap batch sends instead of paying a round trip for each

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,34 @@ owns the addresses it keys them by. When the broker refuses a delivery,
 `lastSendError` carries the AMQP condition and description that the Zig error
 cannot.
 
+### Sending several batches at once
+
+`sendBatch` waits for the broker to confirm before returning, so a caller with
+several batches ready pays a full round trip for each one. Across a link with
+any real latency that, and not the encoding, is what sets the ceiling.
+
+```zig
+try producer.sendBatches(allocator, &.{ batch_a, batch_b, batch_c });
+```
+
+`sendBatches` keeps several on the wire at once and collects the confirmations
+afterwards, so the round trip is paid once for the window rather than once per
+batch. Retries, connection recovery and the at-least-once guarantee are exactly
+`sendBatch`'s — a batch the broker accepted but could not acknowledge may be
+published twice, either way.
+
+Batches are grouped into runs by partition, because each partition is its own
+link and only batches sharing one can overlap. Passing them already grouped —
+the natural order when they were built per partition — makes every batch
+eligible. A `null` partition is the gateway, a destination in its own right
+rather than a wildcard, so it forms runs of its own.
+
+For finer control, `SenderPool` exposes the pieces underneath: `sendAsync`
+returns a token without waiting, `confirm` collects the next verdict in send
+order and names it, `unconfirmed` reports how many are outstanding, and
+`sendPipelined` runs the window without retrying. `SenderPool.Options.max_in_flight`
+sets the window size and defaults to 1, which is the blocking behaviour.
+
 ## Receiving
 
 A partition is read through one receiver link held open for the life of a

--- a/README.md
+++ b/README.md
@@ -145,9 +145,13 @@ refuses to overlap with anything, so raising it only affects `sendBatches`.
 Both calls are at-least-once — a batch the broker accepted but could not
 acknowledge may be published twice — and overlapping widens that window. When a
 send fails, the batches behind it are already on the wire and may well be
-accepted, but their verdicts are abandoned unread, so they are re-sent. At most
-`max_in_flight` batches are ever at risk. The answer is the same as it is for
-`sendBatch`: give events an application property the consumer deduplicates on.
+accepted, but their verdicts are abandoned unread; they are reported as not
+accepted and may be sent again. At most `max_in_flight` batches are ever at
+risk. The answer is the same as it is for `sendBatch`: give events an
+application property the consumer deduplicates on.
+
+Nothing is silently dropped in either direction: a batch counts as accepted
+only once the broker has said so.
 
 Batches are grouped into runs by partition, because each partition is its own
 link and only batches sharing one can overlap. Passing them already grouped —

--- a/README.md
+++ b/README.md
@@ -135,9 +135,19 @@ try producer.sendBatches(allocator, &.{ batch_a, batch_b, batch_c });
 
 `sendBatches` keeps several on the wire at once and collects the confirmations
 afterwards, so the round trip is paid once for the window rather than once per
-batch. Retries, connection recovery and the at-least-once guarantee are exactly
-`sendBatch`'s — a batch the broker accepted but could not acknowledge may be
-published twice, either way.
+batch. Retries and connection recovery are exactly `sendBatch`'s.
+
+`max_in_flight` on `HubConnection.Options` sets how many a link may have
+unconfirmed, and defaults to 8. The ring is allocated once when the link
+attaches and costs a few dozen bytes a slot, and the blocking `sendBatch` still
+refuses to overlap with anything, so raising it only affects `sendBatches`.
+
+Both calls are at-least-once — a batch the broker accepted but could not
+acknowledge may be published twice — and overlapping widens that window. When a
+send fails, the batches behind it are already on the wire and may well be
+accepted, but their verdicts are abandoned unread, so they are re-sent. At most
+`max_in_flight` batches are ever at risk. The answer is the same as it is for
+`sendBatch`: give events an application property the consumer deduplicates on.
 
 Batches are grouped into runs by partition, because each partition is its own
 link and only batches sharing one can overlap. Passing them already grouped —
@@ -148,8 +158,10 @@ rather than a wildcard, so it forms runs of its own.
 For finer control, `SenderPool` exposes the pieces underneath: `sendAsync`
 returns a token without waiting, `confirm` collects the next verdict in send
 order and names it, `unconfirmed` reports how many are outstanding, and
-`sendPipelined` runs the window without retrying. `SenderPool.Options.max_in_flight`
-sets the window size and defaults to 1, which is the blocking behaviour.
+`sendPipelined` runs the window without retrying. It needs the link to itself:
+it reads the link's depth as its own and empties the ring when it finishes, so
+it returns `error.DeliveriesInFlight` rather than sharing a link whose verdicts
+someone else is still waiting for.
 
 ## Receiving
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#12ee60bac9ca2233b4a0083309fd167b3a9f261c",
-            .hash = "azure_sdk_amqp-0.4.0-fUByf1kMBQCZMc-pdQEvU4BRbv-OwCRZh_jfdsf5gVyG",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#861257786bdc69df5a87f1cea758bf630126cf60",
+            .hash = "azure_sdk_amqp-0.4.0-fUByf9oLBgAV5AXiW7-2bYt3E0vLBZZZ5mS47NQoaPwD",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/recovery.zig
+++ b/recovery.zig
@@ -125,6 +125,9 @@ pub const RecoverableConnection = struct {
         instance_id: []const u8 = "eventhubs",
         /// Distinguishes this client's sender links from any others.
         link_id: []const u8 = "eventhubs",
+        /// How many batches a sender link may have on the wire unconfirmed.
+        /// Only `sendBatches` overlaps them; `sendBatch` waits either way.
+        max_in_flight: u32 = sending.default_max_in_flight,
         partition_client: PartitionClientOptions = .{},
     };
 
@@ -137,6 +140,7 @@ pub const RecoverableConnection = struct {
             .sender_options = .{
                 .deadline_ms = options.deadline_ms,
                 .link_id = options.link_id,
+                .max_in_flight = options.max_in_flight,
             },
             .receiver_options = .{
                 .instance_id = options.instance_id,
@@ -943,4 +947,34 @@ test "a reattached receiver resumes from the last sequence number" {
     // Reattaching with the original filter would replay event 40, which the
     // caller has already been given.
     try testing.expectEqualStrings("amqp.annotation.x-opt-sequence-number > '40'", filters[1]);
+}
+
+test "the client's window reaches the sender links it is meant to size" {
+    // Without this the whole pipelining path is inert: the pool defaults its
+    // window from its own options, so an option that stops anywhere along the
+    // chain leaves every real client sending one batch per round trip while
+    // the documentation promises otherwise.
+    const allocator = std.testing.allocator;
+
+    var factory: ConnectionFactory = undefined;
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory,
+        .deadline_ms = 1_000,
+        .max_in_flight = 5,
+    });
+    defer connection.deinit();
+
+    try std.testing.expectEqual(@as(u32, 5), connection.sender_options.max_in_flight);
+
+    // And the default is a window worth having, not one.
+    var defaulted = RecoverableConnection.init(allocator, .{
+        .factory = &factory,
+        .deadline_ms = 1_000,
+    });
+    defer defaulted.deinit();
+    try std.testing.expectEqual(
+        sending.default_max_in_flight,
+        defaulted.sender_options.max_in_flight,
+    );
+    try std.testing.expect(sending.default_max_in_flight > 1);
 }

--- a/root.zig
+++ b/root.zig
@@ -313,10 +313,12 @@ pub const LinkTransport = struct {
     /// ordinary retrying path — which also recovers the connection if that is
     /// what went wrong.
     ///
-    /// Retrying means a batch the broker accepted but did not get to report
-    /// can be published twice. That is already true of `sendBatch`, and a
-    /// consumer deduplicating on an application property is the answer in both
-    /// cases; batching more of them together does not change the bargain.
+    /// The resend loop stops at the first failure, which is usually the batch
+    /// the broker just refused — so the ones behind it in the window, whose
+    /// verdicts were abandoned unread, are often neither re-sent nor reported.
+    /// That costs nothing in safety: `accepted` only ever counts acceptances
+    /// the broker stated, so the caller is never told a batch landed when it
+    /// might not have.
     fn sendBatchesImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batches: []const EventDataBatch) !void {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
         if (batches.len == 0) return;
@@ -781,11 +783,15 @@ pub const ProducerClient = struct {
     /// the broker accepted it but the acknowledgement was lost.
     ///
     /// Overlapping widens that window. When a send fails, the batches behind
-    /// it in the window are already on the wire and the broker may well accept
-    /// them, but their verdicts are abandoned unread — so they are re-sent,
-    /// and a consumer can see them twice. The number at risk is bounded by
-    /// `max_in_flight`, and the answer is the same as for `sendBatch`: give
-    /// events an application property the consumer can deduplicate on.
+    /// it are already on the wire and the broker may well accept them, but
+    /// their verdicts are abandoned unread. They are then reported as not
+    /// accepted and may be sent again, so a consumer can see them twice. The
+    /// number at risk is bounded by `max_in_flight`, and the answer is the
+    /// same as for `sendBatch`: give events an application property the
+    /// consumer can deduplicate on.
+    ///
+    /// Nothing is silently dropped either way: a batch is only ever counted as
+    /// accepted once the broker has said so.
     pub fn sendBatches(
         self: *ProducerClient,
         allocator: std.mem.Allocator,

--- a/root.zig
+++ b/root.zig
@@ -129,6 +129,10 @@ pub const max_credit = receiving.max_credit;
 /// Abstracts over uamqp to enable unit testing.
 pub const AmqpTransport = struct {
     sendBatchFn: *const fn (self: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) anyerror!void,
+    /// Send several batches with as few round trips as the transport can
+    /// manage. Optional: a transport that cannot pipeline leaves it null and
+    /// `sendBatches` sends them one at a time, which is correct but slower.
+    sendBatchesFn: ?*const fn (self: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batches: []const EventDataBatch) anyerror!void = null,
     receiveFn: *const fn (self: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) anyerror![]ReceivedEventData,
     getHubPropertiesFn: *const fn (self: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) anyerror!EventHubProperties,
     getPartitionPropertiesFn: *const fn (self: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) anyerror!PartitionProperties,
@@ -139,6 +143,11 @@ pub const AmqpTransport = struct {
 
     pub fn sendBatch(self: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batch: EventDataBatch) !void {
         return self.sendBatchFn(self, allocator, target, batch);
+    }
+
+    pub fn sendBatches(self: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batches: []const EventDataBatch) !void {
+        if (self.sendBatchesFn) |f| return f(self, allocator, target, batches);
+        for (batches) |batch| try self.sendBatch(allocator, target, batch);
     }
 
     pub fn receive(self: *AmqpTransport, allocator: std.mem.Allocator, source: []const u8, filter: ?[]const u8, max_count: u32) ![]ReceivedEventData {
@@ -220,6 +229,7 @@ pub const LinkTransport = struct {
             .retry = options.retry,
             .transport = .{
                 .sendBatchFn = &sendBatchImpl,
+                .sendBatchesFn = &sendBatchesImpl,
                 .receiveFn = &receiveImpl,
                 .getHubPropertiesFn = &getHubPropsImpl,
                 .getPartitionPropertiesFn = &getPartitionPropsImpl,
@@ -291,6 +301,37 @@ pub const LinkTransport = struct {
             };
         }
         return pool.send(allocator, target, batch);
+    }
+
+    /// Send every batch, pipelining them and falling back for whatever the
+    /// pipeline did not get accepted.
+    ///
+    /// The fast path keeps `max_in_flight` batches on the wire at once, so the
+    /// round trip is paid once for the window rather than once per batch. It
+    /// does not retry, so anything it did not land is re-sent through the
+    /// ordinary retrying path — which also recovers the connection if that is
+    /// what went wrong.
+    ///
+    /// Retrying means a batch the broker accepted but did not get to report
+    /// can be published twice. That is already true of `sendBatch`, and a
+    /// consumer deduplicating on an application property is the answer in both
+    /// cases; batching more of them together does not change the bargain.
+    fn sendBatchesImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batches: []const EventDataBatch) !void {
+        const self: *LinkTransport = @fieldParentPtr("transport", t);
+        if (batches.len == 0) return;
+
+        var accepted: usize = 0;
+        // A pool is not guaranteed — `senderPool` fails before the client is
+        // connected — and the fallback reports that better than we can here.
+        if (self.senderPool()) |pool| {
+            const result = pool.sendPipelined(allocator, target, batches);
+            if (result.err == null) return;
+            accepted = result.accepted;
+        } else |_| {}
+
+        for (batches[accepted..]) |batch| {
+            try sendBatchImpl(t, allocator, target, batch);
+        }
     }
 
     /// One send attempt against whichever sender pool the connection has now.
@@ -438,12 +479,29 @@ pub const MockAmqpTransport = struct {
     partition_properties: PartitionProperties = .{ .id = "0" },
     /// Stands in for a sender link's negotiated limit.
     link_max_message_size: ?u64 = null,
+    /// One entry per `sendBatches` group, so a test can see how the client
+    /// split its batches across links rather than only the total that arrived.
+    groups: [8]Group = undefined,
+    group_count: usize = 0,
     transport: AmqpTransport,
+
+    pub const Group = struct {
+        len: usize,
+        target_buf: [256]u8,
+        target_len: usize,
+
+        pub fn target(self: *const Group) []const u8 {
+            return self.target_buf[0..self.target_len];
+        }
+    };
 
     pub fn init() MockAmqpTransport {
         return .{
             .transport = .{
                 .sendBatchFn = &sendBatchImpl,
+                // Records the grouping, then hands every batch to
+                // `sendBatchImpl` so the existing per-batch counts still hold.
+                .sendBatchesFn = &sendBatchesImpl,
                 .receiveFn = &receiveImpl,
                 .getHubPropertiesFn = &getHubPropsImpl,
                 .getPartitionPropertiesFn = &getPartitionPropsImpl,
@@ -465,6 +523,23 @@ pub const MockAmqpTransport = struct {
         const len = @min(target.len, self.send_target_buf.len);
         @memcpy(self.send_target_buf[0..len], target[0..len]);
         self.send_target_len = len;
+    }
+
+    fn sendBatchesImpl(t: *AmqpTransport, allocator: std.mem.Allocator, target: []const u8, batches: []const EventDataBatch) !void {
+        const self: *MockAmqpTransport = @fieldParentPtr("transport", t);
+        if (self.group_count < self.groups.len) {
+            var group: Group = .{ .len = batches.len, .target_buf = undefined, .target_len = 0 };
+            group.target_len = @min(target.len, group.target_buf.len);
+            @memcpy(group.target_buf[0..group.target_len], target[0..group.target_len]);
+            self.groups[self.group_count] = group;
+            self.group_count += 1;
+        }
+        for (batches) |batch| try sendBatchImpl(t, allocator, target, batch);
+    }
+
+    /// The groups `sendBatches` was called with, in order.
+    pub fn sentGroups(self: *const MockAmqpTransport) []const Group {
+        return self.groups[0..self.group_count];
     }
 
     /// The address of the most recent send, or null if there was none.
@@ -591,6 +666,13 @@ pub const ProducerClientOptions = struct {
 };
 
 /// Sends events to an Event Hub.
+/// Whether two batches address the same link. Null is the gateway, which is a
+/// distinct destination from any named partition rather than a wildcard.
+fn samePartition(a: ?[]const u8, b: ?[]const u8) bool {
+    if (a == null or b == null) return a == null and b == null;
+    return std.mem.eql(u8, a.?, b.?);
+}
+
 pub const ProducerClient = struct {
     options: ProducerClientOptions,
     credential: Credential,
@@ -678,6 +760,48 @@ pub const ProducerClient = struct {
         const address = try self.entityPath(allocator, batch.partition_id);
         defer allocator.free(address);
         return self.amqp_transport.sendBatch(allocator, address, batch);
+    }
+
+    /// Send several batches, overlapping them on the wire instead of waiting
+    /// for each to be confirmed before starting the next.
+    ///
+    /// This is `sendBatch` for callers that have more than one batch ready. A
+    /// blocking send costs a full round trip per batch, so across a link with
+    /// any real latency it is the round trips, not the encoding, that set the
+    /// ceiling; overlapping them lifts it by roughly the window size.
+    ///
+    /// Batches are grouped into runs by partition, because each partition is a
+    /// separate link and only batches sharing one can overlap. Passing them
+    /// already grouped — which is the natural order if they were built per
+    /// partition — makes every batch eligible.
+    ///
+    /// Retries and connection recovery are the same as `sendBatch`'s, and so
+    /// is the guarantee: at-least-once, so a batch may be published twice if
+    /// the broker accepted it but the acknowledgement was lost. On error some
+    /// prefix of `batches` may have been sent.
+    pub fn sendBatches(
+        self: *ProducerClient,
+        allocator: std.mem.Allocator,
+        batches: []const EventDataBatch,
+    ) !void {
+        for (batches) |batch| {
+            if (batch.count() == 0) return SendError.EmptyBatch;
+        }
+
+        var start: usize = 0;
+        while (start < batches.len) {
+            var end = start + 1;
+            while (end < batches.len and samePartition(
+                batches[start].partition_id,
+                batches[end].partition_id,
+            )) : (end += 1) {}
+
+            const address = try self.entityPath(allocator, batches[start].partition_id);
+            defer allocator.free(address);
+            try self.amqp_transport.sendBatches(allocator, address, batches[start..end]);
+
+            start = end;
+        }
     }
 
     /// Create a batch sized for this producer.
@@ -1571,6 +1695,146 @@ test "ConsumerClient receiveEvents" {
 
     const events = try consumer.receiveEvents(allocator, "0", EventPosition.earliest(), 10);
     try std.testing.expectEqual(@as(usize, 0), events.len);
+}
+
+test "sendBatches groups batches by the link each one addresses" {
+    // Only batches sharing a partition share a link, so only they can overlap
+    // on the wire. Everything else has to be split.
+    const allocator = std.testing.allocator;
+    var mock_amqp = MockAmqpTransport.init();
+    const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
+    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    defer producer.deinit();
+
+    const partitions = [_]?[]const u8{ "0", "0", "1", null, null };
+    var batches: [partitions.len]EventDataBatch = undefined;
+    for (&batches, partitions) |*b, partition| {
+        b.* = try EventDataBatch.init(.{ .partition_id = partition });
+        var event = EventData.init("hello");
+        defer event.deinit(allocator);
+        try std.testing.expect(try b.tryAdd(allocator, event));
+    }
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    try producer.sendBatches(allocator, &batches);
+
+    const groups = mock_amqp.sentGroups();
+    try std.testing.expectEqual(@as(usize, 3), groups.len);
+
+    try std.testing.expectEqual(@as(usize, 2), groups[0].len);
+    try std.testing.expectEqualStrings("hub/Partitions/0", groups[0].target());
+
+    try std.testing.expectEqual(@as(usize, 1), groups[1].len);
+    try std.testing.expectEqualStrings("hub/Partitions/1", groups[1].target());
+
+    // Null is the gateway, a destination of its own rather than a wildcard
+    // that could be folded into either partition's run.
+    try std.testing.expectEqual(@as(usize, 2), groups[2].len);
+    try std.testing.expectEqualStrings("hub", groups[2].target());
+
+    // And every batch reached the wire exactly once.
+    try std.testing.expectEqual(@as(u32, 5), mock_amqp.send_batch_count);
+}
+
+test "sendBatches keeps one run whole when every batch shares a partition" {
+    // The case worth optimising: batches built per partition arrive already
+    // grouped, so the whole slice is eligible to pipeline.
+    const allocator = std.testing.allocator;
+    var mock_amqp = MockAmqpTransport.init();
+    const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
+    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    defer producer.deinit();
+
+    var batches: [4]EventDataBatch = undefined;
+    for (&batches) |*b| {
+        b.* = try EventDataBatch.init(.{ .partition_id = "3" });
+        var event = EventData.init("hello");
+        defer event.deinit(allocator);
+        try std.testing.expect(try b.tryAdd(allocator, event));
+    }
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    try producer.sendBatches(allocator, &batches);
+
+    const groups = mock_amqp.sentGroups();
+    try std.testing.expectEqual(@as(usize, 1), groups.len);
+    try std.testing.expectEqual(@as(usize, 4), groups[0].len);
+    try std.testing.expectEqualStrings("hub/Partitions/3", groups[0].target());
+}
+
+test "sendBatches refuses an empty batch before sending anything" {
+    // Checked up front rather than per batch: a caller that gets an error
+    // should not have to work out how much of its slice went out first.
+    const allocator = std.testing.allocator;
+    var mock_amqp = MockAmqpTransport.init();
+    const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
+    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    defer producer.deinit();
+
+    var full = try EventDataBatch.init(.{});
+    defer full.deinit(allocator);
+    var event = EventData.init("hello");
+    defer event.deinit(allocator);
+    try std.testing.expect(try full.tryAdd(allocator, event));
+
+    var empty = try EventDataBatch.init(.{});
+    defer empty.deinit(allocator);
+
+    const batches = [_]EventDataBatch{ full, empty };
+    try std.testing.expectError(SendError.EmptyBatch, producer.sendBatches(allocator, &batches));
+    try std.testing.expect(!mock_amqp.send_called);
+}
+
+test "a transport that cannot pipeline still sends every batch" {
+    // `sendBatchesFn` is optional so an implementation outside this package
+    // keeps compiling and keeps working; the default just costs a round trip
+    // per batch.
+    const allocator = std.testing.allocator;
+
+    const Serial = struct {
+        transport: AmqpTransport,
+        count: u32 = 0,
+
+        fn sendBatchImpl(t: *AmqpTransport, _: std.mem.Allocator, _: []const u8, _: EventDataBatch) !void {
+            const self: *@This() = @fieldParentPtr("transport", t);
+            self.count += 1;
+        }
+        fn unreachableReceive(_: *AmqpTransport, _: std.mem.Allocator, _: []const u8, _: ?[]const u8, _: u32) ![]ReceivedEventData {
+            return error.Unimplemented;
+        }
+        fn unreachableHub(_: *AmqpTransport, _: std.mem.Allocator, _: []const u8) !EventHubProperties {
+            return error.Unimplemented;
+        }
+        fn unreachablePartition(_: *AmqpTransport, _: std.mem.Allocator, _: []const u8, _: []const u8) !PartitionProperties {
+            return error.Unimplemented;
+        }
+        fn noLimit(_: *AmqpTransport, _: []const u8) !?u64 {
+            return null;
+        }
+        fn closeImpl(_: *AmqpTransport) void {}
+    };
+
+    var serial = Serial{ .transport = .{
+        .sendBatchFn = &Serial.sendBatchImpl,
+        .receiveFn = &Serial.unreachableReceive,
+        .getHubPropertiesFn = &Serial.unreachableHub,
+        .getPartitionPropertiesFn = &Serial.unreachablePartition,
+        .maxMessageSizeFn = &Serial.noLimit,
+        .closeFn = &Serial.closeImpl,
+    } };
+    try std.testing.expect(serial.transport.sendBatchesFn == null);
+
+    var batches: [3]EventDataBatch = undefined;
+    for (&batches) |*b| {
+        b.* = try EventDataBatch.init(.{});
+        var event = EventData.init("hello");
+        defer event.deinit(allocator);
+        try std.testing.expect(try b.tryAdd(allocator, event));
+    }
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    try serial.transport.sendBatches(allocator, "hub", &batches);
+    try std.testing.expectEqual(@as(u32, 3), serial.count);
 }
 
 test "ProducerClient fromConnectionString" {

--- a/root.zig
+++ b/root.zig
@@ -61,6 +61,7 @@ pub const EventDataBatch = batching.EventDataBatch;
 
 pub const sending = @import("sender.zig");
 pub const SenderPool = sending.SenderPool;
+pub const default_max_in_flight = sending.default_max_in_flight;
 pub const SendError = sending.SendError;
 pub const entityPathFor = sending.entityPathFor;
 
@@ -777,8 +778,14 @@ pub const ProducerClient = struct {
     ///
     /// Retries and connection recovery are the same as `sendBatch`'s, and so
     /// is the guarantee: at-least-once, so a batch may be published twice if
-    /// the broker accepted it but the acknowledgement was lost. On error some
-    /// prefix of `batches` may have been sent.
+    /// the broker accepted it but the acknowledgement was lost.
+    ///
+    /// Overlapping widens that window. When a send fails, the batches behind
+    /// it in the window are already on the wire and the broker may well accept
+    /// them, but their verdicts are abandoned unread — so they are re-sent,
+    /// and a consumer can see them twice. The number at risk is bounded by
+    /// `max_in_flight`, and the answer is the same as for `sendBatch`: give
+    /// events an application property the consumer can deduplicate on.
     pub fn sendBatches(
         self: *ProducerClient,
         allocator: std.mem.Allocator,
@@ -1231,6 +1238,10 @@ pub const HubConnection = struct {
         container_id: []const u8 = "azure-sdk-for-zig",
         /// Distinguishes this client's links from any other on the connection.
         link_id: []const u8 = "eventhubs",
+        /// How many batches a sender link may have on the wire unconfirmed.
+        /// This is what lets `sendBatches` overlap them; `sendBatch` waits for
+        /// each one either way.
+        max_in_flight: u32 = sending.default_max_in_flight,
         /// Identifies this reader to the broker, and is what a stolen-link
         /// message names.
         instance_id: []const u8 = default_instance_id,
@@ -1265,6 +1276,7 @@ pub const HubConnection = struct {
             .deadline_ms = options.deadline_ms,
             .instance_id = options.instance_id,
             .link_id = options.link_id,
+            .max_in_flight = options.max_in_flight,
             .partition_client = options.partition_client,
         });
         self.transport = LinkTransport.initRecoverable(
@@ -1695,6 +1707,243 @@ test "ConsumerClient receiveEvents" {
 
     const events = try consumer.receiveEvents(allocator, "0", EventPosition.earliest(), 10);
     try std.testing.expectEqual(@as(usize, 0), events.len);
+}
+
+test "a client passes its window down to the connection that sizes the links" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    defer threaded.deinit();
+
+    var hub: HubConnection = undefined;
+    hub.open(.{
+        .allocator = allocator,
+        .io = threaded.io(),
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .max_in_flight = 6,
+    });
+    defer hub.deinit();
+    try std.testing.expectEqual(@as(u32, 6), hub.connection.sender_options.max_in_flight);
+}
+
+test "the pipeline refuses a link somebody else is still waiting on" {
+    // Its accounting reads the link's depth as its own, and it empties the
+    // whole ring on the way out, so sharing would both misreport which
+    // batches landed and throw away a verdict its caller was waiting for.
+    const allocator = std.testing.allocator;
+    const harness = amqp.test_peer;
+
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: amqp.connection_driver.ManualClock = .{};
+    const peer = harness.Peer{ .allocator = allocator, .mem = &mem };
+
+    try harness.scriptHandshake(peer, 512);
+    try peer.push(0, .{ .attach = .{
+        .name = "my-hub-sender-eventhubs",
+        .handle = 0,
+        .role = .receiver,
+        .max_message_size = null,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 20,
+    } });
+
+    var conn = try amqp.connection_driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var fixture = try harness.Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var pool = SenderPool.init(allocator, &fixture.session, .{
+        .deadline_ms = 10_000,
+        .max_in_flight = 4,
+    });
+    defer pool.deinit();
+
+    var batch = try EventDataBatch.init(.{});
+    defer batch.deinit(allocator);
+    var event = EventData.init("x");
+    defer event.deinit(allocator);
+    try std.testing.expect(try batch.tryAdd(allocator, event));
+
+    // Someone takes a token and has not collected its verdict yet.
+    _ = try pool.sendAsync(allocator, "my-hub", batch);
+    try std.testing.expectEqual(@as(usize, 1), try pool.unconfirmed("my-hub"));
+
+    const batches = [_]EventDataBatch{batch};
+    const result = pool.sendPipelined(allocator, "my-hub", &batches);
+    try std.testing.expectEqual(@as(usize, 0), result.accepted);
+    try std.testing.expectEqual(@as(?anyerror, error.DeliveriesInFlight), result.err);
+
+    // Refused rather than half-done: the other delivery is untouched, and
+    // nothing of this call's was put on the wire.
+    try std.testing.expectEqual(@as(usize, 1), try pool.unconfirmed("my-hub"));
+}
+
+test "the pipeline's fallback resends exactly the batches it was not told were accepted" {
+    // `accepted` is the one number standing between a duplicated batch and a
+    // dropped one, and `LinkTransport` is the only place it is turned into a
+    // resend slice. So drive a real pool over a scripted peer and count what
+    // actually reaches the wire.
+    const allocator = std.testing.allocator;
+    const harness = amqp.test_peer;
+
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: amqp.connection_driver.ManualClock = .{};
+    const peer = harness.Peer{ .allocator = allocator, .mem = &mem };
+
+    try harness.scriptHandshake(peer, 512);
+    try peer.push(0, .{ .attach = .{
+        .name = "my-hub-sender-eventhubs",
+        .handle = 0,
+        .role = .receiver,
+        .max_message_size = null,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 20,
+    } });
+
+    // Window of two, three batches. The pipeline sends 0 and 1, retires 0 to
+    // make room, sends 2, then collects 1 — which is refused. Delivery 2 is
+    // still on the wire and gets abandoned, so the fallback owes batches 1
+    // and 2, which it sends as deliveries 3 and 4.
+    for ([_]struct { u32, bool }{ .{ 0, true }, .{ 1, false }, .{ 3, true }, .{ 4, true } }) |d| {
+        try peer.push(0, .{ .disposition = .{
+            .role = .receiver,
+            .first = d[0],
+            .last = d[0],
+            .settled = true,
+            .state = if (d[1]) .accepted else .{ .rejected = .{
+                .condition = "amqp:link:message-size-exceeded",
+                .description = "too big",
+            } },
+        } });
+    }
+
+    var conn = try amqp.connection_driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var fixture = try harness.Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var pool = SenderPool.init(allocator, &fixture.session, .{
+        .deadline_ms = 10_000,
+        .max_in_flight = 2,
+    });
+    defer pool.deinit();
+
+    var transport = LinkTransport.initEmpty(.{ .deadline_ms = 10_000 });
+    transport.senders = &pool;
+
+    var batches: [3]EventDataBatch = undefined;
+    for (&batches, 0..) |*b, i| {
+        b.* = try EventDataBatch.init(.{});
+        var event = EventData.init(&[_]u8{@intCast('a' + i)});
+        defer event.deinit(allocator);
+        try std.testing.expect(try b.tryAdd(allocator, event));
+    }
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    try transport.transport.sendBatches(allocator, "my-hub", &batches);
+
+    var frames = try harness.EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, amqp.performative.descriptor.transfer);
+    defer allocator.free(transfers);
+
+    // Five, not six: the accepted batch 0 is never sent again. Six would mean
+    // a duplicate, four would mean the refused batch was silently dropped.
+    try std.testing.expectEqual(@as(usize, 5), transfers.len);
+}
+
+test "sendBatches leaves the link idle enough for an ordinary send afterwards" {
+    // The failure path abandons deliveries, and a sender holding any refuses
+    // every blocking send. If that were not cleaned up, the very next
+    // `sendBatch` on the same client would fail for an unrelated reason.
+    const allocator = std.testing.allocator;
+    const harness = amqp.test_peer;
+
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: amqp.connection_driver.ManualClock = .{};
+    const peer = harness.Peer{ .allocator = allocator, .mem = &mem };
+
+    try harness.scriptHandshake(peer, 512);
+    try peer.push(0, .{ .attach = .{
+        .name = "my-hub-sender-eventhubs",
+        .handle = 0,
+        .role = .receiver,
+        .max_message_size = null,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 20,
+    } });
+    // Refuse the first, then accept the two resends and the later plain send.
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .{ .rejected = .{ .condition = "amqp:internal-error", .description = "no" } },
+    } });
+    for ([_]u32{ 2, 3, 4 }) |id| {
+        try peer.push(0, .{ .disposition = .{
+            .role = .receiver,
+            .first = id,
+            .last = id,
+            .settled = true,
+            .state = .accepted,
+        } });
+    }
+
+    var conn = try amqp.connection_driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var fixture = try harness.Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var pool = SenderPool.init(allocator, &fixture.session, .{
+        .deadline_ms = 10_000,
+        .max_in_flight = 2,
+    });
+    defer pool.deinit();
+    var transport = LinkTransport.initEmpty(.{ .deadline_ms = 10_000 });
+    transport.senders = &pool;
+
+    var batches: [2]EventDataBatch = undefined;
+    for (&batches) |*b| {
+        b.* = try EventDataBatch.init(.{});
+        var event = EventData.init("x");
+        defer event.deinit(allocator);
+        try std.testing.expect(try b.tryAdd(allocator, event));
+    }
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    // Batch 0 is refused, so both are resent; the resends are accepted.
+    try transport.transport.sendBatches(allocator, "my-hub", &batches);
+    try std.testing.expectEqual(@as(usize, 0), try pool.unconfirmed("my-hub"));
+
+    // And a plain send still works on the same link.
+    try transport.transport.sendBatch(allocator, "my-hub", batches[0]);
 }
 
 test "sendBatches groups batches by the link each one addresses" {

--- a/sender.zig
+++ b/sender.zig
@@ -50,6 +50,8 @@ pub const SenderPool = struct {
     /// a payload, so it is recorded here as `Management` does for its status.
     /// Borrowed from the sender that failed and valid until its next send.
     last_rejection: ?amqp.Rejection = null,
+    /// How many batches a link may have on the wire unconfirmed.
+    max_in_flight: u32 = 1,
 
     const Entry = struct {
         address: []u8,
@@ -59,6 +61,14 @@ pub const SenderPool = struct {
     pub const Options = struct {
         deadline_ms: i64,
         link_id: []const u8 = "eventhubs",
+        /// How many batches a link may have on the wire unconfirmed.
+        ///
+        /// One makes every send wait a full round trip for the broker's
+        /// disposition, which caps a link at one batch per round trip however
+        /// large the batches are. Raising it lets `sendAsync` keep that many
+        /// batches in flight. `send` waits either way, so the default of one
+        /// leaves existing callers exactly as they were.
+        max_in_flight: u32 = 1,
     };
 
     pub fn init(allocator: Allocator, session: *amqp.Session, options: Options) SenderPool {
@@ -67,6 +77,7 @@ pub const SenderPool = struct {
             .session = session,
             .deadline_ms = options.deadline_ms,
             .link_id = options.link_id,
+            .max_in_flight = options.max_in_flight,
         };
     }
 
@@ -102,6 +113,7 @@ pub const SenderPool = struct {
             .name = name,
             .target_address = address,
             .desired_capabilities = &.{amqp.georeplication_capability},
+            .max_in_flight = self.max_in_flight,
         }, self.deadline_ms);
 
         self.entries.appendAssumeCapacity(.{ .address = owned, .sender = sender });
@@ -173,6 +185,168 @@ pub const SenderPool = struct {
             self.last_rejection = sender.rejection;
             return err;
         };
+    }
+
+    /// Write `batch` to `address` without waiting for the broker to confirm
+    /// it, returning the token that names the delivery.
+    ///
+    /// The bytes are on the wire when this returns, so `batch` and its
+    /// encoding may be released immediately; only the broker's verdict is
+    /// outstanding. Collect it with `confirm`, which reports outcomes in send
+    /// order and names each one, so a caller keeping several batches in flight
+    /// can tell exactly which batch was refused and resend that one.
+    ///
+    /// Returns `error.InFlightWindowFull` once `max_in_flight` batches on
+    /// `address` are unconfirmed; `confirm` retires one and makes room.
+    pub fn sendAsync(
+        self: *SenderPool,
+        allocator: Allocator,
+        address: []const u8,
+        batch: EventDataBatch,
+    ) !amqp.DeliveryToken {
+        if (batch.count() == 0) return SendError.EmptyBatch;
+
+        const sender = try self.senderFor(address);
+        const payload = try encodeBatchTransfer(allocator, batch);
+        defer allocator.free(payload);
+
+        return sender.sendBytesAsync(
+            payload,
+            .{ .message_format = batch_message_format },
+            self.deadline_ms,
+        );
+    }
+
+    /// Wait for the broker's verdict on the oldest unconfirmed batch on
+    /// `address`.
+    ///
+    /// A refusal comes back as `Settlement.outcome` rather than as an error,
+    /// because the point of pipelining is knowing *which* batch was refused;
+    /// `lastError` describes it until the next `confirm` on the same address.
+    /// An error here means the link itself failed.
+    pub fn confirm(self: *SenderPool, address: []const u8) !amqp.Settlement {
+        const sender = try self.senderFor(address);
+        const settlement = try sender.awaitSettlement(self.deadline_ms);
+        self.last_rejection = settlement.rejection;
+        return settlement;
+    }
+
+    /// How many batches on `address` are on the wire unconfirmed.
+    pub fn unconfirmed(self: *SenderPool, address: []const u8) !usize {
+        const sender = try self.senderFor(address);
+        return sender.inFlight();
+    }
+
+    /// The result of a pipelined send. Total rather than an error union: the
+    /// caller needs the accepted prefix even when it stopped early, since that
+    /// is exactly what it must not send again.
+    pub const PipelinedSend = struct {
+        /// How many batches, counting from the front, the broker accepted.
+        /// Deliveries settle in the order they were sent, so the accepted set
+        /// is always a prefix.
+        accepted: usize,
+        /// Why it stopped, or null when every batch was accepted. The batch at
+        /// index `accepted` is the one that failed; those after it were never
+        /// given a verdict.
+        err: ?anyerror = null,
+    };
+
+    /// Send every batch to `address`, keeping up to `max_in_flight` of them on
+    /// the wire at once.
+    ///
+    /// This is the throughput path: one round trip covers the whole window
+    /// instead of one batch. It does not retry — a caller wanting the Event
+    /// Hubs schedule should resend the unaccepted remainder through
+    /// `sendWithRetry`, which is what `ProducerClient.sendBatches` does.
+    ///
+    /// The link is always left idle, so the caller can fall straight back to
+    /// the blocking path. Anything still unconfirmed when this stops early is
+    /// abandoned, which means a batch the broker went on to accept can be sent
+    /// twice — the same at-least-once bargain a retry already makes.
+    pub fn sendPipelined(
+        self: *SenderPool,
+        allocator: Allocator,
+        address: []const u8,
+        batches: []const EventDataBatch,
+    ) PipelinedSend {
+        self.last_rejection = null;
+
+        var accepted: usize = 0;
+        const err = self.pipeline(allocator, address, batches, &accepted);
+
+        // Every exit runs this. The caller has been told its accepted prefix
+        // and will resend the rest, so a verdict arriving for the remainder
+        // now has nobody to report to. Dropping the window is also what lets
+        // the link be used again: a sender still holding unsettled deliveries
+        // refuses every blocking send, so without this one timed-out pipeline
+        // would wedge the fallback path it is supposed to hand off to.
+        self.abandonInFlight(address);
+
+        return .{ .accepted = accepted, .err = err };
+    }
+
+    /// The body of `sendPipelined`, split out so the window is emptied on
+    /// every path rather than at each of half a dozen returns.
+    fn pipeline(
+        self: *SenderPool,
+        allocator: Allocator,
+        address: []const u8,
+        batches: []const EventDataBatch,
+        accepted: *usize,
+    ) ?anyerror {
+        var sent: usize = 0;
+        while (sent < batches.len) {
+            const outstanding = self.unconfirmed(address) catch |err| return err;
+            // Retire the oldest to make room, so the window stays full rather
+            // than draining between batches.
+            if (outstanding >= self.max_in_flight) {
+                self.confirmOne(address) catch |err| return err;
+                accepted.* += 1;
+            }
+
+            _ = self.sendAsync(allocator, address, batches[sent]) catch |err| {
+                // The send failed, but the deliveries already on the wire are
+                // being judged on their own merits, so collect their verdicts
+                // instead of abandoning batches the broker is about to accept.
+                accepted.* += self.drain(address, sent - accepted.*);
+                return err;
+            };
+            sent += 1;
+        }
+
+        while (accepted.* < sent) {
+            self.confirmOne(address) catch |err| return err;
+            accepted.* += 1;
+        }
+        return null;
+    }
+
+    /// Collect one verdict, mapping a refusal onto an error the way `send`
+    /// does so that a pipelined failure classifies like a blocking one.
+    fn confirmOne(self: *SenderPool, address: []const u8) !void {
+        const settlement = try self.confirm(address);
+        if (settlement.outcome != .accepted) return error.SendRejected;
+    }
+
+    /// Collect up to `count` outstanding verdicts, stopping at the first that
+    /// is not an acceptance. Returns how many were accepted.
+    fn drain(self: *SenderPool, address: []const u8, count: usize) usize {
+        var accepted: usize = 0;
+        while (accepted < count) : (accepted += 1) {
+            self.confirmOne(address) catch return accepted;
+        }
+        return accepted;
+    }
+
+    /// Drop any verdicts still outstanding on `address`, leaving the link free
+    /// for a blocking send. Nothing to do if the link was never opened.
+    fn abandonInFlight(self: *SenderPool, address: []const u8) void {
+        for (self.entries.items) |entry| {
+            if (std.mem.eql(u8, entry.address, address)) {
+                entry.sender.abandonInFlight();
+                return;
+            }
+        }
     }
 
     /// Send under the Event Hubs retry schedule.
@@ -336,9 +510,20 @@ const Scripted = struct {
         clock: *driver.ManualClock,
         conn: *driver.Driver,
     ) !void {
+        return self.openWith(allocator, mem, clock, conn, .{ .deadline_ms = 10_000 });
+    }
+
+    fn openWith(
+        self: *Scripted,
+        allocator: Allocator,
+        mem: *MemoryTransport,
+        clock: *driver.ManualClock,
+        conn: *driver.Driver,
+        options: SenderPool.Options,
+    ) !void {
         self.* = .{ .fixture = try Fixture.init(allocator, mem, clock, conn) };
         errdefer self.fixture.deinit();
-        self.pool = SenderPool.init(allocator, &self.fixture.session, .{ .deadline_ms = 10_000 });
+        self.pool = SenderPool.init(allocator, &self.fixture.session, options);
     }
 
     fn deinit(self: *Scripted) void {
@@ -464,6 +649,139 @@ fn annotation(entries: []const amqp.uamqp.MapEntry, key: []const u8) ?amqp.uamqp
         if (std.mem.eql(u8, name, key)) return entry.value;
     }
     return null;
+}
+
+test "a pipelined send that stops early leaves the link fit for a blocking send" {
+    // The failure path hands off to `sendWithRetry`, which is a blocking send,
+    // and a sender still holding unsettled deliveries refuses those outright.
+    // So if the window were not emptied here, the very first pipelined failure
+    // would take the retry path down with it — permanently, for this link.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, null, 4);
+    // Refuse the first batch. The second is on the wire by then and never
+    // gets a verdict; the third is never sent.
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .{ .rejected = .{
+            .condition = "amqp:link:message-size-exceeded",
+            .description = "too big",
+        } },
+    } });
+    // The blocking send that follows takes delivery id 2: the abandoned
+    // deliveries spent 0 and 1, and ids never rewind.
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 2,
+        .last = 2,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.openWith(allocator, &mem, &clock, &conn, .{
+        .deadline_ms = 10_000,
+        .max_in_flight = 2,
+    });
+    defer scripted.deinit();
+
+    var batches: [3]EventDataBatch = undefined;
+    for (&batches) |*b| b.* = try batchOf(allocator, &.{"hello"}, .{});
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    const result = scripted.pool.sendPipelined(allocator, "my-hub", &batches);
+    try testing.expectEqual(@as(usize, 0), result.accepted);
+    try testing.expectEqual(@as(?anyerror, error.SendRejected), result.err);
+
+    // Nothing outstanding, so the caller can fall straight back to the
+    // retrying blocking path with the batches it was not told were accepted.
+    try testing.expectEqual(@as(usize, 0), try scripted.pool.unconfirmed("my-hub"));
+    try scripted.pool.send(allocator, "my-hub", batches[0]);
+}
+
+test "a fully accepted pipeline reports every batch and stays idle" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, null, 4);
+    for (0..3) |i| {
+        try peer.push(0, .{ .disposition = .{
+            .role = .receiver,
+            .first = @intCast(i),
+            .last = @intCast(i),
+            .settled = true,
+            .state = .accepted,
+        } });
+    }
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.openWith(allocator, &mem, &clock, &conn, .{
+        .deadline_ms = 10_000,
+        .max_in_flight = 2,
+    });
+    defer scripted.deinit();
+
+    var batches: [3]EventDataBatch = undefined;
+    for (&batches) |*b| b.* = try batchOf(allocator, &.{"hello"}, .{});
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    const result = scripted.pool.sendPipelined(allocator, "my-hub", &batches);
+    try testing.expectEqual(@as(usize, 3), result.accepted);
+    try testing.expectEqual(@as(?anyerror, null), result.err);
+    try testing.expectEqual(@as(usize, 0), try scripted.pool.unconfirmed("my-hub"));
+}
+
+test "a pipelined send keeps the window full instead of draining between batches" {
+    // The point of the exercise: with a window of 3, all three batches are on
+    // the wire before the first verdict is collected, so the round trip is
+    // paid once rather than three times.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, null, 4);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 2,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.openWith(allocator, &mem, &clock, &conn, .{
+        .deadline_ms = 10_000,
+        .max_in_flight = 3,
+    });
+    defer scripted.deinit();
+
+    var batches: [3]EventDataBatch = undefined;
+    for (&batches) |*b| b.* = try batchOf(allocator, &.{"hello"}, .{});
+    defer for (&batches) |*b| b.deinit(allocator);
+
+    // One disposition covering all three is the only thing the peer sends, so
+    // this passes only if nothing waited for a verdict mid-flight.
+    const result = scripted.pool.sendPipelined(allocator, "my-hub", &batches);
+    try testing.expectEqual(@as(usize, 3), result.accepted);
+    try testing.expectEqual(@as(?anyerror, null), result.err);
 }
 
 test "a rejected batch surfaces the broker's condition" {

--- a/sender.zig
+++ b/sender.zig
@@ -39,6 +39,15 @@ pub fn entityPathFor(
 /// deinitialised; this pool only owns the addresses it keys them by. Reusing a
 /// link matters beyond the attach round trip: the peer's credit and the
 /// negotiated `max-message-size` are per link.
+/// How many batches a link keeps on the wire unconfirmed by default.
+///
+/// Eight covers a round trip an order of magnitude longer than the time it
+/// takes to encode a batch, which is the regime that matters, and costs a ring
+/// of eight slots per link. Raising it further trades memory and the number of
+/// batches whose fate is unknown after a failure for very little more
+/// throughput.
+pub const default_max_in_flight: u32 = 8;
+
 pub const SenderPool = struct {
     allocator: Allocator,
     session: *amqp.Session,
@@ -65,10 +74,13 @@ pub const SenderPool = struct {
         ///
         /// One makes every send wait a full round trip for the broker's
         /// disposition, which caps a link at one batch per round trip however
-        /// large the batches are. Raising it lets `sendAsync` keep that many
-        /// batches in flight. `send` waits either way, so the default of one
-        /// leaves existing callers exactly as they were.
-        max_in_flight: u32 = 1,
+        /// large the batches are. Raising it lets `sendAsync`, and so
+        /// `sendPipelined`, keep that many batches in flight.
+        ///
+        /// The blocking `send` still refuses to overlap with anything, so this
+        /// only ever costs the ring: a few dozen bytes per slot, allocated
+        /// once when the link attaches. Zero is treated as one.
+        max_in_flight: u32 = default_max_in_flight,
     };
 
     pub fn init(allocator: Allocator, session: *amqp.Session, options: Options) SenderPool {
@@ -77,7 +89,7 @@ pub const SenderPool = struct {
             .session = session,
             .deadline_ms = options.deadline_ms,
             .link_id = options.link_id,
-            .max_in_flight = options.max_in_flight,
+            .max_in_flight = @max(options.max_in_flight, 1),
         };
     }
 
@@ -271,6 +283,15 @@ pub const SenderPool = struct {
     ) PipelinedSend {
         self.last_rejection = null;
 
+        // Checked before anything below can abandon the window: this call
+        // reads the link's depth as its own and empties the ring on the way
+        // out, so sharing the link would both misreport which batches landed
+        // and throw away a verdict its owner is still waiting for.
+        const already = self.unconfirmed(address) catch |err| {
+            return .{ .accepted = 0, .err = err };
+        };
+        if (already != 0) return .{ .accepted = 0, .err = error.DeliveriesInFlight };
+
         var accepted: usize = 0;
         const err = self.pipeline(allocator, address, batches, &accepted);
 
@@ -296,7 +317,7 @@ pub const SenderPool = struct {
     ) ?anyerror {
         var sent: usize = 0;
         while (sent < batches.len) {
-            const outstanding = self.unconfirmed(address) catch |err| return err;
+            const outstanding = sent - accepted.*;
             // Retire the oldest to make room, so the window stays full rather
             // than draining between batches.
             if (outstanding >= self.max_in_flight) {
@@ -781,6 +802,43 @@ test "a pipelined send keeps the window full instead of draining between batches
     // this passes only if nothing waited for a verdict mid-flight.
     const result = scripted.pool.sendPipelined(allocator, "my-hub", &batches);
     try testing.expectEqual(@as(usize, 3), result.accepted);
+    try testing.expectEqual(@as(?anyerror, null), result.err);
+}
+
+test "a window of zero is read as one rather than stalling every send" {
+    // A caller computing the window — from a config value, say — can land on
+    // zero, and an unclamped zero makes the very first batch look like an
+    // overflow, so `sendPipelined` fails before sending anything.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: driver.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSender(peer, null, 2);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+    var scripted: Scripted = undefined;
+    try scripted.openWith(allocator, &mem, &clock, &conn, .{
+        .deadline_ms = 10_000,
+        .max_in_flight = 0,
+    });
+    defer scripted.deinit();
+
+    var batch = try batchOf(allocator, &.{"hello"}, .{});
+    defer batch.deinit(allocator);
+
+    const batches = [_]EventDataBatch{batch};
+    const result = scripted.pool.sendPipelined(allocator, "my-hub", &batches);
+    try testing.expectEqual(@as(usize, 1), result.accepted);
     try testing.expectEqual(@as(?anyerror, null), result.err);
 }
 


### PR DESCRIPTION
Audit item 2.6, Event Hubs half. The amqp half was #323; #329 added the escape hatch this needs.

`sendBatch` waits for the broker to confirm before returning, so a producer with several batches ready spends most of its time waiting. At 30 ms RTT that caps a link near 33 batches/sec however fast the encoding is — which is what #313, #314, #317, #319, #321 and #322 have been tuning. This is the one that lifts the ceiling.

```zig
try producer.sendBatches(allocator, &.{ batch_a, batch_b, batch_c });
```

Batches are grouped into runs by partition, because each partition is its own link and only batches sharing one can overlap. A null partition is the gateway — a destination in its own right, not a wildcard — so it forms runs of its own.

### Layering

| layer | what it gives you |
| --- | --- |
| `amqp.Sender.sendBytesAsync` / `awaitSettlement` | the protocol primitives (#323) |
| `SenderPool.sendAsync` / `confirm` / `unconfirmed` / `sendPipelined` | link-level, no retry |
| `ProducerClient.sendBatches` | retrying, recovering, app-facing |

`sendPipelined` returns a struct rather than an error union deliberately: the caller needs the accepted prefix even when it stopped early, since that prefix is exactly what it must not send again. Deliveries settle in order, so the accepted set is always a prefix.

`AmqpTransport.sendBatchesFn` is optional, so an implementation outside this package keeps compiling and keeps working — the default sends one at a time, which is correct and just slower.

### The wedge this had to solve first

A pipelined send that stops early leaves unsettled deliveries on the link, and `sendBytes` refuses to run while any are there. The fallback path *is* a blocking send, so without #329's `abandonInFlight` the first pipelined failure would take the retry path down with it, permanently. `sendPipelined` now empties the window on every exit; the test for it fails without that.

185 tests, 4 new here plus 3 in `sender.zig`. Mutations checked:

| mutation | caught |
| --- | --- |
| don't abandon the window on failure | yes |
| drain after every batch (window of 1) | yes |
| null partition groups with anything | yes |
| never group / group everything | yes |
| check empty batches per batch, not up front | yes |
| ignore `sendBatchesFn` and always loop | yes |

Repins `azure_sdk_amqp` onto #329's merge commit. No version change.