### PR TITLE
eventhubs: return the received property maps by pointer, not by value

### DIFF
--- a/event_data.zig
+++ b/event_data.zig
@@ -342,6 +342,14 @@ pub const EventData = struct {
 /// The consequence is that the fields are not individually owned: do not free
 /// one, replace one with allocated memory, or add to `properties` with
 /// `PropertyMap.put`. Free the event with `deinit` or `freeReceivedEvents`.
+///
+/// Read the two maps through `properties` and `systemProperties`, which return
+/// `*const` so that releasing one through the accessor is a compile error
+/// rather than a double free. Zig has no private fields, so `event_data` and
+/// `system_properties` are still reachable directly and copying either out by
+/// value still yields a map whose `deinit` frees storage the event will free
+/// again; the accessors make the path a caller is likely to find the safe one,
+/// they do not make the unsafe one unreachable.
 pub const ReceivedEventData = struct {
     event_data: EventData = .{},
     /// UTC time the service accepted the event, in Unix milliseconds.
@@ -373,8 +381,23 @@ pub const ReceivedEventData = struct {
         return self.event_data.correlation_id;
     }
 
-    pub fn properties(self: ReceivedEventData) PropertyMap {
-        return self.event_data.properties;
+    /// The event's application properties.
+    ///
+    /// Returned by pointer, not by value. A `PropertyMap` copy shares the
+    /// original's storage but not its identity, so `deinit` on the copy frees
+    /// that storage and empties only the copy, leaving the event holding a
+    /// dangling `entries` that `ReceivedEventData.deinit` then frees a second
+    /// time. `borrowed` does not save it: it suppresses freeing the keys and
+    /// values, never the map's own storage. A `*const` result makes that
+    /// mistake a compile error, because `deinit` needs a mutable pointer.
+    pub fn properties(self: *const ReceivedEventData) *const PropertyMap {
+        return &self.event_data.properties;
+    }
+
+    /// The annotations not surfaced as dedicated fields. `*const` for the
+    /// same reason as `properties`.
+    pub fn systemProperties(self: *const ReceivedEventData) *const PropertyMap {
+        return &self.system_properties;
     }
 
     /// Calling this twice on the same event is harmless: it is left empty, so
@@ -1673,6 +1696,40 @@ test "a borrowed property map survives being released twice" {
     decoded.deinit(allocator);
 
     try std.testing.expectEqual(@as(usize, 0), decoded.system_properties.count());
+}
+
+test "the property accessors alias the event's maps rather than copying them" {
+    const allocator = std.testing.allocator;
+
+    var annotations = [_]MapEntry{
+        .{ .key = .{ .symbol = "x-opt-vendor" }, .value = .{ .string = "v" } },
+    };
+    var properties = [_]MapEntry{.{ .key = .{ .string = "k" }, .value = .{ .string = "v" } }};
+    var decoded = try fromRawMessage(allocator, .{
+        .body = "b",
+        .message_annotations = &annotations,
+        .application_properties = &properties,
+    });
+    defer decoded.deinit(allocator);
+
+    const props = decoded.properties();
+    const system = decoded.systemProperties();
+    try std.testing.expectEqual(@as(usize, 1), props.count());
+    try std.testing.expectEqual(@as(usize, 1), system.count());
+
+    // Release both maps through the event. Each accessor result has to observe
+    // that, which is only true if it aliases the field. An accessor returning
+    // `PropertyMap` by value would hand back a copy that still reported one
+    // entry and still pointed at the storage just freed - and whose own
+    // `deinit` would free it a second time. That is the double free these
+    // signatures exist to prevent, so the staleness is what this asserts.
+    decoded.event_data.deinit(allocator);
+    decoded.system_properties.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), props.count());
+    try std.testing.expectEqual(@as(usize, 0), system.count());
+    // The backing block is untouched by either release.
+    try std.testing.expectEqualStrings("b", decoded.body());
 }
 
 test "a repeated application property key keeps the last value" {


### PR DESCRIPTION
`ReceivedEventData.properties()` returned `PropertyMap` by value. A
`PropertyMap` copy shares the original's `entries` storage but not its
identity, so the obvious-looking

    var props = event.properties();
    defer props.deinit(allocator);

frees that storage and empties only the copy. The event still points at it,
and `ReceivedEventData.deinit` frees it a second time. Reproduced against
this branch before the change: the test crashes inside `decoded.deinit` at
`self.event_data.properties.deinit(allocator)`.

`borrowed` does not save it. That flag suppresses freeing the keys and
values - which for a decoded event are interior pointers into `backing` -
but `deinit` frees `self.entries` unconditionally, because the map's index
storage is the one thing it does own on the allocator. So the double free
happens on exactly the events where the flag is set.

The accessors now return `*const PropertyMap`, and `systemProperties` joins
`properties` so the other map has a safe reader too. `deinit` takes
`*PropertyMap`, so the misuse above is now a compile error - verified, it
fails at the `deinit` call with `expected type '*T', found '*const T'`.
Every read path is unaffected: `count`, `get`, `getString`, `keys` and
`values` all take `PropertyMap` by value and Zig dereferences the pointer
at the call, including when the receiver is itself a by-value copy of the
event. `self` also had to become `*const ReceivedEventData`, since a
by-value parameter would put the returned pointer into a dead temporary.

What this does not do: Zig has no private fields, so `event_data` and
`system_properties` remain public and copying either out by hand still
reaches the same double free. This narrows the path a caller is likely to
take; it does not close the hole. The type doc now says so rather than
implying the problem is gone.

Two deeper fixes would close it properly, both larger than this change.
Sizing the maps' index storage inside `backing` couples the package to
`StringArrayHashMapUnmanaged`'s private capacity math - a `MultiArrayList`
plus an `IndexHeader` whose index width and load-factor rounding are
implementation detail. That coupling is uncomfortable but it is not unsafe:
`fromRawMessage` already allocates the block through a
`FixedBufferAllocator` (line 694), so an under-estimate returns
`error.OutOfMemory` rather than overflowing anything. The real cost is the
fallback - on OOM the map's storage has to come from the real allocator
instead, and `deinit` would then need to distinguish storage it owns from
storage inside the block, which is a third ownership state on top of
`borrowed`. The alternative is to hold decoded properties as a flat borrowed
key/value slice in `backing` with linear lookup, which AMQP's single-digit
property counts make cheap; a decoded map would then own nothing at all and
its `deinit` would be a no-op, so copies become harmless outright. That is
the better end state and it needs its own change.

The changed return type is a breaking change to a public function, and
`systemProperties` is a new public declaration. No package depends on
`azure_sdk_eventhubs`, and nothing in this branch outside the tests calls
either accessor, so nothing needed repinning or editing.

194 tests pass in Debug, ReleaseSafe and ReleaseFast, up from 193 - one
added, none removed. The suite runs in two steps; the new test is in the 176
of the first, alongside an unchanged 18 in the second. It asserts the
accessors alias the event's maps: it releases both through the event and
requires the results already in hand to observe the reset. Mutation-verified
by reverting both signatures to by-value, which fails it with `expected 0,
found 1` - the stale count that is the copy bug's signature.

