### PR TITLE
eventhubs: encode batch events into one buffer instead of one each

### DIFF
--- a/batch.zig
+++ b/batch.zig
@@ -1,6 +1,7 @@
 //! Packing events into a single Event Hubs batch transfer.
 
 const std = @import("std");
+const uamqp = @import("uamqp");
 const event_data = @import("event_data.zig");
 
 const EventData = event_data.EventData;
@@ -41,9 +42,24 @@ pub const EventDataBatchOptions = struct {
 /// work this way; estimating from body length under-counts properties,
 /// annotations, and per-message framing.
 pub const EventDataBatch = struct {
-    /// Fully encoded sub-messages, each of which becomes one data section of
-    /// the batch transfer.
-    marshaled: std.ArrayList([]u8) = .empty,
+    /// Every encoded sub-message, concatenated. Each becomes one data section
+    /// of the batch transfer. Held as one buffer rather than a slice per event
+    /// so that adding an event allocates nothing once the blob has capacity.
+    ///
+    /// Slices into this are invalidated by any later `tryAdd`, so `payloadAt`
+    /// results must not be held across one.
+    blob: std.ArrayList(u8) = .empty,
+    /// End offset in `blob` of each encoded sub-message.
+    ends: std.ArrayList(usize) = .empty,
+    /// Reused across events so encoding one does not allocate. Once this has
+    /// grown to fit the largest event seen, every later event encodes into the
+    /// capacity already there.
+    scratch: uamqp.encoder.Buffer = .{
+        .data = &.{},
+        .pos = 0,
+        .allocator = null,
+        .is_fixed = false,
+    },
     /// Encoded non-body sections of the first event, which become the batch
     /// envelope. Go reuses the first message this way.
     envelope: ?[]u8 = null,
@@ -67,8 +83,10 @@ pub const EventDataBatch = struct {
     }
 
     pub fn deinit(self: *EventDataBatch, allocator: std.mem.Allocator) void {
-        for (self.marshaled.items) |encoded| allocator.free(encoded);
-        self.marshaled.deinit(allocator);
+        self.blob.deinit(allocator);
+        self.ends.deinit(allocator);
+        self.scratch.deinit();
+        self.scratch = .{ .data = &.{}, .pos = 0, .allocator = null, .is_fixed = false };
         if (self.envelope) |envelope| allocator.free(envelope);
         self.envelope = null;
         self.current_size = 0;
@@ -82,7 +100,7 @@ pub const EventDataBatch = struct {
         self: *EventDataBatch,
         link_max_bytes: usize,
     ) BatchError!void {
-        if (self.marshaled.items.len > 0) return BatchError.BatchNotEmpty;
+        if (self.ends.items.len > 0) return BatchError.BatchNotEmpty;
         if (self.requested_max_bytes) |requested| {
             if (requested > link_max_bytes) return BatchError.MaxBytesExceedsLinkLimit;
             return;
@@ -101,15 +119,18 @@ pub const EventDataBatch = struct {
         defer borrowed.deinit();
         const message = &borrowed.message;
 
-        // Both buffers are discarded unless the event is actually adopted,
-        // which includes the `false` return when it simply does not fit.
+        // Encoded into the reused scratch buffer rather than a fresh one, then
+        // copied into `blob` only once the event is known to fit. Nothing is
+        // committed before that check, so a rejected event needs no rollback.
+        self.scratch.allocator = allocator;
+        self.scratch.reset();
+        try event_data.encodeMessageIntoBuffer(&self.scratch, message);
+        const encoded = self.scratch.written();
+
         var adopted = false;
 
-        const encoded = try event_data.encodeMessage(allocator, message);
-        defer if (!adopted) allocator.free(encoded);
-
         // The first event also fixes the envelope, so its cost is charged here.
-        const is_first = self.marshaled.items.len == 0;
+        const is_first = self.ends.items.len == 0;
         const envelope: ?[]u8 = if (is_first)
             try event_data.encodeMessageEnvelope(allocator, message)
         else
@@ -121,19 +142,50 @@ pub const EventDataBatch = struct {
         const envelope_size = if (envelope) |bytes| bytes.len else 0;
         const projected = self.current_size + envelope_size + dataSectionSize(encoded.len);
         if (projected > self.max_size_bytes) {
+            self.releaseOversizedScratch();
             if (is_first) return BatchError.EventDataTooLarge;
             return false;
         }
 
-        try self.marshaled.append(allocator, encoded);
+        // Both reservations happen before either container is mutated, so a
+        // failure to grow one cannot leave the batch holding half an event.
+        try self.blob.ensureUnusedCapacity(allocator, encoded.len);
+        try self.ends.ensureUnusedCapacity(allocator, 1);
+        self.blob.appendSliceAssumeCapacity(encoded);
+        self.ends.appendAssumeCapacity(self.blob.items.len);
+
         if (envelope) |bytes| self.envelope = bytes;
         self.current_size = projected;
         adopted = true;
         return true;
     }
 
+    /// Release `scratch` when a refused event grew it past anything the batch
+    /// could ever accept.
+    ///
+    /// Reusing the buffer is what makes encoding free, but it also means the
+    /// buffer keeps the high-water mark of every event *offered*, not every
+    /// event adopted. The path this replaced allocated and freed each event's
+    /// encoding immediately, so refusing a 10 MiB event cost nothing after the
+    /// refusal; here it would park 10 MiB on the batch until `deinit`. An
+    /// accepted event has to fit in `max_size_bytes` by definition, so
+    /// anything above that is capacity no future event can use.
+    fn releaseOversizedScratch(self: *EventDataBatch) void {
+        if (self.scratch.data.len <= self.max_size_bytes) return;
+        self.scratch.deinit();
+        self.scratch = .{ .data = &.{}, .pos = 0, .allocator = null, .is_fixed = false };
+    }
+
     pub fn count(self: EventDataBatch) usize {
-        return self.marshaled.items.len;
+        return self.ends.items.len;
+    }
+
+    /// The encoded bytes of event `index`.
+    ///
+    /// Invalidated by any later `tryAdd`, which may move `blob`.
+    pub fn payloadAt(self: EventDataBatch, index: usize) []const u8 {
+        const start = if (index == 0) 0 else self.ends.items[index - 1];
+        return self.blob.items[start..self.ends.items[index]];
     }
 
     /// Encoded size of the batch as it would go on the wire.

--- a/benchmarks/main.zig
+++ b/benchmarks/main.zig
@@ -8,8 +8,21 @@
 //!   zig build bench -Doptimize=ReleaseFast
 //!
 //! Allocation counts are the primary signal. Wall-clock numbers on a shared or
-//! virtualised host move between runs; `allocs/op` and `B/op` do not, so treat
-//! those as the regression gate and the timings as advisory.
+//! virtualised host move between runs; `allocs/op` and `B/op` are deterministic
+//! within one launch environment, so treat those as the regression gate and the
+//! timings as advisory.
+//!
+//! The thousand-event and eight-batch send cases carry a caveat —
+//! `batch.tryAdd x1000`, `encodeBatchTransfer x1000`, `send x1000`,
+//! `send x8x100` and `sendPipelined x8x100`. `EventDataBatch`
+//! grows its blob geometrically, and the counting allocator charges a
+//! reallocation only when the block actually moves, so both `allocs/op` and
+//! `B/op` for those cases depend on the heap layout the process starts with:
+//! the same binary reports different figures under `zig build bench` and under
+//! direct exec, including in the second decimal of `allocs/op`. They repeat
+//! exactly when the launch is held fixed. Compare across commits only with both
+//! sides launched the same way. The one-event, hundred-event and receive cases
+//! were identical in every launch environment measured.
 //!
 //! Everything is driven through the package's public API, so these measure
 //! what a consumer actually pays.
@@ -244,25 +257,30 @@ fn sendScripted(allocator: std.mem.Allocator, count: usize) !void {
 /// Eight accepted 100-event batches through sequential `SenderPool.send`.
 ///
 /// Paired with `benchSendPipelined`, which does identical work and differs
-/// only in whether the eight batches overlap. In steady state both cost
-/// exactly 1716 allocations and 386507 B per iteration, so pipelining
-/// changes neither. Its real benefit is one round trip per window rather
-/// than one per batch, and a `MemoryTransport` peer has zero round-trip
-/// latency, so that benefit is invisible here by construction. Do not read
-/// either line as evidence for or against pipelining. The timings are a
-/// worse trap than the counts: which of the two looks faster flips with
-/// run order, so the ops/s ranking here means nothing at all.
+/// only in whether the eight batches overlap. Both measure the same
+/// allocations and bytes in steady state, so pipelining changes neither. Its
+/// real benefit is one round trip per window rather than one per batch, and a
+/// `MemoryTransport` peer has zero round-trip latency, so that benefit is
+/// invisible here by construction. Do not read either line as evidence for or
+/// against pipelining. The timings are a worse trap than the counts: which of
+/// the two looks faster flips with run order, so the ops/s ranking here means
+/// nothing at all.
 ///
-/// Whichever of the two runs first also pays one extra 95400 B allocation
-/// on each of its first several iterations. That is the scripted peer's own
-/// `MemoryTransport.outbound` growing from 54635 B, which the counting
-/// allocator charges only when the general purpose allocator cannot remap
-/// it in place; once such a span has been grown and freed, later remaps
-/// succeed in place and cost nothing. It settles at six such iterations, so
-/// at 20 iterations the first of the two lines reads 1716.30 / 415127
-/// rather than the steady state. It is the test peer's buffer, not the send
-/// path, and it follows run order rather than send mode: swapping the two
-/// cases moves it to the other one.
+/// One or both of the two also pay a few extra 95400 B allocations across
+/// their early iterations, so those lines read higher than the steady state.
+/// That is the scripted peer's own `MemoryTransport.outbound` growing from
+/// 54635 B, which the counting allocator charges only when the general purpose
+/// allocator cannot remap it in place; once such a span has been grown and
+/// freed, later remaps succeed in place and cost nothing. It is the test
+/// peer's buffer, not the send path.
+///
+/// How many of those growths land, and on which of the two cases — sometimes
+/// both, in equal measure — is a property of the starting heap layout rather
+/// than of either case: the same binary gives different counts under `zig
+/// build bench` than under direct exec, and the excess does not always fall on
+/// whichever runs first. Each growth is worth 95400/20 = 4770 B/op, so a line
+/// can be reduced to its steady state by subtracting whole multiples of that.
+/// Compare the two cases only within a single run.
 fn benchSendSequential(allocator: std.mem.Allocator) !void {
     var mem = amqp.MemoryTransport.init(allocator);
     defer mem.deinit();

--- a/event_data.zig
+++ b/event_data.zig
@@ -589,6 +589,34 @@ fn encodeMessageSections(
     var buffer = uamqp.encoder.Buffer.initDynamic(allocator);
     errdefer buffer.deinit();
 
+    try encodeMessageSectionsInto(&buffer, message, include_body);
+
+    // `toOwnedSlice` shrinks the buffer's own allocation to the written length
+    // and hands it over. Duplicating `written()` instead would allocate a
+    // second full-size buffer and copy every byte into it.
+    return buffer.toOwnedSlice();
+}
+
+/// Encode a message into a buffer the caller owns.
+///
+/// A batch reuses one buffer across every event it encodes, so the per-event
+/// path allocates nothing once that buffer has grown to fit the largest event
+/// seen. `encodeMessage` starts from an empty dynamic buffer instead and pays
+/// `Buffer.ensureCapacity`'s 64-then-double series on every call.
+///
+/// Appends at the buffer's current position; the caller resets it.
+pub fn encodeMessageIntoBuffer(
+    buffer: *uamqp.encoder.Buffer,
+    message: *const Message,
+) !void {
+    return encodeMessageSectionsInto(buffer, message, true);
+}
+
+fn encodeMessageSectionsInto(
+    buffer: *uamqp.encoder.Buffer,
+    message: *const Message,
+    include_body: bool,
+) !void {
     if (message.header) |header| {
         var fields = [_]AmqpValue{
             .{ .boolean = header.durable },
@@ -597,19 +625,19 @@ fn encodeMessageSections(
             .{ .boolean = header.first_acquirer },
             .{ .uint = header.delivery_count },
         };
-        try encodeSection(&buffer, uamqp.definitions.descriptor.header, .{
+        try encodeSection(buffer, uamqp.definitions.descriptor.header, .{
             .list = trimTrailingNulls(&fields),
         });
     }
 
     if (message.delivery_annotations) |entries| {
-        try encodeSection(&buffer, uamqp.definitions.descriptor.delivery_annotations, .{
+        try encodeSection(buffer, uamqp.definitions.descriptor.delivery_annotations, .{
             .map = entries,
         });
     }
 
     if (message.message_annotations) |entries| {
-        try encodeSection(&buffer, uamqp.definitions.descriptor.message_annotations, .{
+        try encodeSection(buffer, uamqp.definitions.descriptor.message_annotations, .{
             .map = entries,
         });
     }
@@ -630,13 +658,13 @@ fn encodeMessageSections(
             if (properties.group_sequence) |v| .{ .uint = v } else .null,
             optionalString(properties.reply_to_group_id),
         };
-        try encodeSection(&buffer, uamqp.definitions.descriptor.properties, .{
+        try encodeSection(buffer, uamqp.definitions.descriptor.properties, .{
             .list = trimTrailingNulls(&fields),
         });
     }
 
     if (message.application_properties) |entries| {
-        try encodeSection(&buffer, uamqp.definitions.descriptor.application_properties, .{
+        try encodeSection(buffer, uamqp.definitions.descriptor.application_properties, .{
             .map = entries,
         });
     }
@@ -645,58 +673,66 @@ fn encodeMessageSections(
         switch (message.body_type) {
             .none => {},
             .data => for (message.body_data_sections.items) |section| {
-                try encodeSection(&buffer, uamqp.definitions.descriptor.data, .{
+                try encodeSection(buffer, uamqp.definitions.descriptor.data, .{
                     .binary = section.bytes,
                 });
             },
             .sequence => for (message.body_sequence_sections.items) |sequence| {
-                try encodeSection(&buffer, uamqp.definitions.descriptor.amqp_sequence, .{
+                try encodeSection(buffer, uamqp.definitions.descriptor.amqp_sequence, .{
                     .list = sequence,
                 });
             },
             .value => if (message.body_value) |value| {
-                try encodeSection(&buffer, uamqp.definitions.descriptor.amqp_value, value);
+                try encodeSection(buffer, uamqp.definitions.descriptor.amqp_value, value);
             },
         }
     }
 
     if (message.footer) |entries| {
-        try encodeSection(&buffer, uamqp.definitions.descriptor.footer, .{ .map = entries });
+        try encodeSection(buffer, uamqp.definitions.descriptor.footer, .{ .map = entries });
     }
-
-    // `toOwnedSlice` shrinks the buffer's own allocation to the written length
-    // and hands it over. Duplicating `written()` instead would allocate a
-    // second full-size buffer and copy every byte into it, on the per-event
-    // path of every batch.
-    return buffer.toOwnedSlice();
 }
 
-/// Append one data section per payload to an already encoded prefix.
+/// Append one data section per payload to an already encoded prefix, with the
+/// payloads held as one concatenated blob.
 ///
 /// This is how an Event Hubs batch is laid out: the envelope from
 /// `encodeMessageEnvelope` followed by the contained messages, each wrapped in
 /// its own data section. `EventData.toAmqpMessage` produces no footer, so
 /// nothing in the envelope has to follow the body.
-pub fn encodeDataSections(
+///
+/// A batch stores its encoded events as one buffer plus an end offset per
+/// event, so that adding an event allocates nothing once the blob has
+/// capacity. `ends` holds each payload's end offset in `blob`, so payload `i`
+/// runs from `ends[i-1]` (or 0) to `ends[i]`.
+pub fn encodeDataSectionsFromBlob(
     allocator: std.mem.Allocator,
     prefix: []const u8,
-    payloads: []const []u8,
+    blob: []const u8,
+    ends: []const usize,
 ) ![]u8 {
-    // The exact size is plain arithmetic here — `dataSectionSize` is the same
+    // The exact size is plain arithmetic — `dataSectionSize` is the same
     // constant-overhead formula batching already charges per event — so the
     // whole concatenation is one allocation. Growing a dynamic buffer instead
     // costs a doubling series of reallocations across a batch that may reach
     // the 1 MiB message limit, and then a full copy of the result.
     var total: usize = prefix.len;
-    for (payloads) |payload| total += dataSectionSize(payload.len);
+    var start: usize = 0;
+    for (ends) |end| {
+        total += dataSectionSize(end - start);
+        start = end;
+    }
 
     const bytes = try allocator.alloc(u8, total);
     errdefer allocator.free(bytes);
 
     var buffer = uamqp.encoder.Buffer.initFixed(bytes);
     try buffer.writeAll(prefix);
-    for (payloads) |payload| {
+    start = 0;
+    for (ends) |end| {
+        const payload = blob[start..end];
         try encodeSection(&buffer, uamqp.definitions.descriptor.data, .{ .binary = payload });
+        start = end;
     }
 
     // `dataSectionSize` is exact, so this holds; shrinking rather than
@@ -711,8 +747,8 @@ pub fn encodeDataSections(
 /// Go's `calcActualSizeForPayload` uses the same constants.
 ///
 /// Batching charges this per event without encoding anything, so it has to
-/// agree with what `encodeDataSections` writes; sharing one function rather
-/// than restating the constants is what keeps them from drifting apart.
+/// agree with what `encodeDataSectionsFromBlob` writes; sharing one function
+/// rather than restating the constants is what keeps them from drifting apart.
 pub fn dataSectionSize(payload_len: usize) usize {
     const vbin8_overhead = 5;
     const vbin32_overhead = 8;
@@ -1560,12 +1596,13 @@ test "encodeMessageEnvelope drops the body" {
     try std.testing.expectEqualSlices(u8, envelope, full[0..envelope.len]);
 }
 
-test "dataSectionSize matches what encodeDataSections writes" {
+test "dataSectionSize matches what encodeDataSectionsFromBlob writes" {
     const allocator = std.testing.allocator;
 
-    // `encodeDataSections` allocates exactly `dataSectionSize` per payload and
-    // encodes into a fixed buffer, so a disagreement would truncate the wire
-    // payload. The vbin8/vbin32 boundary is where the two would drift first.
+    // `encodeDataSectionsFromBlob` allocates exactly `dataSectionSize` per
+    // payload and encodes into a fixed buffer, so a disagreement would truncate
+    // the wire payload. The vbin8/vbin32 boundary is where the two would drift
+    // first.
     const lengths = [_]usize{ 0, 1, 254, 255, 256, 257, 1024 };
 
     for (lengths) |len| {
@@ -1573,8 +1610,8 @@ test "dataSectionSize matches what encodeDataSections writes" {
         defer allocator.free(payload);
         @memset(payload, 0x5a);
 
-        const payloads = [_][]u8{payload};
-        const encoded = try encodeDataSections(allocator, "", &payloads);
+        const ends = [_]usize{len};
+        const encoded = try encodeDataSectionsFromBlob(allocator, "", payload, &ends);
         defer allocator.free(encoded);
 
         try std.testing.expectEqual(dataSectionSize(len), encoded.len);
@@ -1590,14 +1627,15 @@ test "dataSectionSize matches what encodeDataSections writes" {
     }
 }
 
-test "encodeDataSections keeps the prefix and appends one section per payload" {
+test "encodeDataSectionsFromBlob keeps the prefix and appends one section per payload" {
     const allocator = std.testing.allocator;
 
-    var first = [_]u8{ 1, 2, 3 };
-    var second = [_]u8{ 4, 5 };
-    const payloads = [_][]u8{ &first, &second };
+    const first = [_]u8{ 1, 2, 3 };
+    const second = [_]u8{ 4, 5 };
+    const blob = first ++ second;
+    const ends = [_]usize{ first.len, first.len + second.len };
 
-    const encoded = try encodeDataSections(allocator, "PREFIX", &payloads);
+    const encoded = try encodeDataSectionsFromBlob(allocator, "PREFIX", &blob, &ends);
     defer allocator.free(encoded);
 
     try std.testing.expectEqualSlices(u8, "PREFIX", encoded[0..6]);

--- a/root.zig
+++ b/root.zig
@@ -1477,7 +1477,8 @@ test "EventDataBatch size matches the encoded bytes" {
     try std.testing.expect(try batch.tryAdd(allocator, second));
 
     var expected = batch.envelope.?.len;
-    for (batch.marshaled.items) |encoded| {
+    for (0..batch.count()) |i| {
+        const encoded = batch.payloadAt(i);
         expected += if (encoded.len < 256) 5 + encoded.len else 8 + encoded.len;
     }
     try std.testing.expectEqual(expected, batch.sizeInBytes());

--- a/sender.zig
+++ b/sender.zig
@@ -456,7 +456,12 @@ pub const SenderPool = struct {
 /// never produces a footer, so the data sections simply follow it.
 pub fn encodeBatchTransfer(allocator: Allocator, batch: EventDataBatch) ![]u8 {
     const envelope = batch.envelope orelse return SendError.EmptyBatch;
-    return event_data.encodeDataSections(allocator, envelope, batch.marshaled.items);
+    return event_data.encodeDataSectionsFromBlob(
+        allocator,
+        envelope,
+        batch.blob.items,
+        batch.ends.items,
+    );
 }
 
 // ─────────────────────── Tests ───────────────────────
@@ -575,6 +580,155 @@ fn batchOf(allocator: Allocator, bodies: []const []const u8, options: batch_mod.
         try testing.expect(try out.tryAdd(allocator, event));
     }
     return out;
+}
+
+test "a rejected event leaves no trace in the encoded transfer" {
+    const allocator = testing.allocator;
+
+    // An event is encoded into the batch's scratch buffer before it is known
+    // to fit, so a batch that refused one must still encode exactly as a batch
+    // that was never offered it. Byte equality is what proves the refused
+    // event left nothing behind in the shared blob.
+    var event = EventData.init("z" ** 48);
+    defer event.deinit(allocator);
+
+    var filled = try EventDataBatch.init(.{ .max_bytes = 512 });
+    defer filled.deinit(allocator);
+    var accepted: usize = 0;
+    while (try filled.tryAdd(allocator, event)) : (accepted += 1) {}
+    try testing.expect(accepted > 1);
+    // The loop above stopped on a refusal, so one has already happened here.
+    try testing.expect(!try filled.tryAdd(allocator, event));
+
+    var clean = try EventDataBatch.init(.{ .max_bytes = 512 });
+    defer clean.deinit(allocator);
+    for (0..accepted) |_| try testing.expect(try clean.tryAdd(allocator, event));
+
+    try testing.expectEqual(clean.count(), filled.count());
+    try testing.expectEqual(clean.sizeInBytes(), filled.sizeInBytes());
+    // The blob itself, not just the sections cut from it: a refusal that
+    // appended before checking the fit leaves bytes here that no end offset
+    // names, and the encoded transfer alone cannot see them.
+    try testing.expectEqual(clean.blob.items.len, filled.blob.items.len);
+
+    const from_filled = try encodeBatchTransfer(allocator, filled);
+    defer allocator.free(from_filled);
+    const from_clean = try encodeBatchTransfer(allocator, clean);
+    defer allocator.free(from_clean);
+
+    try testing.expectEqualSlices(u8, from_clean, from_filled);
+}
+
+test "an event accepted after a refusal carries only its own bytes" {
+    const allocator = testing.allocator;
+
+    // An event is encoded before it is known to fit, so a commit ordered ahead
+    // of the fit check would leave the refused bytes in the blob with no end
+    // offset naming them. The next accepted event's section then starts at the
+    // previous end and runs to the new one, swallowing the refused event
+    // whole. Refusing at the end of a batch cannot show this: nothing is
+    // appended afterwards, so the stray bytes fall outside every section.
+    var small = EventData.init("small");
+    defer small.deinit(allocator);
+    var big = EventData.init("B" ** 600);
+    defer big.deinit(allocator);
+
+    var batch = try EventDataBatch.init(.{ .max_bytes = 512 });
+    defer batch.deinit(allocator);
+
+    try testing.expect(try batch.tryAdd(allocator, small));
+    try testing.expect(!try batch.tryAdd(allocator, big));
+    try testing.expect(try batch.tryAdd(allocator, small));
+
+    try testing.expectEqual(@as(usize, 2), batch.count());
+    for (0..2) |i| {
+        const payload = batch.payloadAt(i);
+        try testing.expect(std.mem.indexOf(u8, payload, "small") != null);
+        try testing.expect(std.mem.indexOf(u8, payload, "BBBB") == null);
+    }
+
+    // The two events are identical, so their sections are the same length and
+    // between them account for every byte of the blob.
+    try testing.expectEqual(batch.payloadAt(0).len, batch.payloadAt(1).len);
+    try testing.expectEqual(batch.blob.items.len, batch.payloadAt(0).len * 2);
+}
+
+test "a refused oversized event does not park its encoding on the batch" {
+    const allocator = testing.allocator;
+
+    // `scratch` is reused, so it keeps the high-water mark of every event
+    // *offered*, not every event adopted — and an event is encoded in full
+    // before its size is checked. Without a release on the refusal path a
+    // batch that refused one huge event would hold that encoding until
+    // `deinit`, which the per-event allocation this replaced never did.
+    var small = EventData.init("small");
+    defer small.deinit(allocator);
+    var huge = EventData.init("H" ** 200_000);
+    defer huge.deinit(allocator);
+
+    var batch = try EventDataBatch.init(.{ .max_bytes = 4096 });
+    defer batch.deinit(allocator);
+
+    try testing.expect(try batch.tryAdd(allocator, small));
+    try testing.expect(!try batch.tryAdd(allocator, huge));
+
+    // Nothing the batch can accept needs more than `max_size_bytes`.
+    try testing.expect(batch.scratch.data.len <= batch.max_size_bytes);
+
+    // Still usable afterwards: the release must not have left a buffer that
+    // the next event cannot encode into.
+    try testing.expect(try batch.tryAdd(allocator, small));
+    try testing.expectEqual(@as(usize, 2), batch.count());
+    try testing.expectEqual(batch.payloadAt(0).len, batch.payloadAt(1).len);
+    try testing.expectEqual(batch.blob.items.len, batch.payloadAt(0).len * 2);
+}
+
+test "scratch is reused across accepted events rather than released" {
+    const allocator = testing.allocator;
+
+    // Reuse is the entire point of `scratch` — it is what makes encoding cost
+    // nothing per event after the first. Releasing it on the accept path as
+    // well as the refusal path would be harmless for correctness, would leave
+    // every other test passing, and would quietly restore the per-event
+    // allocation this change exists to remove.
+    var small = EventData.init("small");
+    defer small.deinit(allocator);
+
+    var batch = try EventDataBatch.init(.{ .max_bytes = 4096 });
+    defer batch.deinit(allocator);
+
+    try testing.expect(try batch.tryAdd(allocator, small));
+    const after_first = batch.scratch.data.len;
+    try testing.expect(after_first > 0);
+
+    try testing.expect(try batch.tryAdd(allocator, small));
+    try testing.expectEqual(after_first, batch.scratch.data.len);
+}
+
+test "payloadAt returns each event's own encoded bytes" {
+    const allocator = testing.allocator;
+
+    const bodies = [_][]const u8{ "first", "second body", "third body is longest" };
+    var batch = try batchOf(allocator, &bodies, .{});
+    defer batch.deinit(allocator);
+
+    try testing.expectEqual(bodies.len, batch.count());
+
+    // Every payload must both differ from its neighbours and contain its own
+    // body, so an off-by-one in the end offsets cannot pass.
+    var total: usize = 0;
+    for (bodies, 0..) |body, i| {
+        const payload = batch.payloadAt(i);
+        try testing.expect(std.mem.indexOf(u8, payload, body) != null);
+        for (bodies, 0..) |other, j| {
+            if (i == j) continue;
+            try testing.expect(std.mem.indexOf(u8, payload, other) == null);
+        }
+        total += payload.len;
+    }
+
+    // The payloads tile the blob exactly, with no gap and no overlap.
+    try testing.expectEqual(batch.blob.items.len, total);
 }
 
 test "a batch goes out as one transfer whose data sections are the events" {


### PR DESCRIPTION
#369 took `tryAdd` from 5 allocations per event to 2. Both survivors were
`encodeMessage`'s dynamic buffer, measured directly rather than inferred:
a temporary `encodeMessage ONLY` benchmark case reported 2.00 allocs/op
and 192 B/op for one event. `Buffer.ensureCapacity` grows by
`@max(len * 2, needed, 64)`, so an ~80 byte message allocates 64, then
reallocs to 128 — two allocations and 192 B requested to hold 80 B. The
`ArrayList` append was never the problem; it amortises to about 0.01.

So the per-event allocation was the *encoder's* buffer, not the batch's
storage. Two changes follow from that:

  - `EventDataBatch` keeps one `scratch` buffer and reuses it for every
    event, via a new `encodeMessageIntoBuffer`. Once it has grown to fit
    the largest event seen, encoding allocates nothing.
  - `marshaled: ArrayList([]u8)` becomes `blob: ArrayList(u8)` plus
    `ends: ArrayList(usize)`, so an adopted event is a memcpy into space
    already reserved rather than an owned slice per event.

Encoding into scratch first also means the fit check happens before
anything is committed, so a refused event needs no rollback: it is simply
never copied out of scratch. `blob` and `ends` are both reserved with
`ensureUnusedCapacity` before either is touched, so a failed growth
cannot leave the batch holding half an event.

  case                       allocs/op          B/op
  batch.tryAdd x1000    2010.00 ->  19.45   230158 -> 134851
  encodeBatchTransfer   2011.00 ->  20.20   320188 -> 203856
  send x1000            2051.00 ->  60.90   603189 -> 539381
  send x8x100           1716.15 -> 180.05   400817 -> 409301
  sendPipelined x8x100  1716.00 -> 180.00   386507 -> 404531
  batch.tryAdd x100      206.00 ->  14.00    21710 ->  23963
  batch.tryAdd x1          5.00 ->   6.00      430 ->    677
  send x1                 43.00 ->  44.00    21808 ->  22055

Both sides re-measured for this table rather than carried over from
#370, interleaved and repeated three times under one fixed launch
environment; every figure above repeated exactly. That control matters
more than usual here. `blob` grows geometrically — `ArrayList` takes
`minimum + minimum / 2 + init_capacity`, not doubling — and the counting
allocator charges a reallocation only when the block moves, so both
`B/op` *and* the second decimal of `allocs/op` depend on the heap layout
the process starts with. The same head binary reports `batch.tryAdd
x1000` anywhere from 110830 to 181382 B, and 19.15 to 20.05 allocations,
depending only on how it was launched; the base, which allocated exactly
per event, reported 2010.00 / 230158 in every environment tried. Only
the thousand-event and eight-batch rows move; the one-event,
hundred-event and receive rows were identical in every launch
environment tried. The benchmark's module comment now says all of this.
(Every figure here is ReleaseFast, which is what the benchmark
documents; figures taken under another optimisation mode are not
comparable to these.)

The marginal cost of an event is now (19.45 - 6.00) / 999 = 0.013
allocations. That is the number this change was aimed at.

Two regressions, both real:

A one-event batch costs one allocation and 247 B more than before. The
cause is one growable container becoming two: `marshaled` was itself a
growable `ArrayList([]u8)` that over-allocated to capacity 9, so it cost
1 allocation and 144 B, while `blob` plus `ends` cost 2 and 391 B. The
two sides decompose exactly — 430 = 192 encoder + 94 envelope + 144
marshaled, and 677 = 192 scratch + 94 envelope + 255 blob + 136 ends —
which also shows `scratch` is neutral rather than part of the
regression: it replaces `encodeMessage`'s buffer one for one at 2
allocations and 192 B. `send x1` inherits the same +1 allocation.
Anything sending single events in a batch of one pays that.

Bytes rise wherever batches stay small: +10% at 100 events and +4.7% on
the eight-batch cases, because geometric growth overshoots where exact
per-event allocation did not. It inverts well before 1000 events, where
one growing buffer beats 1000 separate 2.4x-overshooting allocations and
bytes fall 41%.

The eight-batch figure needs its own note, because the two rows in the
table disagree with each other (+2.1% and +4.7%) and neither is the
change. Both rows carry some number of the scripted peer's own
`MemoryTransport.outbound` growths, which `benchSendSequential` already
documents as the test peer's buffer rather than the send path. Each is
worth 95400 / 20 = 4770 B/op, and every eight-batch figure I measured
decomposes onto a fixed steady state plus a whole number of them:
400817 = 386507 + 3, 409301 = 404531 + 1, 499931 = 404531 + 20. Against
the steady states the trade is 386507 -> 404531, +4.7%, in every
environment. The apparent range was the artifact, not the change.

Allocation count is the stated regression gate and it improves 9x to
100x on every case with more than one event, but the byte trade is a
trade, not a free win.

Reusing one scratch buffer has a third cost, which is fixed here rather
than disclosed. The buffer keeps the high-water mark of every event
*offered*, not every event adopted, and an event is encoded in full
before its size is checked — so refusing one 10 MiB event would park 10
MiB on the batch until `deinit`, where the per-event allocation this
replaces freed it on the spot. `tryAdd` now releases `scratch` on the
refusal path when it exceeds `max_size_bytes`, which no acceptable event
can need.

`marshaled` was a public field and is gone. `count()` and `sizeInBytes()`
are unchanged; `payloadAt(i)` replaces indexing it. Slices it returns
point into `blob` and are invalidated by any later `tryAdd`, which is
documented on both. No caller outside the package used `marshaled`.

`encodeDataSections` had no caller left once `encodeBatchTransfer`
switched to `encodeDataSectionsFromBlob`, so its two tests were guarding
a function the send path no longer runs — including the one that pins
`dataSectionSize` against what is actually written, which is the
invariant a disagreement would truncate a payload over. The dead
function is deleted and both tests now drive the blob form.
`encodeMessage` is now unreachable in the same way, but is kept: it
delegates to `encodeMessageSectionsInto`, the live batch path, so its
tests cannot drift away from what ships. `encodeDataSections` had its
own independent loop, which is what made it a hazard.

Five tests, all mutation-verified rather than assumed to work:

  - "a rejected event leaves no trace in the encoded transfer" fills a
    batch to refusal and asserts its encoded transfer is byte-identical
    to a batch that was never offered the refused event, and that its
    `blob` is the same length. Moving the whole commit before the fit
    check fails it with `expected 8, found 10`; committing only into
    `blob` fails the length assertion with `expected 456, found 570`.
  - "an event accepted after a refusal carries only its own bytes" is
    the shape that makes a `blob` half-commit observable at all. A
    refusal at the end of a batch leaves stray bytes outside every
    section, so the encoded transfer cannot see them; a refusal between
    two accepted events puts them inside the next event's section. The
    mutation that appends to `blob` before the fit check while leaving
    `ends` after it fails three tests: this one, the blob-length
    assertion above, and the oversized-refusal test below. Before those
    assertions existed it passed the entire suite, which is what made it
    worth adding them.
  - "a refused oversized event does not park its encoding on the batch"
    covers the scratch release. Dropping the release fails it alone.
  - "scratch is reused across accepted events rather than released"
    pins the optimisation itself. Releasing on the accept path as well
    is harmless for correctness and passed every other test, while
    quietly restoring the per-event allocation this change removes.
  - "payloadAt returns each event's own encoded bytes" checks each
    payload contains its own body, contains no neighbour's, and that the
    payloads tile `blob` exactly. An off-by-one start offset fails it,
    along with the existing size test.

The receive path is untouched and measures byte-identically
(`fromAmqpMessage` 2.00 / 260, `receive x1000` 4066.00 / 1122672), which
is what confirms the change is confined to sending. `toAmqpMessage` is
also unchanged at 3.00 / 608, confirming the owning single-event path
was not disturbed.

