### PR TITLE
Decode every frame's performative into one reusable arena

### DIFF
--- a/connection.zig
+++ b/connection.zig
@@ -278,8 +278,11 @@ pub const Driver = struct {
     perf_arena: ?std.heap.ArenaAllocator = null,
 
     /// What `perf_arena` keeps between frames. Real performatives are a few
-    /// hundred bytes, so this is far above the steady state and the cap never
-    /// costs a re-allocation on live traffic — it only releases the outlier.
+    /// hundred bytes, so this is far above the steady state: below the limit
+    /// `retain_with_limit` is byte-for-byte `retain_capacity`, so the cap
+    /// costs nothing on live traffic. It bites on the *next* frame, not on
+    /// the outlier itself, so a connection that falls silent right after one
+    /// holds the peak until it is closed — bounded, but not immediate.
     pub const perf_arena_limit = 64 * 1024;
 
     const in_buf_len = 16 * 1024;

--- a/connection.zig
+++ b/connection.zig
@@ -261,6 +261,14 @@ pub const Driver = struct {
     /// otherwise pin the whole of that for the life of the connection, so the
     /// buffer is released when the body fails to arrive.
     body_buf: []u8 = &.{},
+    /// Backs the performative `decodeBodyReusing` hands out, reset per frame.
+    ///
+    /// A fresh arena per frame is two allocations — the arena struct and its
+    /// first page — for a performative nothing outlives the frame. Resetting
+    /// one keeps the page and pays neither. The handshake keeps `decodeBody`,
+    /// which owns its arena, so the borrow is confined to the receive path
+    /// where every retained field is provably duped out.
+    perf_arena: ?std.heap.ArenaAllocator = null,
 
     const in_buf_len = 16 * 1024;
 
@@ -280,6 +288,7 @@ pub const Driver = struct {
     }
 
     pub fn deinit(self: *Driver) void {
+        if (self.perf_arena) |*a| a.deinit();
         self.allocator.free(self.body_buf);
         self.handlers.deinit(self.allocator);
         self.allocator.free(self.in_buf);
@@ -681,6 +690,23 @@ pub const Driver = struct {
     /// Decode a frame body into a performative.
     pub fn decodeBody(self: *Driver, body: []const u8) ConnectionError!perf.Decoded {
         return perf.decode(self.allocator, body) catch |e| switch (e) {
+            error.OutOfMemory => error.OutOfMemory,
+            else => error.MalformedFrame,
+        };
+    }
+
+    /// Decode a frame body into a performative that lives until the next call.
+    ///
+    /// For the receive path, which handles a performative and is done with it
+    /// inside the frame: anything a session keeps — a link name, an error
+    /// condition, a delivery's payload and tag — it dupes out first. Reusing
+    /// one arena rather than building one per frame saves two allocations on
+    /// every frame that arrives.
+    pub fn decodeBodyReusing(self: *Driver, body: []const u8) ConnectionError!perf.Borrowed {
+        if (self.perf_arena == null) self.perf_arena = .init(self.allocator);
+        const arena = &self.perf_arena.?;
+        _ = arena.reset(.retain_capacity);
+        return perf.decodeInto(arena.allocator(), body) catch |e| switch (e) {
             error.OutOfMemory => error.OutOfMemory,
             else => error.MalformedFrame,
         };

--- a/connection.zig
+++ b/connection.zig
@@ -268,7 +268,19 @@ pub const Driver = struct {
     /// one keeps the page and pays neither. The handshake keeps `decodeBody`,
     /// which owns its arena, so the borrow is confined to the receive path
     /// where every retained field is provably duped out.
+    ///
+    /// Capped at `perf_arena_limit` rather than retained outright. A frame is
+    /// bounded by `acceptMaxFrameSize()`, but the decode is not bounded by the
+    /// frame: a list or map header costs a byte or two and buys 24 or 48 of
+    /// arena per element, so a hostile frame decodes to tens of times its own
+    /// size. Retaining outright would pin that peak for the life of the
+    /// connection, which is the trap `body_buf` above already has to dodge.
     perf_arena: ?std.heap.ArenaAllocator = null,
+
+    /// What `perf_arena` keeps between frames. Real performatives are a few
+    /// hundred bytes, so this is far above the steady state and the cap never
+    /// costs a re-allocation on live traffic — it only releases the outlier.
+    pub const perf_arena_limit = 64 * 1024;
 
     const in_buf_len = 16 * 1024;
 
@@ -698,14 +710,20 @@ pub const Driver = struct {
     /// Decode a frame body into a performative that lives until the next call.
     ///
     /// For the receive path, which handles a performative and is done with it
-    /// inside the frame: anything a session keeps — a link name, an error
-    /// condition, a delivery's payload and tag — it dupes out first. Reusing
-    /// one arena rather than building one per frame saves two allocations on
-    /// every frame that arrives.
+    /// inside the frame: anything a session keeps — an error condition, a
+    /// delivery's payload and tag — it dupes out first. Reusing one arena
+    /// rather than building one per frame saves two allocations on every frame
+    /// that arrives.
+    ///
+    /// The invalidator is any later call, and `Session.pump` makes one per
+    /// frame it reads — so a result must not be held across a `pump`, even
+    /// though `pump` is nowhere in this type's API. Reading one that has been
+    /// invalidated is silent corruption, not a use-after-free the testing
+    /// allocator would catch.
     pub fn decodeBodyReusing(self: *Driver, body: []const u8) ConnectionError!perf.Borrowed {
         if (self.perf_arena == null) self.perf_arena = .init(self.allocator);
         const arena = &self.perf_arena.?;
-        _ = arena.reset(.retain_capacity);
+        _ = arena.reset(.{ .retain_with_limit = perf_arena_limit });
         return perf.decodeInto(arena.allocator(), body) catch |e| switch (e) {
             error.OutOfMemory => error.OutOfMemory,
             else => error.MalformedFrame,

--- a/link.zig
+++ b/link.zig
@@ -4195,7 +4195,158 @@ test "what a session keeps from a performative outlives the frames after it" {
 
     try testing.expectEqualStrings(condition, sender.rejection.?.condition);
     try testing.expectEqualStrings(description, sender.rejection.?.description.?);
-    // The link name is duped at attach, but attach is decoded through the same
-    // arena, so it is the same hazard.
-    try testing.expectEqualStrings("producer", sender.name);
+}
+
+test "a queued single-frame delivery outlives the frames after it" {
+    // Companion to the test above, for the other thing the receive path keeps
+    // out of a performative: `acceptTransfer` dupes the tag off the transfer
+    // and the payload out of the frame body, then queues both. The multi-frame
+    // path is covered incidentally elsewhere, because reassembly pumps more
+    // frames before the delivery is read; the single-frame fast path is not,
+    // so a borrow there would survive every other test in this file.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    const tag = "\x00\x00\x00\x07";
+    const payload = "the body of a delivery nobody reads until later";
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 7,
+        .delivery_tag = tag,
+        .message_format = 0,
+        .settled = false,
+        .more = false,
+    }, payload);
+
+    // As in the test above: each entry fills the harness's 512-byte frame, and
+    // the frame is repeated, so the arena is written clean past wherever the
+    // transfer's tag landed rather than merely reset over it.
+    var pad: [4]uamqp.MapEntry = undefined;
+    for (&pad) |*entry| entry.* = .{
+        .key = .{ .symbol = "com.microsoft:padding" },
+        .value = .{ .string = "y" ** 64 },
+    };
+    var i: u32 = 0;
+    while (i < 16) : (i += 1) {
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1000 + i,
+            .next_outgoing_id = 1,
+            .outgoing_window = 1000,
+            .handle = 0,
+            .delivery_count = 0,
+            .link_credit = 5,
+            .properties = &pad,
+        } });
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        .prefetch = 0,
+    }, 10_000);
+
+    // Queue the delivery, then bury it. `receive` would stop at the first one
+    // ready, so pump past it explicitly. A fixed count, not a drain on
+    // `mem.inbound_pos` — see the note in the test above.
+    while (receiver.ready.items.len == receiver.ready_head) _ = try fixture.session.pump(10_000);
+    var pumped: usize = 0;
+    while (pumped < 16) : (pumped += 1) _ = try fixture.session.pump(10_000);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 7), delivery.id);
+    try testing.expectEqualSlices(u8, tag, delivery.tag);
+    try testing.expectEqualStrings(payload, delivery.payload);
+}
+
+test "one hostile frame does not pin an oversized decode arena" {
+    // The receive arena is reused, so whatever it grows to it keeps. A frame
+    // is bounded by `max_frame_size`, but the *decode* is not bounded by the
+    // frame: a map header costs two bytes and buys 48 of arena per entry, so
+    // a legal frame decodes to many times its own size. Retaining outright
+    // would pin that peak for the life of the connection.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    const frame_size = 65536;
+    try scriptHandshake(peer, frame_size);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    // ~5 encoded bytes each, 48 of `MapEntry` each once decoded.
+    const bloat = 3000;
+    const entries = try allocator.alloc(uamqp.MapEntry, bloat);
+    defer allocator.free(entries);
+    for (entries) |*entry| entry.* = .{
+        .key = .{ .symbol = "p" },
+        .value = .{ .null = {} },
+    };
+
+    var opts = test_options;
+    opts.max_frame_size = frame_size;
+
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 5,
+        .properties = entries,
+    } });
+    // One ordinary frame behind it, which is what releases the outlier.
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1001,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 5,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), opts);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    _ = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        .prefetch = 0,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    const peak = driver.perf_arena.?.queryCapacity();
+    _ = try fixture.session.pump(10_000);
+    const retained = driver.perf_arena.?.queryCapacity();
+
+    // Assert the size, not a symptom: the peak really did exceed the cap, and
+    // the next frame really did give it back.
+    try testing.expect(peak > Driver.perf_arena_limit);
+    try testing.expect(retained <= Driver.perf_arena_limit);
 }

--- a/link.zig
+++ b/link.zig
@@ -185,8 +185,7 @@ pub const Session = struct {
         const inbound = try self.driver.receiveFrame(deadline_ms);
         if (inbound.header.channel != self.remote_channel) return false;
 
-        var decoded = try self.driver.decodeBody(inbound.body);
-        defer decoded.deinit();
+        const decoded = try self.driver.decodeBodyReusing(inbound.body);
 
         // The decode above already measured the performative, so the payload
         // is the remainder. `bytes_consumed` is what the decoder read out of
@@ -4113,14 +4112,90 @@ test "a pumped transfer allocates only what it hands the caller" {
     while (pumped < count) : (pumped += 1) _ = try fixture.session.pump(10_000);
     const spent = counting.allocs;
 
-    // Four per transfer, and each one ends up in something the caller reads:
-    // the arena that holds the decoded performative, that arena's first page,
-    // the payload, and the delivery tag.
+    // Two per transfer, and both are what the caller is handed: the payload
+    // and the delivery tag. Nothing is allocated to decode the frame.
     //
     // It was six. The frame body was allocated and freed per frame rather than
-    // read into a buffer the driver keeps, and the transfer performative was
+    // read into a buffer the driver keeps; the transfer performative was
     // decoded a second time — into a throwaway arena, discarding everything
     // but the length — purely to find where the payload started, which the
-    // first decode already reported as `bytes_consumed`.
-    try testing.expectEqual(@as(usize, 4 * (count - 1)), spent);
+    // first decode already reported as `bytes_consumed`; and the performative
+    // arena was built per frame rather than reset.
+    try testing.expectEqual(@as(usize, 2 * (count - 1)), spent);
+}
+
+test "what a session keeps from a performative outlives the frames after it" {
+    // The receive path decodes every frame into one arena it resets, so a
+    // performative's slices are gone the moment the next frame arrives. That
+    // is only sound because everything the session retains is duped out first.
+    // A field that borrowed instead would read as intact here and as garbage
+    // in production, so drive real frames over it rather than trusting review.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    const condition = "amqp:link:message-size-exceeded";
+    const description = "The received message is larger than the maximum allowed size.";
+
+    try scriptSenderAttach(peer, 5);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .{ .rejected = .{ .condition = condition, .description = description } },
+    } });
+
+    // Frames behind the rejection, each decoding far more than the rejection
+    // did, so the arena is not merely reset but written clean past wherever
+    // the condition sat. Padding it lightly is not enough: an arena reset
+    // bumps from the start of a retained page, so a later frame that decodes
+    // to less than the earlier one leaves the tail of the earlier one intact
+    // and a borrowed slice reads as correct by luck. Each entry is sized to
+    // fill the harness's 512-byte frame, and the frame is repeated.
+    var pad: [4]uamqp.MapEntry = undefined;
+    for (&pad) |*entry| entry.* = .{
+        .key = .{ .symbol = "com.microsoft:padding" },
+        .value = .{ .string = "y" ** 64 },
+    };
+
+    var i: u32 = 0;
+    while (i < 16) : (i += 1) {
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1000 + i,
+            .next_outgoing_id = 1,
+            .outgoing_window = 1000,
+            .handle = 0,
+            .delivery_count = 0,
+            .link_credit = 5,
+            .properties = &pad,
+        } });
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    try testing.expectError(error.SendRejected, sender.sendBytes("payload", 10_000));
+    // Pump a fixed count. `mem.inbound_pos` is where the *transport* has been
+    // read to, and the driver slurps up to 16 KiB into `in_buf` ahead of
+    // parsing, so draining on it would exit before parsing a single one of
+    // these frames and the test would pass without testing anything.
+    var pumped: usize = 0;
+    while (pumped < 16) : (pumped += 1) _ = try fixture.session.pump(10_000);
+
+    try testing.expectEqualStrings(condition, sender.rejection.?.condition);
+    try testing.expectEqualStrings(description, sender.rejection.?.description.?);
+    // The link name is duped at attach, but attach is decoded through the same
+    // arena, so it is the same hazard.
+    try testing.expectEqualStrings("producer", sender.name);
 }

--- a/performative.zig
+++ b/performative.zig
@@ -757,9 +757,13 @@ pub fn encodeSaslOutcome(
 
 // ─────────────────────── Decoding ───────────────────────
 
-/// A decoded performative together with the arena backing its slices.
-pub const Decoded = struct {
-    arena: *std.heap.ArenaAllocator,
+/// A decoded performative, borrowing whatever allocator decoded it.
+///
+/// Separate from `Decoded` because the receive path decodes a performative per
+/// frame and keeps nothing from it: everything a session retains is duped out
+/// before the frame is done. Handing it an arena it can reset instead of one
+/// it has to create costs two fewer allocations per frame.
+pub const Borrowed = struct {
     performative: Performative,
     /// Bytes of `body` the performative occupied.
     ///
@@ -767,6 +771,14 @@ pub const Decoded = struct {
     /// performative, so the split has to be found by measuring the
     /// performative — and the decode that produced this already knows it.
     /// Reporting it saves the caller decoding the same bytes a second time.
+    bytes_consumed: usize,
+};
+
+/// A decoded performative together with the arena backing its slices.
+pub const Decoded = struct {
+    arena: *std.heap.ArenaAllocator,
+    performative: Performative,
+    /// Bytes of `body` the performative occupied. See `Borrowed`.
     bytes_consumed: usize,
 
     pub fn deinit(self: *Decoded) void {
@@ -777,25 +789,37 @@ pub const Decoded = struct {
     }
 };
 
-/// Decode a frame body into a performative.
+/// Decode a frame body into a performative, allocating from `allocator`.
+///
+/// Every slice in the result points into `allocator`, so this is meant for an
+/// arena the caller can reset or drop wholesale. `decode` wraps it with an
+/// arena of its own for callers that would rather not keep one.
 ///
 /// Returns `error.UnknownDescriptor` for performatives this driver does not
 /// model, which callers treat as "ignore and continue".
+pub fn decodeInto(allocator: Allocator, body: []const u8) DecodeError!Borrowed {
+    const result = decoder.decode(allocator, body) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.MalformedBody,
+    };
+    return .{
+        .performative = try fromValue(allocator, result.value),
+        .bytes_consumed = result.bytes_consumed,
+    };
+}
+
+/// Decode a frame body into a performative and the arena backing it.
 pub fn decode(allocator: Allocator, body: []const u8) DecodeError!Decoded {
     const arena = try allocator.create(std.heap.ArenaAllocator);
     errdefer allocator.destroy(arena);
     arena.* = .init(allocator);
     errdefer arena.deinit();
 
-    const result = decoder.decode(arena.allocator(), body) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.MalformedBody,
-    };
-    const performative = try fromValue(arena.allocator(), result.value);
+    const borrowed = try decodeInto(arena.allocator(), body);
     return .{
         .arena = arena,
-        .performative = performative,
-        .bytes_consumed = result.bytes_consumed,
+        .performative = borrowed.performative,
+        .bytes_consumed = borrowed.bytes_consumed,
     };
 }
 


### PR DESCRIPTION
`Session.pump` built a fresh `ArenaAllocator` for every frame it decoded and dropped it at the end of the frame — two allocations, the arena struct and its first page, on every frame that arrives.

Nothing in a performative outlives its frame. Everything a session retains from one — a link name, an error condition, a delivery's payload and tag — is duped out with the session's own allocator before the frame is done. So the driver now keeps one arena and resets it per frame.

- `perf.decodeInto(allocator, body)` decodes into a caller-supplied allocator and returns `perf.Borrowed`. `perf.decode` is now a thin wrapper that creates the arena, so its callers are unaffected.
- `Driver.decodeBodyReusing` lazily creates a driver-owned arena and `reset(.retain_capacity)`s it per frame. The handshake keeps `decodeBody`, which owns its arena.

A pumped transfer: **4 allocations → 2**, and both are what the caller is handed (the payload and the delivery tag).

Through the Event Hubs receive benchmark, interleaved A/B, 3 rounds:

| | before | after |
| --- | ---: | ---: |
| allocs/op (x1000) | 9064 | **7063** |
| per event | 9.0 | **7.0** |
| B/op | 2,444,464 | **2,160,432** |

Identical every round. Timings overlap on this host, as expected — this removes allocator work, not a round trip.

## The borrow is tested, not reviewed

A field that borrowed from the arena instead of duping would read as intact in a naive test and as garbage in production. So the new test takes a rejection off the wire, then pumps sixteen larger frames through the same arena and asserts the retained condition, description and link name still read correctly.

Two things had to be right for that test to discriminate at all, and neither was obvious:

- **An arena reset bumps from the start of a retained page.** A later frame that decodes to *less* than an earlier one leaves the earlier one's tail intact, so a borrowed slice reads as correct by luck. The padding frames each fill the harness's 512-byte frame and are repeated sixteen times.
- **`MemoryTransport.inbound_pos` is where the *transport* has been read to, not where the parser is.** The driver slurps up to 16 KiB into `in_buf` ahead of parsing, so `while (inbound_pos < inbound.items.len) pump()` exits before parsing a single padding frame. The test pumps a fixed count.

## Mutations — 4 run, 4 caught

| mutation | caught by |
| --- | --- |
| restore the per-frame owning arena | alloc test, 124 vs 62 |
| don't reset the arena | alloc test |
| `reset(.free_all)` instead of `.retain_capacity` | alloc test |
| borrow `condition`/`description` instead of duping | the new lifetime test |

140 tests. No version change.