### PR TITLE
data_tables: repin azure_sdk_core and azure_rest_data_tables together

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,16 +5,16 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
             .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
         },
         .azure_rest_data_tables = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b218272ec35cbb7feaadcdb77fc7c34f6cfd3339",
-            .hash = "azure_rest_data_tables-0.1.0-CqXnR3B2AQAHRViUkjfOeAz-3hAkn2W4x1xF2zcL7JRf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#8297d5d01eeae21424d27dc05994a37c838f48e1",
+            .hash = "azure_rest_data_tables-0.1.0-CqXnR3B2AQCHyNhUN69ICYtAVvcKAu1we4peIGM8xycF",
         },
     },
     .paths = .{


### PR DESCRIPTION
Two pins moved, and they had to move together:

  - azure_sdk_core b7b47b2b1 -> 1d73a90ee (0.1.3 -> 0.2.0), skipping #255,
    #298, #299 and #300.
  - azure_rest_data_tables b218272ec -> 8297d5d01, which is that package's
    tip now that it has been repinned onto the same core (#361).

Moving core alone does not work, and this is measured rather than assumed:
repinning only `azure_sdk_core` produced 17 errors of the shape

    protocol_client.zig:417:85: error: expected type
    'http.pipeline.HttpPipeline', found 'http.pipeline.HttpPipeline'

which is Zig reporting that one type reached the same expression by two
different paths. `azure_rest_data_tables` still pinned core 0.1.3 while this
branch pinned 0.2.0, so `HttpPipeline` existed twice in one graph. The base
branch compiles cleanly, so the split was introduced by the half-repin and
not pre-existing. With both pins moved there is exactly one core in the
graph and the errors are gone.

Nothing in the source needed changing. `azure_sdk_core` gained five new
public names over those four commits - `CredentialKind`,
`TokenCredentialSelection`, `CountingAllocator`, `benchmarkAllocating` and
`nowNs`, declared at seven sites because two are re-exported - and removed
none. One existing
declaration changed value: `pub const version` went from the literal "0.1.0"
to `@import("build_options").version`, which resolves to the manifest's
"0.2.0", and `user_agent_prefix` follows it. The type is unchanged, and this
is a fix rather than a regression - the literal had drifted from the
manifest, which already read 0.1.3. Neither constant is referenced outside
core's own definition of it.

`AzureDeveloperCliCredential.init` also gained a required `io: std.Io`
parameter. That is a breaking signature change to an existing public
function, but this branch does not call it.

The one consumer-visible behaviour change is #298: the default IMDS probe is
gone and `AZURE_TOKEN_CREDENTIALS` is honoured. This branch references
neither and builds no default credential chain.

140 tests pass in Debug, ReleaseSafe and ReleaseFast, none added and none
removed. Reverting either pin on its own reproduces the 17 errors above,
which is the closest thing to a mutation this change admits: the two pins
are only correct as a pair.

Part of the repin sweep that follows #345. Versions are deliberately left
alone and will be bumped for the whole chain at release time.
