### PR TITLE
Pin amqp at the frame-decode work

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#861257786bdc69df5a87f1cea758bf630126cf60",
-            .hash = "azure_sdk_amqp-0.4.0-fUByf9oLBgAV5AXiW7-2bYt3E0vLBZZZ5mS47NQoaPwD",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#061873d2ebd30d9bbd0ac4c0cfa2c2989308ed33",
+            .hash = "azure_sdk_amqp-0.4.0-fUByf1swBgCKRZp3Da39Nd25hj4WpoBE-Eoe9nfl7dYx",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",


### PR DESCRIPTION
Picks up cataggar/azure-sdk-for-zig#333 in `azure_sdk_amqp`, which stops decoding every transfer performative twice and reads frame bodies into a buffer the driver keeps instead of allocating one per frame.

Measured here, through the receive benchmark added in #332:

| | before | after |
| --- | ---: | ---: |
| allocs/op (x1000) | 11064 | **9064** |
| per received event | 11.0 | **9.0** |
| B/op | 2,932,598 | **2,444,464** |

191/191 tests. Pin and hash only — **no version change** on either side.