### PR TITLE
Decode received events into one client-owned arena

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#061873d2ebd30d9bbd0ac4c0cfa2c2989308ed33",
-            .hash = "azure_sdk_amqp-0.4.0-fUByf1swBgCKRZp3Da39Nd25hj4WpoBE-Eoe9nfl7dYx",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b0bf347c4da5ccb9cb63772011c98a769d838f74",
+            .hash = "azure_sdk_amqp-0.4.0-fUByf6x_BgAoO05o4uHh89hyi9PiEKQzfvtT4ucPs-Ts",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/receiver.zig
+++ b/receiver.zig
@@ -246,10 +246,10 @@ pub const PartitionClient = struct {
 
             const received = blk: {
                 // Decode into the client's scratch arena rather than a fresh
-                // one per message. Nothing survives the block: the decoded
-                // message points into the arena and into the driver's frame
-                // buffer, and `fromRawMessage` copies what it keeps into
-                // `allocator`.
+                // one per message. Nothing survives the block: the decode
+                // borrows nothing from `delivery.payload`, so the message is
+                // wholly arena-backed, and `fromRawMessage` copies what it
+                // keeps into `allocator`.
                 if (self.decode_arena == null) self.decode_arena = .init(self.allocator);
                 const arena = &self.decode_arena.?;
                 _ = arena.reset(.{ .retain_with_limit = decode_arena_limit });
@@ -829,20 +829,30 @@ test "receiveEvents settles a whole batch in one disposition" {
 }
 
 test "decoding a batch costs the same whatever the batch size" {
-    // `decodeMessage` charges an arena and its pages per message, and the
-    // receive loop discards each decode as soon as `fromRawMessage` has copied
-    // out of it. Decoding into one client-owned arena, reset per event, makes
-    // that cost fixed rather than per event.
+    // `decodeMessage` charged an arena and its pages to the *events*
+    // allocator, once per message, and the receive loop discarded each decode
+    // as soon as `fromRawMessage` had copied out of it. Decoding into one
+    // client-owned arena, reset per event, makes that cost fixed rather than
+    // per event.
     //
-    // Assert exactly that — two batches of very different sizes cost the same
-    // — rather than asserting a number. A number would pin the fixed cost
-    // (the filter expression `receiveEvents` re-renders once per call) and
-    // break for reasons that have nothing to do with this.
+    // So one counting allocator has to serve both the client and the events:
+    // counting only the client's would miss the allocations this removes
+    // entirely, and the test would pass against the very code it exists to
+    // rule out.
+    //
+    // What is asserted is the *marginal* cost of an event, which cancels
+    // every fixed cost of a call (the filter expression, the events list, the
+    // arena's own first growth) without having to know any of them. Two
+    // allocation per event is `fromRawMessage`'s one block — these events
+    // carry no application properties, so the property map allocates no
+    // storage of its own. The decode used to add three more on top of it.
     const allocator = testing.allocator;
     var counting = CountingAllocator.init(allocator);
+    const counted = counting.allocator();
 
     const small = 4;
     const large = 36;
+    const per_event = 1;
 
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -860,26 +870,23 @@ test "decoding a batch costs the same whatever the batch size" {
     var scripted: Scripted = undefined;
     try scripted.open(allocator, &mem, &clock, &conn, .{});
     defer scripted.deinit();
-
-    // Count only the client's own allocator. The events themselves are handed
-    // back on `allocator` and are not what this is about.
-    scripted.client.allocator = counting.allocator();
+    scripted.client.allocator = counted;
 
     // Warm: the arena is the client's, so the first batch is the one that
     // builds it and every batch after finds it sized.
-    event_data.freeReceivedEvents(allocator, try scripted.client.receiveEvents(allocator, small));
+    event_data.freeReceivedEvents(counted, try scripted.client.receiveEvents(counted, small));
 
     const a = counting.allocations;
-    event_data.freeReceivedEvents(allocator, try scripted.client.receiveEvents(allocator, small));
+    event_data.freeReceivedEvents(counted, try scripted.client.receiveEvents(counted, small));
     const cost_small = counting.allocations - a;
 
     const b = counting.allocations;
-    const batch = try scripted.client.receiveEvents(allocator, large);
-    defer event_data.freeReceivedEvents(allocator, batch);
+    const batch = try scripted.client.receiveEvents(counted, large);
+    defer event_data.freeReceivedEvents(counted, batch);
     const cost_large = counting.allocations - b;
 
     try testing.expectEqual(@as(usize, large), batch.len);
-    try testing.expectEqual(cost_small, cost_large);
+    try testing.expectEqual(@as(usize, per_event * (large - small)), cost_large - cost_small);
 }
 
 test "one outsized event does not pin the decode arena" {

--- a/receiver.zig
+++ b/receiver.zig
@@ -82,6 +82,25 @@ pub const PartitionClient = struct {
     /// `amqp:link:stolen` here. Its strings belong to the receiver, so read it
     /// before the session is torn down.
     last_error: ?errors.EventHubsError = null,
+    /// Scratch for decoding a received message, reset per event.
+    ///
+    /// `fromRawMessage` copies everything it keeps into the caller's
+    /// allocator, so a decoded message is dead by the end of its iteration —
+    /// but `decodeMessage` charges an arena and its pages for each one. One
+    /// arena reset per event costs that once. It lives on the client rather
+    /// than in `receiveEvents` because a caller asking for a few events at a
+    /// time is the common shape, and a per-call arena would be cold every
+    /// call.
+    ///
+    /// Capped rather than retained outright: an event may be up to a megabyte
+    /// and decoding expands it, so the largest event ever received would
+    /// otherwise stay pinned per partition for the life of the client.
+    decode_arena: ?std.heap.ArenaAllocator = null,
+
+    /// What `decode_arena` keeps between events. Below it,
+    /// `retain_with_limit` is byte-for-byte `retain_capacity`, so ordinary
+    /// traffic pays nothing for the cap.
+    pub const decode_arena_limit = 256 * 1024;
 
     pub const Args = struct {
         /// `{hub}/ConsumerGroups/{group}/Partitions/{id}`.
@@ -164,6 +183,8 @@ pub const PartitionClient = struct {
     pub fn deinit(self: *PartitionClient) void {
         self.allocator.free(self.filter_expression);
         self.filter_expression = &.{};
+        if (self.decode_arena) |*a| a.deinit();
+        self.decode_arena = null;
     }
 
     /// Detach the link and release the client.
@@ -224,9 +245,16 @@ pub const PartitionClient = struct {
             };
 
             const received = blk: {
-                var decoded = try amqp.decodeMessage(allocator, delivery.payload);
-                defer decoded.deinit();
-                break :blk try event_data.fromRawMessage(allocator, rawFrom(&decoded.message));
+                // Decode into the client's scratch arena rather than a fresh
+                // one per message. Nothing survives the block: the decoded
+                // message points into the arena and into the driver's frame
+                // buffer, and `fromRawMessage` copies what it keeps into
+                // `allocator`.
+                if (self.decode_arena == null) self.decode_arena = .init(self.allocator);
+                const arena = &self.decode_arena.?;
+                _ = arena.reset(.{ .retain_with_limit = decode_arena_limit });
+                const message = try amqp.decodeMessageInto(arena.allocator(), delivery.payload);
+                break :blk try event_data.fromRawMessage(allocator, rawFrom(&message));
             };
 
             // Capacity for `count` was reserved up front and the loop runs
@@ -554,6 +582,59 @@ fn pushEvent(
     }, payload);
 }
 
+/// Push one event split across transfer frames, which is how anything larger
+/// than the negotiated frame size actually arrives.
+fn pushChunkedEvent(
+    allocator: Allocator,
+    peer: Peer,
+    id: u32,
+    sequence_number: i64,
+    body: []const u8,
+    chunk_len: usize,
+) !void {
+    var annotations = [_]amqp.MapEntry{
+        .{
+            .key = .{ .symbol = event_data.sequence_number_annotation },
+            .value = .{ .long = sequence_number },
+        },
+        .{
+            .key = .{ .symbol = event_data.offset_annotation },
+            .value = .{ .string = "100" },
+        },
+    };
+    const bodies = [_][]const u8{body};
+    const payload = try amqp.encodeMessageAlloc(allocator, .{
+        .message_annotations = &annotations,
+        .body = .{ .data = &bodies },
+    });
+    defer allocator.free(payload);
+
+    const tag = [_]u8{@intCast(id)};
+    var offset: usize = 0;
+    var first = true;
+    while (offset < payload.len) {
+        const take = @min(chunk_len, payload.len - offset);
+        const more = offset + take < payload.len;
+        if (first) {
+            try peer.pushTransfer(0, .{
+                .handle = 0,
+                .delivery_id = id,
+                .delivery_tag = &tag,
+                .message_format = 0,
+                .settled = true,
+                .more = more,
+            }, payload[offset..][0..take]);
+            first = false;
+        } else {
+            try peer.pushTransfer(0, .{
+                .handle = 0,
+                .more = more,
+            }, payload[offset..][0..take]);
+        }
+        offset += take;
+    }
+}
+
 /// The attach the client wrote, decoded. Caller must `deinit` it.
 fn sentAttach(allocator: Allocator, mem: *MemoryTransport) !amqp.performative.Decoded {
     var frames = try EmittedFrames.parse(allocator, mem.written());
@@ -745,6 +826,98 @@ test "receiveEvents settles a whole batch in one disposition" {
     try testing.expectEqual(@as(usize, 1), dispositions);
     try testing.expectEqual(@as(u32, 0), covered_first.?);
     try testing.expectEqual(@as(u32, batch - 1), covered_last.?);
+}
+
+test "decoding a batch costs the same whatever the batch size" {
+    // `decodeMessage` charges an arena and its pages per message, and the
+    // receive loop discards each decode as soon as `fromRawMessage` has copied
+    // out of it. Decoding into one client-owned arena, reset per event, makes
+    // that cost fixed rather than per event.
+    //
+    // Assert exactly that — two batches of very different sizes cost the same
+    // — rather than asserting a number. A number would pin the fixed cost
+    // (the filter expression `receiveEvents` re-renders once per call) and
+    // break for reasons that have nothing to do with this.
+    const allocator = testing.allocator;
+    var counting = CountingAllocator.init(allocator);
+
+    const small = 4;
+    const large = 36;
+
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    var i: u32 = 0;
+    while (i < small + small + large) : (i += 1) {
+        try pushEvent(allocator, peer, i, @as(i64, i) + 1, "event");
+    }
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    // Count only the client's own allocator. The events themselves are handed
+    // back on `allocator` and are not what this is about.
+    scripted.client.allocator = counting.allocator();
+
+    // Warm: the arena is the client's, so the first batch is the one that
+    // builds it and every batch after finds it sized.
+    event_data.freeReceivedEvents(allocator, try scripted.client.receiveEvents(allocator, small));
+
+    const a = counting.allocations;
+    event_data.freeReceivedEvents(allocator, try scripted.client.receiveEvents(allocator, small));
+    const cost_small = counting.allocations - a;
+
+    const b = counting.allocations;
+    const batch = try scripted.client.receiveEvents(allocator, large);
+    defer event_data.freeReceivedEvents(allocator, batch);
+    const cost_large = counting.allocations - b;
+
+    try testing.expectEqual(@as(usize, large), batch.len);
+    try testing.expectEqual(cost_small, cost_large);
+}
+
+test "one outsized event does not pin the decode arena" {
+    // The decode arena is reused, so whatever it grows to it keeps. An Event
+    // Hubs event may be up to a megabyte, and every partition holds a client,
+    // so retaining outright would let one outlier pin that per partition for
+    // as long as the consumer runs.
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const big = try allocator.alloc(u8, PartitionClient.decode_arena_limit + 64 * 1024);
+    defer allocator.free(big);
+    @memset(big, 'x');
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    // 300 bytes a frame, as a real one would arrive under a negotiated frame
+    // size far smaller than the message.
+    try pushChunkedEvent(allocator, peer, 0, 1, big, 300);
+    try pushEvent(allocator, peer, 1, 2, "back to normal");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    event_data.freeReceivedEvents(allocator, try scripted.client.receiveEvents(allocator, 1));
+    const peak = scripted.client.decode_arena.?.queryCapacity();
+    event_data.freeReceivedEvents(allocator, try scripted.client.receiveEvents(allocator, 1));
+    const retained = scripted.client.decode_arena.?.queryCapacity();
+
+    // Assert the size, not a symptom: the outlier really did exceed the cap,
+    // and the ordinary event behind it really did give it back.
+    try testing.expect(peak > PartitionClient.decode_arena_limit);
+    try testing.expect(retained <= PartitionClient.decode_arena_limit);
 }
 
 test "a quiet partition returns the events that did arrive" {
@@ -975,3 +1148,48 @@ test "a pool reuses one link and resumes where it left off" {
     }
     try testing.expectEqual(@as(usize, 1), attaches);
 }
+
+/// Counts allocations so a test can assert that a code path performs none.
+const CountingAllocator = struct {
+    parent: Allocator,
+    allocations: usize = 0,
+
+    fn init(parent: Allocator) CountingAllocator {
+        return .{ .parent = parent };
+    }
+
+    fn allocator(self: *CountingAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.allocations += 1;
+        return self.parent.rawAlloc(len, alignment, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.parent.rawResize(buf, alignment, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        const out = self.parent.rawRemap(buf, alignment, new_len, ra);
+        // Only a move is a new allocation; growing in place is not.
+        if (out) |p| if (p != buf.ptr) {
+            self.allocations += 1;
+        };
+        return out;
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.parent.rawFree(buf, alignment, ra);
+    }
+};

--- a/receiver.zig
+++ b/receiver.zig
@@ -842,10 +842,11 @@ test "decoding a batch costs the same whatever the batch size" {
     //
     // What is asserted is the *marginal* cost of an event, which cancels
     // every fixed cost of a call (the filter expression, the events list, the
-    // arena's own first growth) without having to know any of them. Two
-    // allocation per event is `fromRawMessage`'s one block — these events
-    // carry no application properties, so the property map allocates no
-    // storage of its own. The decode used to add three more on top of it.
+    // arena's own first growth) without having to know any of them. The one
+    // allocation per event is `fromRawMessage`'s block — these events carry
+    // no application properties, so the property map allocates no storage of
+    // its own, and a fixture that gave them some would make this 2. The
+    // decode used to add three more on top of it.
     const allocator = testing.allocator;
     var counting = CountingAllocator.init(allocator);
     const counted = counting.allocator();


### PR DESCRIPTION
Third and last of the decode-arena tranche, after #335 (driver-owned arena for every frame's performative) and #336 (`message.decodeInto`). Together they take the receive path from **9.0 to 4.0 allocations per received event**.

`decodeMessage` built a fresh arena per message that `fromRawMessage` immediately copied out of and discarded — three allocations per event (the arena struct and two pages) whose entire contents were dead by the time `receiveEvents` returned. `PartitionClient` now owns one arena, reset per event, and decodes into it with `amqp.decodeMessageInto`.

Nothing outlives the reset: `fromRawMessage` copies everything it keeps into its own block, which is the design P2.3 established.

## Measured

Scripted-peer receive benchmark, interleaved A/B, 3 rounds each, ReleaseFast:

| | before | after |
| --- | ---: | ---: |
| allocs/op (x1000) | 7063 | **4066** |
| per event | 7.0 | **4.0** |
| B/op | 2,160,432 | **1,122,616** |
| min ns | 1262624 / 1285369 / 1272148 | **1218949 / 1207300 / 1214712** |

Allocation and byte counts were identical in every round, and all three after-minima sit below all three before-minima.

`4066 - 57 = 4009`, `999 x 4 = 3996`, and the residual 13 are the credit-replenishment `flow` frames the x1000 case emits.

The remaining 4 are the amqp payload and delivery-tag dupes — both of which the caller reads — and `fromRawMessage`'s block and property-map storage.

## The cap

`retain_capacity` keeps the high-water mark for the life of the client, and a decode is not bounded by the frame that carried it: a map header costs two bytes and buys 48 of arena per entry. So one outsized event would pin megabytes. `retain_with_limit` at 256 KiB instead; below the limit it is byte-for-byte `retain_capacity`, so ordinary traffic pays nothing.

## Tests

Both verified against mutations restoring the actual prior code:

| test | mutation | result |
| --- | --- | --- |
| a batch costs the same whatever its size | per-message `decodeMessage` | marginal cost per event reads 128 where it expects 32, over batches of 4 and 36 |
| one outsized event does not pin the arena | `retain_capacity` | arena stays above the cap after an ordinary event follows an outsized one |

The second asserts the *size* (`queryCapacity`), not a symptom.

Also adds `pushChunkedEvent` to the test peer: `pushEvent` sends a single-frame transfer, so a body past the 512-byte spec-minimum frame fails with `error.FrameTooLarge`. The chunked version is the realistic path and exercises reassembly incidentally.

193 tests. No version change.


**Corrected after review.** The first version of that test counted only the client's own allocator, while `decodeMessage` charged its per-message arena to the *events* allocator — so it passed against the code it exists to rule out, and the 13-vs-109 figures originally quoted here came from a mutation that was not the actual prior code. One counting allocator now serves both, and the assertion is the **marginal** cost of an event, which cancels every fixed per-call cost without needing to know any of them.
