### PR TITLE
eventhubs: encode batched events from borrowed sections, not a copy

### DIFF
--- a/batch.zig
+++ b/batch.zig
@@ -96,24 +96,22 @@ pub const EventDataBatch = struct {
     /// batched, and `BatchError.EventDataTooLarge` when it would not fit even
     /// an empty batch.
     pub fn tryAdd(self: *EventDataBatch, allocator: std.mem.Allocator, event: EventData) !bool {
-        var message = try event.toAmqpMessage(allocator);
-        defer event_data.freeAmqpMessage(allocator, &message);
-
-        if (self.partition_key) |partition_key| {
-            try event_data.setPartitionKeyAnnotation(allocator, &message, partition_key);
-        }
+        var borrowed: event_data.BorrowedMessage = undefined;
+        try borrowed.init(allocator, event, self.partition_key);
+        defer borrowed.deinit();
+        const message = &borrowed.message;
 
         // Both buffers are discarded unless the event is actually adopted,
         // which includes the `false` return when it simply does not fit.
         var adopted = false;
 
-        const encoded = try event_data.encodeMessage(allocator, &message);
+        const encoded = try event_data.encodeMessage(allocator, message);
         defer if (!adopted) allocator.free(encoded);
 
         // The first event also fixes the envelope, so its cost is charged here.
         const is_first = self.marshaled.items.len == 0;
         const envelope: ?[]u8 = if (is_first)
-            try event_data.encodeMessageEnvelope(allocator, &message)
+            try event_data.encodeMessageEnvelope(allocator, message)
         else
             null;
         defer if (!adopted) {

--- a/event_data.zig
+++ b/event_data.zig
@@ -10,6 +10,7 @@ const uamqp = @import("uamqp");
 pub const AmqpValue = uamqp.AmqpValue;
 pub const MapEntry = uamqp.MapEntry;
 pub const Message = uamqp.message.Message;
+const DataSection = uamqp.message.DataSection;
 
 /// Message annotations Event Hubs stamps on every received event. Values match
 /// the Go SDK's `event_data.go` constants byte for byte.
@@ -328,6 +329,94 @@ pub const EventData = struct {
         }
 
         return message;
+    }
+};
+
+/// How many application properties a `BorrowedMessage` can describe without
+/// allocating. Eight covers the small tag sets events are normally stamped
+/// with; beyond it the entries go to the heap rather than being refused.
+pub const inline_property_slots: usize = 8;
+
+/// A `Message` whose sections alias an `EventData` instead of copying it.
+///
+/// `EventDataBatch.tryAdd` encodes and discards each AMQP message before it
+/// returns, while the caller's `EventData` outlives the call. This avoids
+/// paying for the owning `toAmqpMessage` conversion on that path.
+///
+/// `init` fills this object in place. Do not move or copy it afterwards: the
+/// message's body, annotation, and property slices point into this struct.
+pub const BorrowedMessage = struct {
+    message: Message,
+    body_storage: [1]DataSection,
+    annotation_storage: [1]MapEntry,
+    property_storage: [inline_property_slots]MapEntry,
+    heap_properties: ?[]MapEntry,
+    allocator: std.mem.Allocator,
+
+    pub fn init(
+        self: *BorrowedMessage,
+        allocator: std.mem.Allocator,
+        event: EventData,
+        partition_key: ?[]const u8,
+    ) !void {
+        self.* = .{
+            .message = Message.init(allocator),
+            .body_storage = undefined,
+            .annotation_storage = undefined,
+            .property_storage = undefined,
+            .heap_properties = null,
+            .allocator = allocator,
+        };
+        errdefer self.deinit();
+
+        self.body_storage[0] = .{ .bytes = event.body };
+        self.message.body_type = .data;
+        self.message.body_data_sections.items = self.body_storage[0..1];
+        self.message.body_data_sections.capacity = 1;
+
+        // Go always attaches a properties section, even when every field is
+        // unset, so the wire shape stays identical across SDKs.
+        self.message.properties = .{};
+        if (event.message_id) |message_id| {
+            self.message.properties.?.message_id = message_id.toAmqpValue();
+        }
+        if (event.correlation_id) |correlation_id| {
+            self.message.properties.?.correlation_id = correlation_id.toAmqpValue();
+        }
+        if (event.content_type) |content_type| {
+            self.message.properties.?.content_type = content_type;
+        }
+
+        const property_count = event.properties.count();
+        if (property_count > 0) {
+            const entries = if (property_count <= inline_property_slots)
+                self.property_storage[0..property_count]
+            else entries: {
+                const heap = try allocator.alloc(MapEntry, property_count);
+                self.heap_properties = heap;
+                break :entries heap;
+            };
+            for (event.properties.keys(), event.properties.values(), entries) |key, value, *entry| {
+                entry.* = .{ .key = .{ .string = key }, .value = value };
+            }
+            self.message.application_properties = entries;
+        }
+
+        if (partition_key) |key| {
+            self.annotation_storage[0] = .{
+                .key = .{ .symbol = partition_key_annotation },
+                .value = .{ .string = key },
+            };
+            self.message.message_annotations = self.annotation_storage[0..1];
+        }
+    }
+
+    pub fn deinit(self: *BorrowedMessage) void {
+        if (self.heap_properties) |entries| {
+            self.allocator.free(entries);
+            self.heap_properties = null;
+        }
+        self.message.deinit();
     }
 };
 
@@ -1302,6 +1391,103 @@ test "setPartitionKeyAnnotation stamps the annotation Event Hubs hashes" {
     var decoded = try fromAmqpMessage(allocator, &message);
     defer decoded.deinit(allocator);
     try std.testing.expectEqualStrings("pk-10", decoded.partition_key.?);
+}
+
+fn expectBorrowedMessageMatchesOwned(
+    allocator: std.mem.Allocator,
+    event: EventData,
+    partition_key: ?[]const u8,
+) !void {
+    var owned = try event.toAmqpMessage(allocator);
+    defer freeAmqpMessage(allocator, &owned);
+    if (partition_key) |key| try setPartitionKeyAnnotation(allocator, &owned, key);
+
+    const owned_encoded = try encodeMessage(allocator, &owned);
+    defer allocator.free(owned_encoded);
+    const owned_envelope = try encodeMessageEnvelope(allocator, &owned);
+    defer allocator.free(owned_envelope);
+
+    var borrowed: BorrowedMessage = undefined;
+    try borrowed.init(allocator, event, partition_key);
+    defer borrowed.deinit();
+
+    const borrowed_encoded = try encodeMessage(allocator, &borrowed.message);
+    defer allocator.free(borrowed_encoded);
+    const borrowed_envelope = try encodeMessageEnvelope(allocator, &borrowed.message);
+    defer allocator.free(borrowed_envelope);
+
+    try std.testing.expectEqualSlices(u8, owned_encoded, borrowed_encoded);
+    try std.testing.expectEqualSlices(u8, owned_envelope, borrowed_envelope);
+}
+
+test "BorrowedMessage encodes byte-identically to owning EventData conversion" {
+    const allocator = std.testing.allocator;
+
+    {
+        var event = EventData.init("plain");
+        defer event.deinit(allocator);
+        try expectBorrowedMessageMatchesOwned(allocator, event, null);
+    }
+    {
+        var event = EventData.init("typed");
+        defer event.deinit(allocator);
+        event.content_type = "application/json";
+        try expectBorrowedMessageMatchesOwned(allocator, event, null);
+    }
+    {
+        var event = EventData.init("string ids");
+        defer event.deinit(allocator);
+        event.message_id = .{ .string = "msg-1" };
+        event.correlation_id = .{ .string = "corr-1" };
+        try expectBorrowedMessageMatchesOwned(allocator, event, null);
+    }
+    {
+        var event = EventData.init("numeric ids");
+        defer event.deinit(allocator);
+        event.message_id = .{ .ulong = 42 };
+        event.correlation_id = .{ .ulong = 9001 };
+        try expectBorrowedMessageMatchesOwned(allocator, event, null);
+    }
+    {
+        var event = EventData.init("inline props");
+        defer event.deinit(allocator);
+        try event.setStringProperty(allocator, "tenant", "contoso");
+        try event.setProperty(allocator, "attempt", .{ .long = 3 });
+        try event.setProperty(allocator, "enabled", .{ .boolean = true });
+        try expectBorrowedMessageMatchesOwned(allocator, event, null);
+    }
+    {
+        var event = EventData.init("heap props");
+        defer event.deinit(allocator);
+        const keys = [_][]const u8{ "p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9" };
+        for (keys, 0..) |key, i| {
+            try event.setProperty(allocator, key, .{ .long = @intCast(i) });
+        }
+        try std.testing.expect(keys.len > inline_property_slots);
+        try expectBorrowedMessageMatchesOwned(allocator, event, null);
+    }
+    // The two counts either side of the inline/heap boundary, because an
+    // off-by-one in that comparison is invisible at 3 and at 10: taking the
+    // inline path for one property too many overruns `property_storage`,
+    // and taking the heap path one property too early still encodes
+    // correctly and so would go unnoticed.
+    inline for (.{ inline_property_slots, inline_property_slots + 1 }) |count| {
+        var event = EventData.init("boundary props");
+        defer event.deinit(allocator);
+        var buf: [8]u8 = undefined;
+        for (0..count) |i| {
+            const key = try std.fmt.bufPrint(&buf, "k{d}", .{i});
+            try event.setProperty(allocator, key, .{ .long = @intCast(i) });
+        }
+        try std.testing.expectEqual(count, event.properties.count());
+        try expectBorrowedMessageMatchesOwned(allocator, event, null);
+    }
+    {
+        var event = EventData.init("partitioned");
+        defer event.deinit(allocator);
+        event.content_type = "text/plain";
+        try expectBorrowedMessageMatchesOwned(allocator, event, "pk-1");
+    }
 }
 
 test "encodeMessage emits a data section in AMQP wire format" {


### PR DESCRIPTION
`EventDataBatch.tryAdd` built a fully owning `uamqp` `Message` per event,
encoded it, and freed it before returning. Measured on the benchmark event -
a 50-byte JSON body with a `content_type`, no ids and no application
properties - that intermediate message was 3 of the 5 allocations and 608 of
the 838 bytes each event cost:

    BENCH toAmqpMessage: 3.00 allocs/op, 608 B/op
    BENCH batch.tryAdd x1000: 5010 allocs, 838158 B

The ownership `toAmqpMessage` provides is what costs that: it opens an arena,
dupes the body into it, dupes `content_type`, clones `message_id` and
`correlation_id`, and allocates a `[]MapEntry` for the application
properties. On the batch path none of it is used: the caller's `EventData`
already owns that storage and outlives `tryAdd`, and the message is encoded
and discarded inside the call. Note the event is not merely a bundle of
borrowed slices - `PropertyMap.put` dupes its keys and clones its values, and
an id may be a `.ulong` or `.uuid` held by value. Aliasing is safe because of
the lifetime, not because nothing is owned.

`BorrowedMessage` builds the same message with its sections pointing at the
event instead of at copies of it. Checked against the uamqp source rather
than assumed, three things make that sound: `Message.deinit` does only
`arena.deinit()` and never touches `body_data_sections` or any `[]MapEntry`
field; `ArenaAllocator.init` allocates nothing, so the unused arena is free;
and `encodeMessageSections` only ever reads the message. Application
properties still need a `[]MapEntry`, so eight fit in an inline array and
more spill to the heap, the same shape `ProducerClient.EntityPath` uses for
over-long entity names.

    per event          before      after
    allocations             5          2
    bytes                 838        230

Those are marginal per-event costs; the batch totals quoted above are ten
allocations higher than a thousand times them, which is `marshaled` growing.

The remaining two allocations are `encodeMessage`'s dynamic buffer. Folding
those into the batch's own storage is a larger change and is not attempted
here.

`toAmqpMessage`, `freeAmqpMessage` and `setPartitionKeyAnnotation` are
untouched and still own everything they produce; the single-event send path
and every existing caller keep their current behaviour, which the unchanged
`BENCH toAmqpMessage` line at 3.00 allocs/op confirms.

Timings moved the right way but this host is too noisy to put a number on:
repeat runs of the unchanged baseline varied by more than a third. The
allocation and byte counts above are deterministic and are the gate the
harness documents.

197 tests pass in Debug, ReleaseSafe and ReleaseFast, up from 196. The new
test encodes nine events both ways and asserts the results are byte-identical
for the message and for the envelope: a plain body, a body with a
`content_type`, string ids, ulong ids, a property set that fits inline, one
that spills to the heap, both counts either side of that boundary, and the
partition-key annotation.

Mutation-verified. Not attaching the properties section unconditionally fails
the byte-equality test, which is what pins the wire shape to Go's. Taking the
inline path for one property too many panics with `index out of bounds: index
9, len 8` - that one is only caught because the test covers the boundary
counts themselves; at three and ten properties the same mistake is invisible.
Dropping the borrowed application properties and dropping the partition
annotation each fail the same test.