### PR TITLE
Benchmark the receive loop, not just one message at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,14 @@ transfer payload, and converting a received AMQP message back. Nothing touches
 the network, so a result is attributable to a code change rather than to
 service latency.
 
+The last two run the whole receive path against a scripted peer: frames off the
+transport, deliveries reassembled, messages decoded, events converted,
+dispositions written back. That loop is where a consumer actually spends its
+time, and none of it is visible one message at a time. Both cases replay the
+same thousand-transfer script and differ only in how many events they ask for,
+so subtracting them and dividing by 999 gives the cost of one received event
+with all the fixed setup cancelled out.
+
 Prefer `allocs/op` and `B/op` as the regression signal: they are stable across
 machines, while wall-clock timings move on shared or virtualised hosts. The
 benchmarks are built (but not run) by `zig build test`, so a signature change

--- a/benchmarks/main.zig
+++ b/benchmarks/main.zig
@@ -18,6 +18,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const core = @import("azure_sdk_core");
 const eh = @import("azure_sdk_eventhubs");
+const amqp = @import("azure_sdk_amqp");
 const uamqp = @import("uamqp");
 
 const perf = core.perf;
@@ -99,6 +100,127 @@ fn benchFromAmqpMessage(allocator: std.mem.Allocator) !void {
     received.deinit(allocator);
 }
 
+// ─────────────────── Receive over a scripted peer ───────────────────
+//
+// Everything above measures one message in isolation. This measures the loop:
+// frames off the transport, deliveries reassembled, messages decoded, events
+// converted, dispositions written back. That is where a receiver actually
+// spends its time, and where the batching and buffering work in this package
+// either pays off or does not — none of it is visible one message at a time.
+//
+// The peer is a byte script built once, so an iteration pays a memcpy for it
+// rather than re-encoding a thousand transfers into the measurement.
+//
+// Both cases replay the same script and differ only in how many events they
+// ask for, so the handshake, the attach, the session and that memcpy are
+// identical in each. Subtract them and divide by 999 and what is left is one
+// received event, with every fixed cost cancelled out.
+
+const bench_source = "my-hub/ConsumerGroups/$default/Partitions/0";
+const bench_instance = "bench-reader";
+const bench_link_name = bench_source ++ "-receiver-" ++ bench_instance;
+
+/// Well past what these events need, so the loop is not measuring frame
+/// reassembly that a real Event Hubs connection would never do.
+const bench_max_frame = 65_536;
+
+const bench_options = amqp.connection_driver.Options{
+    .container_id = "bench-container",
+    .hostname = "ns.servicebus.windows.net",
+    .sasl = .none,
+    .max_frame_size = bench_max_frame,
+    .idle_timeout_ms = 0,
+};
+
+/// The peer's whole side of the conversation: handshake, attach, and one
+/// settled transfer per event.
+var receive_script: []u8 = &.{};
+
+fn buildReceiveScript(allocator: std.mem.Allocator, events: u32) ![]u8 {
+    var scratch = amqp.MemoryTransport.init(allocator);
+    defer scratch.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &scratch };
+    try amqp.test_peer.scriptHandshake(peer, bench_max_frame);
+    try peer.push(0, .{ .attach = .{
+        .name = bench_link_name,
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var bench_annotations = [_]uamqp.MapEntry{
+        .{ .key = .{ .symbol = "x-opt-sequence-number" }, .value = .{ .long = 0 } },
+        .{ .key = .{ .symbol = "x-opt-offset" }, .value = .{ .string = "100" } },
+        .{ .key = .{ .symbol = "x-opt-partition-key" }, .value = .{ .string = "device-01" } },
+    };
+    const bodies = [_][]const u8{small_body};
+
+    var id: u32 = 0;
+    while (id < events) : (id += 1) {
+        bench_annotations[0].value = .{ .long = @intCast(id) };
+        const payload = try amqp.encodeMessageAlloc(allocator, .{
+            .message_annotations = &bench_annotations,
+            .application_properties = &properties,
+            .properties = .{ .content_type = "application/json" },
+            .body = .{ .data = &bodies },
+        });
+        defer allocator.free(payload);
+
+        const tag = std.mem.asBytes(&id);
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = id,
+            .delivery_tag = tag,
+            .message_format = 0,
+            .settled = true,
+            .more = false,
+        }, payload);
+    }
+
+    return allocator.dupe(u8, scratch.inbound.items);
+}
+
+/// Receive every event the script holds, through the public pool.
+fn receiveScripted(allocator: std.mem.Allocator, count: u32) !void {
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    try mem.pushPeerBytes(receive_script);
+
+    var clock: amqp.connection_driver.ManualClock = .{};
+    var conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        mem.transport(),
+        clock.clock(),
+        bench_options,
+    );
+    defer conn.deinit();
+
+    var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var pool = eh.ReceiverPool.init(allocator, &fixture.session, .{
+        .instance_id = bench_instance,
+        .deadline_ms = 10_000,
+    });
+    defer pool.deinit();
+
+    const events = try pool.receive(allocator, bench_source, null, count);
+    defer eh.freeReceivedEvents(allocator, events);
+
+    if (events.len != count) return error.ShortReceive;
+}
+
+fn benchReceive1(allocator: std.mem.Allocator) !void {
+    return receiveScripted(allocator, 1);
+}
+
+fn benchReceive1000(allocator: std.mem.Allocator) !void {
+    return receiveScripted(allocator, bench_receive_events);
+}
+
+const bench_receive_events: u32 = 1000;
+
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const io = init.io;
@@ -109,6 +231,9 @@ pub fn main(init: std.process.Init) !void {
     receive_message.message_annotations = &annotations;
     receive_message.application_properties = &properties;
     receive_message.properties = .{ .content_type = "application/json" };
+
+    receive_script = try buildReceiveScript(allocator, bench_receive_events);
+    defer allocator.free(receive_script);
 
     std.debug.print("Event Hubs benchmarks (mode: {s})\n", .{@tagName(builtin.mode)});
     if (builtin.mode == .Debug) {
@@ -126,6 +251,10 @@ pub fn main(init: std.process.Init) !void {
         .{ "batch.tryAdd x1000", 20, benchBatchAdd1000 },
         .{ "encodeBatchTransfer x1000", 20, benchEncodeBatchTransfer },
         .{ "fromAmqpMessage", 10_000, benchFromAmqpMessage },
+        // Session setup dominates the x1 case; the difference between the two,
+        // divided by 999, is what one event costs on the receive path.
+        .{ "receive x1 (scripted peer)", 500, benchReceive1 },
+        .{ "receive x1000 (scripted peer)", 20, benchReceive1000 },
     };
 
     inline for (cases) |case| {

--- a/build.zig
+++ b/build.zig
@@ -153,6 +153,8 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{ .name = "azure_sdk_core", .module = core_mod },
                 .{ .name = "azure_sdk_eventhubs", .module = sdk_mod },
+                // For the scripted peer the receive benchmark reads from.
+                .{ .name = "azure_sdk_amqp", .module = amqp_mod },
                 .{ .name = "uamqp", .module = uamqp_mod },
             },
         }),


### PR DESCRIPTION
Closes the gap that has been sitting under all of Phase 2's receive work: every benchmark here measures a single message in isolation, so the cost of the actual receive loop — frames off the transport, deliveries reassembled, messages decoded, events converted, dispositions written back — has never been measured. That loop is where a consumer spends its time, and where the disposition batching in #319 and the one-block decode in #321 either pay off or do not.

Drives `ReceiverPool.receive` against `amqp.test_peer` over a byte script built once, so an iteration pays a memcpy for the peer rather than re-encoding a thousand transfers inside the measurement.

Both cases replay the same script and differ only in how many events they ask for, so the handshake, attach, session and memcpy are identical in each. Subtract them, divide by 999, and what is left is one received event with every fixed cost cancelled out.

ReleaseFast on this host:

| | allocs/op | B/op | avg |
| --- | --- | --- | --- |
| `receive x1` | 63 | 392,915 | ~126 us |
| `receive x1000` | 11,064 | 2,932,598 | ~1,500 us |

**11.0 allocations and 1.4 us per event.** For comparison `fromAmqpMessage` alone is 2 allocations and 166 ns — so the loop around the decode costs roughly nine allocations an event. Most of that looks like `decodeMessage` building annotation and property maps that `fromRawMessage` immediately copies out of and discards. That is a real target, and one nothing in the suite could previously see; I would rather land the measurement first than fold it into a change it is supposed to be judging.

Allocation counts are bit-identical between runs (63.00 and 11064.00 twice), so they serve as the regression gate the file already asks for. Timings move on this shared host, as the header warns.

No version change.