### PR TITLE
amqp: report a failed allocation as one when measuring a performative

### DIFF
--- a/cbs.zig
+++ b/cbs.zig
@@ -426,7 +426,7 @@ fn sentPutTokenProperties(allocator: Allocator, written: []const u8) !message.De
     defer allocator.free(transfers);
     try testing.expectEqual(@as(usize, 1), transfers.len);
 
-    const payload = harness.transferPayload(allocator, transfers[0]).?;
+    const payload = try harness.transferPayload(allocator, transfers[0]);
     return message.decode(allocator, payload);
 }
 

--- a/link.zig
+++ b/link.zig
@@ -377,10 +377,23 @@ pub const Session = struct {
 /// the same number as a by-product of the decode that `pump` already performs,
 /// which is why decoding a second time here would be pure waste. It remains
 /// for peers and tests, which hold a frame body without having decoded it.
-pub fn performativeLength(allocator: Allocator, body: []const u8) ?usize {
+///
+/// Distinguishing `error.OutOfMemory` from `error.MalformedFrame` still matters
+/// now that only peers and tests call this, because `checkAllAllocationFailures`
+/// injects the former deliberately. Collapsing the two — as returning `?usize`
+/// did — makes an injected failure indistinguishable from the peer sending
+/// garbage. Until #333 that was a live receive-path bug; what is left is that
+/// every caller that consumed the optional unwrapped it with `.?`, so an
+/// injected failure aborted the test process on a null unwrap instead of being
+/// reported as the allocation failure it was. (`transferPayload` forwarded the
+/// null instead, which merely moved the unwrap to its own callers.)
+pub fn performativeLength(allocator: Allocator, body: []const u8) connection.ConnectionError!usize {
     var arena: std.heap.ArenaAllocator = .init(allocator);
     defer arena.deinit();
-    const result = uamqp.decoder.decode(arena.allocator(), body) catch return null;
+    const result = uamqp.decoder.decode(arena.allocator(), body) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.MalformedFrame,
+    };
     return result.bytes_consumed;
 }
 
@@ -1492,7 +1505,7 @@ test "a message past max-frame-size is split and reassembles to the original" {
             try testing.expectEqual(@as(?[]const u8, null), t.delivery_tag);
         }
 
-        const consumed = performativeLength(allocator, body).?;
+        const consumed = try performativeLength(allocator, body);
         try reassembled.appendSlice(allocator, body[consumed..]);
         if (!t.more) saw_final = true;
     }
@@ -1565,7 +1578,7 @@ test "a delivery carries the requested message format" {
     defer decoded.deinit();
     try testing.expectEqual(@as(u32, 0x80013700), decoded.performative.transfer.message_format.?);
 
-    const consumed = performativeLength(allocator, transfers[0]).?;
+    const consumed = try performativeLength(allocator, transfers[0]);
     try testing.expectEqualStrings("payload", transfers[0][consumed..]);
 }
 
@@ -1639,7 +1652,7 @@ test "a formatted delivery split across frames keeps every frame within the limi
             try testing.expectEqual(@as(?u32, null), decoded.performative.transfer.message_format);
         }
 
-        const consumed = performativeLength(allocator, body).?;
+        const consumed = try performativeLength(allocator, body);
         try reassembled.appendSlice(allocator, body[consumed..]);
         try testing.expect(body.len + frame.frame_header_size <= 512);
     }
@@ -2921,6 +2934,125 @@ fn rejectedSendUnderAllocator(allocator: Allocator) !void {
     };
 }
 
+fn multiFrameReceiveUnderAllocator(allocator: Allocator) !void {
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 4,
+        .delivery_tag = "\x00\x00\x00\x04",
+        .message_format = 0,
+        .settled = false,
+        .more = true,
+    }, "part-one|");
+    try peer.pushTransfer(0, .{ .handle = 0, .more = true }, "part-two|");
+    try peer.pushTransfer(0, .{ .handle = 0, .more = false }, "part-three");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh/ConsumerGroups/$default/Partitions/0",
+        .prefetch = 0,
+    }, 10_000);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("part-one|part-two|part-three", delivery.payload);
+    try receiver.accept(delivery);
+}
+
+test "reassembling a delivery leaks nothing however the allocator fails" {
+    // A multi-frame delivery is the receive path's allocating shape: the
+    // payload buffer grows per frame, and on completion the payload and the
+    // delivery tag are each duped out of their own reassembly buffer. Every
+    // one of those is a place a failure could leave a half-built delivery
+    // behind.
+    //
+    // Until #333 this could not have passed: `applyTransfer` measured the
+    // performative through `performativeLength` and turned the injected
+    // failure into `error.MalformedFrame`. So this is regression cover for
+    // #333, not for the signature change this commit makes — it passes
+    // either way, and fails if the pre-#333 measurement is reinstated.
+    try testing.checkAllAllocationFailures(
+        testing.allocator,
+        multiFrameReceiveUnderAllocator,
+        .{},
+    );
+}
+
+fn inspectWrittenPayloadUnderAllocator(allocator: Allocator) !void {
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 10);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    mem.clearWritten();
+    _ = try sender.sendBytesAsync("payload", .{}, 10_000);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    // Through `of` rather than indexing `bodies`, because `of` is how a test
+    // that selects frames by descriptor reaches a body, and `of` leaked its
+    // list when an append failed. That is a different defect from the sentinel
+    // — `of` reported the failure faithfully and merely stranded memory on
+    // the way out — but for those tests it was an independent blocker, so
+    // fixing `transferPayload` alone would have left the road closed one step
+    // earlier. Tests that walk `bodies` directly, which most here do, met only
+    // the sentinel.
+    const transfers = try frames.of(allocator, perf.descriptor.transfer);
+    defer allocator.free(transfers);
+    const payload = try harness.transferPayload(allocator, transfers[0]);
+    try testing.expectEqualStrings("payload", payload);
+}
+
+test "inspecting what was written survives a failing allocator" {
+    // Regression cover for both of the things that stopped
+    // `checkAllAllocationFailures` being pointed at a test that inspects
+    // written bytes: `performativeLength` answering `?usize`, and
+    // `EmittedFrames.of` stranding its list. Note that this is a different
+    // set of tests from "the receive path" the issue named — #333 had
+    // already cleared that, as the test above shows.
+    //
+    // Splitting a transfer's payload from its performative means decoding the
+    // performative again, which allocates, so an injected failure lands here.
+    // While that answered `?usize` the failure was indistinguishable from a
+    // malformed frame, and since every caller that consumed it unwrapped it,
+    // the injection aborted the test process on a null unwrap.
+    //
+    // Revert the signature and this does not fail — it panics. Drop the
+    // `errdefer` in `of` and it fails with a leak instead.
+    try testing.checkAllAllocationFailures(
+        testing.allocator,
+        inspectWrittenPayloadUnderAllocator,
+        .{},
+    );
+}
+
 test "a rejected send leaks nothing however the allocator fails" {
     // Recording a rejection allocates twice, and the second dupe failing is
     // the only way to observe a half-built `Rejection`. Assigning the struct
@@ -3843,7 +3975,7 @@ test "a message round-trips from the sender's encoding to the receiver's payload
     try testing.expectEqual(@as(usize, 1), frames.bodies.items.len);
 
     const body = frames.bodies.items[0];
-    const consumed = performativeLength(allocator, body).?;
+    const consumed = try performativeLength(allocator, body);
     var decoded = try message.decode(allocator, body[consumed..]);
     defer decoded.deinit();
 

--- a/management.zig
+++ b/management.zig
@@ -341,7 +341,7 @@ test "a request carries the operation, type, name, and security token" {
     defer allocator.free(transfers);
     try testing.expectEqual(@as(usize, 1), transfers.len);
 
-    var decoded = try message.decode(allocator, harness.transferPayload(allocator, transfers[0]).?);
+    var decoded = try message.decode(allocator, try harness.transferPayload(allocator, transfers[0]));
     defer decoded.deinit();
     const props = decoded.message.application_properties.?;
 

--- a/test_peer.zig
+++ b/test_peer.zig
@@ -84,6 +84,11 @@ pub const EmittedFrames = struct {
     /// Bodies whose descriptor matches `code`.
     pub fn of(self: EmittedFrames, allocator: Allocator, code: u64) ![]const []const u8 {
         var out: std.ArrayList([]const u8) = .empty;
+        // `parse` above guards its list the same way. Without this, a failing
+        // `append` or `toOwnedSlice` strands the buffer. The error itself was
+        // always reported faithfully, which is why this stayed invisible until
+        // a test ran under `checkAllAllocationFailures`.
+        errdefer out.deinit(allocator);
         for (self.bodies.items) |b| {
             if (perf.peekDescriptor(b) == code) try out.append(allocator, b);
         }
@@ -144,7 +149,11 @@ pub fn scriptHandshake(peer: Peer, max_frame_size: u32) !void {
 }
 
 /// The message payload carried after a transfer performative in `body`.
-pub fn transferPayload(allocator: Allocator, body: []const u8) ?[]const u8 {
-    const consumed = link.performativeLength(allocator, body) orelse return null;
+///
+/// Returns an error rather than null so that a test running under
+/// `checkAllAllocationFailures` can tell an injected `error.OutOfMemory` from
+/// a frame that really is malformed.
+pub fn transferPayload(allocator: Allocator, body: []const u8) ![]const u8 {
+    const consumed = try link.performativeLength(allocator, body);
     return body[consumed..];
 }


### PR DESCRIPTION
Closes #325. The issue was right when it was filed and is still right about
the package as published. Both of the consequences it names had already been
retired on this branch, two commits before its base, by a change that was not
looking for them. What is fixed here is a third thing the issue did not name.

`performativeLength` answers `?usize`, collapsing every decode failure into
one value. #325 says a transient OOM therefore tears the connection down as
`amqp:decode-error`, and that the same collapse blocks OOM-injection coverage
of the receive path. Both were true, and both are still true of
`azure_sdk_amqp` 0.4.0: in the vendored copy at `link.zig:286`,
`Session.applyTransfer` reads

    const consumed = performativeLength(self.allocator, body) orelse
        return error.MalformedFrame;

That is a live receive path turning an allocation failure into a protocol
violation, exactly as reported. (Consequence 2 was mildly overstated even
then: `connection.zig`'s handshake test already covered the connection level
under injected failure. What was blocked was the delivery path.)

#333 (`061873d2e`) removed that call while doing something else -- it stopped
decoding every transfer twice by carrying `bytes_consumed` out of the decode
`Session.pump` already performs. With no receive-path caller left, both of the
issue's consequences went with it. Neither the issue nor #333 noticed.

What survives at HEAD is the same sentinel in a now test-only helper, where it
is worse than a wrong error code. Splitting a transfer's payload from its
performative means decoding again, which allocates, so under
`checkAllAllocationFailures` this helper fails -- and every caller that
consumed its answer unwrapped it with `.?`. An injected failure did not surface as a wrong error; it
**panicked** on a null unwrap and took the test process down. That blocks
OOM-injection coverage of tests that inspect written bytes, which is a
different set from the receive path #325 named. It is the shape used at
`cbs.zig:429`, `management.zig:344` and four sites in `link.zig`, and
`test_peer` is public, so the same trap was set for downstream test suites.

`performativeLength` now returns `ConnectionError!usize` and
`test_peer.transferPayload` an error union, both modelled on
`Driver.decodeBody`.

Two tests, covering different things:

- `reassembling a delivery leaks nothing however the allocator fails` is the
  delivery-receive coverage #325 asked for, which nothing had written;
  `connection.zig`'s handshake test covers only the connection level. It is
  regression cover for #333 rather than for this change: it passes with the
  old `?usize` sentinel just as it does with the new signature, and it fails
  if the pre-#333 measurement is reinstated in `applyTransfer`. Also verified
  non-vacuous by dropping the `errdefer` on the reassembled payload.
- `inspecting what was written survives a failing allocator` covers what
  survives. Revert the signature and it panics rather than fails.

`EmittedFrames.of` was a second, independent blocker for tests that select
frames by descriptor: it leaked its list when an append failed. A different
defect from the sentinel -- it reported the failure faithfully and merely
stranded memory on the way out -- and one `parse` directly above it already
guards against. Fixed, and the second test goes through `of` rather than
indexing `bodies` so both are covered at once; drop the `errdefer` and it
fails with a leak. Tests that walk `bodies` directly, which most in this file
do, met only the sentinel.

Breaking change to two public test helpers. `azure_sdk_eventhubs` 0.5.0 calls
`transferPayload(...).?` at `sender.zig:317` and `management.zig:736` (line
numbers at the v0.5.0 tag). Service Bus has three more, at
`amqp_transport.zig:1814`, `:1823` and `:3497` as of `origin/sdk/servicebus`
`81f75374f` -- branch-tip numbers, since no Service Bus release contains that
file yet. Nothing breaks until each repins, since consumers pin by commit and
hash; tracked in #345.

## Four rounds of corrections to this description

Round 1 found a real defect in the change -- the missing `errdefer` in
`EmittedFrames.of`, which is an added line in this diff -- and the public-API
break that became #345. Every round also found the same class of defect in the
prose: correct code, false stated reason. Recording them because the pattern
is the interesting part.

**Round 1.** The first version claimed both of the issue's assertions were
false. I had checked that `performativeLength` is unreachable from non-test
code, found that it is, and concluded the issue had never been right, without
checking whether it had been right *when filed*. It had; #333 is what changed
that, and the released 0.4.0 every consumer pins still has the receive-path
call. **Lesson: when a bug report looks wrong, date it before contradicting
it.**

**Round 2.** The rewrite said #333 retired both consequences, then
contradicted itself seventeen lines later by saying it retired only one. Both
is correct. The decisive evidence is that the receive-path test passes with
the old sentinel still in place -- it is insensitive to this PR's change,
because #333 had already made that coverage possible. The rewrite also called
`EmittedFrames.of` "the same failure-swallowing shape" when its defect was the
opposite (it propagated the error faithfully and leaked), and claimed "every
payload-inspecting test comes through `of`" when most walk `bodies` directly
-- including one in this very diff, in `test "a message round-trips from the
sender's encoding to the receiver's payload"`.

**Round 3.** Five smaller ones, two of them more instances of the same
over-general absolute: the `performativeLength` doc comment still said "every
caller unwrapped the optional" when `transferPayload` forwarded the null
instead, and "the receive-path coverage nothing had written" had a
counterexample in `connection.zig`'s handshake test, which predates the issue
by two days and covers the connection level. Also, the round-2 note above
cited a line number that the round-2 amend had itself shifted by eight lines.
**Lesson: re-derive line numbers after amending, never carry them forward** --
which is why the sentence above names the test instead. Service Bus line
numbers in the commit message are labelled branch-tip for the same reason.

**Round 4.** The "every caller unwrapped it" claim carved out in round 3
survived in two more places, one of them a screen below a comment that now
said the opposite. And this very section claimed review had found defects
"never in the change" -- while sitting above a diff containing review's own
fix. **Lesson: meta-commentary about a failure pattern is not exempt from it.**

## Verification

- 146/146 tests, Debug + ReleaseSafe + ReleaseFast, `zig fmt --check` clean.
- Four mutations, all compiling, all caught:

| Mutation | Result |
|---|---|
| restore `?usize` + `.?` at all seven call sites | `thread panic: attempt to use null value`, ABRT |
| drop the `errdefer` in `EmittedFrames.of` | `1 leaks` at `fail_index 39/41` |
| drop the `errdefer` on the reassembled payload | `1 leaks` at `fail_index 41/45` |
| reinstate the pre-#333 measurement in `applyTransfer` | receive-path test fails |
