### PR TITLE
Stop decoding every transfer performative twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ defer allocator.free(bytes);
   all of them — skips reassembly entirely, and `receive` hands out the buffer
   the delivery already owns rather than copying it into scratch storage, so a
   received body is copied once rather than three times
+- frames are read into a buffer the driver keeps and grows to the largest frame
+  it has actually seen, rather than allocating and freeing a body per frame,
+  and a transfer's payload is split off using the length the performative
+  decode already reported instead of decoding the performative a second time.
+  Together those take a received delivery from six allocations to four, each of
+  which ends up in something the caller reads. The body is valid until the next
+  `receiveFrame`, as before; decoded performatives copy into their own arena,
+  so they outlive it
 - settlement: accepted, rejected, and released outcomes, with a rejection
   surfacing the peer's error condition, one delivery at a time or a whole
   contiguous run in a single disposition

--- a/connection.zig
+++ b/connection.zig
@@ -657,6 +657,12 @@ pub const Driver = struct {
             // The header is the peer's claim; the body is the peer keeping it.
             // Holding a buffer sized to a claim that never arrived would let
             // one bogus header pin `max_frame_size` for the connection.
+            //
+            // Freeing costs nothing on a legitimate slow peer either, because
+            // there is no such retry to be had: the header lives only in this
+            // frame and `readExact` discards what it consumed, so a failed
+            // body read leaves the stream desynced and the next call parses
+            // body bytes as a header. Nothing here can resume mid-frame.
             errdefer {
                 self.allocator.free(self.body_buf);
                 self.body_buf = &.{};

--- a/connection.zig
+++ b/connection.zig
@@ -251,9 +251,15 @@ pub const Driver = struct {
     /// frame.
     ///
     /// Bodies were allocated and freed one per frame, which on a busy receiver
-    /// is a malloc/free pair for every message that arrives. The buffer grows
-    /// to the largest frame actually read — never to `acceptMaxFrameSize`,
-    /// which a peer can drive to 4 GiB by omitting `max-frame-size` (§2.7.1).
+    /// is a malloc/free pair for every message that arrives.
+    ///
+    /// The size comes from the frame header, so it is what the peer *claimed*
+    /// to be sending, not what it went on to send. `receiveFrame` rejects a
+    /// header above `acceptMaxFrameSize` — a value only this endpoint sets, so
+    /// the high-water mark is bounded by our own `max_frame_size` and never by
+    /// the peer. But one header a peer never follows with a body would
+    /// otherwise pin the whole of that for the life of the connection, so the
+    /// buffer is released when the body fails to arrive.
     body_buf: []u8 = &.{},
 
     const in_buf_len = 16 * 1024;
@@ -648,6 +654,13 @@ pub const Driver = struct {
                 self.body_buf = grown;
             }
             const body = self.body_buf[0..body_size];
+            // The header is the peer's claim; the body is the peer keeping it.
+            // Holding a buffer sized to a claim that never arrived would let
+            // one bogus header pin `max_frame_size` for the connection.
+            errdefer {
+                self.allocator.free(self.body_buf);
+                self.body_buf = &.{};
+            }
             try self.readExact(body, deadline_ms);
             return .{ .header = header, .body = body };
         }
@@ -1209,4 +1222,66 @@ test "the handshake survives allocation failure" {
 
 test "type check the Io-backed clock" {
     std.testing.refAllDecls(IoClock);
+}
+
+/// An AMQP frame header: size, data offset in 4-byte words, type, channel.
+fn frameHeaderBytes(size: u32, doff: u8, kind: u8, channel: u16) [8]u8 {
+    var out: [8]u8 = undefined;
+    std.mem.writeInt(u32, out[0..4], size, .big);
+    out[4] = doff;
+    out[5] = kind;
+    std.mem.writeInt(u16, out[6..8], channel, .big);
+    return out;
+}
+
+test "a header whose body never arrives does not pin the frame buffer" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{};
+
+    // The largest frame this endpoint accepts, and then nothing behind it.
+    // Sizing the buffer to a claim the peer never keeps would hand a peer a
+    // permanent 64 KiB — the whole of `max_frame_size` — for eight bytes.
+    const header = frameHeaderBytes(test_options.max_frame_size, 2, 0, 0);
+    try mem.pushPeerBytes(&header);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+
+    try testing.expectError(error.ConnectionClosed, driver.receiveFrame(10_000));
+    try testing.expectEqual(@as(usize, 0), driver.body_buf.len);
+}
+
+test "the frame buffer grows to the largest body and is not resized below it" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{};
+
+    // A 512-byte body, then a 16-byte one. The second must reuse the buffer
+    // rather than resize it, and must be handed out at its own length — a
+    // frame sliced to the buffer instead of to its body would carry 496 bytes
+    // of the previous frame behind it.
+    const big = [_]u8{'a'} ** 512;
+    const small = [_]u8{'b'} ** 16;
+    inline for (.{ big, small }) |payload| {
+        const header = frameHeaderBytes(8 + payload.len, 2, 0, 0);
+        try mem.pushPeerBytes(&header);
+        try mem.pushPeerBytes(&payload);
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+
+    const first = try driver.receiveFrame(10_000);
+    try testing.expectEqual(@as(usize, 512), first.body.len);
+    try testing.expectEqualSlices(u8, &big, first.body);
+    const high_water = driver.body_buf.len;
+    try testing.expectEqual(@as(usize, 512), high_water);
+
+    const second = try driver.receiveFrame(10_000);
+    try testing.expectEqual(@as(usize, 16), second.body.len);
+    try testing.expectEqualSlices(u8, &small, second.body);
+    try testing.expectEqual(high_water, driver.body_buf.len);
 }

--- a/connection.zig
+++ b/connection.zig
@@ -247,9 +247,14 @@ pub const Driver = struct {
     in_buf: []u8,
     in_start: usize = 0,
     in_end: usize = 0,
-    /// The body most recently returned by `receiveFrame`, owned by the driver.
-    current_body: ?[]u8 = null,
-    current_header: ?FrameHeader = null,
+    /// The body most recently returned by `receiveFrame`, reused frame to
+    /// frame.
+    ///
+    /// Bodies were allocated and freed one per frame, which on a busy receiver
+    /// is a malloc/free pair for every message that arrives. The buffer grows
+    /// to the largest frame actually read — never to `acceptMaxFrameSize`,
+    /// which a peer can drive to 4 GiB by omitting `max-frame-size` (§2.7.1).
+    body_buf: []u8 = &.{},
 
     const in_buf_len = 16 * 1024;
 
@@ -269,7 +274,7 @@ pub const Driver = struct {
     }
 
     pub fn deinit(self: *Driver) void {
-        if (self.current_body) |b| self.allocator.free(b);
+        self.allocator.free(self.body_buf);
         self.handlers.deinit(self.allocator);
         self.allocator.free(self.in_buf);
         if (self.remote_container_id) |id| self.allocator.free(id);
@@ -619,11 +624,6 @@ pub const Driver = struct {
     /// handed, which cannot work across the protocol-header exchange that
     /// separates the SASL layer from the AMQP layer.
     pub fn receiveFrame(self: *Driver, deadline_ms: i64) ConnectionError!InboundFrame {
-        if (self.current_body) |b| {
-            self.allocator.free(b);
-            self.current_body = null;
-            self.current_header = null;
-        }
         while (true) {
             var header_bytes: [frame.frame_header_size]u8 = undefined;
             try self.readExact(&header_bytes, deadline_ms);
@@ -643,11 +643,12 @@ pub const Driver = struct {
             const body_size = header.size - prefix;
             if (body_size == 0) continue; // heartbeat
 
-            const body = try self.allocator.alloc(u8, body_size);
-            errdefer self.allocator.free(body);
+            if (body_size > self.body_buf.len) {
+                const grown = try self.allocator.realloc(self.body_buf, body_size);
+                self.body_buf = grown;
+            }
+            const body = self.body_buf[0..body_size];
             try self.readExact(body, deadline_ms);
-            self.current_body = body;
-            self.current_header = header;
             return .{ .header = header, .body = body };
         }
     }

--- a/link.zig
+++ b/link.zig
@@ -188,11 +188,16 @@ pub const Session = struct {
         var decoded = try self.driver.decodeBody(inbound.body);
         defer decoded.deinit();
 
-        const body = inbound.body;
+        // The decode above already measured the performative, so the payload
+        // is the remainder. `bytes_consumed` is what the decoder read out of
+        // `body`, so it cannot exceed it, but a corrupt length would slice out
+        // of bounds rather than fail cleanly.
+        if (decoded.bytes_consumed > inbound.body.len) return error.MalformedFrame;
+        const payload = inbound.body[decoded.bytes_consumed..];
         switch (decoded.performative) {
             .flow => |f| try self.applyFlow(f),
             .disposition => |d| try self.applyDisposition(d),
-            .transfer => |t| try self.applyTransfer(t, body),
+            .transfer => |t| try self.applyTransfer(t, payload),
             .attach => |a| try self.applyAttach(a),
             .detach => |d| try self.applyDetach(d),
             .end => |e| {
@@ -331,7 +336,7 @@ pub const Session = struct {
         }
     }
 
-    fn applyTransfer(self: *Session, t: perf.Transfer, body: []const u8) LinkError!void {
+    fn applyTransfer(self: *Session, t: perf.Transfer, payload: []const u8) LinkError!void {
         // `incoming_window` is capacity, not a countdown, so it is not spent
         // here. This endpoint takes every transfer it is sent — the receiver
         // buffers the delivery and link credit is what bounds a peer — so the
@@ -343,9 +348,7 @@ pub const Session = struct {
         self.next_incoming_id +%= 1;
 
         const receiver = self.receiverFor(t.handle) orelse return error.UnknownHandle;
-        // The payload is whatever follows the performative in the frame.
-        const consumed = performativeLength(self.allocator, body) orelse return error.MalformedFrame;
-        try receiver.acceptTransfer(t, body[consumed..]);
+        try receiver.acceptTransfer(t, payload);
     }
 
     /// Emit a session `flow`, optionally carrying link credit.
@@ -370,7 +373,11 @@ pub const Session = struct {
 ///
 /// A transfer frame carries the message payload immediately after the
 /// performative, so the split has to be found by measuring the performative.
-/// Byte length of the performative at the head of `body`; the rest is payload.
+///
+/// The receive path does not use this: `perf.Decoded.bytes_consumed` reports
+/// the same number as a by-product of the decode that `pump` already performs,
+/// which is why decoding a second time here would be pure waste. It remains
+/// for peers and tests, which hold a frame body without having decoded it.
 pub fn performativeLength(allocator: Allocator, body: []const u8) ?usize {
     var arena: std.heap.ArenaAllocator = .init(allocator);
     defer arena.deinit();
@@ -4050,4 +4057,70 @@ test "closing a receiver the peer already detached sends no detach" {
     for (frames.bodies.items) |body| {
         try testing.expect(perf.peekDescriptor(body) != perf.descriptor.detach);
     }
+}
+
+test "a pumped transfer allocates only what it hands the caller" {
+    var counting = CountingAllocator{ .child = testing.allocator };
+    const allocator = counting.allocator();
+
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    const count = 32;
+    const body = "0123456789" ** 20;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = i,
+            .delivery_tag = "tag!",
+            .message_format = 0,
+            .settled = true,
+            .more = false,
+        }, body);
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        // Comfortably more than `count`, so no `flow` is emitted to top credit
+        // back up inside the window measured below.
+        .prefetch = 256,
+    }, 10_000);
+
+    // Pump one transfer to size the frame buffer and the queue, so the window
+    // below measures the steady state rather than one-off growth.
+    _ = try fixture.session.pump(10_000);
+    try receiver.ready.ensureTotalCapacity(allocator, count);
+
+    counting.allocs = 0;
+    var pumped: usize = 1;
+    while (pumped < count) : (pumped += 1) _ = try fixture.session.pump(10_000);
+    const spent = counting.allocs;
+
+    // Four per transfer, and each one ends up in something the caller reads:
+    // the arena that holds the decoded performative, that arena's first page,
+    // the payload, and the delivery tag.
+    //
+    // It was six. The frame body was allocated and freed per frame rather than
+    // read into a buffer the driver keeps, and the transfer performative was
+    // decoded a second time — into a throwaway arena, discarding everything
+    // but the length — purely to find where the payload started, which the
+    // first decode already reported as `bytes_consumed`.
+    try testing.expectEqual(@as(usize, 4 * (count - 1)), spent);
 }

--- a/performative.zig
+++ b/performative.zig
@@ -761,6 +761,13 @@ pub fn encodeSaslOutcome(
 pub const Decoded = struct {
     arena: *std.heap.ArenaAllocator,
     performative: Performative,
+    /// Bytes of `body` the performative occupied.
+    ///
+    /// A transfer frame carries its message payload immediately after the
+    /// performative, so the split has to be found by measuring the
+    /// performative — and the decode that produced this already knows it.
+    /// Reporting it saves the caller decoding the same bytes a second time.
+    bytes_consumed: usize,
 
     pub fn deinit(self: *Decoded) void {
         const child = self.arena.child_allocator;
@@ -785,7 +792,11 @@ pub fn decode(allocator: Allocator, body: []const u8) DecodeError!Decoded {
         else => return error.MalformedBody,
     };
     const performative = try fromValue(arena.allocator(), result.value);
-    return .{ .arena = arena, .performative = performative };
+    return .{
+        .arena = arena,
+        .performative = performative,
+        .bytes_consumed = result.bytes_consumed,
+    };
 }
 
 /// Peek at the descriptor code of a frame body without fully decoding it.
@@ -1620,4 +1631,48 @@ test "a modified delivery state round-trips" {
     const m = decoded.performative.disposition.state.?.modified;
     try testing.expect(m.delivery_failed);
     try testing.expect(m.undeliverable_here);
+}
+
+test "bytes_consumed splits a transfer frame from its payload" {
+    const allocator = testing.allocator;
+
+    // A transfer frame is the performative followed immediately by the message
+    // payload, with nothing marking the join. `bytes_consumed` is where the
+    // receive path cuts, so it has to be the performative's own length and not
+    // the whole body.
+    const head = try encodeAlloc(allocator, .{ .transfer = .{
+        .handle = 2,
+        .delivery_id = 11,
+        .delivery_tag = "\x00\x00\x00\x0b",
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    } });
+    defer allocator.free(head);
+
+    const payload = "\x00\x53\x75\xa0\x03abc";
+    const body = try std.mem.concat(allocator, u8, &.{ head, payload });
+    defer allocator.free(body);
+
+    var decoded = try decode(allocator, body);
+    defer decoded.deinit();
+
+    try testing.expectEqual(head.len, decoded.bytes_consumed);
+    try testing.expectEqualSlices(u8, payload, body[decoded.bytes_consumed..]);
+}
+
+test "bytes_consumed is the whole body when nothing follows" {
+    const allocator = testing.allocator;
+    const bytes = try encodeAlloc(allocator, .{ .flow = .{
+        .next_incoming_id = 1,
+        .incoming_window = 100,
+        .next_outgoing_id = 2,
+        .outgoing_window = 100,
+    } });
+    defer allocator.free(bytes);
+
+    var decoded = try decode(allocator, bytes);
+    defer decoded.deinit();
+
+    try testing.expectEqual(bytes.len, decoded.bytes_consumed);
 }


### PR DESCRIPTION
The receive benchmark added in the Event Hubs package (#332) put a number on the receive loop for the first time: **11.0 allocations per received event**, against 2 for the decode itself. This is where 2 of the other 9 went.

## The double decode

`Session.pump` decodes the frame body into a performative. That decode knows exactly how many bytes the performative occupied — and threw the number away. `applyTransfer` then recovered it by calling `performativeLength`, which decodes the same bytes all over again into a throwaway arena and discards everything except the length.

So every received message paid for two full decodes of its transfer performative to learn one number the first decode already had.

`perf.Decoded` now reports `bytes_consumed`, `pump` slices the payload itself, and `applyTransfer` takes it directly. `performativeLength` stays for peers and tests, which hold a frame body without having decoded it.

## The per-frame body allocation

`receiveFrame` allocated a body per frame and freed it at the start of the next one — a malloc/free pair for every frame that arrives. The driver now reads into a buffer it keeps, grown to the largest frame it has actually seen.

The size comes from the frame header — what the peer *claimed* to be sending. `acceptMaxFrameSize()` is `@max(options.max_frame_size, min)`, purely local, and a header above it is rejected before the buffer grows, so the high-water mark is bounded by our own `max_frame_size` and never by the peer.

The *trigger*, though, is peer-controlled: one eight-byte header never followed by a body would otherwise pin the whole of `max_frame_size` for the life of the connection. So the buffer is released when the body fails to arrive, which is what the `errdefer` in the code this replaces did.

## Result

A pumped transfer goes from six allocations to four, and each of the four ends up in something the caller reads: the arena holding the decoded performative, that arena's first page, the payload, and the delivery tag.

Measured end to end through the Event Hubs receive benchmark — the public API, replaying a thousand-transfer script — interleaved A/B, three rounds each:

| | before | after |
| --- | ---: | ---: |
| allocs/op (x1000) | 11064 | **9064** |
| per event | 11.0 | **9.0** |
| B/op | 2,932,598 | **2,444,464** |
| min ns, 3 rounds | 1413461 / 1448114 / 1417267 | **1333701 / 1301192 / 1319369** |

Allocation counts were identical in every round; the three minima do not overlap.

## Why reusing the body is safe

Same lifetime as before — valid until the next `receiveFrame` — and nothing retains it past that:

- the uamqp decoder **dupes** strings, symbols and binaries into the performative's arena (`decoder.zig:190,203`) rather than borrowing from the input, so a decoded performative outlives the buffer
- `acceptTransfer` dupes both payload and tag (`link.zig:1086,1088`)
- every `receiveFrame` caller is internal and consumes the body before the next call

`current_header` was written and never read; it is gone with `current_body`.

## Tests

- `bytes_consumed` splits a transfer frame from its payload, and equals the whole body when nothing follows
- a pumped transfer allocates exactly four times, which is the regression gate for both halves

Verified to discriminate — five mutations, five caught:

| mutation | caught by |
| --- | --- |
| restore the `performativeLength` re-decode | alloc test, 155 vs 124 |
| free and re-allocate the body every frame | alloc test, 155 vs 124 |
| `bytes_consumed = body.len` | transfer split test + 12 others |
| `bytes_consumed - 1` | transfer split test + others |
| `bytes_consumed + 1` | transfer split test + others |

137/137 tests, `zig fmt` clean.

**No version change** — `perf.Decoded` gains a field, which is additive for readers but would break an out-of-package struct literal. Flagging rather than bumping.
