### PR TITLE
Page builds off the continuation token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,12 @@ pub fn fetch(self: *Fetcher, allocator: std.mem.Allocator, token: ?[]const u8) !
 ```
 
 Some Azure DevOps operations report the next token in the response body
-and some in the `x-ms-continuationtoken` response header. Only the
-body-field form is reachable today: the upstream Swagger does not declare
-that header, so the generated operations do not return it. See
-`examples/page_audit_log.zig` for a working body-token pager and
-`examples/list_builds.zig` for the `$top` workaround.
+and some in the `x-ms-continuationtoken` response header. Both are
+reachable: header-paged operations return a result union whose
+`status_200.headers` carries `x_ms_continuationtoken`, and an absent
+header is the end-of-collection signal. See
+`examples/list_builds.zig` for a header-token pager and
+`examples/page_audit_log.zig` for a body-token one.
 
 ## Raw operations
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
         },
         .azure_rest_devops = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1bb8d2c4f0ea720832e03ad3b52a102c0de5129a",
-            .hash = "azure_rest_devops-0.1.0-anpXMg1SQwCoGccK5iz7ZKy4mcPFiHYHR8fiFA9Jas6v",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bff2a105d6293237cd34915d842814cb84fe052e",
+            .hash = "azure_rest_devops-0.1.0-anpXMvm8QwAzYDuUfhq19MTgnhwP3hqX-le-ttVFkdCc",
         },
     },
     .paths = .{

--- a/examples/list_builds.zig
+++ b/examples/list_builds.zig
@@ -1,4 +1,12 @@
-//! List a project's most recent builds.
+//! Page through a project's builds with `ContinuationPager`.
+//!
+//! `Builds.list` is one of the Azure DevOps operations that returns its
+//! continuation token in the `x-ms-continuationtoken` response header.
+//! The generated operation surfaces it on `status_200.headers`, so the
+//! pager can drive the listing to exhaustion.
+//!
+//! See `page_audit_log.zig` for the other flavour, where the token
+//! arrives on the response *body* instead.
 //!
 //! ```sh
 //! AZURE_DEVOPS_ORGANIZATION=contoso \
@@ -6,19 +14,82 @@
 //! AZURE_DEVOPS_PAT=… \
 //! zig build examples && ./zig-out/bin/devops-list-builds
 //! ```
-//!
-//! `Builds.list` reports its continuation token in the
-//! `x-ms-continuationtoken` response header, which the Azure DevOps
-//! Swagger does not declare and the generated operation therefore does
-//! not return. Until it does, this asks for one bounded page via `$top`.
-//! See `page_audit_log.zig` for paging an operation whose token *is* in
-//! the response body.
 
 const std = @import("std");
 const core = @import("azure_sdk_core");
+const devops = @import("azure_sdk_devops");
 const support = @import("devops_example_support");
 
+const models = devops.protocol.build.models;
+const Build = models.Build;
+
 const page_size: i32 = 25;
+
+/// Captures the sub-client and the operation's fixed parameters so the
+/// pager only has to supply the continuation token.
+const BuildFetcher = struct {
+    builds: devops.protocol.build.Builds,
+    organization: []const u8,
+    project: []const u8,
+    /// The header value is owned by the response, which is freed once
+    /// the page is handed back, so it is copied here to outlive it.
+    token_buffer: ?[]u8 = null,
+    allocator: std.mem.Allocator,
+
+    pub fn fetch(
+        self: *BuildFetcher,
+        allocator: std.mem.Allocator,
+        token: ?[]const u8,
+    ) !devops.Page(Build) {
+        const result = try self.builds.list(
+            allocator,
+            self.organization,
+            self.project,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page_size,
+            token,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+        );
+
+        switch (result) {
+            .status_200 => |ok| {
+                defer allocator.free(ok.body);
+                const items = try allocator.dupe(Build, ok.body);
+                errdefer allocator.free(items);
+
+                if (self.token_buffer) |buffer| self.allocator.free(buffer);
+                self.token_buffer = null;
+                // An absent header is the end-of-collection signal.
+                if (ok.headers.x_ms_continuationtoken) |next| {
+                    if (next.len != 0) self.token_buffer = try self.allocator.dupe(u8, next);
+                }
+
+                return .{ .items = items, .continuation_token = self.token_buffer };
+            },
+        }
+    }
+
+    fn deinit(self: *BuildFetcher) void {
+        if (self.token_buffer) |buffer| self.allocator.free(buffer);
+        self.token_buffer = null;
+    }
+};
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
@@ -33,42 +104,29 @@ pub fn main(init: std.process.Init) !void {
     defer client.deinit();
 
     var build_client = client.build();
-    var builds = build_client.builds();
-    const list = try builds.list(
-        allocator,
-        settings.organization,
-        project,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        page_size,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-    );
-    defer allocator.free(list);
+    var fetcher: BuildFetcher = .{
+        .builds = build_client.builds(),
+        .organization = settings.organization,
+        .project = project,
+        .allocator = allocator,
+    };
+    defer fetcher.deinit();
 
-    std.debug.print("{d} most recent builds in {s}\n", .{ list.len, project });
-    for (list) |build| {
-        std.debug.print(
-            "  #{s}  {s}\n",
-            .{
-                build.build_number orelse "<none>",
-                if (build.status) |status| @tagName(status) else "unknown",
-            },
-        );
+    var pages = devops.ContinuationPager(Build, BuildFetcher).init(&fetcher);
+
+    var total: usize = 0;
+    while (try pages.next(allocator)) |page| {
+        defer allocator.free(page);
+        for (page) |build| {
+            total += 1;
+            std.debug.print(
+                "  #{s}  {s}\n",
+                .{
+                    build.build_number orelse "<none>",
+                    if (build.status) |status| @tagName(status) else "unknown",
+                },
+            );
+        }
     }
+    std.debug.print("{d} builds in {s}\n", .{ total, project });
 }

--- a/src/continuation.zig
+++ b/src/continuation.zig
@@ -9,10 +9,10 @@
 //! not apply; the caller has to re-invoke the same operation with the new
 //! token.
 //!
-//! Only the body-field form is reachable through the generated clients
-//! today: the Azure DevOps Swagger does not declare the
-//! `x-ms-continuationtoken` response header, so the generated operations
-//! do not return it.
+//! Both forms are reachable through the generated clients. Header-paged
+//! operations return a result union whose `status_200.headers` carries
+//! `x_ms_continuationtoken`; body-paged operations put the token on the
+//! model itself. Either way the token is null on the last page.
 //!
 //! `ContinuationPager` owns that loop so callers write a `while` instead
 //! of hand-rolling token plumbing:


### PR DESCRIPTION
`rest/devops` now surfaces the `x-ms-continuationtoken` response header on 35 paged operations, so the header form of continuation-token paging is reachable for the first time.

- Repin `azure_rest_devops` to `bff2a105d`.
- Rewrite `examples/list_builds.zig` as a real `ContinuationPager`. It previously asked for a single bounded page via `\` because the token could not be read.
- Update the paging notes in `src/continuation.zig` and `README.md`, which both still claimed only the body-field form worked.