### PR TITLE
container_registry: repin azure_sdk_core and azure_rest_container_registry together

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,12 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
         .azure_rest_container_registry = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#70cf5bf1e8155fc9a5ae23206a6b092c2182d21b",
-            .hash = "azure_rest_container_registry-0.1.0-k4rjoQrxAQA6F4uP72ZGQ9F_OjPJ6Gluqk1l6kPOXANM",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5a8b907c312adc9d28157e7ed65d54de5f6607aa",
+            .hash = "azure_rest_container_registry-0.1.0-k4rjoQrxAQCNBUjIKxjoLMs_0O-IW0rS87pM2spGgtAT",
         },
     },
     .paths = .{


### PR DESCRIPTION
Two pins moved, and they are moved together deliberately:

  - azure_sdk_core b7b47b2b1 -> 1d73a90ee (0.1.3 -> 0.2.0), skipping #255,
    #298, #299 and #300.
  - azure_rest_container_registry 70cf5bf1e -> 5a8b907c3, which is that
    package's tip now that it has been repinned onto the same core (#360).

Unlike `sdk/data_tables`, this branch does *not* fail when only core moves.
That was measured, not assumed: repinning core alone still built and passed
all 113 tests. The graph nonetheless contained two copies of
`azure_sdk_core` - this branch's 0.2.0 and the 0.1.0 that
`azure_rest_container_registry` still pinned (its old pin 70cf5bf1e points
at core 5c37f2997, which is 0.1.0 - not the 0.1.3 this branch itself had) - because no core type crosses
the boundary between the two packages here, so nothing collided. On
`sdk/data_tables` the same split produced 17 `expected type
'http.pipeline.HttpPipeline', found 'http.pipeline.HttpPipeline'` errors.

A latent duplicate is worth removing on its own account: it is a second
copy of the credential and pipeline machinery that happens not to be
observable today, and would become observable the first time a core type
did cross that boundary. So both pins move.

Nothing in the source needed changing. `azure_sdk_core` gained five new
public names over those four commits - `CredentialKind`,
`TokenCredentialSelection`, `CountingAllocator`, `benchmarkAllocating` and
`nowNs`, declared at seven sites because two are re-exported - and removed
none. One existing
declaration changed value: `pub const version` went from the literal "0.1.0"
to `@import("build_options").version`, which resolves to the manifest's
"0.2.0", and `user_agent_prefix` follows it. The type is unchanged, and this
is a fix rather than a regression - the literal had drifted from the
manifest, which already read 0.1.3. Neither constant is referenced outside
core's own definition of it.

`AzureDeveloperCliCredential.init` also gained a required `io: std.Io`
parameter. That is a breaking signature change to an existing public
function, but this branch does not call it.

The one consumer-visible behaviour change is #298 - the default IMDS probe
is gone and the chain is built from `AZURE_TOKEN_CREDENTIALS` - and unlike
every other branch in this sweep, **this one is affected**.
`examples/support.zig:23` and `live_tests/main.zig:55` both construct
`core.identity.DefaultAzureCredential`, and `build.zig:97` puts the examples
on `test_step`, so the suite builds a default chain on every run.

What changes for those callers: `ManagedIdentityCredential` is no longer
probed unconditionally, so the 169.254.169.254 stall on a developer machine
is gone; the chain is instead selected by `AZURE_TOKEN_CREDENTIALS`, and two
new failure modes exist - `error.UnknownTokenCredentialSelection` for an
unrecognised value and `error.NoCredentialConfigured` for a selection that
empties the chain. `init`'s signature is unchanged, which is why nothing
here failed to compile. The suite is green, but this is a real behaviour
change on this branch rather than a theoretical one.

113 tests pass in Debug, ReleaseSafe and ReleaseFast, none added and none
removed. Because the half-repin compiles here, compilation is *not* a
discriminator on this branch - the honest statement is that the duplicate
was found by reading the dependency graph, not by a failing build, and that
the test suite cannot tell the two states apart.

Part of the repin sweep that follows #345. Versions are deliberately left
alone and will be bumped for the whole chain at release time.
