### PR TITLE
eventhubs: key the sender pool by address and stop allocating it per send

### DIFF
--- a/root.zig
+++ b/root.zig
@@ -64,6 +64,7 @@ pub const SenderPool = sending.SenderPool;
 pub const default_max_in_flight = sending.default_max_in_flight;
 pub const SendError = sending.SendError;
 pub const entityPathFor = sending.entityPathFor;
+pub const entityPathInto = sending.entityPathInto;
 
 /// Metadata models and the `$management` operations that produce them. Both
 /// carry an optional arena, so a decoded value owns its strings and one built
@@ -747,6 +748,35 @@ pub const ProducerClient = struct {
         return self.credential.getToken(ctx);
     }
 
+    /// Scratch space for an entity path that is only needed long enough to
+    /// look a link up.
+    ///
+    /// Every send builds the same address to key `SenderPool` by, and it was
+    /// costing an allocation each time. This holds it inline for any name
+    /// Event Hubs accepts and only allocates for one it would not, so the
+    /// longer name keeps working rather than becoming a client-side error.
+    const EntityPath = struct {
+        buf: [sending.entity_path_buffer_len]u8 = undefined,
+        owned: ?[]u8 = null,
+
+        fn resolve(
+            self: *EntityPath,
+            allocator: std.mem.Allocator,
+            name: []const u8,
+            partition_id: ?[]const u8,
+        ) ![]const u8 {
+            return sending.entityPathInto(&self.buf, name, partition_id) catch {
+                const owned = try sending.entityPathFor(allocator, name, partition_id);
+                self.owned = owned;
+                return owned;
+            };
+        }
+
+        fn deinit(self: *EntityPath, allocator: std.mem.Allocator) void {
+            if (self.owned) |owned| allocator.free(owned);
+        }
+    };
+
     /// The AMQP address a batch is published to: the hub, letting the service
     /// pick a partition, or `{hub}/Partitions/{id}`. Caller owns the result.
     pub fn entityPath(
@@ -760,8 +790,9 @@ pub const ProducerClient = struct {
     /// Send a batch of events over AMQP.
     pub fn sendBatch(self: *ProducerClient, allocator: std.mem.Allocator, batch: EventDataBatch) !void {
         if (batch.count() == 0) return SendError.EmptyBatch;
-        const address = try self.entityPath(allocator, batch.partition_id);
-        defer allocator.free(address);
+        var entity_path: EntityPath = .{};
+        defer entity_path.deinit(allocator);
+        const address = try entity_path.resolve(allocator, self.options.event_hub_name, batch.partition_id);
         return self.amqp_transport.sendBatch(allocator, address, batch);
     }
 
@@ -809,8 +840,9 @@ pub const ProducerClient = struct {
                 batches[end].partition_id,
             )) : (end += 1) {}
 
-            const address = try self.entityPath(allocator, batches[start].partition_id);
-            defer allocator.free(address);
+            var entity_path: EntityPath = .{};
+            defer entity_path.deinit(allocator);
+            const address = try entity_path.resolve(allocator, self.options.event_hub_name, batches[start].partition_id);
             try self.amqp_transport.sendBatches(allocator, address, batches[start..end]);
 
             start = end;
@@ -831,8 +863,9 @@ pub const ProducerClient = struct {
         var new_batch = try EventDataBatch.init(options);
         errdefer new_batch.deinit(allocator);
 
-        const address = try self.entityPath(allocator, options.partition_id);
-        defer allocator.free(address);
+        var entity_path: EntityPath = .{};
+        defer entity_path.deinit(allocator);
+        const address = try entity_path.resolve(allocator, self.options.event_hub_name, options.partition_id);
 
         if (try self.amqp_transport.maxMessageSize(address)) |limit| {
             try new_batch.applyLinkMaxMessageSize(@intCast(limit));
@@ -2410,4 +2443,39 @@ test {
     _ = errors;
     _ = event_data;
     _ = checkpoint;
+}
+
+test "the entity path stays on the stack for a real hub and falls back for a long one" {
+    const allocator = std.testing.allocator;
+
+    {
+        var entity_path: ProducerClient.EntityPath = .{};
+        defer entity_path.deinit(allocator);
+        const address = try entity_path.resolve(allocator, "my-hub", "3");
+        try std.testing.expectEqualStrings("my-hub/Partitions/3", address);
+        // Nothing was allocated: the path points into the struct's own buffer.
+        try std.testing.expect(entity_path.owned == null);
+        try std.testing.expect(@intFromPtr(address.ptr) == @intFromPtr(&entity_path.buf));
+    }
+
+    {
+        var entity_path: ProducerClient.EntityPath = .{};
+        defer entity_path.deinit(allocator);
+        const address = try entity_path.resolve(allocator, "hub-with-no-partition", null);
+        try std.testing.expectEqualStrings("hub-with-no-partition", address);
+        try std.testing.expect(entity_path.owned == null);
+    }
+
+    {
+        // Longer than Event Hubs accepts, so the inline buffer cannot hold it.
+        // It has to keep working rather than become a client-side error, which
+        // is the whole reason the fallback exists.
+        const long_name = "n" ** (sending.entity_path_buffer_len + 16);
+        var entity_path: ProducerClient.EntityPath = .{};
+        defer entity_path.deinit(allocator);
+        const address = try entity_path.resolve(allocator, long_name, "7");
+        try std.testing.expectEqualStrings(long_name ++ "/Partitions/7", address);
+        // And this one did allocate, so `deinit` has something to release.
+        try std.testing.expect(entity_path.owned != null);
+    }
 }

--- a/sender.zig
+++ b/sender.zig
@@ -33,6 +33,30 @@ pub fn entityPathFor(
     return std.fmt.allocPrint(allocator, "{s}/Partitions/{s}", .{ event_hub_name, id });
 }
 
+/// Longest entity path Azure can name: a 256-character hub, the separator, and
+/// a partition id with room to spare. `entity_path_buffer_len` sizes a stack
+/// buffer that never has to grow for a real hub.
+pub const entity_path_buffer_len = 320;
+
+/// `entityPathFor` without the allocation, for callers that only need the path
+/// long enough to look a link up.
+///
+/// Returns `error.NoSpaceLeft` if `buf` is too small, which a caller with a
+/// `entity_path_buffer_len` buffer only sees for a name Event Hubs would not
+/// accept. Falling back to `entityPathFor` keeps such a name working.
+pub fn entityPathInto(
+    buf: []u8,
+    event_hub_name: []const u8,
+    partition_id: ?[]const u8,
+) ![]const u8 {
+    const id = partition_id orelse {
+        if (event_hub_name.len > buf.len) return error.NoSpaceLeft;
+        @memcpy(buf[0..event_hub_name.len], event_hub_name);
+        return buf[0..event_hub_name.len];
+    };
+    return std.fmt.bufPrint(buf, "{s}/Partitions/{s}", .{ event_hub_name, id });
+}
+
 /// Sender links keyed by entity address, opened on demand.
 ///
 /// The links belong to the session, which detaches and frees them when it is
@@ -51,7 +75,13 @@ pub const default_max_in_flight: u32 = 8;
 pub const SenderPool = struct {
     allocator: Allocator,
     session: *amqp.Session,
-    entries: std.ArrayList(Entry) = .empty,
+    /// Keyed by entity address rather than scanned, so the cost of finding a
+    /// link does not grow with the caller's partition count. Measured worst
+    /// case, 1000 lookups per timed iteration so the result is not the
+    /// clock floor: a scan costs 8.1ns at N=4, 66ns at N=32, 467ns at N=256
+    /// and 1.68us at N=1024, against a flat 4.8ns hashed at every N. The
+    /// hash never loses, including at N=4. The pool owns the keys.
+    entries: std.StringHashMapUnmanaged(*amqp.Sender) = .empty,
     deadline_ms: i64,
     /// Distinguishes these links from any others on the connection.
     link_id: []const u8,
@@ -61,11 +91,6 @@ pub const SenderPool = struct {
     last_rejection: ?amqp.Rejection = null,
     /// How many batches a link may have on the wire unconfirmed.
     max_in_flight: u32 = 1,
-
-    const Entry = struct {
-        address: []u8,
-        sender: *amqp.Sender,
-    };
 
     pub const Options = struct {
         deadline_ms: i64,
@@ -95,7 +120,8 @@ pub const SenderPool = struct {
 
     /// Release the pool's own bookkeeping. The senders are the session's.
     pub fn deinit(self: *SenderPool) void {
-        for (self.entries.items) |entry| self.allocator.free(entry.address);
+        var it = self.entries.iterator();
+        while (it.next()) |entry| self.allocator.free(entry.key_ptr.*);
         self.entries.deinit(self.allocator);
         self.entries = .empty;
         self.last_rejection = null;
@@ -103,9 +129,7 @@ pub const SenderPool = struct {
 
     /// The sender attached to `address`, attaching one if there is none.
     pub fn senderFor(self: *SenderPool, address: []const u8) !*amqp.Sender {
-        for (self.entries.items) |entry| {
-            if (std.mem.eql(u8, entry.address, address)) return entry.sender;
-        }
+        if (self.entries.get(address)) |sender| return sender;
 
         const name = try std.fmt.allocPrint(
             self.allocator,
@@ -128,7 +152,7 @@ pub const SenderPool = struct {
             .max_in_flight = self.max_in_flight,
         }, self.deadline_ms);
 
-        self.entries.appendAssumeCapacity(.{ .address = owned, .sender = sender });
+        self.entries.putAssumeCapacityNoClobber(owned, sender);
         return sender;
     }
 
@@ -139,21 +163,18 @@ pub const SenderPool = struct {
     /// into a dead connection would fail, and the link died with the session
     /// regardless.
     pub fn drop(self: *SenderPool, address: []const u8, detach: bool) void {
-        for (self.entries.items, 0..) |entry, i| {
-            if (!std.mem.eql(u8, entry.address, address)) continue;
-            if (detach) self.session.closeSender(entry.sender, self.deadline_ms);
-            self.allocator.free(entry.address);
-            _ = self.entries.orderedRemove(i);
-            self.last_rejection = null;
-            return;
-        }
+        const removed = self.entries.fetchRemove(address) orelse return;
+        if (detach) self.session.closeSender(removed.value, self.deadline_ms);
+        self.allocator.free(removed.key);
+        self.last_rejection = null;
     }
 
     /// Forget every sender.
     pub fn dropAll(self: *SenderPool, detach: bool) void {
-        for (self.entries.items) |entry| {
-            if (detach) self.session.closeSender(entry.sender, self.deadline_ms);
-            self.allocator.free(entry.address);
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            if (detach) self.session.closeSender(entry.value_ptr.*, self.deadline_ms);
+            self.allocator.free(entry.key_ptr.*);
         }
         self.entries.clearRetainingCapacity();
         self.last_rejection = null;
@@ -362,12 +383,7 @@ pub const SenderPool = struct {
     /// Drop any verdicts still outstanding on `address`, leaving the link free
     /// for a blocking send. Nothing to do if the link was never opened.
     fn abandonInFlight(self: *SenderPool, address: []const u8) void {
-        for (self.entries.items) |entry| {
-            if (std.mem.eql(u8, entry.address, address)) {
-                entry.sender.abandonInFlight();
-                return;
-            }
-        }
+        if (self.entries.get(address)) |sender| sender.abandonInFlight();
     }
 
     /// Send under the Event Hubs retry schedule.
@@ -427,13 +443,10 @@ pub const SenderPool = struct {
     /// delivery, which is more precise than "the link went away".
     pub fn recordFailure(self: *const SenderPool, address: []const u8, attempt: *errors.Attempt) void {
         if (self.last_rejection != null) return self.recordCondition(attempt);
-        for (self.entries.items) |entry| {
-            if (!std.mem.eql(u8, entry.address, address)) continue;
-            const detached = entry.sender.detach_error orelse return;
-            attempt.condition = detached.condition;
-            attempt.description = detached.description;
-            return;
-        }
+        const sender = self.entries.get(address) orelse return;
+        const detached = sender.detach_error orelse return;
+        attempt.condition = detached.condition;
+        attempt.description = detached.description;
     }
 };
 
@@ -959,6 +972,22 @@ test "an empty batch is refused before a link is touched" {
         SendError.EmptyBatch,
         scripted.pool.send(allocator, "my-hub", empty),
     );
+}
+
+test "entityPathInto writes what entityPathFor would allocate" {
+    const allocator = std.testing.allocator;
+    var buf: [entity_path_buffer_len]u8 = undefined;
+
+    for ([_]?[]const u8{ null, "3", "1023" }) |partition_id| {
+        const allocated = try entityPathFor(allocator, "my-hub", partition_id);
+        defer allocator.free(allocated);
+        try std.testing.expectEqualStrings(allocated, try entityPathInto(&buf, "my-hub", partition_id));
+    }
+
+    // Too small to hold either shape, and it says so rather than truncating.
+    var tiny: [4]u8 = undefined;
+    try std.testing.expectError(error.NoSpaceLeft, entityPathInto(&tiny, "my-hub", "3"));
+    try std.testing.expectError(error.NoSpaceLeft, entityPathInto(&tiny, "my-hub", null));
 }
 
 test "entityPathFor targets the hub or one partition" {


### PR DESCRIPTION
P2.7 listed three items. Measuring them first turned two into changes worth
making, retired one as already done, and refuted my own prediction about a
third.

**Sender pool lookup: O(N) per send.** `SenderPool` held its links in an
`ArrayList` scanned with `mem.eql`, in four places - `senderFor`, `drop`,
`abandonInFlight` and `recordFailure`. I expected a hash map to lose at
realistic N, reasoning that hashing must read the whole key while a scan can
reject on the first byte. Measured, that is backwards, and my reason for
expecting it was also wrong: `mem.eql` on `[]const u8` routes to `eqlBytes`,
which does a fixed number of loads for short keys and fixed-width vector
chunks for long ones. There is no per-byte early exit, so where the keys
first differ barely matters. The scan simply loses because it is O(N) in the
caller's partition count while a hash lookup is flat.

Worst case (needle last), 1000 lookups per timed iteration so the figures are
not the harness clock floor, which is 0.3ns/op here:

    N      scan, shared prefix   scan, distinct first byte    hashed
    4                    8.1ns                       8.0ns     4.8ns
    32                    66ns                        57ns     4.8ns
    256                  467ns                       467ns     4.8ns
    1024                1.68us                      1.95us     4.8ns

The two scan columns are the control for the first-byte theory: making every
key differ in its first byte does not rescue the scan, and at N=1024 it is
slower. The hash map wins at every size including N=4, and its cost does not
move. Lookups now allocate nothing; only a new address does, once.

**Entity path: an allocation per send to build a lookup key.** Every
`sendBatch`, `sendBatches` run and `createBatch` called `entityPathFor`,
which `allocPrint`s the address, hands it to the pool, and frees it. Measured
against a counting allocator that is 3 allocations and 200 bytes to produce a
20-byte address, because `allocPrint` grows its buffer; on the clock it is
50ns against 6.0ns for the same format into a stack buffer. `EntityPath` now
holds it inline for any name Event Hubs accepts, and falls back to allocating
for one it would not, so an over-long name keeps working rather than becoming
a client-side error the SDK never used to raise.

**Reserve `events` capacity: already done.** `receiver.zig:224` has called
`ensureTotalCapacityPrecise(allocator, count)` since P2.3, with a comment
explaining why. The plan item was stale.

**Reserve `marshaled` capacity: declined, with numbers.** A batch grows until
an event does not fit, so the count is not known when the list is created,
and estimating it from the first event's encoded size would over-reserve
badly for mixed-size events. The cost being avoided is small either way:
`batch.tryAdd` is 8 allocations for one event, 506 for a hundred and 5010 for
a thousand. That is 5 per event plus a residual of 3/6/10, and the residual
covers the batch envelope as well as the list's growth, so the growth this
item would remove is at most that - about 0.2% of the batch.

Honest about the size of all this: none of it shows up in
`zig build bench`, because no offline benchmark exercises `sendBatch` - that
needs a transport. Per batch send this removes 3 allocations and 200 bytes
and replaces a scan with a hash lookup, which against the ~400us and ~5011
allocations of encoding a 1000-event batch is a rounding error, and against
the round trip that follows it is nothing at all. The defensible reason to
take it is the algorithmic one: a per-send cost that grew with the customer's
partition count is now flat, and 1024 partitions is a supported
configuration.

The measurements above came from temporary cases added to `benchmarks/main.zig`
and removed again before commit; they benchmark two implementations against
each other, which is not something a regression suite should carry.

`SenderPool.entries` changes type, and it is a public field, so this is a
breaking change for anyone who read it directly. Nothing in this branch does
outside `sender.zig`, and no package depends on `azure_sdk_eventhubs`.
`entityPathInto` and `entity_path_buffer_len` are new public declarations;
`entityPathFor` is untouched.

196 tests pass in Debug, ReleaseSafe and ReleaseFast, up from 194 - two
added, none removed. Mutation-verified four ways, each caught: dropping the
bounds check in `entityPathInto`'s no-partition branch crashes; removing the
allocating fallback fails the long-name test; and having either `drop` or
`dropAll` stop freeing the pool's owned key reports 2 leaks, which also
confirms the existing tests reach both paths through the new container.