### PR TITLE
servicebus: repin azure_sdk_amqp at the branch tip

### DIFF
--- a/amqp_transport.zig
+++ b/amqp_transport.zig
@@ -1811,7 +1811,7 @@ test "a send authorises the entity before it puts the message on the wire" {
     // so the CBS put-token has to precede the message.
     try testing.expectEqual(@as(usize, 2), transfers.len);
 
-    var claim = try amqp.decodeMessage(allocator, harness.transferPayload(allocator, transfers[0]).?);
+    var claim = try amqp.decodeMessage(allocator, try harness.transferPayload(allocator, transfers[0]));
     defer claim.deinit();
     try testing.expectEqualStrings("put-token", propertyOf(claim.message, "operation").?.string);
     try testing.expectEqualStrings(
@@ -1820,7 +1820,7 @@ test "a send authorises the entity before it puts the message on the wire" {
     );
     try testing.expectEqualStrings("stub-jwt", claim.message.body.value.string);
 
-    var decoded = try amqp.decodeMessage(allocator, harness.transferPayload(allocator, transfers[1]).?);
+    var decoded = try amqp.decodeMessage(allocator, try harness.transferPayload(allocator, transfers[1]));
     defer decoded.deinit();
 
     const got = message_codec.fromAmqpMessage(decoded.message);
@@ -3494,7 +3494,7 @@ fn pushManagementReply(
 fn requestAt(allocator: Allocator, written: []const u8, index: usize) !amqp.message_codec.Decoded {
     const transfers = try emittedTransfers(allocator, written);
     defer allocator.free(transfers);
-    return amqp.decodeMessage(allocator, harness.transferPayload(allocator, transfers[index]).?);
+    return amqp.decodeMessage(allocator, try harness.transferPayload(allocator, transfers[index]));
 }
 
 test "scheduling sends the whole encoded message and reads back its sequence number" {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "azure_sdk_messaging_common-0.2.0-YklmSkWIAADy4QHeNJAVUdRq-xKFeRx75G1TjE5lMeHR",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b0bf347c4da5ccb9cb63772011c98a769d838f74",
-            .hash = "azure_sdk_amqp-0.4.0-fUByf6x_BgAoO05o4uHh89hyi9PiEKQzfvtT4ucPs-Ts",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bd5330d983ca75a56771a085659ec1136c9a81f6",
+            .hash = "azure_sdk_amqp-0.4.0-fUByfyWRBwDU9pQlQL3AnageJI-noNZtH_5PxOJAk90U",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",


### PR DESCRIPTION
Repins `azure_sdk_amqp` on `sdk/servicebus` from `b0bf347c4` to the branch tip `bd5330d98`, and fixes the signature break that lands as a result. This is the `sdk/servicebus` half of #345; `sdk/eventhubs` is #350.

## What the pin was missing

Four commits: #344 (allocation failure reported as one when measuring a performative), #346 (granted credit enforced on the receive path), #348 (an abandoned window hands back the verdicts it holds), #349 (receiver reassembly bounded by our own max-message-size).

## The break, and why it exists

`test_peer.transferPayload` went `?[]const u8` → `![]const u8` in #344. The sentinel it shared with `performativeLength` made `std.testing.checkAllAllocationFailures` unusable against any test that inspects written bytes: an injected allocation failure aborted the test process on a null unwrap rather than reporting itself as a failure.

Three call sites, all already in error-returning contexts, so `.?` → `try`:

- `amqp_transport.zig:1814` and `:1823` — the CBS put-token test
- `amqp_transport.zig:3497` — `requestAt`, a helper returning `!Decoded`

Note the compiler reported only **two** errors, not three: `:1814` and `:1823` are in the same function and the second is masked until the first is fixed. All three were found by reading the call sites rather than by trusting the error count.

There is exactly one `azure_sdk_amqp` pin in the branch and no stale reference to `b0bf347c4` survives anywhere (`grep -rn b0bf347c4` over `*.zon`, `*.zig`, `*.md`, `*.yml` is empty).

## Two behaviour changes ride along

Neither is load-bearing here, but both are worth stating rather than discovering later.

**#349 — receivers now declare a 128 MiB max-message-size.** `amqp_transport.zig:698` calls `openReceiver` without passing `max_message_size`, so it takes the new default and now declares it in its attach. Service Bus caps a message at 256 KB on Standard and 100 MB on Premium. 128 MiB (134,217,728 bytes) clears even the Premium ceiling (104,857,600 bytes) by **28 MiB** (29,360,128 bytes) — headroom for the `x-opt-*` annotations the broker adds on delivery, and exactly why 100 MiB was rejected as the default in #349, since it equals the Premium maximum to the byte. The refusal path is therefore unreachable against a real broker. Note the bound is per message, not per link.

**#346 — granted credit is enforced on the receive path.** A peer sending beyond its granted credit is refused rather than absorbed.

To be precise rather than convenient about both: these are not no-ops at the code level. The attach we emit now carries a `max-message-size` field it did not carry before, and per-transfer credit accounting runs differently on every receive. What is unchanged is the *observable outcome* against a conformant broker — Azure never oversends and never exceeds its own ceiling, and no test on this branch asserted on the old receiver-attach bytes, which is why the suite passes untouched.

## Verification

115 tests pass in Debug, ReleaseSafe and ReleaseFast. **0 added, 0 removed** — this is a repin, not new behaviour, so the honest claim is that it is covered by the existing suite rather than by anything new.

The mutation argument is degenerate but worth stating explicitly: reverting any of the three `try`s to `.?` fails to compile (`expected optional type, found ...error_union...`). That is the entire proof obligation the repin creates on this branch — the change is a type-level fix, so compilation is the discriminator, and there is no runtime behaviour here that a new test could pin down.

Diff is 2 files, 5 insertions, 5 deletions.

Part of #345.
