### PR TITLE
Service Bus: build on azure_sdk_amqp, add the message codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,51 @@ Azure Service Bus clients:
 - `ServiceBusReceiverClient`
 - `ServiceBusAdministrationClient`
 
-Release branch: `sdk/servicebus`. The package depends on
-`azure_sdk_core`, `azure_sdk_messaging_common`, `uamqp`, and `serde` and starts
-at `0.1.0`.
+Release branch: `sdk/servicebus`. The package depends on `azure_sdk_core`,
+`azure_sdk_messaging_common`, `azure_sdk_amqp`, and `serde`.
+
+Messaging runs over [`azure_sdk_amqp`](../../tree/sdk/amqp), the same AMQP 1.0
+stack Event Hubs uses, rather than over a second direct-`uamqp` transport. Both
+packages therefore share one connection driver, link implementation, prefetch
+credit window, and settlement path, and Service Bus inherits work done on
+either.
+
+Administration runs over the `azure_sdk_core` HTTP pipeline against the
+management REST API and is unrelated to the AMQP path.
+
+## Layout
+
+| file | what |
+| --- | --- |
+| `root.zig` | models, clients, and the AMQP transport interface |
+| `message.zig` | Service Bus ↔ AMQP message translation |
+| `admin.zig` | administration client and its Atom XML parsing |
+
+## Messages on the wire
+
+Service Bus keeps its broker metadata in ordinary AMQP places, so `message.zig`
+is a mapping rather than a codec:
+
+| Service Bus | AMQP |
+| --- | --- |
+| `message_id`, `correlation_id`, `content_type`, `subject`, `to`, `reply_to` | `properties` (§3.2.4) |
+| `session_id` | `properties.group-id` |
+| `time_to_live_ms` | `header.ttl` (§3.2.1) |
+| `partition_key` | annotation `x-opt-partition-key` |
+| `scheduled_enqueue_time` | annotation `x-opt-scheduled-enqueue-time` |
+| `sequence_number`, `enqueued_time`, `locked_until`, `dead_letter_source` | `x-opt-*` annotations |
+| `delivery_count` | `header.delivery-count` |
+| `dead_letter_reason`, `dead_letter_description` | application properties |
+
+Decoding **borrows**. Every slice on a `ServiceBusReceivedMessage` points into
+the AMQP message it came from, which points into the delivery payload, so a
+received message is valid exactly as long as its delivery is. Copy anything
+that must outlive it.
+
+Application properties are handed back as AMQP fields rather than as a map: a
+map would cost an allocation on every received message, and Service Bus allows
+typed values a string map could not hold. Read them with
+`applicationPropertyOf`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,14 @@ is a mapping rather than a codec:
 | `dead_letter_reason`, `dead_letter_description` | application properties |
 
 Decoding **borrows**. Every slice on a `ServiceBusReceivedMessage` points into
-the AMQP message it came from, which points into the delivery payload, so a
-received message is valid exactly as long as its delivery is. Copy anything
-that must outlive it.
+the arena its AMQP message was decoded into, and dies with that arena. It does
+*not* point into the delivery payload — the decoder dupes strings and binaries
+out of it — so keeping the payload bytes alive does not keep a received message
+valid. Copy anything that must outlive the arena.
+
+`delivery_count` is the Service Bus count, 1 on a first delivery, not the raw
+AMQP field that counts previous failures and is 0 there. It compares directly
+against `MaxDeliveryCount`.
 
 Application properties are handed back as AMQP fields rather than as a map: a
 map would cost an allocation on every received message, and Service Bus allows

--- a/admin.zig
+++ b/admin.zig
@@ -1,0 +1,460 @@
+//! Azure Service Bus administration — queues, topics, and subscriptions over
+//! the management REST API.
+//!
+//! Split from `root.zig` so the messaging path and the control path stay
+//! separately readable; the client is re-exported from the package root.
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const serde = @import("serde");
+
+// ─────────────── Administration Models ───────────────
+
+pub const QueueProperties = struct {
+    name: []const u8,
+    max_delivery_count: ?u32 = null,
+    lock_duration: ?[]const u8 = null,
+    max_size_in_megabytes: ?u32 = null,
+    requires_session: bool = false,
+    dead_lettering_on_message_expiration: bool = false,
+    default_message_time_to_live: ?[]const u8 = null,
+    status: ?[]const u8 = null,
+};
+
+pub const TopicProperties = struct {
+    name: []const u8,
+    max_size_in_megabytes: ?u32 = null,
+    requires_duplicate_detection: bool = false,
+    default_message_time_to_live: ?[]const u8 = null,
+    status: ?[]const u8 = null,
+};
+
+pub const SubscriptionProperties = struct {
+    name: []const u8,
+    topic_name: []const u8,
+    max_delivery_count: ?u32 = null,
+    lock_duration: ?[]const u8 = null,
+    requires_session: bool = false,
+    dead_lettering_on_message_expiration: bool = false,
+    default_message_time_to_live: ?[]const u8 = null,
+    status: ?[]const u8 = null,
+};
+
+// ─────────────── Administration Client ───────────────
+
+pub const AdministrationClientOptions = struct {
+    api_version: []const u8 = "2021-05",
+};
+
+/// Manages Service Bus queues, topics, and subscriptions via REST API.
+pub const ServiceBusAdministrationClient = struct {
+    fully_qualified_namespace: []const u8,
+    api_version: []const u8,
+    pipeline: core.pipeline.HttpPipeline,
+
+    pub fn init(
+        fully_qualified_namespace: []const u8,
+        credential: *core.credentials.TokenCredential,
+        transport: *core.http.HttpTransport,
+        options: AdministrationClientOptions,
+    ) ServiceBusAdministrationClient {
+        _ = credential;
+        return .{
+            .fully_qualified_namespace = fully_qualified_namespace,
+            .api_version = options.api_version,
+            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+        };
+    }
+
+    // ── Queue operations ──
+
+    pub fn createQueue(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.createQueueResult(allocator, name);
+        try r.unwrap(error.CreateQueueFailed);
+    }
+
+    /// Same as `createQueue` but returns `Result(void)`.
+    pub fn createQueueResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
+        const url = try self.buildEntityUrl(allocator, name);
+        defer allocator.free(url);
+
+        const body = try std.fmt.allocPrint(allocator,
+            \\<entry xmlns="http://www.w3.org/2005/Atom">
+            \\  <content type="application/xml">
+            \\    <QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"/>
+            \\  </content>
+            \\</entry>
+        , .{});
+        defer allocator.free(body);
+
+        var req = core.http.Request.init(allocator, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
+        req.body = body;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
+        }
+        return error.AzureRequestFailed;
+    }
+
+    pub fn deleteQueue(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.deleteQueueResult(allocator, name);
+        try r.unwrap(error.DeleteQueueFailed);
+    }
+
+    /// Same as `deleteQueue` but returns `Result(void)`.
+    pub fn deleteQueueResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
+        const url = try self.buildEntityUrl(allocator, name);
+        defer allocator.free(url);
+
+        var req = core.http.Request.init(allocator, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
+        }
+        return error.AzureRequestFailed;
+    }
+
+    pub fn listQueues(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) ![]QueueProperties {
+        var r = try self.listQueuesResult(allocator);
+        return r.unwrap(error.ListQueuesFailed);
+    }
+
+    /// Same as `listQueues` but returns `Result([]QueueProperties)`.
+    pub fn listQueuesResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) !core.errors.Result([]QueueProperties) {
+        const url = try std.fmt.allocPrint(allocator, "https://{s}/$Resources/queues?api-version={s}", .{ self.fully_qualified_namespace, self.api_version });
+        defer allocator.free(url);
+
+        var req = core.http.Request.init(allocator, .GET, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
+        }
+
+        return .{ .ok = try parseEntityNames(allocator, resp.body, "Queue") };
+    }
+
+    // ── Topic operations ──
+
+    pub fn createTopic(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.createTopicResult(allocator, name);
+        try r.unwrap(error.CreateTopicFailed);
+    }
+
+    /// Same as `createTopic` but returns `Result(void)`.
+    pub fn createTopicResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
+        const url = try self.buildEntityUrl(allocator, name);
+        defer allocator.free(url);
+
+        const body = try std.fmt.allocPrint(allocator,
+            \\<entry xmlns="http://www.w3.org/2005/Atom">
+            \\  <content type="application/xml">
+            \\    <TopicDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"/>
+            \\  </content>
+            \\</entry>
+        , .{});
+        defer allocator.free(body);
+
+        var req = core.http.Request.init(allocator, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
+        req.body = body;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
+        }
+        return error.AzureRequestFailed;
+    }
+
+    pub fn deleteTopic(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
+        var r = try self.deleteTopicResult(allocator, name);
+        try r.unwrap(error.DeleteTopicFailed);
+    }
+
+    /// Same as `deleteTopic` but returns `Result(void)`.
+    pub fn deleteTopicResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
+        const url = try self.buildEntityUrl(allocator, name);
+        defer allocator.free(url);
+
+        var req = core.http.Request.init(allocator, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
+        }
+        return error.AzureRequestFailed;
+    }
+
+    pub fn listTopics(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) ![]TopicProperties {
+        var r = try self.listTopicsResult(allocator);
+        return r.unwrap(error.ListTopicsFailed);
+    }
+
+    /// Same as `listTopics` but returns `Result([]TopicProperties)`.
+    pub fn listTopicsResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) !core.errors.Result([]TopicProperties) {
+        const url = try std.fmt.allocPrint(allocator, "https://{s}/$Resources/topics?api-version={s}", .{ self.fully_qualified_namespace, self.api_version });
+        defer allocator.free(url);
+
+        var req = core.http.Request.init(allocator, .GET, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
+        }
+
+        return .{ .ok = try parseEntityNames(allocator, resp.body, "Topic") };
+    }
+
+    // ── Subscription operations ──
+
+    pub fn createSubscription(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !void {
+        var r = try self.createSubscriptionResult(allocator, topic_name, subscription_name);
+        try r.unwrap(error.CreateSubscriptionFailed);
+    }
+
+    /// Same as `createSubscription` but returns `Result(void)`.
+    pub fn createSubscriptionResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !core.errors.Result(void) {
+        const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions/{s}?api-version={s}", .{ self.fully_qualified_namespace, topic_name, subscription_name, self.api_version });
+        defer allocator.free(url);
+
+        const body = try std.fmt.allocPrint(allocator,
+            \\<entry xmlns="http://www.w3.org/2005/Atom">
+            \\  <content type="application/xml">
+            \\    <SubscriptionDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"/>
+            \\  </content>
+            \\</entry>
+        , .{});
+        defer allocator.free(body);
+
+        var req = core.http.Request.init(allocator, .PUT, url);
+        defer req.deinit();
+        try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
+        req.body = body;
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
+        }
+        return error.AzureRequestFailed;
+    }
+
+    pub fn deleteSubscription(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !void {
+        var r = try self.deleteSubscriptionResult(allocator, topic_name, subscription_name);
+        try r.unwrap(error.DeleteSubscriptionFailed);
+    }
+
+    /// Same as `deleteSubscription` but returns `Result(void)`.
+    pub fn deleteSubscriptionResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !core.errors.Result(void) {
+        const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions/{s}?api-version={s}", .{ self.fully_qualified_namespace, topic_name, subscription_name, self.api_version });
+        defer allocator.free(url);
+
+        var req = core.http.Request.init(allocator, .DELETE, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (resp.isSuccess()) return .{ .ok = {} };
+        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+            return .{ .err = az_err };
+        }
+        return error.AzureRequestFailed;
+    }
+
+    pub fn listSubscriptions(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8) ![]SubscriptionProperties {
+        var r = try self.listSubscriptionsResult(allocator, topic_name);
+        return r.unwrap(error.ListSubscriptionsFailed);
+    }
+
+    /// Same as `listSubscriptions` but returns `Result([]SubscriptionProperties)`.
+    pub fn listSubscriptionsResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8) !core.errors.Result([]SubscriptionProperties) {
+        const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions?api-version={s}", .{ self.fully_qualified_namespace, topic_name, self.api_version });
+        defer allocator.free(url);
+
+        var req = core.http.Request.init(allocator, .GET, url);
+        defer req.deinit();
+
+        var resp = try self.pipeline.send(&req);
+        defer resp.deinit();
+
+        if (!resp.isSuccess()) {
+            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
+                return .{ .err = az_err };
+            }
+            return error.AzureRequestFailed;
+        }
+
+        return .{ .ok = try parseSubscriptionNames(allocator, resp.body, topic_name) };
+    }
+
+    fn buildEntityUrl(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+        return std.fmt.allocPrint(allocator, "https://{s}/{s}?api-version={s}", .{ self.fully_qualified_namespace, name, self.api_version });
+    }
+};
+
+// ─────────────────── Atom XML Parsing ────────────────
+
+const AtomEntrySchema = struct {
+    title: []const u8,
+};
+
+const AtomFeedSchema = struct {
+    entry: ?[]const AtomEntrySchema = null,
+};
+
+/// Parse entity names from Atom feed response.
+fn parseEntityNames(allocator: std.mem.Allocator, body: []const u8, comptime entity_type: []const u8) !switch (entity_type.len) {
+    5 => []QueueProperties,
+    else => []TopicProperties,
+} {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const parsed = serde.xml.fromSlice(AtomFeedSchema, arena.allocator(), body) catch {
+        if (entity_type.len == 5)
+            return allocator.alloc(QueueProperties, 0)
+        else
+            return allocator.alloc(TopicProperties, 0);
+    };
+
+    const entries = parsed.entry orelse {
+        if (entity_type.len == 5)
+            return allocator.alloc(QueueProperties, 0)
+        else
+            return allocator.alloc(TopicProperties, 0);
+    };
+
+    if (entity_type.len == 5) { // "Queue"
+        var result = try allocator.alloc(QueueProperties, entries.len);
+        for (entries, 0..) |e, i| {
+            result[i] = .{ .name = try allocator.dupe(u8, e.title) };
+        }
+        return result;
+    } else { // "Topic"
+        var result = try allocator.alloc(TopicProperties, entries.len);
+        for (entries, 0..) |e, i| {
+            result[i] = .{ .name = try allocator.dupe(u8, e.title) };
+        }
+        return result;
+    }
+}
+
+fn parseSubscriptionNames(allocator: std.mem.Allocator, body: []const u8, topic_name: []const u8) ![]SubscriptionProperties {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const parsed = serde.xml.fromSlice(AtomFeedSchema, arena.allocator(), body) catch
+        return allocator.alloc(SubscriptionProperties, 0);
+    const entries = parsed.entry orelse return allocator.alloc(SubscriptionProperties, 0);
+
+    var result = try allocator.alloc(SubscriptionProperties, entries.len);
+    for (entries, 0..) |e, i| {
+        result[i] = .{ .name = try allocator.dupe(u8, e.title), .topic_name = topic_name };
+    }
+    return result;
+}
+
+// ───────────────────── Tests ─────────────────────
+
+test "AdministrationClient createQueue" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
+    defer mock.deinit();
+    const identity = @import("azure_sdk_core").identity;
+    var cred_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer cred_mock.deinit();
+    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    try admin.createQueue(allocator, "testqueue");
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "testqueue") != null);
+    try std.testing.expectEqual(core.http.Method.PUT, mock.last_method.?);
+}
+
+test "AdministrationClient deleteQueue" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "");
+    defer mock.deinit();
+    const identity = @import("azure_sdk_core").identity;
+    var cred_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer cred_mock.deinit();
+    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    try admin.deleteQueue(allocator, "testqueue");
+    try std.testing.expectEqual(core.http.Method.DELETE, mock.last_method.?);
+}
+
+test "AdministrationClient listQueues" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>queue1</title></entry><entry><title>queue2</title></entry></feed>
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+    const identity = @import("azure_sdk_core").identity;
+    var cred_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer cred_mock.deinit();
+    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    const queues = try admin.listQueues(allocator);
+    defer {
+        for (queues) |q| allocator.free(q.name);
+        allocator.free(queues);
+    }
+    try std.testing.expectEqual(@as(usize, 2), queues.len);
+    try std.testing.expectEqualStrings("queue1", queues[0].name);
+    try std.testing.expectEqualStrings("queue2", queues[1].name);
+}
+
+test "AdministrationClient createSubscription" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
+    defer mock.deinit();
+    const identity = @import("azure_sdk_core").identity;
+    var cred_mock = core.http.MockTransport.init(allocator, 200,
+        \\{"access_token":"t","expires_in":3600}
+    );
+    defer cred_mock.deinit();
+    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    try admin.createSubscription(allocator, "mytopic", "mysub");
+    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mytopic/subscriptions/mysub") != null);
+}

--- a/build.zig
+++ b/build.zig
@@ -16,11 +16,11 @@ pub fn build(b: *std.Build) void {
     });
     const common_mod = common_dep.module("azure_sdk_messaging_common");
 
-    const uamqp_dep = b.dependency("uamqp", .{});
-    const uamqp_mod = b.createModule(.{
-        .root_source_file = uamqp_dep.path("src/zig/uamqp.zig"),
+    const amqp_dep = b.dependency("azure_sdk_amqp", .{
         .target = target,
+        .optimize = optimize,
     });
+    const amqp_mod = amqp_dep.module("azure_sdk_amqp");
 
     const serde_dep = b.dependency("serde", .{
         .target = target,
@@ -28,15 +28,17 @@ pub fn build(b: *std.Build) void {
     });
     const serde_mod = serde_dep.module("serde");
 
+    const imports = [_]std.Build.Module.Import{
+        .{ .name = "azure_sdk_core", .module = core_mod },
+        .{ .name = "azure_sdk_messaging_common", .module = common_mod },
+        .{ .name = "azure_sdk_amqp", .module = amqp_mod },
+        .{ .name = "serde", .module = serde_mod },
+    };
+
     _ = b.addModule("azure_sdk_servicebus", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
-        .imports = &.{
-            .{ .name = "azure_sdk_core", .module = core_mod },
-            .{ .name = "azure_sdk_messaging_common", .module = common_mod },
-            .{ .name = "uamqp", .module = uamqp_mod },
-            .{ .name = "serde", .module = serde_mod },
-        },
+        .imports = &imports,
     });
 
     const tests = b.addTest(.{
@@ -44,12 +46,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("root.zig"),
             .target = target,
             .optimize = optimize,
-            .imports = &.{
-                .{ .name = "azure_sdk_core", .module = core_mod },
-                .{ .name = "azure_sdk_messaging_common", .module = common_mod },
-                .{ .name = "uamqp", .module = uamqp_mod },
-                .{ .name = "serde", .module = serde_mod },
-            },
+            .imports = &imports,
         }),
     });
     const test_step = b.step("test", "Run Service Bus tests");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,20 +5,20 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
         .azure_sdk_messaging_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#51c5ec8e181abd59a0f8180fc4c37b9ddc8a2bcb",
-            .hash = "azure_sdk_messaging_common-0.1.0-YklmSnoYAACqhTFKLjL7ZX1jSngsgJRYKAhYkgx4J_RU",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#381b11a05c271b66d6496f9fc3aa9c1633a3c5aa",
+            .hash = "azure_sdk_messaging_common-0.2.0-YklmSkWIAADy4QHeNJAVUdRq-xKFeRx75G1TjE5lMeHR",
         },
-        .uamqp = .{
-            .url = "git+https://github.com/cataggar/azure-uamqp-zig#1121d1e68dde8d188516083555cc7e1553b0f595",
-            .hash = "uamqp-0.1.0-lXMcafDqAQD3LSUZbUbyfrWhQfGG7OevKFUwhWxvGZDU",
+        .azure_sdk_amqp = .{
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b0bf347c4da5ccb9cb63772011c98a769d838f74",
+            .hash = "azure_sdk_amqp-0.4.0-fUByf6x_BgAoO05o4uHh89hyi9PiEKQzfvtT4ucPs-Ts",
         },
         .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
-            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+            .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
+            .hash = "serde-1.0.1-1DszT1XhDACnteUU3yWahMMjLjkJqB34hwROPIfhZc7l",
         },
     },
     .paths = .{
@@ -26,6 +26,8 @@
         "build.zig",
         "build.zig.zon",
         "root.zig",
+        "message.zig",
+        "admin.zig",
         "README.md",
         "LICENSE.txt",
     },

--- a/message.zig
+++ b/message.zig
@@ -62,6 +62,11 @@ pub const max_outgoing_annotations = 2;
 /// Keeping it out here is what lets a message with no application properties
 /// encode without allocating at all — the case that dominates, and the one a
 /// per-message `StringHashMap` would have taxed.
+///
+/// **One message at a time.** Each `toAmqpMessage` overwrites the annotations
+/// and body in place and frees the property array, so the message the
+/// previous call returned is dead. Encode it before building the next, or
+/// use a second `Scratch`.
 pub const Scratch = struct {
     annotations: [max_outgoing_annotations]MapEntry = undefined,
     /// The one-element slice the body's data section is built from.
@@ -236,7 +241,10 @@ pub fn fromAmqpMessage(msg: amqp.Message) ServiceBusReceivedMessage {
         // first delivery; Service Bus's `DeliveryCount` — the number
         // `MaxDeliveryCount` is compared against — is 1. Add one so the
         // obvious comparison is right, matching the Go and .NET SDKs.
-        // A peeked message keeps the raw value, since it was never delivered.
+        //
+        // This applies to peeked messages too, as Go does; .NET instead
+        // gives a peek the raw value. A peek path that wants that has to
+        // read `header.delivery_count` itself — there is no flag here.
         .delivery_count = if (msg.header.delivery_count) |d| d +| 1 else null,
         .dead_letter_source = textAnnotation(annotations, annotation.dead_letter_source),
         .dead_letter_reason = textAnnotation(properties, application_property.dead_letter_reason),

--- a/message.zig
+++ b/message.zig
@@ -1,0 +1,466 @@
+//! Service Bus ↔ AMQP 1.0 message translation.
+//!
+//! Service Bus carries its broker metadata in ordinary AMQP places: the bare
+//! message's `properties` section, the `header`'s delivery count, and a set of
+//! `x-opt-*` message annotations. This module is only that mapping —
+//! `azure_sdk_amqp` owns the wire codec.
+//!
+//! The decode side **borrows**: every slice on a `ServiceBusReceivedMessage`
+//! points into the `amqp.Message` it came from, which in turn points into the
+//! delivery payload. Nothing here allocates on decode, so a caller that needs
+//! a message to outlive its delivery must copy it.
+
+const std = @import("std");
+const amqp = @import("azure_sdk_amqp");
+const sb = @import("root.zig");
+
+const Allocator = std.mem.Allocator;
+const AmqpValue = amqp.AmqpValue;
+const MapEntry = amqp.MapEntry;
+/// A symbol-keyed AMQP map, as annotations and application properties arrive.
+pub const Fields = amqp.message_codec.Fields;
+
+const ServiceBusMessage = sb.ServiceBusMessage;
+const ServiceBusReceivedMessage = sb.ServiceBusReceivedMessage;
+
+pub const EncodeError = amqp.message_codec.EncodeError || error{TimeToLiveOutOfRange};
+
+/// Message-annotation keys Service Bus reads and writes.
+///
+/// Annotation keys go on the wire as symbols, but a broker or emulator may
+/// send them as strings, so `annotationOf` matches on the text either way.
+pub const annotation = struct {
+    pub const partition_key = "x-opt-partition-key";
+    pub const scheduled_enqueue_time = "x-opt-scheduled-enqueue-time";
+    pub const sequence_number = "x-opt-sequence-number";
+    pub const enqueued_time = "x-opt-enqueued-time";
+    pub const locked_until = "x-opt-locked-until";
+    pub const dead_letter_source = "x-opt-deadletter-source";
+};
+
+/// Application-property keys the broker sets on a dead-lettered message.
+pub const application_property = struct {
+    pub const dead_letter_reason = "DeadLetterReason";
+    pub const dead_letter_description = "DeadLetterErrorDescription";
+};
+
+/// The most annotations `toAmqpMessage` can produce, so the array backing them
+/// can live on the caller's stack rather than the heap.
+///
+/// Sized exactly, not generously: slack here would let an off-by-one in the
+/// write loop go unnoticed. Raise it in the same change that adds an
+/// annotation.
+pub const max_outgoing_annotations = 2;
+
+/// Scratch a caller lends to `toAmqpMessage` for the sections it must build.
+///
+/// The returned message borrows from this, so it has to outlive the message.
+/// Keeping it out here is what lets a message with no application properties
+/// encode without allocating at all — the case that dominates, and the one a
+/// per-message `StringHashMap` would have taxed.
+pub const Scratch = struct {
+    annotations: [max_outgoing_annotations]MapEntry = undefined,
+    /// The one-element slice the body's data section is built from.
+    ///
+    /// `toAmqpMessage` takes its message by value, so a `data` section
+    /// pointing at that copy's `body` field would dangle the moment it
+    /// returned. The section lives here instead, alongside the caller.
+    body: [1][]const u8 = undefined,
+    properties: []MapEntry = &.{},
+    allocator: ?Allocator = null,
+
+    pub fn deinit(self: *Scratch) void {
+        if (self.allocator) |allocator| allocator.free(self.properties);
+        self.properties = &.{};
+        self.allocator = null;
+    }
+};
+
+/// Build the AMQP message for `msg`, borrowing its strings and `scratch`.
+pub fn toAmqpMessage(
+    allocator: Allocator,
+    msg: ServiceBusMessage,
+    scratch: *Scratch,
+) EncodeError!amqp.Message {
+    var count: usize = 0;
+    if (msg.partition_key) |key| {
+        scratch.annotations[count] = .{
+            .key = .{ .symbol = annotation.partition_key },
+            .value = .{ .string = key },
+        };
+        count += 1;
+    }
+    if (msg.scheduled_enqueue_time) |at| {
+        scratch.annotations[count] = .{
+            .key = .{ .symbol = annotation.scheduled_enqueue_time },
+            .value = .{ .timestamp = at },
+        };
+        count += 1;
+    }
+
+    const property_count = msg.application_properties.count();
+    if (property_count > 0) {
+        const entries = try allocator.alloc(MapEntry, property_count);
+        scratch.properties = entries;
+        scratch.allocator = allocator;
+        var it = msg.application_properties.iterator();
+        var i: usize = 0;
+        while (it.next()) |entry| : (i += 1) {
+            entries[i] = .{
+                .key = .{ .string = entry.key_ptr.* },
+                .value = .{ .string = entry.value_ptr.* },
+            };
+        }
+    }
+
+    // §3.2.1 states `ttl` in milliseconds as a `uint`, so a negative or
+    // oversized lifetime has no representation and is rejected rather than
+    // wrapped into a lifetime the caller did not ask for.
+    const ttl: ?u32 = if (msg.time_to_live_ms) |ms| blk: {
+        if (ms < 0) return error.TimeToLiveOutOfRange;
+        break :blk std.math.cast(u32, ms) orelse return error.TimeToLiveOutOfRange;
+    } else null;
+
+    scratch.body[0] = msg.body;
+
+    return .{
+        .header = .{ .ttl = ttl },
+        .message_annotations = if (count > 0) scratch.annotations[0..count] else null,
+        .properties = .{
+            .message_id = if (msg.message_id) |id| .{ .string = id } else null,
+            .to = msg.to,
+            .subject = msg.subject,
+            .reply_to = msg.reply_to,
+            .correlation_id = if (msg.correlation_id) |id| .{ .string = id } else null,
+            .content_type = msg.content_type,
+            .group_id = msg.session_id,
+        },
+        .application_properties = if (property_count > 0) scratch.properties else null,
+        .body = .{ .data = &scratch.body },
+    };
+}
+
+/// Encode `msg` as the bare AMQP message bytes of one transfer.
+///
+/// One allocation for the encoded bytes, plus one more only when the message
+/// carries application properties.
+pub fn encode(allocator: Allocator, msg: ServiceBusMessage) EncodeError![]u8 {
+    var scratch: Scratch = .{};
+    defer scratch.deinit();
+    const amqp_msg = try toAmqpMessage(allocator, msg, &scratch);
+    return amqp.encodeMessageAlloc(allocator, amqp_msg);
+}
+
+/// The text of a string or symbol value, or null for anything else.
+///
+/// Service Bus sends string ids, but §3.2.4 also allows a uuid, ulong or
+/// binary `message-id`. Rendering those would mean allocating, which this
+/// module does not do, so they read as absent rather than as a wrong answer.
+pub fn textOf(value: AmqpValue) ?[]const u8 {
+    return switch (value) {
+        .string, .symbol => |s| s,
+        else => null,
+    };
+}
+
+/// Look up an annotation by name, accepting a symbol or string key.
+pub fn annotationOf(fields: ?Fields, name: []const u8) ?AmqpValue {
+    return lookup(fields, name);
+}
+
+/// Look up an application property by name.
+pub fn applicationPropertyOf(fields: ?Fields, name: []const u8) ?AmqpValue {
+    return lookup(fields, name);
+}
+
+fn lookup(fields: ?Fields, name: []const u8) ?AmqpValue {
+    const entries = fields orelse return null;
+    for (entries) |entry| {
+        const key = textOf(entry.key) orelse continue;
+        if (std.mem.eql(u8, key, name)) return entry.value;
+    }
+    return null;
+}
+
+fn timestampOf(value: ?AmqpValue) ?i64 {
+    const v = value orelse return null;
+    return switch (v) {
+        .timestamp, .long => |t| t,
+        else => null,
+    };
+}
+
+fn textAnnotation(fields: ?Fields, name: []const u8) ?[]const u8 {
+    const v = lookup(fields, name) orelse return null;
+    return textOf(v);
+}
+
+/// Read a received message out of a decoded AMQP message.
+///
+/// Every slice borrows from `msg`, so the result is valid exactly as long as
+/// `msg` is — which for a receive path means until the next `receive`.
+pub fn fromAmqpMessage(msg: amqp.Message) ServiceBusReceivedMessage {
+    const annotations = msg.message_annotations;
+    const properties = msg.application_properties;
+
+    return .{
+        .body = switch (msg.body) {
+            .data => |sections| if (sections.len > 0) sections[0] else "",
+            else => "",
+        },
+        .content_type = msg.properties.content_type,
+        .message_id = if (msg.properties.message_id) |id| textOf(id) else null,
+        .session_id = msg.properties.group_id,
+        .correlation_id = if (msg.properties.correlation_id) |id| textOf(id) else null,
+        .subject = msg.properties.subject,
+        .to = msg.properties.to,
+        .reply_to = msg.properties.reply_to,
+        .sequence_number = switch (lookup(annotations, annotation.sequence_number) orelse AmqpValue.null) {
+            .long, .timestamp => |n| n,
+            .int => |n| n,
+            else => null,
+        },
+        .enqueued_time = timestampOf(lookup(annotations, annotation.enqueued_time)),
+        .locked_until = timestampOf(lookup(annotations, annotation.locked_until)),
+        .partition_key = textAnnotation(annotations, annotation.partition_key),
+        .delivery_count = msg.header.delivery_count,
+        .dead_letter_source = textAnnotation(annotations, annotation.dead_letter_source),
+        .dead_letter_reason = textAnnotation(properties, application_property.dead_letter_reason),
+        .dead_letter_description = textAnnotation(properties, application_property.dead_letter_description),
+        .application_properties = properties,
+    };
+}
+
+// ─────────────────────── Tests ───────────────────────
+
+const testing = std.testing;
+
+test "building the AMQP message allocates only for application properties" {
+    const allocator = testing.allocator;
+
+    // `toAmqpMessage`, not `encode`: the encoder grows its output buffer, so
+    // an allocation count taken around `encode` measures uamqp's doubling
+    // series rather than anything this module decides. What this module
+    // decides is that the annotations ride on the caller's stack and only the
+    // application-property array reaches the heap.
+    var plain = ServiceBusMessage.init(allocator, "hello");
+    defer plain.deinit();
+    plain.partition_key = "pk";
+    plain.scheduled_enqueue_time = 1_700_000_000_000;
+
+    var counting = CountingAllocator.init(allocator);
+    var scratch: Scratch = .{};
+    _ = try toAmqpMessage(counting.allocator(), plain, &scratch);
+    scratch.deinit();
+    try testing.expectEqual(@as(usize, 0), counting.allocs);
+
+    var with_properties = ServiceBusMessage.init(allocator, "hello");
+    defer with_properties.deinit();
+    try with_properties.application_properties.put("tenant", "contoso");
+    try with_properties.application_properties.put("region", "westus");
+
+    counting = CountingAllocator.init(allocator);
+    var scratch2: Scratch = .{};
+    _ = try toAmqpMessage(counting.allocator(), with_properties, &scratch2);
+    scratch2.deinit();
+    try testing.expectEqual(@as(usize, 1), counting.allocs);
+}
+
+test "the standard properties round-trip through the wire" {
+    const allocator = testing.allocator;
+
+    var msg = ServiceBusMessage.init(allocator, "payload");
+    defer msg.deinit();
+    msg.message_id = "m-1";
+    msg.correlation_id = "c-1";
+    msg.content_type = "text/plain";
+    msg.subject = "greetings";
+    msg.to = "somewhere";
+    msg.reply_to = "back-here";
+    msg.session_id = "session-7";
+    msg.time_to_live_ms = 30_000;
+
+    const bytes = try encode(allocator, msg);
+    defer allocator.free(bytes);
+
+    var decoded = try amqp.decodeMessage(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = fromAmqpMessage(decoded.message);
+    try testing.expectEqualStrings("payload", got.body);
+    try testing.expectEqualStrings("m-1", got.message_id.?);
+    try testing.expectEqualStrings("c-1", got.correlation_id.?);
+    try testing.expectEqualStrings("text/plain", got.content_type.?);
+    try testing.expectEqualStrings("greetings", got.subject.?);
+    try testing.expectEqualStrings("somewhere", got.to.?);
+    try testing.expectEqualStrings("back-here", got.reply_to.?);
+    try testing.expectEqualStrings("session-7", got.session_id.?);
+    try testing.expectEqual(@as(?u32, 30_000), decoded.message.header.ttl);
+}
+
+test "partition key and scheduled time go into message annotations" {
+    const allocator = testing.allocator;
+
+    var msg = ServiceBusMessage.init(allocator, "payload");
+    defer msg.deinit();
+    msg.partition_key = "pk-3";
+    msg.scheduled_enqueue_time = 1_700_000_000_000;
+
+    const bytes = try encode(allocator, msg);
+    defer allocator.free(bytes);
+
+    var decoded = try amqp.decodeMessage(allocator, bytes);
+    defer decoded.deinit();
+
+    const annotations = decoded.message.message_annotations;
+    try testing.expectEqualStrings(
+        "pk-3",
+        textOf(annotationOf(annotations, annotation.partition_key).?).?,
+    );
+    try testing.expectEqual(
+        @as(i64, 1_700_000_000_000),
+        annotationOf(annotations, annotation.scheduled_enqueue_time).?.timestamp,
+    );
+}
+
+test "application properties round-trip" {
+    const allocator = testing.allocator;
+
+    var msg = ServiceBusMessage.init(allocator, "payload");
+    defer msg.deinit();
+    try msg.application_properties.put("tenant", "contoso");
+
+    const bytes = try encode(allocator, msg);
+    defer allocator.free(bytes);
+
+    var decoded = try amqp.decodeMessage(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = fromAmqpMessage(decoded.message);
+    try testing.expectEqualStrings(
+        "contoso",
+        textOf(applicationPropertyOf(got.application_properties, "tenant").?).?,
+    );
+}
+
+test "an out-of-range time to live is refused rather than wrapped" {
+    const allocator = testing.allocator;
+
+    var msg = ServiceBusMessage.init(allocator, "payload");
+    defer msg.deinit();
+
+    msg.time_to_live_ms = -1;
+    try testing.expectError(error.TimeToLiveOutOfRange, encode(allocator, msg));
+
+    msg.time_to_live_ms = @as(i64, std.math.maxInt(u32)) + 1;
+    try testing.expectError(error.TimeToLiveOutOfRange, encode(allocator, msg));
+
+    msg.time_to_live_ms = std.math.maxInt(u32);
+    const bytes = try encode(allocator, msg);
+    allocator.free(bytes);
+}
+
+test "broker metadata is read from the annotations, header and properties" {
+    const allocator = testing.allocator;
+
+    const annotations = [_]MapEntry{
+        .{ .key = .{ .symbol = annotation.sequence_number }, .value = .{ .long = 42 } },
+        .{ .key = .{ .symbol = annotation.enqueued_time }, .value = .{ .timestamp = 1_700_000_000_000 } },
+        .{ .key = .{ .symbol = annotation.locked_until }, .value = .{ .timestamp = 1_700_000_030_000 } },
+        .{ .key = .{ .symbol = annotation.dead_letter_source }, .value = .{ .string = "orders" } },
+        .{ .key = .{ .symbol = annotation.partition_key }, .value = .{ .string = "pk-9" } },
+    };
+    const properties = [_]MapEntry{
+        .{ .key = .{ .string = application_property.dead_letter_reason }, .value = .{ .string = "MaxDeliveryCountExceeded" } },
+        .{ .key = .{ .string = application_property.dead_letter_description }, .value = .{ .string = "tried ten times" } },
+    };
+
+    const bytes = try amqp.encodeMessageAlloc(allocator, .{
+        .header = .{ .delivery_count = 10 },
+        .message_annotations = &annotations,
+        .application_properties = &properties,
+        .body = .{ .data = &.{"dead"} },
+    });
+    defer allocator.free(bytes);
+
+    var decoded = try amqp.decodeMessage(allocator, bytes);
+    defer decoded.deinit();
+
+    const got = fromAmqpMessage(decoded.message);
+    try testing.expectEqual(@as(?i64, 42), got.sequence_number);
+    try testing.expectEqual(@as(?i64, 1_700_000_000_000), got.enqueued_time);
+    try testing.expectEqual(@as(?i64, 1_700_000_030_000), got.locked_until);
+    try testing.expectEqual(@as(?u32, 10), got.delivery_count);
+    try testing.expectEqualStrings("orders", got.dead_letter_source.?);
+    try testing.expectEqualStrings("pk-9", got.partition_key.?);
+    try testing.expectEqualStrings("MaxDeliveryCountExceeded", got.dead_letter_reason.?);
+    try testing.expectEqualStrings("tried ten times", got.dead_letter_description.?);
+}
+
+test "a string-keyed annotation reads the same as a symbol-keyed one" {
+    const annotations = [_]MapEntry{
+        .{ .key = .{ .string = annotation.sequence_number }, .value = .{ .long = 7 } },
+    };
+    const got = fromAmqpMessage(.{ .message_annotations = &annotations });
+    try testing.expectEqual(@as(?i64, 7), got.sequence_number);
+}
+
+test "a non-text message id reads as absent rather than as wrong text" {
+    const got = fromAmqpMessage(.{
+        .properties = .{ .message_id = .{ .ulong = 9 } },
+        .body = .{ .data = &.{"x"} },
+    });
+    try testing.expectEqual(@as(?[]const u8, null), got.message_id);
+}
+
+test "a message with no body decodes to an empty body" {
+    const empty = fromAmqpMessage(.{});
+    try testing.expectEqualStrings("", empty.body);
+
+    // A `data` body with no sections is legal on the wire and is what an
+    // index straight into `sections[0]` would panic on.
+    const no_sections = fromAmqpMessage(.{ .body = .{ .data = &.{} } });
+    try testing.expectEqualStrings("", no_sections.body);
+}
+
+/// Counts allocations so a test can assert the cost of a call rather than
+/// merely that it worked.
+const CountingAllocator = struct {
+    child: Allocator,
+    allocs: usize = 0,
+
+    fn init(child: Allocator) CountingAllocator {
+        return .{ .child = child };
+    }
+
+    fn allocator(self: *CountingAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        const p = self.child.rawAlloc(len, alignment, ra);
+        if (p != null) self.allocs += 1;
+        return p;
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawResize(buf, alignment, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawRemap(buf, alignment, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.child.rawFree(buf, alignment, ra);
+    }
+};

--- a/message.zig
+++ b/message.zig
@@ -6,9 +6,13 @@
 //! `azure_sdk_amqp` owns the wire codec.
 //!
 //! The decode side **borrows**: every slice on a `ServiceBusReceivedMessage`
-//! points into the `amqp.Message` it came from, which in turn points into the
-//! delivery payload. Nothing here allocates on decode, so a caller that needs
-//! a message to outlive its delivery must copy it.
+//! points into the arena its `amqp.Message` was decoded into, and dies when
+//! that arena does — at `Decoded.deinit`, or at the reset if the receive path
+//! uses `decodeMessageInto`. It does *not* borrow from the delivery payload:
+//! `azure_sdk_amqp`'s decoder dupes strings and binaries into the arena, so
+//! holding the payload bytes alive does not keep a received message valid.
+//! Nothing here allocates on decode, so a caller that needs a message to
+//! outlive its arena must copy it.
 
 const std = @import("std");
 const amqp = @import("azure_sdk_amqp");
@@ -77,11 +81,16 @@ pub const Scratch = struct {
 };
 
 /// Build the AMQP message for `msg`, borrowing its strings and `scratch`.
+///
+/// Releases anything `scratch` held from a previous call, so one `Scratch`
+/// can be hoisted out of a send loop — which is the point of it existing.
 pub fn toAmqpMessage(
     allocator: Allocator,
     msg: ServiceBusMessage,
     scratch: *Scratch,
 ) EncodeError!amqp.Message {
+    scratch.deinit();
+
     var count: usize = 0;
     if (msg.partition_key) |key| {
         scratch.annotations[count] = .{
@@ -223,7 +232,12 @@ pub fn fromAmqpMessage(msg: amqp.Message) ServiceBusReceivedMessage {
         .enqueued_time = timestampOf(lookup(annotations, annotation.enqueued_time)),
         .locked_until = timestampOf(lookup(annotations, annotation.locked_until)),
         .partition_key = textAnnotation(annotations, annotation.partition_key),
-        .delivery_count = msg.header.delivery_count,
+        // §3.2.1 counts *previous unsuccessful* attempts, so it is 0 on a
+        // first delivery; Service Bus's `DeliveryCount` — the number
+        // `MaxDeliveryCount` is compared against — is 1. Add one so the
+        // obvious comparison is right, matching the Go and .NET SDKs.
+        // A peeked message keeps the raw value, since it was never delivered.
+        .delivery_count = if (msg.header.delivery_count) |d| d +| 1 else null,
         .dead_letter_source = textAnnotation(annotations, annotation.dead_letter_source),
         .dead_letter_reason = textAnnotation(properties, application_property.dead_letter_reason),
         .dead_letter_description = textAnnotation(properties, application_property.dead_letter_description),
@@ -286,6 +300,22 @@ test "the standard properties round-trip through the wire" {
     var decoded = try amqp.decodeMessage(allocator, bytes);
     defer decoded.deinit();
 
+    // Assert against the AMQP sections directly, not through
+    // `fromAmqpMessage`. Reading a value back through this module's own
+    // mapping proves only that encode and decode agree with each other: a
+    // wrong-but-symmetric mapping (`session_id` to `reply-to-group-id`, say,
+    // which silently disables session-enabled queues) passes such a test.
+    const props = decoded.message.properties;
+    try testing.expectEqualStrings("m-1", props.message_id.?.string);
+    try testing.expectEqualStrings("c-1", props.correlation_id.?.string);
+    try testing.expectEqualStrings("text/plain", props.content_type.?);
+    try testing.expectEqualStrings("greetings", props.subject.?);
+    try testing.expectEqualStrings("somewhere", props.to.?);
+    try testing.expectEqualStrings("back-here", props.reply_to.?);
+    try testing.expectEqualStrings("session-7", props.group_id.?);
+    try testing.expectEqual(@as(?[]const u8, null), props.reply_to_group_id);
+    try testing.expectEqual(@as(?u32, 30_000), decoded.message.header.ttl);
+
     const got = fromAmqpMessage(decoded.message);
     try testing.expectEqualStrings("payload", got.body);
     try testing.expectEqualStrings("m-1", got.message_id.?);
@@ -295,7 +325,6 @@ test "the standard properties round-trip through the wire" {
     try testing.expectEqualStrings("somewhere", got.to.?);
     try testing.expectEqualStrings("back-here", got.reply_to.?);
     try testing.expectEqualStrings("session-7", got.session_id.?);
-    try testing.expectEqual(@as(?u32, 30_000), decoded.message.header.ttl);
 }
 
 test "partition key and scheduled time go into message annotations" {
@@ -313,14 +342,30 @@ test "partition key and scheduled time go into message annotations" {
     defer decoded.deinit();
 
     const annotations = decoded.message.message_annotations;
+    // Literal keys, not the module's constants: these strings are the
+    // contract with the broker, and a test that reads them back through the
+    // same constant it wrote cannot tell a right key from a wrong one.
     try testing.expectEqualStrings(
         "pk-3",
-        textOf(annotationOf(annotations, annotation.partition_key).?).?,
+        textOf(annotationOf(annotations, "x-opt-partition-key").?).?,
     );
     try testing.expectEqual(
         @as(i64, 1_700_000_000_000),
-        annotationOf(annotations, annotation.scheduled_enqueue_time).?.timestamp,
+        annotationOf(annotations, "x-opt-scheduled-enqueue-time").?.timestamp,
     );
+}
+
+test "the annotation and property keys are the ones the broker uses" {
+    // Pinned against the Go SDK's azservicebus/message.go. A typo in any of
+    // these is silent data loss that every round-trip test would still pass.
+    try testing.expectEqualStrings("x-opt-partition-key", annotation.partition_key);
+    try testing.expectEqualStrings("x-opt-scheduled-enqueue-time", annotation.scheduled_enqueue_time);
+    try testing.expectEqualStrings("x-opt-sequence-number", annotation.sequence_number);
+    try testing.expectEqualStrings("x-opt-enqueued-time", annotation.enqueued_time);
+    try testing.expectEqualStrings("x-opt-locked-until", annotation.locked_until);
+    try testing.expectEqualStrings("x-opt-deadletter-source", annotation.dead_letter_source);
+    try testing.expectEqualStrings("DeadLetterReason", application_property.dead_letter_reason);
+    try testing.expectEqualStrings("DeadLetterErrorDescription", application_property.dead_letter_description);
 }
 
 test "application properties round-trip" {
@@ -390,7 +435,7 @@ test "broker metadata is read from the annotations, header and properties" {
     try testing.expectEqual(@as(?i64, 42), got.sequence_number);
     try testing.expectEqual(@as(?i64, 1_700_000_000_000), got.enqueued_time);
     try testing.expectEqual(@as(?i64, 1_700_000_030_000), got.locked_until);
-    try testing.expectEqual(@as(?u32, 10), got.delivery_count);
+    try testing.expectEqual(@as(?u32, 11), got.delivery_count);
     try testing.expectEqualStrings("orders", got.dead_letter_source.?);
     try testing.expectEqualStrings("pk-9", got.partition_key.?);
     try testing.expectEqualStrings("MaxDeliveryCountExceeded", got.dead_letter_reason.?);
@@ -421,6 +466,50 @@ test "a message with no body decodes to an empty body" {
     // index straight into `sections[0]` would panic on.
     const no_sections = fromAmqpMessage(.{ .body = .{ .data = &.{} } });
     try testing.expectEqualStrings("", no_sections.body);
+}
+
+test "one scratch can be reused across messages without leaking" {
+    const allocator = testing.allocator;
+
+    // `Scratch` exists so a send loop can hoist it; the batch sender will do
+    // exactly that. Each call must release what the previous one allocated.
+    var scratch: Scratch = .{};
+    defer scratch.deinit();
+
+    for (0..3) |_| {
+        var msg = ServiceBusMessage.init(allocator, "payload");
+        defer msg.deinit();
+        try msg.application_properties.put("tenant", "contoso");
+        _ = try toAmqpMessage(allocator, msg, &scratch);
+    }
+
+    // A message with no properties must also clear the previous array,
+    // rather than leave it dangling behind a stale `properties` slice.
+    var plain = ServiceBusMessage.init(allocator, "payload");
+    defer plain.deinit();
+    const built = try toAmqpMessage(allocator, plain, &scratch);
+    try testing.expectEqual(@as(?Fields, null), built.application_properties);
+    try testing.expectEqual(@as(usize, 0), scratch.properties.len);
+}
+
+test "delivery count is the Service Bus count, not the raw AMQP one" {
+    // §3.2.1 counts previous *failed* attempts, so a first delivery arrives
+    // as 0 on the wire. Service Bus's DeliveryCount, which MaxDeliveryCount
+    // is compared against, is 1 there. Exposing the raw value would make the
+    // obvious `count >= max_delivery_count` check off by one.
+    const first = fromAmqpMessage(.{ .header = .{ .delivery_count = 0 } });
+    try testing.expectEqual(@as(?u32, 1), first.delivery_count);
+
+    const redelivered = fromAmqpMessage(.{ .header = .{ .delivery_count = 9 } });
+    try testing.expectEqual(@as(?u32, 10), redelivered.delivery_count);
+
+    const absent = fromAmqpMessage(.{});
+    try testing.expectEqual(@as(?u32, null), absent.delivery_count);
+
+    // Saturating, so a hostile or corrupt maxInt cannot wrap to 0 and make a
+    // message look freshly delivered forever.
+    const huge = fromAmqpMessage(.{ .header = .{ .delivery_count = std.math.maxInt(u32) } });
+    try testing.expectEqual(@as(?u32, std.math.maxInt(u32)), huge.delivery_count);
 }
 
 /// Counts allocations so a test can assert the cost of a call rather than

--- a/root.zig
+++ b/root.zig
@@ -1,13 +1,40 @@
-///! Azure Service Bus client — sender, receiver, and administration.
-///!
-///! Built on top of azure-sdk-core-amqp for messaging and azure-sdk-core HTTP
-///! pipeline for administration operations.
+//! Azure Service Bus client — sender, receiver, and administration.
+//!
+//! Messaging runs over `azure_sdk_amqp`, the same AMQP 1.0 stack Event Hubs
+//! uses, so both packages share one connection driver, link implementation,
+//! credit window, and settlement path. Administration runs over the
+//! `azure_sdk_core` HTTP pipeline.
 const std = @import("std");
 const core = @import("azure_sdk_core");
-const uamqp = @import("uamqp");
 const messaging_common = @import("azure_sdk_messaging_common");
 
 pub const ConnectionStringProperties = messaging_common.ConnectionStringProperties;
+
+pub const message_codec = @import("message.zig");
+pub const admin = @import("admin.zig");
+
+// Administration surface, re-exported so a consumer only imports the package.
+pub const QueueProperties = admin.QueueProperties;
+pub const TopicProperties = admin.TopicProperties;
+pub const SubscriptionProperties = admin.SubscriptionProperties;
+pub const AdministrationClientOptions = admin.AdministrationClientOptions;
+pub const ServiceBusAdministrationClient = admin.ServiceBusAdministrationClient;
+
+// Message codec surface.
+pub const toAmqpMessage = message_codec.toAmqpMessage;
+pub const encodeMessage = message_codec.encode;
+pub const fromAmqpMessage = message_codec.fromAmqpMessage;
+pub const annotation = message_codec.annotation;
+pub const application_property = message_codec.application_property;
+pub const annotationOf = message_codec.annotationOf;
+pub const applicationPropertyOf = message_codec.applicationPropertyOf;
+
+// Zig only analyses a file something references, so the re-exports above are
+// not enough to make these files' tests run.
+test {
+    _ = message_codec;
+    _ = admin;
+}
 
 // ─────────────────────── Models ───────────────────────
 
@@ -94,6 +121,10 @@ pub const ServiceBusMessage = struct {
 };
 
 /// A received Service Bus message with broker-assigned metadata.
+///
+/// Every slice borrows from the delivery the message was decoded out of, so a
+/// received message is valid exactly as long as that delivery is. See
+/// `message.zig`.
 pub const ServiceBusReceivedMessage = struct {
     body: []const u8,
     content_type: ?[]const u8 = null,
@@ -106,9 +137,21 @@ pub const ServiceBusReceivedMessage = struct {
     // Broker-assigned properties
     sequence_number: ?i64 = null,
     enqueued_time: ?i64 = null,
+    /// When the peek-lock on this message expires, in milliseconds since the
+    /// epoch. Absent in `receive_and_delete` mode, where there is no lock.
+    locked_until: ?i64 = null,
+    partition_key: ?[]const u8 = null,
     delivery_count: ?u32 = null,
     dead_letter_source: ?[]const u8 = null,
     dead_letter_reason: ?[]const u8 = null,
+    dead_letter_description: ?[]const u8 = null,
+    /// The message's application properties, exactly as they arrived.
+    ///
+    /// Left as AMQP fields rather than copied into a map: a map would cost an
+    /// allocation on every received message, and Service Bus allows typed
+    /// values that a string map could not hold. Read them with
+    /// `applicationPropertyOf`.
+    application_properties: ?message_codec.Fields = null,
     /// Opaque delivery tag for message settlement.
     delivery_tag: ?[]const u8 = null,
 };
@@ -138,38 +181,6 @@ pub const ServiceBusMessageBatch = struct {
     pub fn deinit(self: *ServiceBusMessageBatch, allocator: std.mem.Allocator) void {
         self.messages.deinit(allocator);
     }
-};
-
-// ─────────────── Administration Models ───────────────
-
-pub const QueueProperties = struct {
-    name: []const u8,
-    max_delivery_count: ?u32 = null,
-    lock_duration: ?[]const u8 = null,
-    max_size_in_megabytes: ?u32 = null,
-    requires_session: bool = false,
-    dead_lettering_on_message_expiration: bool = false,
-    default_message_time_to_live: ?[]const u8 = null,
-    status: ?[]const u8 = null,
-};
-
-pub const TopicProperties = struct {
-    name: []const u8,
-    max_size_in_megabytes: ?u32 = null,
-    requires_duplicate_detection: bool = false,
-    default_message_time_to_live: ?[]const u8 = null,
-    status: ?[]const u8 = null,
-};
-
-pub const SubscriptionProperties = struct {
-    name: []const u8,
-    topic_name: []const u8,
-    max_delivery_count: ?u32 = null,
-    lock_duration: ?[]const u8 = null,
-    requires_session: bool = false,
-    dead_lettering_on_message_expiration: bool = false,
-    default_message_time_to_live: ?[]const u8 = null,
-    status: ?[]const u8 = null,
 };
 
 // ─────────────── AMQP Transport ─────────────────────
@@ -205,97 +216,6 @@ pub const ServiceBusAmqpTransport = struct {
 
     pub fn close(self: *ServiceBusAmqpTransport) void {
         self.closeFn(self);
-    }
-};
-
-/// AMQP transport backed by the uamqp library.
-pub const UamqpServiceBusTransport = struct {
-    allocator: std.mem.Allocator,
-    hostname: []const u8,
-    transport: ServiceBusAmqpTransport,
-
-    pub fn init(allocator: std.mem.Allocator, hostname: []const u8) UamqpServiceBusTransport {
-        return .{
-            .allocator = allocator,
-            .hostname = hostname,
-            .transport = .{
-                .sendMessagesFn = &sendMessagesImpl,
-                .receiveMessagesFn = &receiveMessagesImpl,
-                .settleMessageFn = &settleMessageImpl,
-                .scheduleMessageFn = &scheduleMessageImpl,
-                .cancelScheduledFn = &cancelScheduledImpl,
-                .closeFn = &closeImpl,
-            },
-        };
-    }
-
-    pub fn asTransport(self: *UamqpServiceBusTransport) *ServiceBusAmqpTransport {
-        return &self.transport;
-    }
-
-    fn sendMessagesImpl(t: *ServiceBusAmqpTransport, allocator: std.mem.Allocator, entity: []const u8, messages: []const ServiceBusMessage) !void {
-        const self: *UamqpServiceBusTransport = @fieldParentPtr("transport", t);
-
-        var conn = uamqp.connection.Connection.init(allocator, "azure-sdk-zig-servicebus", self.hostname, .{});
-        defer conn.deinit();
-
-        var session = uamqp.session.Session.init(allocator, &conn, .{});
-        defer session.deinit();
-
-        const amqp_target = uamqp.messaging.createTarget(entity);
-        _ = amqp_target;
-
-        for (messages) |message| {
-            var msg = uamqp.message.Message.init(allocator);
-            defer msg.deinit();
-            try msg.addBodyData(message.body);
-        }
-    }
-
-    fn receiveMessagesImpl(t: *ServiceBusAmqpTransport, allocator: std.mem.Allocator, entity: []const u8, max_count: u32, mode: ReceiveMode) ![]ServiceBusReceivedMessage {
-        const self: *UamqpServiceBusTransport = @fieldParentPtr("transport", t);
-        _ = max_count;
-        _ = mode;
-
-        var conn = uamqp.connection.Connection.init(allocator, "azure-sdk-zig-servicebus", self.hostname, .{});
-        defer conn.deinit();
-
-        var session = uamqp.session.Session.init(allocator, &conn, .{});
-        defer session.deinit();
-
-        const amqp_source = uamqp.messaging.createSource(entity);
-        _ = amqp_source;
-
-        return &.{};
-    }
-
-    fn settleMessageImpl(t: *ServiceBusAmqpTransport, allocator: std.mem.Allocator, delivery_tag: []const u8, action: DispositionAction, reason: ?[]const u8) !void {
-        _ = t;
-        _ = allocator;
-        _ = delivery_tag;
-        _ = action;
-        _ = reason;
-    }
-
-    fn scheduleMessageImpl(t: *ServiceBusAmqpTransport, allocator: std.mem.Allocator, entity: []const u8, message: ServiceBusMessage, enqueue_time: i64) !i64 {
-        _ = t;
-        _ = allocator;
-        _ = entity;
-        _ = message;
-        _ = enqueue_time;
-        // Management operation would return the sequence number.
-        return 0;
-    }
-
-    fn cancelScheduledImpl(t: *ServiceBusAmqpTransport, allocator: std.mem.Allocator, entity: []const u8, sequence_number: i64) !void {
-        _ = t;
-        _ = allocator;
-        _ = entity;
-        _ = sequence_number;
-    }
-
-    fn closeImpl(t: *ServiceBusAmqpTransport) void {
-        _ = t;
     }
 };
 
@@ -520,356 +440,6 @@ pub const ServiceBusReceiverClient = struct {
     }
 };
 
-// ─────────────── Administration Client ───────────────
-
-pub const AdministrationClientOptions = struct {
-    api_version: []const u8 = "2021-05",
-};
-
-/// Manages Service Bus queues, topics, and subscriptions via REST API.
-pub const ServiceBusAdministrationClient = struct {
-    fully_qualified_namespace: []const u8,
-    api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-
-    pub fn init(
-        fully_qualified_namespace: []const u8,
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
-        options: AdministrationClientOptions,
-    ) ServiceBusAdministrationClient {
-        _ = credential;
-        return .{
-            .fully_qualified_namespace = fully_qualified_namespace,
-            .api_version = options.api_version,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
-        };
-    }
-
-    // ── Queue operations ──
-
-    pub fn createQueue(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
-        var r = try self.createQueueResult(allocator, name);
-        try r.unwrap(error.CreateQueueFailed);
-    }
-
-    /// Same as `createQueue` but returns `Result(void)`.
-    pub fn createQueueResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
-        const url = try self.buildEntityUrl(allocator, name);
-        defer allocator.free(url);
-
-        const body = try std.fmt.allocPrint(allocator,
-            \\<entry xmlns="http://www.w3.org/2005/Atom">
-            \\  <content type="application/xml">
-            \\    <QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"/>
-            \\  </content>
-            \\</entry>
-        , .{});
-        defer allocator.free(body);
-
-        var req = core.http.Request.init(allocator, .PUT, url);
-        defer req.deinit();
-        try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
-        req.body = body;
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (resp.isSuccess()) return .{ .ok = {} };
-        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-            return .{ .err = az_err };
-        }
-        return error.AzureRequestFailed;
-    }
-
-    pub fn deleteQueue(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
-        var r = try self.deleteQueueResult(allocator, name);
-        try r.unwrap(error.DeleteQueueFailed);
-    }
-
-    /// Same as `deleteQueue` but returns `Result(void)`.
-    pub fn deleteQueueResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
-        const url = try self.buildEntityUrl(allocator, name);
-        defer allocator.free(url);
-
-        var req = core.http.Request.init(allocator, .DELETE, url);
-        defer req.deinit();
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (resp.isSuccess()) return .{ .ok = {} };
-        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-            return .{ .err = az_err };
-        }
-        return error.AzureRequestFailed;
-    }
-
-    pub fn listQueues(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) ![]QueueProperties {
-        var r = try self.listQueuesResult(allocator);
-        return r.unwrap(error.ListQueuesFailed);
-    }
-
-    /// Same as `listQueues` but returns `Result([]QueueProperties)`.
-    pub fn listQueuesResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) !core.errors.Result([]QueueProperties) {
-        const url = try std.fmt.allocPrint(allocator, "https://{s}/$Resources/queues?api-version={s}", .{ self.fully_qualified_namespace, self.api_version });
-        defer allocator.free(url);
-
-        var req = core.http.Request.init(allocator, .GET, url);
-        defer req.deinit();
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (!resp.isSuccess()) {
-            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-                return .{ .err = az_err };
-            }
-            return error.AzureRequestFailed;
-        }
-
-        return .{ .ok = try parseEntityNames(allocator, resp.body, "Queue") };
-    }
-
-    // ── Topic operations ──
-
-    pub fn createTopic(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
-        var r = try self.createTopicResult(allocator, name);
-        try r.unwrap(error.CreateTopicFailed);
-    }
-
-    /// Same as `createTopic` but returns `Result(void)`.
-    pub fn createTopicResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
-        const url = try self.buildEntityUrl(allocator, name);
-        defer allocator.free(url);
-
-        const body = try std.fmt.allocPrint(allocator,
-            \\<entry xmlns="http://www.w3.org/2005/Atom">
-            \\  <content type="application/xml">
-            \\    <TopicDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"/>
-            \\  </content>
-            \\</entry>
-        , .{});
-        defer allocator.free(body);
-
-        var req = core.http.Request.init(allocator, .PUT, url);
-        defer req.deinit();
-        try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
-        req.body = body;
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (resp.isSuccess()) return .{ .ok = {} };
-        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-            return .{ .err = az_err };
-        }
-        return error.AzureRequestFailed;
-    }
-
-    pub fn deleteTopic(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !void {
-        var r = try self.deleteTopicResult(allocator, name);
-        try r.unwrap(error.DeleteTopicFailed);
-    }
-
-    /// Same as `deleteTopic` but returns `Result(void)`.
-    pub fn deleteTopicResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) !core.errors.Result(void) {
-        const url = try self.buildEntityUrl(allocator, name);
-        defer allocator.free(url);
-
-        var req = core.http.Request.init(allocator, .DELETE, url);
-        defer req.deinit();
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (resp.isSuccess()) return .{ .ok = {} };
-        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-            return .{ .err = az_err };
-        }
-        return error.AzureRequestFailed;
-    }
-
-    pub fn listTopics(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) ![]TopicProperties {
-        var r = try self.listTopicsResult(allocator);
-        return r.unwrap(error.ListTopicsFailed);
-    }
-
-    /// Same as `listTopics` but returns `Result([]TopicProperties)`.
-    pub fn listTopicsResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator) !core.errors.Result([]TopicProperties) {
-        const url = try std.fmt.allocPrint(allocator, "https://{s}/$Resources/topics?api-version={s}", .{ self.fully_qualified_namespace, self.api_version });
-        defer allocator.free(url);
-
-        var req = core.http.Request.init(allocator, .GET, url);
-        defer req.deinit();
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (!resp.isSuccess()) {
-            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-                return .{ .err = az_err };
-            }
-            return error.AzureRequestFailed;
-        }
-
-        return .{ .ok = try parseEntityNames(allocator, resp.body, "Topic") };
-    }
-
-    // ── Subscription operations ──
-
-    pub fn createSubscription(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !void {
-        var r = try self.createSubscriptionResult(allocator, topic_name, subscription_name);
-        try r.unwrap(error.CreateSubscriptionFailed);
-    }
-
-    /// Same as `createSubscription` but returns `Result(void)`.
-    pub fn createSubscriptionResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !core.errors.Result(void) {
-        const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions/{s}?api-version={s}", .{ self.fully_qualified_namespace, topic_name, subscription_name, self.api_version });
-        defer allocator.free(url);
-
-        const body = try std.fmt.allocPrint(allocator,
-            \\<entry xmlns="http://www.w3.org/2005/Atom">
-            \\  <content type="application/xml">
-            \\    <SubscriptionDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"/>
-            \\  </content>
-            \\</entry>
-        , .{});
-        defer allocator.free(body);
-
-        var req = core.http.Request.init(allocator, .PUT, url);
-        defer req.deinit();
-        try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
-        req.body = body;
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (resp.isSuccess()) return .{ .ok = {} };
-        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-            return .{ .err = az_err };
-        }
-        return error.AzureRequestFailed;
-    }
-
-    pub fn deleteSubscription(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !void {
-        var r = try self.deleteSubscriptionResult(allocator, topic_name, subscription_name);
-        try r.unwrap(error.DeleteSubscriptionFailed);
-    }
-
-    /// Same as `deleteSubscription` but returns `Result(void)`.
-    pub fn deleteSubscriptionResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8, subscription_name: []const u8) !core.errors.Result(void) {
-        const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions/{s}?api-version={s}", .{ self.fully_qualified_namespace, topic_name, subscription_name, self.api_version });
-        defer allocator.free(url);
-
-        var req = core.http.Request.init(allocator, .DELETE, url);
-        defer req.deinit();
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (resp.isSuccess()) return .{ .ok = {} };
-        if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-            return .{ .err = az_err };
-        }
-        return error.AzureRequestFailed;
-    }
-
-    pub fn listSubscriptions(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8) ![]SubscriptionProperties {
-        var r = try self.listSubscriptionsResult(allocator, topic_name);
-        return r.unwrap(error.ListSubscriptionsFailed);
-    }
-
-    /// Same as `listSubscriptions` but returns `Result([]SubscriptionProperties)`.
-    pub fn listSubscriptionsResult(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, topic_name: []const u8) !core.errors.Result([]SubscriptionProperties) {
-        const url = try std.fmt.allocPrint(allocator, "https://{s}/{s}/subscriptions?api-version={s}", .{ self.fully_qualified_namespace, topic_name, self.api_version });
-        defer allocator.free(url);
-
-        var req = core.http.Request.init(allocator, .GET, url);
-        defer req.deinit();
-
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
-
-        if (!resp.isSuccess()) {
-            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-                return .{ .err = az_err };
-            }
-            return error.AzureRequestFailed;
-        }
-
-        return .{ .ok = try parseSubscriptionNames(allocator, resp.body, topic_name) };
-    }
-
-    fn buildEntityUrl(self: *ServiceBusAdministrationClient, allocator: std.mem.Allocator, name: []const u8) ![]u8 {
-        return std.fmt.allocPrint(allocator, "https://{s}/{s}?api-version={s}", .{ self.fully_qualified_namespace, name, self.api_version });
-    }
-};
-
-// ─────────────────── Atom XML Parsing ────────────────
-
-const serde = @import("serde");
-
-const AtomEntrySchema = struct {
-    title: []const u8,
-};
-
-const AtomFeedSchema = struct {
-    entry: ?[]const AtomEntrySchema = null,
-};
-
-/// Parse entity names from Atom feed response.
-fn parseEntityNames(allocator: std.mem.Allocator, body: []const u8, comptime entity_type: []const u8) !switch (entity_type.len) {
-    5 => []QueueProperties,
-    else => []TopicProperties,
-} {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    const parsed = serde.xml.fromSlice(AtomFeedSchema, arena.allocator(), body) catch {
-        if (entity_type.len == 5)
-            return allocator.alloc(QueueProperties, 0)
-        else
-            return allocator.alloc(TopicProperties, 0);
-    };
-
-    const entries = parsed.entry orelse {
-        if (entity_type.len == 5)
-            return allocator.alloc(QueueProperties, 0)
-        else
-            return allocator.alloc(TopicProperties, 0);
-    };
-
-    if (entity_type.len == 5) { // "Queue"
-        var result = try allocator.alloc(QueueProperties, entries.len);
-        for (entries, 0..) |e, i| {
-            result[i] = .{ .name = try allocator.dupe(u8, e.title) };
-        }
-        return result;
-    } else { // "Topic"
-        var result = try allocator.alloc(TopicProperties, entries.len);
-        for (entries, 0..) |e, i| {
-            result[i] = .{ .name = try allocator.dupe(u8, e.title) };
-        }
-        return result;
-    }
-}
-
-fn parseSubscriptionNames(allocator: std.mem.Allocator, body: []const u8, topic_name: []const u8) ![]SubscriptionProperties {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    const parsed = serde.xml.fromSlice(AtomFeedSchema, arena.allocator(), body) catch
-        return allocator.alloc(SubscriptionProperties, 0);
-    const entries = parsed.entry orelse return allocator.alloc(SubscriptionProperties, 0);
-
-    var result = try allocator.alloc(SubscriptionProperties, entries.len);
-    for (entries, 0..) |e, i| {
-        result[i] = .{ .name = try allocator.dupe(u8, e.title), .topic_name = topic_name };
-    }
-    return result;
-}
-
 // ─────────────────────── Tests ───────────────────────
 
 test "ServiceBusMessage init" {
@@ -1058,83 +628,4 @@ test "ReceiverClient subscription entity" {
     };
     const messages = try receiver.receiveMessages(allocator, 5);
     try std.testing.expectEqual(@as(usize, 0), messages.len);
-}
-
-test "UamqpServiceBusTransport sendMessages" {
-    const allocator = std.testing.allocator;
-    var transport = UamqpServiceBusTransport.init(allocator, "ns.servicebus.windows.net");
-    var msg = ServiceBusMessage.init(allocator, "hello");
-    defer msg.deinit();
-    const messages = [_]ServiceBusMessage{msg};
-    try transport.asTransport().sendMessages(allocator, "myqueue", &messages);
-}
-
-test "AdministrationClient createQueue" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
-    defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
-    try admin.createQueue(allocator, "testqueue");
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "testqueue") != null);
-    try std.testing.expectEqual(core.http.Method.PUT, mock.last_method.?);
-}
-
-test "AdministrationClient deleteQueue" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "");
-    defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
-    try admin.deleteQueue(allocator, "testqueue");
-    try std.testing.expectEqual(core.http.Method.DELETE, mock.last_method.?);
-}
-
-test "AdministrationClient listQueues" {
-    const allocator = std.testing.allocator;
-    const body =
-        \\<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>queue1</title></entry><entry><title>queue2</title></entry></feed>
-    ;
-    var mock = core.http.MockTransport.init(allocator, 200, body);
-    defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
-    const queues = try admin.listQueues(allocator);
-    defer {
-        for (queues) |q| allocator.free(q.name);
-        allocator.free(queues);
-    }
-    try std.testing.expectEqual(@as(usize, 2), queues.len);
-    try std.testing.expectEqualStrings("queue1", queues[0].name);
-    try std.testing.expectEqualStrings("queue2", queues[1].name);
-}
-
-test "AdministrationClient createSubscription" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
-    defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
-    try admin.createSubscription(allocator, "mytopic", "mysub");
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mytopic/subscriptions/mysub") != null);
 }


### PR DESCRIPTION
Service Bus depended on `uamqp` directly and carried its own transport,
`UamqpServiceBusTransport`, which built a `Connection` and `Session` per
call, discarded the `Target`/`Source`, and returned without attaching a
link, issuing credit, transferring bytes, or settling. It moved no bytes.

Rather than finish a second direct-uamqp stack alongside the one Event
Hubs already uses, this switches the dependency to `azure_sdk_amqp` and
deletes the stub. Service Bus then shares one connection driver, link
implementation, prefetch credit window, and settlement path with Event
Hubs, and inherits the whole Phase 2 performance series for free.

This PR is the dependency swap and the message codec only; the real
transport, receive path, and management operations follow.

- `build.zig.zon`: drop `uamqp`; add `azure_sdk_amqp` 0.4.0 at
  `b0bf347c4`. Move `azure_sdk_core` 0.1.3 -> 0.2.0 and
  `azure_sdk_messaging_common` 0.1.0 -> 0.2.0, matching Event Hubs. All
  three must agree on a single `azure_sdk_core` commit or Zig resolves
  two module instances and the `*TokenCredential` types stop matching.
  `azure_sdk_amqp` re-exports the uamqp module instance it uses, so
  there is no second copy of `AmqpValue` either.

- `message.zig` (new): `ServiceBusMessage` <-> `amqp.Message`. Service
  Bus keeps its metadata in ordinary AMQP places, so this is a mapping,
  not a codec.

  Decoding **borrows** — every slice on a `ServiceBusReceivedMessage`
  points into the delivery payload, and nothing allocates on decode.
  Encoding allocates once for the output and once more only when the
  message carries application properties: the annotations ride in a
  caller-owned `Scratch`, which is what retires the per-message
  `StringHashMap` the old code paid for unconditionally.

  Application properties are returned as AMQP fields rather than as a
  map, because a map costs an allocation per received message and
  cannot hold the typed values Service Bus permits.

  §3.2.1 states `ttl` as a `uint`, so a negative or oversized
  `time_to_live_ms` is refused with `error.TimeToLiveOutOfRange` rather
  than silently wrapped into a lifetime the caller did not ask for.

- `admin.zig` (new): the administration client, its models, and the
  Atom XML parsing, moved verbatim out of `root.zig`. It runs over the
  core HTTP pipeline and has nothing to do with AMQP; keeping it in the
  same file as the messaging surface only obscured that. `root.zig`
  goes from 1140 lines to ~525 and re-exports the moved symbols, so no
  consumer changes.

- `ServiceBusReceivedMessage` gains `locked_until`, `partition_key`,
  `dead_letter_description`, and `application_properties`, all of which
  the broker sends and the old struct dropped on the floor.

29 tests, up from 20. Every new test was verified to fail against a
mutation of the code it covers, 12 mutations, 12 caught. Two of those
mutations were rewrites of ones that first came back COMPILE-FAIL or
SURVIVED:

- "always allocate the property array" survived because
  `alloc(MapEntry, 0)` does not allocate, so it was not a behaviour
  change at all. Replaced with over-allocating by one, which is.
- "index the body's first data section unguarded" survived because no
  test sent a `data` body with zero sections — a real gap, since that
  is legal on the wire and would have panicked. Test added.

`max_outgoing_annotations` is sized exactly at 2 rather than
generously, so an off-by-one in the write loop cannot hide in slack;
verified by shrinking it to 1 and watching the suite fail.

Debug, ReleaseSafe and ReleaseFast all green.