### PR TITLE
kusto: repin core and the three storage packages at their tips

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,20 +5,20 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
+            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
         },
         .azure_sdk_storage_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#93be9fdd48cefa1f30023c5b852f89193671988c",
-            .hash = "azure_sdk_storage_common-0.1.0-JzoreP9kAAAHmHB4xxMQDJ2Gc4wMxrevGjreIYUMiU9O",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#755d3fe130a0ce8b1379a23abfd5ea1ef6ac4f9b",
+            .hash = "azure_sdk_storage_common-0.2.0-JzoreP9kAACIJrt3wR1biYx3X0vYljV9IiAfu86cFa7e",
         },
         .azure_sdk_storage_blobs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#4f1e3c0e3ed14df68956af442cd401ac2974b362",
-            .hash = "azure_sdk_storage_blobs-0.1.0-I5lGdgoKAQCviVvGY2BIs_0Guj5BQj1OpWy_m3VLkKpH",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3beb8819585cb1663975446d1fc6b68ca56e16ef",
+            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
         },
         .azure_sdk_storage_queues = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#fa33ee1b6a02f6dc3f6064e3563d292fd3320f2d",
-            .hash = "azure_sdk_storage_queues-0.1.0-LKTiC7hzAACesUmmsuRTQOhm4jz_vbwPWdE2d0pGCE6X",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#230c3871c66cf01c56cd0e1074b9671469f26937",
+            .hash = "azure_sdk_storage_queues-0.1.0-LKTiC7hzAAAgGj0CZmqC9bZisbmSLm9hCqk7z0anGmj9",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",


### PR DESCRIPTION
Four pins moved, all to their branch tips:

  - azure_sdk_core            b7b47b2b1 -> 1d73a90ee (0.1.3 -> 0.2.0)
  - azure_sdk_storage_common  93be9fdd4 -> 755d3fe13
  - azure_sdk_storage_blobs   4f1e3c0e3 -> 3beb88195
  - azure_sdk_storage_queues  fa33ee1b6 -> 230c3871c

This is the last branch in the repin sweep and the one with the most
internal dependencies, so it is also the one where a partial repin would do
the most damage. All four had to move as a set: each of the three storage
packages, at its own tip, already pins core at 1d73a90ee, so moving core
without them - or any of them without core - would put two copies of
`azure_sdk_core` in one graph. That failure mode is not hypothetical; on
`sdk/data_tables` it produced 17 errors of the shape `expected type
'http.pipeline.HttpPipeline', found 'http.pipeline.HttpPipeline'`.

Verified directly rather than inferred: after the repin, `zig-pkg/` contains
exactly one `azure_sdk_core`, at 0.2.0.

Nothing in the source needed changing. `azure_sdk_core` gained five new
public names over the four commits skipped here (#255, #298, #299, #300) -
`CredentialKind`, `TokenCredentialSelection`, `CountingAllocator`,
`benchmarkAllocating` and `nowNs`, declared at seven sites because two are
re-exported - and removed none. One existing declaration changed value: `pub const version`
went from the literal "0.1.0" to `@import("build_options").version`, which
resolves to the manifest's "0.2.0", and `user_agent_prefix` follows it. The
type is unchanged, and this is a fix rather than a regression - the literal
had drifted from the manifest, which already read 0.1.3. Neither constant is
referenced outside core's own definition of it.

`AzureDeveloperCliCredential.init` also gained a required `io: std.Io`
parameter. That is a breaking signature change to an existing public
function, but this branch does not call it.

Of the three storage packages, `azure_sdk_storage_common` and
`azure_sdk_storage_queues` add and remove no public declaration across their
skipped commits. `azure_sdk_storage_blobs` is the exception and a large one:
across the eight commits skipped here, `root.zig`'s top-level public
declarations go from 22 to 48, and counted across every `.zig` file in the
package from 39 to 182. It *removes* names as well as adding them -
`BlobClientOptions` and `BlobContainerClientOptions` are gone at the new
tip. Kusto compiles and
passes against the new tip, so it consumes none of the removed names, but
"no public declaration changed" would have been false for this package.

The one consumer-visible behaviour change is #298 in core: the default IMDS
probe is gone and `AZURE_TOKEN_CREDENTIALS` is honoured. Nothing on this
branch constructs a default chain; the only mention of it is a doc comment
at `common/root.zig:169` naming `DefaultAzureCredential` as an example of a
`TokenCredential` a caller might pass to `withTokenCredential`.

192 tests pass in Debug, ReleaseSafe and ReleaseFast, none added and none
removed. The change is a manifest repin with no source edit, so the suite
passing against the new dependencies, plus the single-core check above, is
the whole of the verification available.

Completes the repin sweep that follows #345. Versions are deliberately left
alone and will be bumped for the whole chain at release time.
