### PR TITLE
Surface the continuation token on paged operations

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,6 +1,6 @@
-generator_commit=f2ce8857f83eb95fe943fe77b01ca8041a73eae8
+generator_commit=5ec3759d9bf33e1047fcbd884e8ad66519f60156
 source_repository=https://github.com/cataggar/vsts-rest-api-specs
-source_commit=b287bd603fe9801824427c113ad355b001f310f5
+source_commit=6f19fc15d433da057453c99b88debbc209abb5ee
 source_branch=typespec
 source_path=typespec/specs
 selected_api_version=7.2

--- a/src/advanced_security/clients.zig
+++ b/src/advanced_security/clients.zig
@@ -412,6 +412,16 @@ pub const SummaryDashboard = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.DashboardAlert,
+        },
+    };
     /// Get Alert summary by severity for the org
     pub fn getAlertSummaryForOrg(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, criteria_alert_types: ?[]const []const u8, criteria_keywords: ?[]const u8, @"criteria.period": ?enums.GetAlertSummaryForOrgRequestCriteriaPeriod, criteria_projects: ?[]const []const u8, criteria_severities: ?[]const []const u8) !models.OrgAlertSummary {
         @setEvalBranchQuota(100_000);
@@ -502,7 +512,7 @@ pub const SummaryDashboard = struct {
         return try serde.json.fromSlice(models.OrgAlertSummary, alloc, resp.body);
     }
     /// Get Combined Alerts for the org
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"criteria.alert_type": ?enums.ListRequestCriteriaAlertType, @"criteria.alert_validity_status": ?enums.ListRequestCriteriaAlertValidityStatus, criteria_component_names: ?[]const []const u8, criteria_component_types: ?[]const []const u8, criteria_dismissal_types: ?[]const []const u8, criteria_fixed_date_end: ?[]const u8, criteria_fixed_date_start: ?[]const u8, criteria_introduced_date_end: ?[]const u8, criteria_introduced_date_start: ?[]const u8, criteria_keywords: ?[]const u8, criteria_projects: ?[]const []const u8, criteria_repositories: ?[]const []const u8, criteria_repository_ids: ?[]const []const u8, criteria_rule_names: ?[]const []const u8, criteria_secret_types: ?[]const []const u8, criteria_severities: ?[]const []const u8, @"criteria.state": ?enums.ListRequestCriteriaState, criteria_tool_names: ?[]const []const u8, top: ?i32, continuation_token: ?[]const u8) ![]const models.DashboardAlert {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"criteria.alert_type": ?enums.ListRequestCriteriaAlertType, @"criteria.alert_validity_status": ?enums.ListRequestCriteriaAlertValidityStatus, criteria_component_names: ?[]const []const u8, criteria_component_types: ?[]const []const u8, criteria_dismissal_types: ?[]const []const u8, criteria_fixed_date_end: ?[]const u8, criteria_fixed_date_start: ?[]const u8, criteria_introduced_date_end: ?[]const u8, criteria_introduced_date_start: ?[]const u8, criteria_keywords: ?[]const u8, criteria_projects: ?[]const []const u8, criteria_repositories: ?[]const []const u8, criteria_repository_ids: ?[]const []const u8, criteria_rule_names: ?[]const []const u8, criteria_secret_types: ?[]const []const u8, criteria_severities: ?[]const []const u8, @"criteria.state": ?enums.ListRequestCriteriaState, criteria_tool_names: ?[]const []const u8, top: ?i32, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -743,11 +753,27 @@ pub const SummaryDashboard = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("SummaryDashboard.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.DashboardAlert, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("SummaryDashboard.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.DashboardAlert, alloc, resp.body);
     }
     /// Get Enablement summary for the org
     pub fn getEnablementSummaryForOrg(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, criteria_keywords: ?[]const u8, criteria_projects: ?[]const []const u8, criteria_states_any_tool: ?bool, criteria_states_code_alerts: ?bool, criteria_states_code_pr_alerts: ?bool, criteria_states_dependency_alerts: ?bool, criteria_states_dependency_pr_alerts: ?bool, criteria_states_push_protection: ?bool, criteria_states_secret_alerts: ?bool) !models.OrgEnablementSummary {
@@ -842,8 +868,18 @@ pub const Alerts = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.Alert,
+        },
+    };
     /// Get alerts for a repository
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, top: ?i32, order_by: ?[]const u8, criteria_alert_ids: ?[]const i64, @"criteria.alert_type": ?enums.ListRequestCriteriaAlertType, criteria_confidence_levels: ?[]const []const u8, criteria_dependency_name: ?[]const u8, criteria_from_date: ?[]const u8, criteria_has_linked_work_items: ?bool, criteria_is_triaged: ?bool, criteria_keywords: ?[]const u8, criteria_license_name: ?[]const u8, criteria_modified_since: ?[]const u8, criteria_only_default_branch: ?bool, criteria_phase_id: ?[]const u8, criteria_phase_name: ?[]const u8, criteria_pipeline_id: ?i32, criteria_pipeline_name: ?[]const u8, criteria_ref: ?[]const u8, criteria_rule_id: ?[]const u8, criteria_rule_name: ?[]const u8, criteria_severities: ?[]const []const u8, criteria_states: ?[]const []const u8, criteria_to_date: ?[]const u8, criteria_tool_name: ?[]const u8, criteria_validity: ?[]const []const u8, expand: ?enums.ListRequestExpand, continuation_token: ?[]const u8) ![]const models.Alert {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, top: ?i32, order_by: ?[]const u8, criteria_alert_ids: ?[]const i64, @"criteria.alert_type": ?enums.ListRequestCriteriaAlertType, criteria_confidence_levels: ?[]const []const u8, criteria_dependency_name: ?[]const u8, criteria_from_date: ?[]const u8, criteria_has_linked_work_items: ?bool, criteria_is_triaged: ?bool, criteria_keywords: ?[]const u8, criteria_license_name: ?[]const u8, criteria_modified_since: ?[]const u8, criteria_only_default_branch: ?bool, criteria_phase_id: ?[]const u8, criteria_phase_name: ?[]const u8, criteria_pipeline_id: ?i32, criteria_pipeline_name: ?[]const u8, criteria_ref: ?[]const u8, criteria_rule_id: ?[]const u8, criteria_rule_name: ?[]const u8, criteria_severities: ?[]const []const u8, criteria_states: ?[]const []const u8, criteria_to_date: ?[]const u8, criteria_tool_name: ?[]const u8, criteria_validity: ?[]const []const u8, expand: ?enums.ListRequestExpand, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1089,11 +1125,27 @@ pub const Alerts = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Alerts.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.Alert, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Alerts.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.Alert, alloc, resp.body);
     }
     /// Get an alert.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, alert_id: i64, repository: []const u8, ref: ?[]const u8, expand: ?enums.GetRequestExpand) !models.Alert {
@@ -1370,8 +1422,18 @@ pub const Analysis = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.Branch,
+        },
+    };
     /// Returns the branches for which analysis results were submitted.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, alert_type: enums.ListRequestAlertType, continuation_token: ?[]const u8, branch_name_contains: ?[]const u8, top: ?i32, include_pull_request_branches: ?bool) ![]const models.Branch {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, alert_type: enums.ListRequestAlertType, continuation_token: ?[]const u8, branch_name_contains: ?[]const u8, top: ?i32, include_pull_request_branches: ?bool) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1426,11 +1488,27 @@ pub const Analysis = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Analysis.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.Branch, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Analysis.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.Branch, alloc, resp.body);
     }
 };
 

--- a/src/build/clients.zig
+++ b/src/build/clients.zig
@@ -692,6 +692,26 @@ pub const Builds = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.Build,
+        },
+    };
+
+    pub const GetBuildChangesResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.Change,
+        },
+    };
+
     pub const GetBuildLogsResult = union(enum) {
         status_200: struct {
             status: u16 = 200,
@@ -712,7 +732,7 @@ pub const Builds = struct {
         },
     };
     /// Gets a list of builds.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definitions: ?[]const u8, queues: ?[]const u8, build_number: ?[]const u8, min_time: ?[]const u8, max_time: ?[]const u8, requested_for: ?[]const u8, reason_filter: ?enums.ListRequestReasonFilter, status_filter: ?enums.ListRequestStatusFilter, result_filter: ?enums.ListRequestResultFilter, tag_filters: ?[]const u8, properties: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, max_builds_per_definition: ?i32, deleted_filter: ?enums.ListRequestDeletedFilter, query_order: ?enums.ListRequestQueryOrder, branch_name: ?[]const u8, build_ids: ?[]const u8, repository_id: ?[]const u8, repository_type: ?[]const u8) ![]const models.Build {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definitions: ?[]const u8, queues: ?[]const u8, build_number: ?[]const u8, min_time: ?[]const u8, max_time: ?[]const u8, requested_for: ?[]const u8, reason_filter: ?enums.ListRequestReasonFilter, status_filter: ?enums.ListRequestStatusFilter, result_filter: ?enums.ListRequestResultFilter, tag_filters: ?[]const u8, properties: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, max_builds_per_definition: ?i32, deleted_filter: ?enums.ListRequestDeletedFilter, query_order: ?enums.ListRequestQueryOrder, branch_name: ?[]const u8, build_ids: ?[]const u8, repository_id: ?[]const u8, repository_type: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -873,11 +893,27 @@ pub const Builds = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Builds.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.Build, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Builds.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.Build, alloc, resp.body);
     }
     /// Updates multiple builds.
     pub fn updateBuilds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.Build) ![]const models.Build {
@@ -1091,7 +1127,7 @@ pub const Builds = struct {
         return try serde.json.fromSlice(models.Build, alloc, resp.body);
     }
     /// Gets the changes associated with a build
-    pub fn getBuildChanges(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, continuation_token: ?[]const u8, @"$top": ?i32, include_source_change: ?bool) ![]const models.Change {
+    pub fn getBuildChanges(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, continuation_token: ?[]const u8, @"$top": ?i32, include_source_change: ?bool) !GetBuildChangesResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1135,11 +1171,27 @@ pub const Builds = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Builds.getBuildChanges", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.Change, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Builds.getBuildChanges", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.Change, alloc, resp.body);
     }
     /// Gets all retention leases that apply to a specific build.
     pub fn getRetentionLeasesForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) ![]const models.RetentionLease {
@@ -2534,8 +2586,18 @@ pub const Definitions = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.BuildDefinitionReference,
+        },
+    };
     /// Gets a list of definitions.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name: ?[]const u8, repository_id: ?[]const u8, repository_type: ?[]const u8, query_order: ?enums.ListRequestQueryOrder1, @"$top": ?i32, continuation_token: ?[]const u8, min_metrics_time: ?[]const u8, definition_ids: ?[]const u8, path: ?[]const u8, built_after: ?[]const u8, not_built_after: ?[]const u8, include_all_properties: ?bool, include_latest_builds: ?bool, task_id_filter: ?[]const u8, process_type: ?i32, yaml_filename: ?[]const u8) ![]const models.BuildDefinitionReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name: ?[]const u8, repository_id: ?[]const u8, repository_type: ?[]const u8, query_order: ?enums.ListRequestQueryOrder1, @"$top": ?i32, continuation_token: ?[]const u8, min_metrics_time: ?[]const u8, definition_ids: ?[]const u8, path: ?[]const u8, built_after: ?[]const u8, not_built_after: ?[]const u8, include_all_properties: ?bool, include_latest_builds: ?bool, task_id_filter: ?[]const u8, process_type: ?i32, yaml_filename: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2664,11 +2726,27 @@ pub const Definitions = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Definitions.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.BuildDefinitionReference, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Definitions.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.BuildDefinitionReference, alloc, resp.body);
     }
     /// Creates a new definition.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_to_clone_id: ?i32, definition_to_clone_revision: ?i32, body: models.BuildDefinition) !models.BuildDefinition {

--- a/src/distributed_task/clients.zig
+++ b/src/distributed_task/clients.zig
@@ -1853,8 +1853,18 @@ pub const Deploymentgroups = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.DeploymentGroup,
+        },
+    };
     /// Get a list of deployment groups by name or IDs.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name: ?[]const u8, action_filter: ?enums.ListRequestActionFilter, @"$expand": ?enums.ListRequestExpand, continuation_token: ?[]const u8, @"$top": ?i32, ids: ?[]const u8) ![]const models.DeploymentGroup {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name: ?[]const u8, action_filter: ?enums.ListRequestActionFilter, @"$expand": ?enums.ListRequestExpand, continuation_token: ?[]const u8, @"$top": ?i32, ids: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1919,11 +1929,27 @@ pub const Deploymentgroups = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Deploymentgroups.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.DeploymentGroup, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Deploymentgroups.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.DeploymentGroup, alloc, resp.body);
     }
     /// Create a deployment group.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.DeploymentGroupCreateParameter) !models.DeploymentGroup {
@@ -2086,8 +2112,18 @@ pub const Targets = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.DeploymentMachine,
+        },
+    };
     /// Get a list of deployment targets in a deployment group.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deployment_group_id: i32, tags: ?[]const u8, name: ?[]const u8, partial_name_match: ?bool, @"$expand": ?enums.ListRequestExpand1, agent_status: ?enums.ListRequestAgentStatus, agent_job_result: ?enums.ListRequestAgentJobResult, continuation_token: ?[]const u8, @"$top": ?i32, enabled: ?bool, property_filters: ?[]const u8) ![]const models.DeploymentMachine {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deployment_group_id: i32, tags: ?[]const u8, name: ?[]const u8, partial_name_match: ?bool, @"$expand": ?enums.ListRequestExpand1, agent_status: ?enums.ListRequestAgentStatus, agent_job_result: ?enums.ListRequestAgentJobResult, continuation_token: ?[]const u8, @"$top": ?i32, enabled: ?bool, property_filters: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2178,11 +2214,27 @@ pub const Targets = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Targets.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.DeploymentMachine, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Targets.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.DeploymentMachine, alloc, resp.body);
     }
     /// Update tags of a list of deployment targets in a deployment group.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deployment_group_id: i32, body: []const models.DeploymentTargetUpdateParameter) ![]const models.DeploymentMachine {
@@ -2718,6 +2770,16 @@ pub const Taskgroups = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TaskGroup,
+        },
+    };
     /// Create a task group.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TaskGroupCreateParameter) !models.TaskGroup {
         @setEvalBranchQuota(100_000);
@@ -2795,7 +2857,7 @@ pub const Taskgroups = struct {
         return;
     }
     /// List task groups.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, task_group_id: []const u8, expanded: ?bool, task_id_filter: ?[]const u8, deleted: ?bool, @"$top": ?i32, continuation_token: ?[]const u8, query_order: ?enums.ListRequestQueryOrder) ![]const models.TaskGroup {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, task_group_id: []const u8, expanded: ?bool, task_id_filter: ?[]const u8, deleted: ?bool, @"$top": ?i32, continuation_token: ?[]const u8, query_order: ?enums.ListRequestQueryOrder) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2858,11 +2920,27 @@ pub const Taskgroups = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Taskgroups.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TaskGroup, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Taskgroups.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TaskGroup, alloc, resp.body);
     }
     /// Update a task group.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, task_group_id: []const u8, body: models.TaskGroupUpdateParameter) !models.TaskGroup {

--- a/src/environments/clients.zig
+++ b/src/environments/clients.zig
@@ -144,8 +144,18 @@ pub const Environments = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.EnvironmentInstance,
+        },
+    };
     /// Get all environments.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name: ?[]const u8, continuation_token: ?[]const u8, @"$top": ?i32) ![]const models.EnvironmentInstance {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name: ?[]const u8, continuation_token: ?[]const u8, @"$top": ?i32) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -189,11 +199,27 @@ pub const Environments = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Environments.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.EnvironmentInstance, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Environments.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.EnvironmentInstance, alloc, resp.body);
     }
     /// Create an environment.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.EnvironmentCreateParameter) !models.EnvironmentInstance {
@@ -349,8 +375,18 @@ pub const Environmentdeploymentrecords = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.EnvironmentDeploymentExecutionRecord,
+        },
+    };
     /// Get environment deployment execution history
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, environment_id: i32, continuation_token: ?[]const u8, top: ?i32) ![]const models.EnvironmentDeploymentExecutionRecord {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, environment_id: i32, continuation_token: ?[]const u8, top: ?i32) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -389,11 +425,27 @@ pub const Environmentdeploymentrecords = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Environmentdeploymentrecords.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.EnvironmentDeploymentExecutionRecord, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Environmentdeploymentrecords.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.EnvironmentDeploymentExecutionRecord, alloc, resp.body);
     }
 };
 
@@ -554,8 +606,18 @@ pub const Vmresource = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.VirtualMachineResource,
+        },
+    };
     /// Get Virtual Machine Resources
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, environment_id: i32, name: ?[]const u8, tags: ?[]const u8, continuation_token: ?[]const u8, @"$top": ?i32) ![]const models.VirtualMachineResource {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, environment_id: i32, name: ?[]const u8, tags: ?[]const u8, continuation_token: ?[]const u8, @"$top": ?i32) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -608,11 +670,27 @@ pub const Vmresource = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Vmresource.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.VirtualMachineResource, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Vmresource.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.VirtualMachineResource, alloc, resp.body);
     }
     /// Update Virtual Machine Resource
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, environment_id: i32, body: models.VirtualMachineResource) !models.VirtualMachineResource {

--- a/src/git/clients.zig
+++ b/src/git/clients.zig
@@ -2798,8 +2798,18 @@ pub const PullRequestCommits = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const GetPullRequestCommitsResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.GitCommitRef,
+        },
+    };
     /// Get the commits for the specified pull request.
-    pub fn getPullRequestCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, @"$top": ?i32, continuation_token: ?[]const u8) ![]const models.GitCommitRef {
+    pub fn getPullRequestCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, @"$top": ?i32, continuation_token: ?[]const u8) !GetPullRequestCommitsResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2840,11 +2850,27 @@ pub const PullRequestCommits = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("PullRequestCommits.getPullRequestCommits", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.GitCommitRef, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("PullRequestCommits.getPullRequestCommits", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.GitCommitRef, alloc, resp.body);
     }
     /// Get the commits for the specified iteration of a pull request.
     pub fn getPullRequestIterationCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8, top: ?i32, skip: ?i32) ![]const models.GitCommitRef {
@@ -4807,8 +4833,18 @@ pub const Refs = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.GitRef,
+        },
+    };
     /// Queries the provided repository for its refs and returns them.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, filter: ?[]const u8, include_links: ?bool, include_statuses: ?bool, include_my_branches: ?bool, latest_statuses_only: ?bool, peel_tags: ?bool, filter_contains: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, include_target_branches: ?bool) ![]const models.GitRef {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, filter: ?[]const u8, include_links: ?bool, include_statuses: ?bool, include_my_branches: ?bool, latest_statuses_only: ?bool, peel_tags: ?bool, filter_contains: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, include_target_branches: ?bool) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4891,11 +4927,27 @@ pub const Refs = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Refs.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.GitRef, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Refs.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.GitRef, alloc, resp.body);
     }
     /// Lock or Unlock a branch.
     pub fn updateRef(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, filter: []const u8, project: []const u8, project_id: ?[]const u8, body: models.GitRefUpdate) !models.GitRef {

--- a/src/graph/clients.zig
+++ b/src/graph/clients.zig
@@ -235,7 +235,7 @@ pub const Groups = struct {
         status_200: struct {
             status: u16 = 200,
             headers: struct {
-                xms_continuation_token: ?[]const u8 = null,
+                x_ms_continuationtoken: ?[]const u8 = null,
             },
             body: []const models.GraphGroup,
         },
@@ -287,7 +287,7 @@ pub const Groups = struct {
 
         switch (resp.status_code) {
             200 => {
-                const response_header_0 = if (resp.getHeader("X-MS-ContinuationToken")) |value|
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
                     try alloc.dupe(u8, value)
                 else
                     null;
@@ -296,7 +296,7 @@ pub const Groups = struct {
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
-                        .xms_continuation_token = response_header_0,
+                        .x_ms_continuationtoken = response_header_0,
                     },
                     .body = response_body,
                 } };
@@ -754,7 +754,7 @@ pub const ServicePrincipals = struct {
         status_200: struct {
             status: u16 = 200,
             headers: struct {
-                xms_continuation_token: ?[]const u8 = null,
+                x_ms_continuationtoken: ?[]const u8 = null,
             },
             body: []const models.GraphServicePrincipal,
         },
@@ -799,7 +799,7 @@ pub const ServicePrincipals = struct {
 
         switch (resp.status_code) {
             200 => {
-                const response_header_0 = if (resp.getHeader("X-MS-ContinuationToken")) |value|
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
                     try alloc.dupe(u8, value)
                 else
                     null;
@@ -808,7 +808,7 @@ pub const ServicePrincipals = struct {
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
-                        .xms_continuation_token = response_header_0,
+                        .x_ms_continuationtoken = response_header_0,
                     },
                     .body = response_body,
                 } };
@@ -1170,7 +1170,7 @@ pub const Users = struct {
         status_200: struct {
             status: u16 = 200,
             headers: struct {
-                xms_continuation_token: ?[]const u8 = null,
+                x_ms_continuationtoken: ?[]const u8 = null,
             },
             body: []const models.GraphUser,
         },
@@ -1222,7 +1222,7 @@ pub const Users = struct {
 
         switch (resp.status_code) {
             200 => {
-                const response_header_0 = if (resp.getHeader("X-MS-ContinuationToken")) |value|
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
                     try alloc.dupe(u8, value)
                 else
                     null;
@@ -1231,7 +1231,7 @@ pub const Users = struct {
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
-                        .xms_continuation_token = response_header_0,
+                        .x_ms_continuationtoken = response_header_0,
                     },
                     .body = response_body,
                 } };

--- a/src/member_entitlement_management/clients.zig
+++ b/src/member_entitlement_management/clients.zig
@@ -457,7 +457,17 @@ pub const MemberEntitlements = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn searchMemberEntitlements(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, continuation_token: ?[]const u8, select: ?enums.SearchMemberEntitlementsRequestSelect, @"$filter": ?[]const u8, @"$order_by": ?[]const u8) ![]const models.JsonValue {
+    pub const SearchMemberEntitlementsResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.JsonValue,
+        },
+    };
+
+    pub fn searchMemberEntitlements(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, continuation_token: ?[]const u8, select: ?enums.SearchMemberEntitlementsRequestSelect, @"$filter": ?[]const u8, @"$order_by": ?[]const u8) !SearchMemberEntitlementsResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -508,11 +518,27 @@ pub const MemberEntitlements = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("MemberEntitlements.searchMemberEntitlements", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.JsonValue, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("MemberEntitlements.searchMemberEntitlements", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.JsonValue, alloc, resp.body);
     }
 };
 

--- a/src/pipelines/clients.zig
+++ b/src/pipelines/clients.zig
@@ -136,8 +136,18 @@ pub const Pipelines = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.Pipeline,
+        },
+    };
     /// Get a list of pipelines.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, order_by: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8) ![]const models.Pipeline {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, order_by: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -181,11 +191,27 @@ pub const Pipelines = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Pipelines.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.Pipeline, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Pipelines.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.Pipeline, alloc, resp.body);
     }
     /// Create a pipeline.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.CreatePipelineParameters) !models.Pipeline {

--- a/src/policy/clients.zig
+++ b/src/policy/clients.zig
@@ -128,8 +128,18 @@ pub const Configurations = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.PolicyConfiguration,
+        },
+    };
     /// Get a list of policy configurations in a project. The 'scope' parameter for this API should not be used, except for legacy compatability reasons. It returns specifically scoped policies and does not support heirarchical nesting. Instead, use the /_apis/git/policy/configurations API, which provides first class scope filtering support. The optional `policyType` parameter can be used to filter the set of policies returned from this method.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, scope: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, policy_type: ?[]const u8) ![]const models.PolicyConfiguration {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, scope: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, policy_type: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -180,11 +190,27 @@ pub const Configurations = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Configurations.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.PolicyConfiguration, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Configurations.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.PolicyConfiguration, alloc, resp.body);
     }
     /// Create a policy configuration of a given policy type.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.PolicyConfiguration) !models.PolicyConfiguration {

--- a/src/release/clients.zig
+++ b/src/release/clients.zig
@@ -287,6 +287,16 @@ pub const Definitions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.ReleaseDefinition,
+        },
+    };
+
     pub const GetDefinitionRevisionResult = union(enum) {
         status_200: struct {
             status: u16 = 200,
@@ -297,7 +307,7 @@ pub const Definitions = struct {
         },
     };
     /// Get a list of release definitions.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, search_text: ?[]const u8, @"$expand": ?enums.ListRequestExpand, artifact_type: ?[]const u8, artifact_source_id: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, query_order: ?enums.ListRequestQueryOrder1, path: ?[]const u8, is_exact_name_match: ?bool, tag_filter: ?[]const u8, property_filters: ?[]const u8, definition_id_filter: ?[]const u8, is_deleted: ?bool, search_text_contains_folder_name: ?bool) ![]const models.ReleaseDefinition {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, search_text: ?[]const u8, @"$expand": ?enums.ListRequestExpand, artifact_type: ?[]const u8, artifact_source_id: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8, query_order: ?enums.ListRequestQueryOrder1, path: ?[]const u8, is_exact_name_match: ?bool, tag_filter: ?[]const u8, property_filters: ?[]const u8, definition_id_filter: ?[]const u8, is_deleted: ?bool, search_text_contains_folder_name: ?bool) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -412,11 +422,27 @@ pub const Definitions = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Definitions.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.ReleaseDefinition, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Definitions.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.ReleaseDefinition, alloc, resp.body);
     }
     /// Create a release definition
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.ReleaseDefinition) !models.ReleaseDefinition {

--- a/src/test_plan/clients.zig
+++ b/src/test_plan/clients.zig
@@ -200,6 +200,16 @@ pub const TestSuites = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const GetTestSuitesForPlanResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestSuite,
+        },
+    };
     /// Find the list of all test suites in which a given test case is present. This is helpful if you need to find out which test suites are using a test case, when you need to make changes to a test case.
     pub fn getSuitesByTestCaseId(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, test_case_id: i32) ![]const models.TestSuite {
         @setEvalBranchQuota(100_000);
@@ -233,7 +243,7 @@ pub const TestSuites = struct {
         return try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
     }
     /// Get test suites for plan.
-    pub fn getTestSuitesForPlan(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, expand: ?enums.GetTestSuitesForPlanRequestExpand, continuation_token: ?[]const u8, as_tree_view: ?bool) ![]const models.TestSuite {
+    pub fn getTestSuitesForPlan(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, expand: ?enums.GetTestSuitesForPlanRequestExpand, continuation_token: ?[]const u8, as_tree_view: ?bool) !GetTestSuitesForPlanResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -279,11 +289,27 @@ pub const TestSuites = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("TestSuites.getTestSuitesForPlan", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("TestSuites.getTestSuitesForPlan", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
     }
     /// Create test suite.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, body: models.TestSuiteCreateParams) !models.TestSuite {
@@ -447,6 +473,16 @@ pub const Configurations = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestConfiguration,
+        },
+    };
     /// Delete a test configuration by its ID.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, test_configuartion_id: i32) !void {
         @setEvalBranchQuota(100_000);
@@ -481,7 +517,7 @@ pub const Configurations = struct {
         return;
     }
     /// Get a list of test configurations.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, continuation_token: ?[]const u8) ![]const models.TestConfiguration {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -513,11 +549,27 @@ pub const Configurations = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Configurations.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestConfiguration, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Configurations.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestConfiguration, alloc, resp.body);
     }
     /// Update a test configuration by its ID.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, test_configuartion_id: i32, body: models.TestConfigurationCreateUpdateParameters) !models.TestConfiguration {
@@ -633,8 +685,18 @@ pub const TestPlans = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestPlan,
+        },
+    };
     /// Get a list of test plans
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, owner: ?[]const u8, continuation_token: ?[]const u8, include_plan_details: ?bool, filter_active_plans: ?bool) ![]const models.TestPlan {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, owner: ?[]const u8, continuation_token: ?[]const u8, include_plan_details: ?bool, filter_active_plans: ?bool) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -683,11 +745,27 @@ pub const TestPlans = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("TestPlans.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestPlan, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("TestPlans.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestPlan, alloc, resp.body);
     }
     /// Create a test plan.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestPlanCreateParams) !models.TestPlan {
@@ -836,6 +914,16 @@ pub const SuiteTestCase = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const GetTestCaseListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestCase,
+        },
+    };
     /// Removes test cases from a suite based on the list of test case Ids provided. This API can be used to remove a larger number of test cases.
     pub fn removeTestCasesListFromSuite(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_ids: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -876,7 +964,7 @@ pub const SuiteTestCase = struct {
         return;
     }
     /// Get Test Case List return those test cases which have all the configuration Ids as mentioned in the optional parameter. If configuration Ids is null, it return all the test cases
-    pub fn getTestCaseList(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_ids: ?[]const u8, configuration_ids: ?[]const u8, wit_fields: ?[]const u8, continuation_token: ?[]const u8, return_identity_ref: ?bool, expand: ?bool, exclude_flags: ?enums.GetTestCaseListRequestExcludeFlags, is_recursive: ?bool) ![]const models.TestCase {
+    pub fn getTestCaseList(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_ids: ?[]const u8, configuration_ids: ?[]const u8, wit_fields: ?[]const u8, continuation_token: ?[]const u8, return_identity_ref: ?bool, expand: ?bool, exclude_flags: ?enums.GetTestCaseListRequestExcludeFlags, is_recursive: ?bool) !GetTestCaseListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -955,11 +1043,27 @@ pub const SuiteTestCase = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("SuiteTestCase.getTestCaseList", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestCase, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("SuiteTestCase.getTestCaseList", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestCase, alloc, resp.body);
     }
     /// Update the configurations for test cases
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, body: []const models.SuiteTestCaseCreateUpdateParameters) ![]const models.TestCase {
@@ -1284,8 +1388,18 @@ pub const TestPlanRecycleBin = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestPlan,
+        },
+    };
     /// Get a list of deleted test plans
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, continuation_token: ?[]const u8) ![]const models.TestPlan {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1317,11 +1431,27 @@ pub const TestPlanRecycleBin = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("TestPlanRecycleBin.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestPlan, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("TestPlanRecycleBin.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestPlan, alloc, resp.body);
     }
     /// Restores the deleted test plan
     pub fn restoreDeletedTestPlan(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, body: models.TestPlanAndSuiteRestoreModel) !void {
@@ -1366,8 +1496,28 @@ pub const TestSuiteRecycleBinOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const GetDeletedTestSuitesForPlanResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestSuite,
+        },
+    };
+
+    pub const GetDeletedTestSuitesForProjectResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestSuite,
+        },
+    };
     /// Get Deleted Test Suites for a Test Plan.
-    pub fn getDeletedTestSuitesForPlan(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, expand: ?enums.GetDeletedTestSuitesForPlanRequestExpand, continuation_token: ?[]const u8, as_tree_view: ?bool) ![]const models.TestSuite {
+    pub fn getDeletedTestSuitesForPlan(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, expand: ?enums.GetDeletedTestSuitesForPlanRequestExpand, continuation_token: ?[]const u8, as_tree_view: ?bool) !GetDeletedTestSuitesForPlanResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1413,14 +1563,30 @@ pub const TestSuiteRecycleBinOperations = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("TestSuiteRecycleBinOperations.getDeletedTestSuitesForPlan", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("TestSuiteRecycleBinOperations.getDeletedTestSuitesForPlan", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
     }
     /// Get Deleted Test Suites within a Project.
-    pub fn getDeletedTestSuitesForProject(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, expand: ?enums.GetDeletedTestSuitesForProjectRequestExpand, continuation_token: ?[]const u8, as_tree_view: ?bool) ![]const models.TestSuite {
+    pub fn getDeletedTestSuitesForProject(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, expand: ?enums.GetDeletedTestSuitesForProjectRequestExpand, continuation_token: ?[]const u8, as_tree_view: ?bool) !GetDeletedTestSuitesForProjectResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1464,11 +1630,27 @@ pub const TestSuiteRecycleBinOperations = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("TestSuiteRecycleBinOperations.getDeletedTestSuitesForProject", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("TestSuiteRecycleBinOperations.getDeletedTestSuitesForProject", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
     }
     /// Restores the deleted test suite
     pub fn restoreDeletedTestSuite(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, suite_id: i32, body: models.TestPlanAndSuiteRestoreModel) !void {
@@ -1794,8 +1976,18 @@ pub const Variables = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TestVariable,
+        },
+    };
     /// Get a list of test variables.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, continuation_token: ?[]const u8) ![]const models.TestVariable {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1827,11 +2019,27 @@ pub const Variables = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Variables.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TestVariable, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Variables.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TestVariable, alloc, resp.body);
     }
     /// Create a test variable.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestVariableCreateUpdateParameters) !models.TestVariable {

--- a/src/test_results/clients.zig
+++ b/src/test_results/clients.zig
@@ -1096,7 +1096,17 @@ pub const Resultgroupsbybuild = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, publish_context: []const u8, fields: ?[]const u8, continuation_token: ?[]const u8) ![]const models.FieldDetailsForTestResults {
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.FieldDetailsForTestResults,
+        },
+    };
+
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, publish_context: []const u8, fields: ?[]const u8, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1141,11 +1151,27 @@ pub const Resultgroupsbybuild = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Resultgroupsbybuild.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.FieldDetailsForTestResults, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Resultgroupsbybuild.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.FieldDetailsForTestResults, alloc, resp.body);
     }
 };
 
@@ -1154,7 +1180,17 @@ pub const Resultgroupsbyrelease = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, publish_context: []const u8, release_env_id: ?i32, fields: ?[]const u8, continuation_token: ?[]const u8) ![]const models.FieldDetailsForTestResults {
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.FieldDetailsForTestResults,
+        },
+    };
+
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, publish_context: []const u8, release_env_id: ?i32, fields: ?[]const u8, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1204,11 +1240,27 @@ pub const Resultgroupsbyrelease = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Resultgroupsbyrelease.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.FieldDetailsForTestResults, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Resultgroupsbyrelease.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.FieldDetailsForTestResults, alloc, resp.body);
     }
 };
 
@@ -1867,7 +1919,17 @@ pub const Resultsbybuild = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, publish_context: ?[]const u8, outcomes: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8) ![]const models.ShallowTestCaseResult {
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.ShallowTestCaseResult,
+        },
+    };
+
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, publish_context: ?[]const u8, outcomes: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1920,11 +1982,27 @@ pub const Resultsbybuild = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Resultsbybuild.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.ShallowTestCaseResult, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Resultsbybuild.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.ShallowTestCaseResult, alloc, resp.body);
     }
 };
 
@@ -2012,7 +2090,17 @@ pub const Resultsbyrelease = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, release_envid: ?i32, publish_context: ?[]const u8, outcomes: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8) ![]const models.ShallowTestCaseResult {
+    pub const ListResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.ShallowTestCaseResult,
+        },
+    };
+
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, release_envid: ?i32, publish_context: ?[]const u8, outcomes: ?[]const u8, @"$top": ?i32, continuation_token: ?[]const u8) !ListResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2070,11 +2158,27 @@ pub const Resultsbyrelease = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Resultsbyrelease.list", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.ShallowTestCaseResult, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Resultsbyrelease.list", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.ShallowTestCaseResult, alloc, resp.body);
     }
 };
 

--- a/src/tfvc/clients.zig
+++ b/src/tfvc/clients.zig
@@ -136,8 +136,18 @@ pub const Changesets = struct {
     endpoint: []const u8,
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
+
+    pub const GetChangesetChangesResult = union(enum) {
+        status_200: struct {
+            status: u16 = 200,
+            headers: struct {
+                x_ms_continuationtoken: ?[]const u8 = null,
+            },
+            body: []const models.TfvcChange,
+        },
+    };
     /// Retrieve Tfvc changes for a given changeset.
-    pub fn getChangesetChanges(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, @"$skip": ?i32, @"$top": ?i32, continuation_token: ?[]const u8) ![]const models.TfvcChange {
+    pub fn getChangesetChanges(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, @"$skip": ?i32, @"$top": ?i32, continuation_token: ?[]const u8) !GetChangesetChangesResult {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -179,11 +189,27 @@ pub const Changesets = struct {
         var resp = try self.pipeline.send(&req);
         defer resp.deinit();
 
-        if (!responseStatusExpected(resp.status_code, &.{200})) {
-            core.pager.logHttpError("Changesets.getChangesetChanges", resp.status_code, resp.body);
-            return error.AzureRequestFailed;
+        switch (resp.status_code) {
+            200 => {
+                const response_header_0 = if (resp.getHeader("x-ms-continuationtoken")) |value|
+                    try alloc.dupe(u8, value)
+                else
+                    null;
+                errdefer if (response_header_0) |value| alloc.free(value);
+                const response_body = try serde.json.fromSlice([]const models.TfvcChange, alloc, resp.body);
+                return .{ .status_200 = .{
+                    .status = resp.status_code,
+                    .headers = .{
+                        .x_ms_continuationtoken = response_header_0,
+                    },
+                    .body = response_body,
+                } };
+            },
+            else => {
+                core.pager.logHttpError("Changesets.getChangesetChanges", resp.status_code, resp.body);
+                return error.AzureRequestFailed;
+            },
         }
-        return try serde.json.fromSlice([]const models.TfvcChange, alloc, resp.body);
     }
     /// Retrieves the work items associated with a particular changeset.
     pub fn getChangesetWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32) ![]const models.AssociatedWorkItem {


### PR DESCRIPTION
Azure DevOps pages long collections with a continuation token returned in the `x-ms-continuationtoken` response header; the caller passes it back as the `continuationToken` query parameter, and an absent header means the last page.

Only 4 of the 50 paged operations declared that header upstream, so for the rest the token never reached generated code and the collection could not be paged at all. The spec fork now declares it wherever the contract implies it, and canonicalises the two upstream spellings so every operation exposes the same field name.

Regenerated against cataggar/vsts-rest-api-specs@6f19fc15. **35 operations across 14 areas** now return the token.

The return type of the 31 newly covered operations changes from a bare body to a result carrying both headers and body.