### PR TITLE
data_cosmos: repin azure_sdk_core at the branch tip

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",


### PR DESCRIPTION
The pin sat at b7b47b2b1, four commits behind the branch tip, so none of
#255, #298, #299 or #300 was reachable from here. It now sits at 1d73a90ee,
which moves azure_sdk_core from 0.1.3 to 0.2.0 and the hash with it.

Nothing on this branch needed changing. `azure_sdk_core` gained five new
public names over those four commits - `CredentialKind`,
`TokenCredentialSelection`, `CountingAllocator`, `benchmarkAllocating` and
`nowNs`, declared at seven sites because two are re-exported - and removed
none. One existing
declaration changed value: `pub const version` went from the literal "0.1.0"
to `@import("build_options").version`, which resolves to the manifest's
"0.2.0", and `user_agent_prefix` follows it from "azsdk-zig-core/0.1.0" to
"azsdk-zig-core/0.2.0". The type is unchanged. This is a fix rather than a
regression: the literal had drifted from the manifest, which already read
0.1.3. It reaches nothing here - `user_agent_prefix` is referenced nowhere
outside its own definition, `TelemetryPolicy` is built only in core's own
tests from hardcoded strings, and this branch names none of them.

`AzureDeveloperCliCredential.init` also gained a required `io: std.Io`
parameter. That is a breaking signature change to an existing public
function, but this branch does not call it.

The one consumer-visible behaviour change is #298: the default IMDS probe is
gone and `AZURE_TOKEN_CREDENTIALS` is honoured, so a caller relying on the
implicit IMDS fallback now has to ask for it. This branch references neither,
and builds no default credential chain, so nothing here is affected.

14 tests pass in Debug, ReleaseSafe and ReleaseFast, none added and none removed. The change is a manifest repin with no
source edit, so the suite passing against the new dependencies is the whole
of the verification available; there is no new behaviour on this branch for
a test to pin down.

Part of the repin sweep that follows #345: every branch-owned manifest is
being moved to its dependencies' current tips. Versions are deliberately left
alone and will be bumped for the whole chain at release time.

---

*Correction, applied after merge:* the body originally read "gained eight
public declarations ... and removed none". Eight is the count of added
`pub` lines in the diff, which includes the `version` line the paragraph
below already describes separately as a value change - and that line's old
form is simultaneously the only removed top-level `pub`, so "eight ...
removed none" double-counted it. The commit message on `sdk/*` carries the
original wording.
