### PR TITLE
eventhubs: repin azure_sdk_amqp at the branch tip

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b0bf347c4da5ccb9cb63772011c98a769d838f74",
-            .hash = "azure_sdk_amqp-0.4.0-fUByf6x_BgAoO05o4uHh89hyi9PiEKQzfvtT4ucPs-Ts",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bd5330d983ca75a56771a085659ec1136c9a81f6",
+            .hash = "azure_sdk_amqp-0.4.0-fUByfyWRBwDU9pQlQL3AnageJI-noNZtH_5PxOJAk90U",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/management.zig
+++ b/management.zig
@@ -733,7 +733,7 @@ const Scripted = struct {
 
         decoded.* = try amqp.decodeMessage(
             self.allocator,
-            harness.transferPayload(self.allocator, transfers[0]).?,
+            try harness.transferPayload(self.allocator, transfers[0]),
         );
         return decoded.message.application_properties.?;
     }

--- a/sender.zig
+++ b/sender.zig
@@ -509,7 +509,7 @@ fn lastDelivery(allocator: Allocator, mem: *MemoryTransport) !SentDelivery {
             format = decoded.performative.transfer.message_format;
             seen = true;
         }
-        try payload.appendSlice(allocator, harness.transferPayload(allocator, body).?);
+        try payload.appendSlice(allocator, try harness.transferPayload(allocator, body));
     }
 
     return .{ .payload = try payload.toOwnedSlice(allocator), .message_format = format };


### PR DESCRIPTION
Repins `azure_sdk_amqp` on `sdk/eventhubs` from `b0bf347c4` to the branch tip `bd5330d98`, and fixes the one signature break that lands as a result. This is the `sdk/eventhubs` half of #345; `sdk/servicebus` follows separately.

## What the pin was missing

Four commits: #344 (allocation failure reported as one when measuring a performative), #346 (granted credit enforced on the receive path), #348 (an abandoned window hands back the verdicts it holds), #349 (receiver reassembly bounded by our own max-message-size).

## The break, and why it exists

`test_peer.transferPayload` went `?[]const u8` → `![]const u8` in #344. The `?usize`/`?[]const u8` sentinel it shared with `performativeLength` made `std.testing.checkAllAllocationFailures` unusable against any test that inspects written bytes: an injected allocation failure aborted the test process on a null unwrap rather than reporting itself as a failure.

Both call sites on this branch are inside tests that already return an error union, so the fix is `.?` → `try`:

- `management.zig:736` — `sentProperties`
- `sender.zig:512` — the emitted-transfer reassembly helper

No other change was needed. There is exactly one `azure_sdk_amqp` pin in the branch and no stale reference to `b0bf347c4` survives anywhere (`grep -rn b0bf347c4` over `*.zon`, `*.zig`, `*.md`, `*.yml` is empty).

## Two behaviour changes ride along

Neither is load-bearing here, but both are worth stating rather than discovering later.

**#349 — receivers now declare a 128 MiB max-message-size.** `receiver.zig:160` calls `openReceiver` without passing `max_message_size`, so it takes the new default and now declares it in its attach. Event Hubs caps a message at 1 MiB, or 20 MiB on Dedicated, so the default is **6.4x** the largest thing the service will send (134,217,728 / 20,971,520) and the refusal path is unreachable against a real broker. Note the bound is per message, not per link — a receiver may hold up to its credit plus overrun concurrently.

**#346 — granted credit is enforced on the receive path.** A peer sending beyond its granted credit is refused rather than absorbed.

To be precise rather than convenient about both: these are not no-ops at the code level. The attach we emit now carries a `max-message-size` field it did not carry before, and per-transfer credit accounting runs differently on every receive. What is unchanged is the *observable outcome* against a conformant broker — Azure never oversends and never exceeds its own ceiling, and no test on this branch asserted on the old receiver-attach bytes, which is why the suite passes untouched.

## Verification

193 tests pass in Debug, ReleaseSafe and ReleaseFast. **0 added, 0 removed** — this is a repin, not new behaviour, so the honest claim is that it is covered by the existing suite rather than by anything new.

The mutation argument is degenerate but worth stating explicitly: reverting either `try` to `.?` fails to compile (`expected optional type, found ...error_union...` at both sites). That is the entire proof obligation the repin creates on this branch — the change is a type-level fix, so compilation is the discriminator, and there is no runtime behaviour here that a new test could pin down.

Diff is 3 files, 4 insertions, 4 deletions.

Part of #345.
