### PR TITLE
Return the collection envelope Azure DevOps actually sends

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,8 +1,8 @@
 generator_commit=5ec3759d9bf33e1047fcbd884e8ad66519f60156
 source_repository=https://github.com/cataggar/vsts-rest-api-specs
-source_commit=6f19fc15d433da057453c99b88debbc209abb5ee
+source_commit=a8ac46b877b40178b07457fbadde128bddfc513a
 source_branch=typespec
 source_path=typespec/specs
 selected_api_version=7.2
 api_areas=44
-command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=da55987aa3c90393a726fc1fa5e86ccd69d72271 -Dazure-sdk-core-hash=azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs generate-devops-package)
+command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=5acfa4e5a9c5c7047f74eff472d8f3e1ebc1fe7b -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EglTBgB_64f-rD5Fd-CYsYveOH0iWOEG_eaomVNX generate-devops-package)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#da55987aa3c90393a726fc1fa5e86ccd69d72271",
-            .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5acfa4e5a9c5c7047f74eff472d8f3e1ebc1fe7b",
+            .hash = "azure_sdk_core-0.2.0-eFY0EglTBgB_64f-rD5Fd-CYsYveOH0iWOEG_eaomVNX",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/src/account/clients.zig
+++ b/src/account/clients.zig
@@ -105,7 +105,7 @@ pub const Accounts = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of accounts for a specific owner or a specific member. One of the following parameters is required: ownerId, memberId.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, owner_id: ?[]const u8, member_id: ?[]const u8, properties: ?[]const u8) ![]const models.Account {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, owner_id: ?[]const u8, member_id: ?[]const u8, properties: ?[]const u8) !models.AccountList {
         @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/_apis/accounts", .{self.endpoint});
         defer alloc.free(base_url);
@@ -151,6 +151,6 @@ pub const Accounts = struct {
             core.pager.logHttpError("Accounts.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Account, alloc, resp.body);
+        return try serde.json.fromSlice(models.AccountList, alloc, resp.body);
     }
 };

--- a/src/account/models.zig
+++ b/src/account/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `Account` as returned by Azure DevOps.
+pub const AccountList = struct {
+    count: ?i32 = null,
+    value: ?[]const Account = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const Account = struct {
     /// Identifier for an Account
     account_id: ?[]const u8 = null,

--- a/src/advanced_security/clients.zig
+++ b/src/advanced_security/clients.zig
@@ -233,7 +233,7 @@ pub const FiltersSettings = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets all advanced filters for the organization.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_deleted: ?bool, keywords: ?[]const u8) ![]const models.AdvancedFilter {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_deleted: ?bool, keywords: ?[]const u8) !models.AdvancedFilterList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -272,7 +272,7 @@ pub const FiltersSettings = struct {
             core.pager.logHttpError("FiltersSettings.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AdvancedFilter, alloc, resp.body);
+        return try serde.json.fromSlice(models.AdvancedFilterList, alloc, resp.body);
     }
     /// Creates a new advanced filter for the organization.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.AdvancedFilterCreate) !models.AdvancedFilter {
@@ -419,7 +419,7 @@ pub const SummaryDashboard = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.DashboardAlert,
+            body: models.DashboardAlertList,
         },
     };
     /// Get Alert summary by severity for the org
@@ -760,7 +760,7 @@ pub const SummaryDashboard = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.DashboardAlert, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.DashboardAlertList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -875,7 +875,7 @@ pub const Alerts = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.Alert,
+            body: models.AlertList,
         },
     };
     /// Get alerts for a repository
@@ -1132,7 +1132,7 @@ pub const Alerts = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Alert, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.AlertList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1244,7 +1244,7 @@ pub const Instances = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get instances of an alert on a branch specified with @ref. If @ref is not provided, return instances of an alert on default branch(if the alert exist in default branch) or latest affected branch.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, alert_id: i64, repository: []const u8, ref: ?[]const u8) ![]const models.AlertAnalysisInstance {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, alert_id: i64, repository: []const u8, ref: ?[]const u8) !models.AlertAnalysisInstanceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1284,7 +1284,7 @@ pub const Instances = struct {
             core.pager.logHttpError("Instances.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AlertAnalysisInstance, alloc, resp.body);
+        return try serde.json.fromSlice(models.AlertAnalysisInstanceList, alloc, resp.body);
     }
 };
 
@@ -1335,7 +1335,7 @@ pub const MetadataBatch = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get alerts metadata.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, body: models.AlertMetadataBatchRequest) ![]const models.AlertMetadata {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, body: models.AlertMetadataBatchRequest) !models.AlertMetadataList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1370,7 +1370,7 @@ pub const MetadataBatch = struct {
             core.pager.logHttpError("MetadataBatch.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AlertMetadata, alloc, resp.body);
+        return try serde.json.fromSlice(models.AlertMetadataList, alloc, resp.body);
     }
 };
 
@@ -1379,7 +1379,7 @@ pub const AlertsBatch = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get alerts by alert IDs Currently supports fetching secret alerts only.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, body: models.AlertBatchRequest) ![]const models.Alert {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, body: models.AlertBatchRequest) !models.AlertList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1414,7 +1414,7 @@ pub const AlertsBatch = struct {
             core.pager.logHttpError("AlertsBatch.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Alert, alloc, resp.body);
+        return try serde.json.fromSlice(models.AlertList, alloc, resp.body);
     }
 };
 
@@ -1429,7 +1429,7 @@ pub const Analysis = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.Branch,
+            body: models.BranchList,
         },
     };
     /// Returns the branches for which analysis results were submitted.
@@ -1495,7 +1495,7 @@ pub const Analysis = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Branch, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.BranchList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{

--- a/src/advanced_security/models.zig
+++ b/src/advanced_security/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `AdvancedFilter` as returned by Azure DevOps.
+pub const AdvancedFilterList = struct {
+    count: ?i32 = null,
+    value: ?[]const AdvancedFilter = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents an advanced filter configuration for the Reporting dashboard.
 pub const AdvancedFilter = struct {
     filter_criteria: ?CombinedAlertFilterCriteria = null,
@@ -222,6 +232,16 @@ pub const AlertSummaryByState = struct {
     };
 };
 
+/// A collection of `DashboardAlert` as returned by Azure DevOps.
+pub const DashboardAlertList = struct {
+    count: ?i32 = null,
+    value: ?[]const DashboardAlert = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// An alert entity used in the dashboard for combined alerts.
 pub const DashboardAlert = struct {
     /// Identifier for the alert. It is unique within Azure DevOps organization.
@@ -350,6 +370,16 @@ pub const ScanTypeSummaryProperties = struct {
 pub const ScanTypeSummaryPropertiesData = struct {
     /// Represents the state of the scan type summary property.
     enabled: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Alert` as returned by Azure DevOps.
+pub const AlertList = struct {
+    count: ?i32 = null,
+    value: ?[]const Alert = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -604,6 +634,16 @@ pub const AlertStateUpdate = struct {
     };
 };
 
+/// A collection of `AlertAnalysisInstance` as returned by Azure DevOps.
+pub const AlertAnalysisInstanceList = struct {
+    count: ?i32 = null,
+    value: ?[]const AlertAnalysisInstance = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Summary of the state of the alert for a given analysis configuration.
 pub const AlertAnalysisInstance = struct {
     analysis_configuration: ?AnalysisConfiguration = null,
@@ -831,12 +871,32 @@ pub const AlertMetadataBatchRequest = struct {
     };
 };
 
+/// A collection of `AlertMetadata` as returned by Azure DevOps.
+pub const AlertMetadataList = struct {
+    count: ?i32 = null,
+    value: ?[]const AlertMetadata = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Request model for getting alerts by IDs with optional alert type filter.
 pub const AlertBatchRequest = struct {
     /// List of alert IDs to retrieve.
     alert_ids: ?[]const i64 = null,
     /// Alert type of the alert IDs.
     alert_type: ?enums.AlertBatchRequestAlertType = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Branch` as returned by Azure DevOps.
+pub const BranchList = struct {
+    count: ?i32 = null,
+    value: ?[]const Branch = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/approvals_and_checks/clients.zig
+++ b/src/approvals_and_checks/clients.zig
@@ -129,7 +129,7 @@ pub const PipelinePermissions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Batch API to authorize/unauthorize a list of definitions for a multiple resources.
-    pub fn updatePipelinePermisionsForResources(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.ResourcePipelinePermissions) ![]const models.ResourcePipelinePermissions {
+    pub fn updatePipelinePermisionsForResources(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.ResourcePipelinePermissions) !models.ResourcePipelinePermissionsList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -162,7 +162,7 @@ pub const PipelinePermissions = struct {
             core.pager.logHttpError("PipelinePermissions.updatePipelinePermisionsForResources", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ResourcePipelinePermissions, alloc, resp.body);
+        return try serde.json.fromSlice(models.ResourcePipelinePermissionsList, alloc, resp.body);
     }
     /// Given a ResourceType and ResourceId, returns authorized definitions for that resource.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, resource_type: []const u8, resource_id: []const u8) !models.ResourcePipelinePermissions {
@@ -247,7 +247,7 @@ pub const CheckConfigurations = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get Check configuration by resource type and id
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, resource_type: ?[]const u8, resource_id: ?[]const u8, @"$expand": ?enums.ListRequestExpand) ![]const models.CheckConfiguration {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, resource_type: ?[]const u8, resource_id: ?[]const u8, @"$expand": ?enums.ListRequestExpand) !models.CheckConfigurationList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -297,7 +297,7 @@ pub const CheckConfigurations = struct {
             core.pager.logHttpError("CheckConfigurations.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.CheckConfiguration, alloc, resp.body);
+        return try serde.json.fromSlice(models.CheckConfigurationList, alloc, resp.body);
     }
     /// Add a check configuration
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.CheckConfiguration) !models.CheckConfiguration {
@@ -448,7 +448,7 @@ pub const CheckConfigurations = struct {
         return try serde.json.fromSlice(models.CheckConfiguration, alloc, resp.body);
     }
     /// Get check configurations for multiple resources by resource type and id.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.QueryRequestExpand, body: []const models.Resource) ![]const models.CheckConfiguration {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.QueryRequestExpand, body: []const models.Resource) !models.CheckConfigurationList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -488,7 +488,7 @@ pub const CheckConfigurations = struct {
             core.pager.logHttpError("CheckConfigurations.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.CheckConfiguration, alloc, resp.body);
+        return try serde.json.fromSlice(models.CheckConfigurationList, alloc, resp.body);
     }
 };
 
@@ -632,7 +632,7 @@ pub const Approvals = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// List Approvals. This can be used to get a set of pending approvals in a pipeline, on an user or for a resource..
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, approval_ids: ?[]const u8, @"$expand": ?enums.QueryRequestExpand, assigned_to: ?[]const u8, state: ?enums.QueryRequestState, top: ?i32) ![]const models.Approval {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, approval_ids: ?[]const u8, @"$expand": ?enums.QueryRequestExpand, assigned_to: ?[]const u8, state: ?enums.QueryRequestState, top: ?i32) !models.ApprovalList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -694,10 +694,10 @@ pub const Approvals = struct {
             core.pager.logHttpError("Approvals.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Approval, alloc, resp.body);
+        return try serde.json.fromSlice(models.ApprovalList, alloc, resp.body);
     }
     /// Update approvals.
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.ApprovalUpdateParameters) ![]const models.Approval {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.ApprovalUpdateParameters) !models.ApprovalList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -730,7 +730,7 @@ pub const Approvals = struct {
             core.pager.logHttpError("Approvals.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Approval, alloc, resp.body);
+        return try serde.json.fromSlice(models.ApprovalList, alloc, resp.body);
     }
     /// Get an approval.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, approval_id: []const u8, @"$expand": ?enums.GetRequestExpand) !models.Approval {

--- a/src/approvals_and_checks/models.zig
+++ b/src/approvals_and_checks/models.zig
@@ -96,6 +96,26 @@ pub const Resource = struct {
     };
 };
 
+/// A collection of `ResourcePipelinePermissions` as returned by Azure DevOps.
+pub const ResourcePipelinePermissionsList = struct {
+    count: ?i32 = null,
+    value: ?[]const ResourcePipelinePermissions = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `CheckConfiguration` as returned by Azure DevOps.
+pub const CheckConfigurationList = struct {
+    count: ?i32 = null,
+    value: ?[]const CheckConfiguration = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const CheckConfiguration = struct {
     /// Check configuration id.
     id: ?i32 = null,
@@ -245,6 +265,16 @@ pub const CheckSuiteUpdateParameter = struct {
     action: ?enums.CheckSuiteUpdateParameterAction = null,
     /// Check id of the check run to be updated.
     check_id: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Approval` as returned by Azure DevOps.
+pub const ApprovalList = struct {
+    count: ?i32 = null,
+    value: ?[]const Approval = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/artifacts/clients.zig
+++ b/src/artifacts/clients.zig
@@ -161,7 +161,7 @@ pub const ServiceSettings = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all service-wide feed creation and administration permissions.
-    pub fn getGlobalPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_ids: ?bool) ![]const models.GlobalPermission {
+    pub fn getGlobalPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_ids: ?bool) !models.GlobalPermissionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -193,10 +193,10 @@ pub const ServiceSettings = struct {
             core.pager.logHttpError("ServiceSettings.getGlobalPermissions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GlobalPermission, alloc, resp.body);
+        return try serde.json.fromSlice(models.GlobalPermissionList, alloc, resp.body);
     }
     /// Set service-wide permissions that govern feed creation and administration.
-    pub fn setGlobalPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: []const models.GlobalPermission) ![]const models.GlobalPermission {
+    pub fn setGlobalPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: []const models.GlobalPermission) !models.GlobalPermissionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -227,7 +227,7 @@ pub const ServiceSettings = struct {
             core.pager.logHttpError("ServiceSettings.setGlobalPermissions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GlobalPermission, alloc, resp.body);
+        return try serde.json.fromSlice(models.GlobalPermissionList, alloc, resp.body);
     }
 };
 
@@ -367,7 +367,7 @@ pub const FeedRecycleBin = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Query for feeds within the recycle bin. If the project parameter is present, gets all feeds in recycle bin in the given project. If omitted, gets all feeds in recycle bin in the organization.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.Feed {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.FeedList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -396,7 +396,7 @@ pub const FeedRecycleBin = struct {
             core.pager.logHttpError("FeedRecycleBin.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Feed, alloc, resp.body);
+        return try serde.json.fromSlice(models.FeedList, alloc, resp.body);
     }
     /// Permanently delete a feed and all of its packages. The action is irreversible and the package content will be deleted immediately. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
     pub fn permanentDeleteFeed(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8) !void {
@@ -475,7 +475,7 @@ pub const FeedManagement = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all feeds in an account where you have the provided role access. If the project parameter is present, gets all feeds in the given project. If omitted, gets all feeds in the organization.
-    pub fn getFeeds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, feed_role: ?enums.GetFeedsRequestFeedRole, include_deleted_upstreams: ?bool, include_urls: ?bool) ![]const models.Feed {
+    pub fn getFeeds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, feed_role: ?enums.GetFeedsRequestFeedRole, include_deleted_upstreams: ?bool, include_urls: ?bool) !models.FeedList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -521,7 +521,7 @@ pub const FeedManagement = struct {
             core.pager.logHttpError("FeedManagement.getFeeds", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Feed, alloc, resp.body);
+        return try serde.json.fromSlice(models.FeedList, alloc, resp.body);
     }
     /// Create a feed, a container for various package types. Feeds can be created in a project if the project parameter is included in the request url. If the project parameter is omitted, the feed will not be associated with a project and will be created at the organization level.
     pub fn createFeed(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.Feed) !models.Feed {
@@ -670,7 +670,7 @@ pub const FeedManagement = struct {
         return try serde.json.fromSlice(models.Feed, alloc, resp.body);
     }
     /// Get the permissions for a feed. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
-    pub fn getFeedPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, include_ids: ?bool, exclude_inherited_permissions: ?bool, identity_descriptor: ?[]const u8, include_deleted_feeds: ?bool) ![]const models.FeedPermission {
+    pub fn getFeedPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, include_ids: ?bool, exclude_inherited_permissions: ?bool, identity_descriptor: ?[]const u8, include_deleted_feeds: ?bool) !models.FeedPermissionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -723,10 +723,10 @@ pub const FeedManagement = struct {
             core.pager.logHttpError("FeedManagement.getFeedPermissions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.FeedPermission, alloc, resp.body);
+        return try serde.json.fromSlice(models.FeedPermissionList, alloc, resp.body);
     }
     /// Update the permissions on a feed. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
-    pub fn setFeedPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, body: []const models.FeedPermission) ![]const models.FeedPermission {
+    pub fn setFeedPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, body: []const models.FeedPermission) !models.FeedPermissionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -761,10 +761,10 @@ pub const FeedManagement = struct {
             core.pager.logHttpError("FeedManagement.setFeedPermissions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.FeedPermission, alloc, resp.body);
+        return try serde.json.fromSlice(models.FeedPermissionList, alloc, resp.body);
     }
     /// Get all views for a feed. The project parameter must be supplied if the feed was created in a project.
-    pub fn getFeedViews(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8) ![]const models.FeedView {
+    pub fn getFeedViews(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8) !models.FeedViewList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -795,7 +795,7 @@ pub const FeedManagement = struct {
             core.pager.logHttpError("FeedManagement.getFeedViews", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.FeedView, alloc, resp.body);
+        return try serde.json.fromSlice(models.FeedViewList, alloc, resp.body);
     }
     /// Create a new view on the referenced feed. The project parameter must be supplied if the feed was created in a project.
     pub fn createFeedView(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, body: models.FeedView) !models.FeedView {
@@ -963,7 +963,7 @@ pub const ArtifactDetails = struct {
         },
     };
 
-    pub fn queryPackageMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, body: models.PackageMetricsQuery) ![]const models.PackageMetrics {
+    pub fn queryPackageMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, body: models.PackageMetricsQuery) !models.PackageMetricsList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -998,10 +998,10 @@ pub const ArtifactDetails = struct {
             core.pager.logHttpError("ArtifactDetails.queryPackageMetrics", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PackageMetrics, alloc, resp.body);
+        return try serde.json.fromSlice(models.PackageMetricsList, alloc, resp.body);
     }
     /// Get details about all of the packages in the feed. Use the various filters to include or exclude information from the result set. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
-    pub fn getPackages(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, protocol_type: ?[]const u8, package_name_query: ?[]const u8, normalized_package_name: ?[]const u8, include_urls: ?bool, include_all_versions: ?bool, is_listed: ?bool, get_top_package_versions: ?bool, is_release: ?bool, include_description: ?bool, @"$top": ?i32, @"$skip": ?i32, include_deleted: ?bool, is_cached: ?bool, direct_upstream_id: ?[]const u8) ![]const models.Package {
+    pub fn getPackages(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, protocol_type: ?[]const u8, package_name_query: ?[]const u8, normalized_package_name: ?[]const u8, include_urls: ?bool, include_all_versions: ?bool, is_listed: ?bool, get_top_package_versions: ?bool, is_release: ?bool, include_description: ?bool, @"$top": ?i32, @"$skip": ?i32, include_deleted: ?bool, is_cached: ?bool, direct_upstream_id: ?[]const u8) !models.PackageList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1110,7 +1110,7 @@ pub const ArtifactDetails = struct {
             core.pager.logHttpError("ArtifactDetails.getPackages", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Package, alloc, resp.body);
+        return try serde.json.fromSlice(models.PackageList, alloc, resp.body);
     }
     /// Get details about a specific package. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
     pub fn getPackage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, include_all_versions: ?bool, include_urls: ?bool, is_listed: ?bool, is_release: ?bool, include_deleted: ?bool, include_description: ?bool) !models.Package {
@@ -1179,7 +1179,7 @@ pub const ArtifactDetails = struct {
         return try serde.json.fromSlice(models.Package, alloc, resp.body);
     }
 
-    pub fn queryPackageVersionMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, body: models.PackageVersionMetricsQuery) ![]const models.PackageVersionMetrics {
+    pub fn queryPackageVersionMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, body: models.PackageVersionMetricsQuery) !models.PackageVersionMetricsList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1216,10 +1216,10 @@ pub const ArtifactDetails = struct {
             core.pager.logHttpError("ArtifactDetails.queryPackageVersionMetrics", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PackageVersionMetrics, alloc, resp.body);
+        return try serde.json.fromSlice(models.PackageVersionMetricsList, alloc, resp.body);
     }
     /// Get a list of package versions, optionally filtering by state. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
-    pub fn getPackageVersions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, include_urls: ?bool, is_listed: ?bool, is_deleted: ?bool) ![]const models.PackageVersion {
+    pub fn getPackageVersions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, include_urls: ?bool, is_listed: ?bool, is_deleted: ?bool) !models.PackageVersionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1267,7 +1267,7 @@ pub const ArtifactDetails = struct {
             core.pager.logHttpError("ArtifactDetails.getPackageVersions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PackageVersion, alloc, resp.body);
+        return try serde.json.fromSlice(models.PackageVersionList, alloc, resp.body);
     }
     /// Get details about a specific package version. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
     pub fn getPackageVersion(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, package_version_id: []const u8, project: []const u8, include_urls: ?bool, is_listed: ?bool, is_deleted: ?bool) !models.PackageVersion {
@@ -1453,7 +1453,7 @@ pub const RecycleBin = struct {
         return try serde.json.fromSlice(models.OperationReference, alloc, resp.body);
     }
     /// Query for packages within the recycle bin. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
-    pub fn getRecycleBinPackages(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, protocol_type: ?[]const u8, package_name_query: ?[]const u8, include_urls: ?bool, @"$top": ?i32, @"$skip": ?i32, include_all_versions: ?bool) ![]const models.Package {
+    pub fn getRecycleBinPackages(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8, protocol_type: ?[]const u8, package_name_query: ?[]const u8, include_urls: ?bool, @"$top": ?i32, @"$skip": ?i32, include_all_versions: ?bool) !models.PackageList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1518,7 +1518,7 @@ pub const RecycleBin = struct {
             core.pager.logHttpError("RecycleBin.getRecycleBinPackages", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Package, alloc, resp.body);
+        return try serde.json.fromSlice(models.PackageList, alloc, resp.body);
     }
     /// Get information about a package and all its versions within the recycle bin. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
     pub fn getRecycleBinPackage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, include_urls: ?bool) !models.Package {
@@ -1562,7 +1562,7 @@ pub const RecycleBin = struct {
         return try serde.json.fromSlice(models.Package, alloc, resp.body);
     }
     /// Get a list of package versions within the recycle bin. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
-    pub fn getRecycleBinPackageVersions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, include_urls: ?bool) ![]const models.RecycleBinPackageVersion {
+    pub fn getRecycleBinPackageVersions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, project: []const u8, include_urls: ?bool) !models.RecycleBinPackageVersionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1600,7 +1600,7 @@ pub const RecycleBin = struct {
             core.pager.logHttpError("RecycleBin.getRecycleBinPackageVersions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.RecycleBinPackageVersion, alloc, resp.body);
+        return try serde.json.fromSlice(models.RecycleBinPackageVersionList, alloc, resp.body);
     }
     /// Get information about a package version within the recycle bin. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
     pub fn getRecycleBinPackageVersion(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_id: []const u8, package_version_id: []const u8, project: []const u8, include_urls: ?bool) !models.RecycleBinPackageVersion {

--- a/src/artifacts/models.zig
+++ b/src/artifacts/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `GlobalPermission` as returned by Azure DevOps.
+pub const GlobalPermissionList = struct {
+    count: ?i32 = null,
+    value: ?[]const GlobalPermission = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Permissions for feed service-wide operations such as the creation of new feeds.
 pub const GlobalPermission = struct {
     identity_descriptor: ?IdentityDescriptor = null,
@@ -435,6 +445,16 @@ pub const ProtocolMetadataData = struct {
     };
 };
 
+/// A collection of `Feed` as returned by Azure DevOps.
+pub const FeedList = struct {
+    count: ?i32 = null,
+    value: ?[]const Feed = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// The JSON model for JSON Patch Operations
 pub const JsonPatchDocument = struct {
     pub const serde = .{
@@ -470,10 +490,40 @@ pub const FeedUpdate = struct {
     };
 };
 
+/// A collection of `FeedPermission` as returned by Azure DevOps.
+pub const FeedPermissionList = struct {
+    count: ?i32 = null,
+    value: ?[]const FeedPermission = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `FeedView` as returned by Azure DevOps.
+pub const FeedViewList = struct {
+    count: ?i32 = null,
+    value: ?[]const FeedView = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Query to get package metrics
 pub const PackageMetricsQuery = struct {
     /// List of package ids
     package_ids: ?[]const []const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `PackageMetrics` as returned by Azure DevOps.
+pub const PackageMetricsList = struct {
+    count: ?i32 = null,
+    value: ?[]const PackageMetrics = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -496,10 +546,30 @@ pub const PackageMetrics = struct {
     };
 };
 
+/// A collection of `Package` as returned by Azure DevOps.
+pub const PackageList = struct {
+    count: ?i32 = null,
+    value: ?[]const Package = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Query to get package version metrics
 pub const PackageVersionMetricsQuery = struct {
     /// List of package version ids
     package_version_ids: ?[]const []const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `PackageVersionMetrics` as returned by Azure DevOps.
+pub const PackageVersionMetricsList = struct {
+    count: ?i32 = null,
+    value: ?[]const PackageVersionMetrics = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -518,6 +588,16 @@ pub const PackageVersionMetrics = struct {
     package_id: ?[]const u8 = null,
     /// Package version id.
     package_version_id: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `PackageVersion` as returned by Azure DevOps.
+pub const PackageVersionList = struct {
+    count: ?i32 = null,
+    value: ?[]const PackageVersion = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -565,6 +645,16 @@ pub const OperationReference = struct {
     status: ?enums.OperationReferenceStatus = null,
     /// URL to get the full operation object.
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `RecycleBinPackageVersion` as returned by Azure DevOps.
+pub const RecycleBinPackageVersionList = struct {
+    count: ?i32 = null,
+    value: ?[]const RecycleBinPackageVersion = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/audit/clients.zig
+++ b/src/audit/clients.zig
@@ -129,7 +129,7 @@ pub const Actions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all auditable actions filterable by area.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, area_name: ?[]const u8) ![]const models.AuditActionInfo {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, area_name: ?[]const u8) !models.AuditActionInfoList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -163,7 +163,7 @@ pub const Actions = struct {
             core.pager.logHttpError("Actions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AuditActionInfo, alloc, resp.body);
+        return try serde.json.fromSlice(models.AuditActionInfoList, alloc, resp.body);
     }
 };
 
@@ -320,7 +320,7 @@ pub const Streams = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Return all Audit Streams scoped to an organization
-    pub fn queryAllStreams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.AuditStream {
+    pub fn queryAllStreams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.AuditStreamList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -347,7 +347,7 @@ pub const Streams = struct {
             core.pager.logHttpError("Streams.queryAllStreams", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AuditStream, alloc, resp.body);
+        return try serde.json.fromSlice(models.AuditStreamList, alloc, resp.body);
     }
     /// Create new Audit Stream
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, days_to_backfill: i32, body: models.AuditStream) !models.AuditStream {

--- a/src/audit/models.zig
+++ b/src/audit/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `AuditActionInfo` as returned by Azure DevOps.
+pub const AuditActionInfoList = struct {
+    count: ?i32 = null,
+    value: ?[]const AuditActionInfo = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const AuditActionInfo = struct {
     /// The action id for the event, i.e Git.CreateRepo, Project.RenameProject
     action_id: ?[]const u8 = null,
@@ -90,6 +100,16 @@ pub const DecoratedAuditLogEntry = struct {
 };
 
 pub const DecoratedAuditLogEntryDatum = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `AuditStream` as returned by Azure DevOps.
+pub const AuditStreamList = struct {
+    count: ?i32 = null,
+    value: ?[]const AuditStream = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };

--- a/src/build/clients.zig
+++ b/src/build/clients.zig
@@ -321,7 +321,7 @@ pub const Controllers = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets controller, optionally filtered by name
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, name: ?[]const u8) ![]const models.BuildController {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, name: ?[]const u8) !models.BuildControllerList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -355,7 +355,7 @@ pub const Controllers = struct {
             core.pager.logHttpError("Controllers.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildController, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildControllerList, alloc, resp.body);
     }
     /// Gets a controller
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, controller_id: i32) !models.BuildController {
@@ -604,7 +604,7 @@ pub const Authorizedresources = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": ?[]const u8, id: ?[]const u8) ![]const models.DefinitionResourceReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": ?[]const u8, id: ?[]const u8) !models.DefinitionResourceReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -647,10 +647,10 @@ pub const Authorizedresources = struct {
             core.pager.logHttpError("Authorizedresources.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.DefinitionResourceReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.DefinitionResourceReferenceList, alloc, resp.body);
     }
 
-    pub fn authorizeProjectResources(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.DefinitionResourceReference) ![]const models.DefinitionResourceReference {
+    pub fn authorizeProjectResources(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.DefinitionResourceReference) !models.DefinitionResourceReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -683,7 +683,7 @@ pub const Authorizedresources = struct {
             core.pager.logHttpError("Authorizedresources.authorizeProjectResources", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.DefinitionResourceReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.DefinitionResourceReferenceList, alloc, resp.body);
     }
 };
 
@@ -698,7 +698,7 @@ pub const Builds = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.Build,
+            body: models.BuildList,
         },
     };
 
@@ -708,7 +708,7 @@ pub const Builds = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.Change,
+            body: models.ChangeList,
         },
     };
 
@@ -718,7 +718,7 @@ pub const Builds = struct {
             headers: struct {
                 content_type: []const u8,
             },
-            body: []const models.BuildLog,
+            body: models.BuildLogList,
         },
     };
 
@@ -900,7 +900,7 @@ pub const Builds = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Build, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.BuildList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -916,7 +916,7 @@ pub const Builds = struct {
         }
     }
     /// Updates multiple builds.
-    pub fn updateBuilds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.Build) ![]const models.Build {
+    pub fn updateBuilds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.Build) !models.BuildList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -949,7 +949,7 @@ pub const Builds = struct {
             core.pager.logHttpError("Builds.updateBuilds", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Build, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildList, alloc, resp.body);
     }
     /// Queues a build
     pub fn queue(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, ignore_warnings: ?bool, check_in_ticket: ?[]const u8, source_build_id: ?i32, definition_id: ?i32, body: models.Build) !models.Build {
@@ -1178,7 +1178,7 @@ pub const Builds = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Change, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.ChangeList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1194,7 +1194,7 @@ pub const Builds = struct {
         }
     }
     /// Gets all retention leases that apply to a specific build.
-    pub fn getRetentionLeasesForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) ![]const models.RetentionLease {
+    pub fn getRetentionLeasesForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) !models.RetentionLeaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1225,7 +1225,7 @@ pub const Builds = struct {
             core.pager.logHttpError("Builds.getRetentionLeasesForBuild", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.RetentionLease, alloc, resp.body);
+        return try serde.json.fromSlice(models.RetentionLeaseList, alloc, resp.body);
     }
     /// Gets the logs for a build.
     pub fn getBuildLogs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) !GetBuildLogsResult {
@@ -1262,7 +1262,7 @@ pub const Builds = struct {
                     resp.getHeader("content-type") orelse return error.MissingResponseHeader,
                 );
                 errdefer alloc.free(response_header_0);
-                const response_body = try serde.json.fromSlice([]const models.BuildLog, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.BuildLogList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1341,7 +1341,7 @@ pub const Builds = struct {
         }
     }
     /// Gets the work items associated with a build. Only work items in the same project are returned.
-    pub fn getBuildWorkItemsRefs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, @"$top": ?i32) ![]const models.ResourceRef {
+    pub fn getBuildWorkItemsRefs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, @"$top": ?i32) !models.ResourceRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1377,10 +1377,10 @@ pub const Builds = struct {
             core.pager.logHttpError("Builds.getBuildWorkItemsRefs", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ResourceRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.ResourceRefList, alloc, resp.body);
     }
     /// Gets the work items associated with a build, filtered to specific commits.
-    pub fn getBuildWorkItemsRefsFromCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, @"$top": ?i32, body: []const []const u8) ![]const models.ResourceRef {
+    pub fn getBuildWorkItemsRefsFromCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, @"$top": ?i32, body: []const []const u8) !models.ResourceRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1420,10 +1420,10 @@ pub const Builds = struct {
             core.pager.logHttpError("Builds.getBuildWorkItemsRefsFromCommits", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ResourceRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.ResourceRefList, alloc, resp.body);
     }
     /// Gets the changes made to the repository between two given builds.
-    pub fn getChangesBetweenBuilds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, from_build_id: ?i32, to_build_id: ?i32, @"$top": ?i32) ![]const models.Change {
+    pub fn getChangesBetweenBuilds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, from_build_id: ?i32, to_build_id: ?i32, @"$top": ?i32) !models.ChangeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1467,10 +1467,10 @@ pub const Builds = struct {
             core.pager.logHttpError("Builds.getChangesBetweenBuilds", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Change, alloc, resp.body);
+        return try serde.json.fromSlice(models.ChangeList, alloc, resp.body);
     }
     /// Gets all the work items between two builds.
-    pub fn getWorkItemsBetweenBuilds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, from_build_id: i32, to_build_id: i32, @"$top": ?i32) ![]const models.ResourceRef {
+    pub fn getWorkItemsBetweenBuilds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, from_build_id: i32, to_build_id: i32, @"$top": ?i32) !models.ResourceRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1508,7 +1508,7 @@ pub const Builds = struct {
             core.pager.logHttpError("Builds.getWorkItemsBetweenBuilds", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ResourceRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.ResourceRefList, alloc, resp.body);
     }
 };
 
@@ -1586,7 +1586,7 @@ pub const Attachments = struct {
         }
     }
     /// Gets the list of attachments of a specific type that are associated with a build.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, @"type": []const u8) ![]const models.Attachment {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, @"type": []const u8) !models.AttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1619,7 +1619,7 @@ pub const Attachments = struct {
             core.pager.logHttpError("Attachments.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Attachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.AttachmentList, alloc, resp.body);
     }
 };
 
@@ -1628,7 +1628,7 @@ pub const Artifacts = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets all artifacts for a build.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) ![]const models.BuildArtifact {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) !models.BuildArtifactList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1659,7 +1659,7 @@ pub const Artifacts = struct {
             core.pager.logHttpError("Artifacts.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildArtifact, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildArtifactList, alloc, resp.body);
     }
     /// Associates an artifact with a build.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, body: models.BuildArtifact) !models.BuildArtifact {
@@ -2593,7 +2593,7 @@ pub const Definitions = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.BuildDefinitionReference,
+            body: models.BuildDefinitionReferenceList,
         },
     };
     /// Gets a list of definitions.
@@ -2733,7 +2733,7 @@ pub const Definitions = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.BuildDefinitionReference, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.BuildDefinitionReferenceList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -2975,7 +2975,7 @@ pub const Definitions = struct {
         return try serde.json.fromSlice(models.BuildDefinition, alloc, resp.body);
     }
     /// Gets all revisions of a definition.
-    pub fn getDefinitionRevisions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32) ![]const models.BuildDefinitionRevision {
+    pub fn getDefinitionRevisions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32) !models.BuildDefinitionRevisionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3006,7 +3006,7 @@ pub const Definitions = struct {
             core.pager.logHttpError("Definitions.getDefinitionRevisions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildDefinitionRevision, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildDefinitionRevisionList, alloc, resp.body);
     }
 };
 
@@ -3015,7 +3015,7 @@ pub const Metrics = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets build metrics for a definition.
-    pub fn getDefinitionMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32, min_metrics_time: ?[]const u8) ![]const models.BuildMetric {
+    pub fn getDefinitionMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32, min_metrics_time: ?[]const u8) !models.BuildMetricList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3053,10 +3053,10 @@ pub const Metrics = struct {
             core.pager.logHttpError("Metrics.getDefinitionMetrics", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildMetric, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildMetricList, alloc, resp.body);
     }
     /// Gets build metrics for a project.
-    pub fn getProjectMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, metric_aggregation_type: []const u8, min_metrics_time: ?[]const u8) ![]const models.BuildMetric {
+    pub fn getProjectMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, metric_aggregation_type: []const u8, min_metrics_time: ?[]const u8) !models.BuildMetricList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3094,7 +3094,7 @@ pub const Metrics = struct {
             core.pager.logHttpError("Metrics.getProjectMetrics", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildMetric, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildMetricList, alloc, resp.body);
     }
 };
 
@@ -3103,7 +3103,7 @@ pub const Resources = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32) ![]const models.DefinitionResourceReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32) !models.DefinitionResourceReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3134,10 +3134,10 @@ pub const Resources = struct {
             core.pager.logHttpError("Resources.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.DefinitionResourceReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.DefinitionResourceReferenceList, alloc, resp.body);
     }
 
-    pub fn authorizeDefinitionResources(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32, body: []const models.DefinitionResourceReference) ![]const models.DefinitionResourceReference {
+    pub fn authorizeDefinitionResources(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32, body: []const models.DefinitionResourceReference) !models.DefinitionResourceReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3172,7 +3172,7 @@ pub const Resources = struct {
             core.pager.logHttpError("Resources.authorizeDefinitionResources", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.DefinitionResourceReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.DefinitionResourceReferenceList, alloc, resp.body);
     }
 };
 
@@ -3245,7 +3245,7 @@ pub const Templates = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets all definition templates.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.BuildDefinitionTemplate {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BuildDefinitionTemplateList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3274,7 +3274,7 @@ pub const Templates = struct {
             core.pager.logHttpError("Templates.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildDefinitionTemplate, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildDefinitionTemplateList, alloc, resp.body);
     }
     /// Deletes a build definition template.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, template_id: []const u8) !void {
@@ -3503,7 +3503,7 @@ pub const Folders = struct {
         return try serde.json.fromSlice(models.Folder, alloc, resp.body);
     }
     /// Gets a list of build definition folders.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, path: []const u8, query_order: ?enums.ListRequestQueryOrder2) ![]const models.Folder {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, path: []const u8, query_order: ?enums.ListRequestQueryOrder2) !models.FolderList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3541,7 +3541,7 @@ pub const Folders = struct {
             core.pager.logHttpError("Folders.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Folder, alloc, resp.body);
+        return try serde.json.fromSlice(models.FolderList, alloc, resp.body);
     }
 };
 
@@ -3671,7 +3671,7 @@ pub const Options = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets all build definition options supported by the system.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.BuildOptionDefinition {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BuildOptionDefinitionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3700,7 +3700,7 @@ pub const Options = struct {
             core.pager.logHttpError("Options.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildOptionDefinition, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildOptionDefinitionList, alloc, resp.body);
     }
 };
 
@@ -3818,7 +3818,7 @@ pub const Leases = struct {
         return;
     }
     /// Returns any leases matching the specified MinimalRetentionLeases
-    pub fn getRetentionLeasesByMinimalRetentionLeases(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, leases_to_fetch: []const u8) ![]const models.RetentionLease {
+    pub fn getRetentionLeasesByMinimalRetentionLeases(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, leases_to_fetch: []const u8) !models.RetentionLeaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3851,10 +3851,10 @@ pub const Leases = struct {
             core.pager.logHttpError("Leases.getRetentionLeasesByMinimalRetentionLeases", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.RetentionLease, alloc, resp.body);
+        return try serde.json.fromSlice(models.RetentionLeaseList, alloc, resp.body);
     }
     /// Adds new leases for pipeline runs.
-    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.NewRetentionLease) ![]const models.RetentionLease {
+    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.NewRetentionLease) !models.RetentionLeaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3887,7 +3887,7 @@ pub const Leases = struct {
             core.pager.logHttpError("Leases.add", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.RetentionLease, alloc, resp.body);
+        return try serde.json.fromSlice(models.RetentionLeaseList, alloc, resp.body);
     }
     /// Returns the details of the retention lease given a lease id.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, lease_id: i32) !models.RetentionLease {
@@ -4145,7 +4145,7 @@ pub const SourceProviders = struct {
         },
     };
     /// Get a list of source providers and their capabilities.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.SourceProviderAttributes {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.SourceProviderAttributesList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4174,7 +4174,7 @@ pub const SourceProviders = struct {
             core.pager.logHttpError("SourceProviders.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SourceProviderAttributes, alloc, resp.body);
+        return try serde.json.fromSlice(models.SourceProviderAttributesList, alloc, resp.body);
     }
     /// Gets a list of branches for the given source code repository.
     pub fn listBranches(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, provider_name: []const u8, service_endpoint_id: ?[]const u8, repository: ?[]const u8, branch_name: ?[]const u8) ![]const []const u8 {
@@ -4311,7 +4311,7 @@ pub const SourceProviders = struct {
         }
     }
     /// Gets the contents of a directory in the given source code repository.
-    pub fn getPathContents(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, provider_name: []const u8, service_endpoint_id: ?[]const u8, repository: ?[]const u8, commit_or_branch: ?[]const u8, path: ?[]const u8) ![]const models.SourceRepositoryItem {
+    pub fn getPathContents(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, provider_name: []const u8, service_endpoint_id: ?[]const u8, repository: ?[]const u8, commit_or_branch: ?[]const u8, path: ?[]const u8) !models.SourceRepositoryItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4370,7 +4370,7 @@ pub const SourceProviders = struct {
             core.pager.logHttpError("SourceProviders.getPathContents", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SourceRepositoryItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.SourceRepositoryItemList, alloc, resp.body);
     }
     /// Gets a pull request object from source provider.
     pub fn getPullRequest(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, provider_name: []const u8, pull_request_id: []const u8, repository_id: ?[]const u8, service_endpoint_id: ?[]const u8) !models.PullRequest {
@@ -4490,7 +4490,7 @@ pub const SourceProviders = struct {
         return try serde.json.fromSlice(models.SourceRepositories, alloc, resp.body);
     }
     /// Gets a list of webhooks installed in the given source code repository.
-    pub fn listWebhooks(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, provider_name: []const u8, service_endpoint_id: ?[]const u8, repository: ?[]const u8) ![]const models.RepositoryWebhook {
+    pub fn listWebhooks(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, provider_name: []const u8, service_endpoint_id: ?[]const u8, repository: ?[]const u8) !models.RepositoryWebhookList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4535,7 +4535,7 @@ pub const SourceProviders = struct {
             core.pager.logHttpError("SourceProviders.listWebhooks", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.RepositoryWebhook, alloc, resp.body);
+        return try serde.json.fromSlice(models.RepositoryWebhookList, alloc, resp.body);
     }
     /// Recreates the webhooks for the specified triggers in the given source code repository.
     pub fn restoreWebhooks(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, provider_name: []const u8, service_endpoint_id: ?[]const u8, repository: ?[]const u8, body: []const []const u8) !void {

--- a/src/build/models.zig
+++ b/src/build/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `BuildController` as returned by Azure DevOps.
+pub const BuildControllerList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildController = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const BuildController = struct {
     /// Id of the resource
     id: ?i32 = null,
@@ -90,6 +100,16 @@ pub const BuildRetentionSample = struct {
     };
 };
 
+/// A collection of `DefinitionResourceReference` as returned by Azure DevOps.
+pub const DefinitionResourceReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const DefinitionResourceReference = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const DefinitionResourceReference = struct {
     /// Indicates whether the resource is authorized for use.
     authorized: ?bool = null,
@@ -99,6 +119,16 @@ pub const DefinitionResourceReference = struct {
     name: ?[]const u8 = null,
     /// The type of the resource.
     type: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Build` as returned by Azure DevOps.
+pub const BuildList = struct {
+    count: ?i32 = null,
+    value: ?[]const Build = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -416,6 +446,16 @@ pub const BuildRequestValidationResult = struct {
     };
 };
 
+/// A collection of `Change` as returned by Azure DevOps.
+pub const ChangeList = struct {
+    count: ?i32 = null,
+    value: ?[]const Change = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a change associated with a build.
 pub const Change = struct {
     author: ?IdentityRef = null,
@@ -435,6 +475,16 @@ pub const Change = struct {
     timestamp: ?[]const u8 = null,
     /// The type of change. 'commit', 'changeset', etc.
     type: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `RetentionLease` as returned by Azure DevOps.
+pub const RetentionLeaseList = struct {
+    count: ?i32 = null,
+    value: ?[]const RetentionLease = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -463,6 +513,16 @@ pub const RetentionLease = struct {
     };
 };
 
+/// A collection of `BuildLog` as returned by Azure DevOps.
+pub const BuildLogList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildLog = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a build log.
 pub const BuildLog = struct {
     /// The ID of the log.
@@ -483,9 +543,29 @@ pub const BuildLog = struct {
     };
 };
 
+/// A collection of `ResourceRef` as returned by Azure DevOps.
+pub const ResourceRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const ResourceRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const ResourceRef = struct {
     id: ?[]const u8 = null,
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Attachment` as returned by Azure DevOps.
+pub const AttachmentList = struct {
+    count: ?i32 = null,
+    value: ?[]const Attachment = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -503,6 +583,16 @@ pub const Attachment = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `BuildArtifact` as returned by Azure DevOps.
+pub const BuildArtifactList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildArtifact = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 
@@ -712,6 +802,16 @@ pub const TaskReference = struct {
     name: ?[]const u8 = null,
     /// The version of the task definition.
     version: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `BuildDefinitionReference` as returned by Azure DevOps.
+pub const BuildDefinitionReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildDefinitionReference = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1032,6 +1132,16 @@ pub const BuildDefinitionVariable = struct {
     };
 };
 
+/// A collection of `BuildDefinitionRevision` as returned by Azure DevOps.
+pub const BuildDefinitionRevisionList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildDefinitionRevision = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a revision of a build definition.
 pub const BuildDefinitionRevision = struct {
     changed_by: ?IdentityRef = null,
@@ -1053,10 +1163,30 @@ pub const BuildDefinitionRevision = struct {
     };
 };
 
+/// A collection of `BuildMetric` as returned by Azure DevOps.
+pub const BuildMetricList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildMetric = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a yaml build.
 pub const YamlBuild = struct {
     /// The yaml used to define the build
     yaml: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `BuildDefinitionTemplate` as returned by Azure DevOps.
+pub const BuildDefinitionTemplateList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildDefinitionTemplate = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1100,6 +1230,16 @@ pub const Folder = struct {
     /// The full path.
     path: ?[]const u8 = null,
     project: ?TeamProjectReference = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Folder` as returned by Azure DevOps.
+pub const FolderList = struct {
+    count: ?i32 = null,
+    value: ?[]const Folder = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1156,6 +1296,16 @@ pub const PipelineGeneralSettings = struct {
         .rename = .{
             .disable_implied_yaml_ci_trigger = "disableImpliedYAMLCiTrigger",
         },
+    };
+};
+
+/// A collection of `BuildOptionDefinition` as returned by Azure DevOps.
+pub const BuildOptionDefinitionList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildOptionDefinition = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 
@@ -1302,6 +1452,16 @@ pub const BuildSettings = struct {
     };
 };
 
+/// A collection of `SourceProviderAttributes` as returned by Azure DevOps.
+pub const SourceProviderAttributesList = struct {
+    count: ?i32 = null,
+    value: ?[]const SourceProviderAttributes = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const SourceProviderAttributes = struct {
     /// The name of the source provider.
     name: ?[]const u8 = null,
@@ -1324,6 +1484,16 @@ pub const SupportedTrigger = struct {
     supported_capabilities: ?std.json.ArrayHashMap(enums.SupportedTriggerSupportedCapability) = null,
     /// The type of trigger.
     type: ?enums.SupportedTriggerType = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `SourceRepositoryItem` as returned by Azure DevOps.
+pub const SourceRepositoryItemList = struct {
+    count: ?i32 = null,
+    value: ?[]const SourceRepositoryItem = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1410,6 +1580,16 @@ pub const SourceRepository = struct {
     source_provider_name: ?[]const u8 = null,
     /// The URL of the repository.
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `RepositoryWebhook` as returned by Azure DevOps.
+pub const RepositoryWebhookList = struct {
+    count: ?i32 = null,
+    value: ?[]const RepositoryWebhook = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/core/clients.zig
+++ b/src/core/clients.zig
@@ -137,7 +137,7 @@ pub const Processes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of processes.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.Process {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.ProcessList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -164,7 +164,7 @@ pub const Processes = struct {
             core.pager.logHttpError("Processes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Process, alloc, resp.body);
+        return try serde.json.fromSlice(models.ProcessList, alloc, resp.body);
     }
     /// Get a process by ID.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8) !models.Process {
@@ -205,7 +205,7 @@ pub const Projects = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all projects in the organization that the authenticated user has access to.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, state_filter: ?enums.ListRequestStateFilter, @"$top": ?i32, @"$skip": ?i32, continuation_token: ?i32, get_default_team_image_url: ?bool) ![]const models.TeamProjectReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, state_filter: ?enums.ListRequestStateFilter, @"$top": ?i32, @"$skip": ?i32, continuation_token: ?i32, get_default_team_image_url: ?bool) !models.TeamProjectReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -259,7 +259,7 @@ pub const Projects = struct {
             core.pager.logHttpError("Projects.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TeamProjectReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.TeamProjectReferenceList, alloc, resp.body);
     }
     /// Queues a project to be created. Use the [GetOperation](../../operations/operations/get) to periodically check for create project status.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.TeamProject) !models.OperationReference {
@@ -406,7 +406,7 @@ pub const Projects = struct {
         return try serde.json.fromSlice(models.OperationReference, alloc, resp.body);
     }
     /// Get a collection of team project properties.
-    pub fn getProjectProperties(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, keys: ?[]const u8) ![]const models.ProjectProperty {
+    pub fn getProjectProperties(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, keys: ?[]const u8) !models.ProjectPropertyList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -442,7 +442,7 @@ pub const Projects = struct {
             core.pager.logHttpError("Projects.getProjectProperties", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ProjectProperty, alloc, resp.body);
+        return try serde.json.fromSlice(models.ProjectPropertyList, alloc, resp.body);
     }
     /// Create, update, and delete team project properties.
     pub fn setProjectProperties(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, body: models.JsonPatchDocument) !void {
@@ -611,7 +611,7 @@ pub const Teams = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of teams.
-    pub fn getTeams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, @"$mine": ?bool, @"$top": ?i32, @"$skip": ?i32, @"$expand_identity": ?bool) ![]const models.WebApiTeam {
+    pub fn getTeams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, @"$mine": ?bool, @"$top": ?i32, @"$skip": ?i32, @"$expand_identity": ?bool) !models.WebApiTeamList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -660,7 +660,7 @@ pub const Teams = struct {
             core.pager.logHttpError("Teams.getTeams", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WebApiTeam, alloc, resp.body);
+        return try serde.json.fromSlice(models.WebApiTeamList, alloc, resp.body);
     }
     /// Create a team in a team project. Possible failure scenarios Invalid project name/ID (project doesn't exist) 404 Invalid team name or description 400 Team already exists 400 Insufficient privileges 400
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, body: models.WebApiTeam) !models.WebApiTeam {
@@ -809,7 +809,7 @@ pub const Teams = struct {
         return try serde.json.fromSlice(models.WebApiTeam, alloc, resp.body);
     }
     /// Get a list of members for a specific team.
-    pub fn getTeamMembersWithExtendedProperties(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, team_id: []const u8, @"$top": ?i32, @"$skip": ?i32) ![]const models.TeamMember {
+    pub fn getTeamMembersWithExtendedProperties(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, team_id: []const u8, @"$top": ?i32, @"$skip": ?i32) !models.TeamMemberList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -850,10 +850,10 @@ pub const Teams = struct {
             core.pager.logHttpError("Teams.getTeamMembersWithExtendedProperties", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TeamMember, alloc, resp.body);
+        return try serde.json.fromSlice(models.TeamMemberList, alloc, resp.body);
     }
     /// Get a list of all teams.
-    pub fn getAllTeams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"$mine": ?bool, @"$top": ?i32, @"$skip": ?i32, @"$expand_identity": ?bool) ![]const models.WebApiTeam {
+    pub fn getAllTeams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"$mine": ?bool, @"$top": ?i32, @"$skip": ?i32, @"$expand_identity": ?bool) !models.WebApiTeamList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -900,6 +900,6 @@ pub const Teams = struct {
             core.pager.logHttpError("Teams.getAllTeams", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WebApiTeam, alloc, resp.body);
+        return try serde.json.fromSlice(models.WebApiTeamList, alloc, resp.body);
     }
 };

--- a/src/core/models.zig
+++ b/src/core/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `Process` as returned by Azure DevOps.
+pub const ProcessList = struct {
+    count: ?i32 = null,
+    value: ?[]const Process = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const Process = struct {
     name: ?[]const u8 = null,
     url: ?[]const u8 = null,
@@ -31,6 +41,16 @@ pub const ReferenceLinks = struct {
 };
 
 pub const ReferenceLinksLink = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TeamProjectReference` as returned by Azure DevOps.
+pub const TeamProjectReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const TeamProjectReference = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };
@@ -122,6 +142,16 @@ pub const OperationReference = struct {
     status: ?enums.OperationReferenceStatus = null,
     /// URL to get the full operation object.
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ProjectProperty` as returned by Azure DevOps.
+pub const ProjectPropertyList = struct {
+    count: ?i32 = null,
+    value: ?[]const ProjectProperty = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -252,6 +282,26 @@ pub const PropertiesCollection = struct {
 };
 
 pub const PropertiesCollectionItem = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WebApiTeam` as returned by Azure DevOps.
+pub const WebApiTeamList = struct {
+    count: ?i32 = null,
+    value: ?[]const WebApiTeam = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TeamMember` as returned by Azure DevOps.
+pub const TeamMemberList = struct {
+    count: ?i32 = null,
+    value: ?[]const TeamMember = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };

--- a/src/dashboard/clients.zig
+++ b/src/dashboard/clients.zig
@@ -197,7 +197,7 @@ pub const Dashboards = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of dashboards under a project.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) ![]const models.Dashboard {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.DashboardList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -228,7 +228,7 @@ pub const Dashboards = struct {
             core.pager.logHttpError("Dashboards.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Dashboard, alloc, resp.body);
+        return try serde.json.fromSlice(models.DashboardList, alloc, resp.body);
     }
     /// Create the supplied dashboard.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, body: models.Dashboard) !models.Dashboard {
@@ -430,7 +430,7 @@ pub const Widgets = struct {
             headers: struct {
                 e_tag: ?[]const u8 = null,
             },
-            body: []const models.Widget,
+            body: models.WidgetList,
         },
     };
 
@@ -440,7 +440,7 @@ pub const Widgets = struct {
             headers: struct {
                 e_tag: ?[]const u8 = null,
             },
-            body: []const models.Widget,
+            body: models.WidgetList,
         },
     };
 
@@ -450,7 +450,7 @@ pub const Widgets = struct {
             headers: struct {
                 e_tag: ?[]const u8 = null,
             },
-            body: []const models.Widget,
+            body: models.WidgetList,
         },
     };
     /// Get widgets contained on the specified dashboard.
@@ -491,7 +491,7 @@ pub const Widgets = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Widget, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.WidgetList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -548,7 +548,7 @@ pub const Widgets = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Widget, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.WidgetList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -645,7 +645,7 @@ pub const Widgets = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Widget, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.WidgetList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{

--- a/src/dashboard/models.zig
+++ b/src/dashboard/models.zig
@@ -119,6 +119,16 @@ pub const WidgetMetadataResponse = struct {
     };
 };
 
+/// A collection of `Dashboard` as returned by Azure DevOps.
+pub const DashboardList = struct {
+    count: ?i32 = null,
+    value: ?[]const Dashboard = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Model of a Dashboard.
 pub const Dashboard = struct {
     links: ?ReferenceLinks = null,
@@ -277,5 +287,15 @@ pub const DashboardGroupEntry = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `Widget` as returned by Azure DevOps.
+pub const WidgetList = struct {
+    count: ?i32 = null,
+    value: ?[]const Widget = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };

--- a/src/distributed_task/clients.zig
+++ b/src/distributed_task/clients.zig
@@ -265,7 +265,7 @@ pub const Elasticpools = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of all Elastic Pools.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.ElasticPool {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.ElasticPoolList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -292,7 +292,7 @@ pub const Elasticpools = struct {
             core.pager.logHttpError("Elasticpools.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ElasticPool, alloc, resp.body);
+        return try serde.json.fromSlice(models.ElasticPoolList, alloc, resp.body);
     }
     /// Create a new elastic pool. This will create a new TaskAgentPool at the organization level. If a project id is provided, this will create a new TaskAgentQueue in the specified project.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_name: []const u8, authorize_all_pipelines: ?bool, auto_provision_project_pools: ?bool, project_id: ?[]const u8, body: models.ElasticPool) !models.ElasticPoolCreationResult {
@@ -424,7 +424,7 @@ pub const Elasticpoollogs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get elastic pool diagnostics logs for a specified Elastic Pool.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, @"$top": ?i32) ![]const models.ElasticPoolLog {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, @"$top": ?i32) !models.ElasticPoolLogList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -458,7 +458,7 @@ pub const Elasticpoollogs = struct {
             core.pager.logHttpError("Elasticpoollogs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ElasticPoolLog, alloc, resp.body);
+        return try serde.json.fromSlice(models.ElasticPoolLogList, alloc, resp.body);
     }
 };
 
@@ -467,7 +467,7 @@ pub const Nodes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of ElasticNodes currently in the ElasticPool
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, @"$state": ?enums.ListRequestState) ![]const models.ElasticNode {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, @"$state": ?enums.ListRequestState) !models.ElasticNodeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -503,7 +503,7 @@ pub const Nodes = struct {
             core.pager.logHttpError("Nodes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ElasticNode, alloc, resp.body);
+        return try serde.json.fromSlice(models.ElasticNodeList, alloc, resp.body);
     }
     /// Update properties on a specified ElasticNode
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, elastic_node_id: i32, body: models.ElasticNodeSettings) !models.ElasticNode {
@@ -773,7 +773,7 @@ pub const Records = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Update timeline records if they already exist, otherwise create new ones for the same timeline.
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_identifier: []const u8, hub_name: []const u8, plan_id: []const u8, timeline_id: []const u8, body: models.VssJsonCollectionWrapper) ![]const models.TimelineRecord {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_identifier: []const u8, hub_name: []const u8, plan_id: []const u8, timeline_id: []const u8, body: models.VssJsonCollectionWrapper) !models.TimelineRecordList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -812,7 +812,7 @@ pub const Records = struct {
             core.pager.logHttpError("Records.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TimelineRecord, alloc, resp.body);
+        return try serde.json.fromSlice(models.TimelineRecordList, alloc, resp.body);
     }
 };
 
@@ -821,7 +821,7 @@ pub const Agentclouds = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.TaskAgentCloud {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.TaskAgentCloudList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -848,7 +848,7 @@ pub const Agentclouds = struct {
             core.pager.logHttpError("Agentclouds.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TaskAgentCloud, alloc, resp.body);
+        return try serde.json.fromSlice(models.TaskAgentCloudList, alloc, resp.body);
     }
 
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.TaskAgentCloud) !models.TaskAgentCloud {
@@ -991,7 +991,7 @@ pub const Requests = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, agent_cloud_id: i32) ![]const models.TaskAgentCloudRequest {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, agent_cloud_id: i32) !models.TaskAgentCloudRequestList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1020,7 +1020,7 @@ pub const Requests = struct {
             core.pager.logHttpError("Requests.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TaskAgentCloudRequest, alloc, resp.body);
+        return try serde.json.fromSlice(models.TaskAgentCloudRequestList, alloc, resp.body);
     }
 };
 
@@ -1029,7 +1029,7 @@ pub const Agentcloudtypes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get agent cloud types.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.TaskAgentCloudType {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.TaskAgentCloudTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1056,7 +1056,7 @@ pub const Agentcloudtypes = struct {
             core.pager.logHttpError("Agentcloudtypes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TaskAgentCloudType, alloc, resp.body);
+        return try serde.json.fromSlice(models.TaskAgentCloudTypeList, alloc, resp.body);
     }
 };
 
@@ -1065,7 +1065,7 @@ pub const Pools = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of agent pools.
-    pub fn getAgentPoolsByIds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_ids: []const u8, action_filter: ?enums.GetAgentPoolsByIdsRequestActionFilter) ![]const models.TaskAgentPool {
+    pub fn getAgentPoolsByIds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_ids: []const u8, action_filter: ?enums.GetAgentPoolsByIdsRequestActionFilter) !models.TaskAgentPoolList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1103,7 +1103,7 @@ pub const Pools = struct {
             core.pager.logHttpError("Pools.getAgentPoolsByIds", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TaskAgentPool, alloc, resp.body);
+        return try serde.json.fromSlice(models.TaskAgentPoolList, alloc, resp.body);
     }
     /// Create an agent pool.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.TaskAgentPool) !models.TaskAgentPool {
@@ -1259,7 +1259,7 @@ pub const Agents = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of agents.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, agent_name: ?[]const u8, include_capabilities: ?bool, include_assigned_request: ?bool, include_last_completed_request: ?bool, property_filters: ?[]const u8, demands: ?[]const u8) ![]const models.TaskAgent {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, agent_name: ?[]const u8, include_capabilities: ?bool, include_assigned_request: ?bool, include_last_completed_request: ?bool, property_filters: ?[]const u8, demands: ?[]const u8) !models.TaskAgentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1324,7 +1324,7 @@ pub const Agents = struct {
             core.pager.logHttpError("Agents.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TaskAgent, alloc, resp.body);
+        return try serde.json.fromSlice(models.TaskAgentList, alloc, resp.body);
     }
     /// Adds an agent to a pool. You probably don't want to call this endpoint directly. Instead, [configure an agent](https://docs.microsoft.com/azure/devops/pipelines/agents/agents) using the agent download package.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, body: models.TaskAgent) !models.TaskAgent {
@@ -1732,7 +1732,7 @@ pub const Variablegroups = struct {
         return try serde.json.fromSlice(models.VariableGroup, alloc, resp.body);
     }
     /// Get variable groups by ids.
-    pub fn getVariableGroupsById(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, group_ids: []const u8, load_secrets: ?bool) ![]const models.VariableGroup {
+    pub fn getVariableGroupsById(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, group_ids: []const u8, load_secrets: ?bool) !models.VariableGroupList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1770,7 +1770,7 @@ pub const Variablegroups = struct {
             core.pager.logHttpError("Variablegroups.getVariableGroupsById", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.VariableGroup, alloc, resp.body);
+        return try serde.json.fromSlice(models.VariableGroupList, alloc, resp.body);
     }
     /// Get a variable group.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, group_id: i32) !models.VariableGroup {
@@ -1860,7 +1860,7 @@ pub const Deploymentgroups = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.DeploymentGroup,
+            body: models.DeploymentGroupList,
         },
     };
     /// Get a list of deployment groups by name or IDs.
@@ -1936,7 +1936,7 @@ pub const Deploymentgroups = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.DeploymentGroup, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.DeploymentGroupList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -2119,7 +2119,7 @@ pub const Targets = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.DeploymentMachine,
+            body: models.DeploymentMachineList,
         },
     };
     /// Get a list of deployment targets in a deployment group.
@@ -2221,7 +2221,7 @@ pub const Targets = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.DeploymentMachine, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.DeploymentMachineList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -2237,7 +2237,7 @@ pub const Targets = struct {
         }
     }
     /// Update tags of a list of deployment targets in a deployment group.
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deployment_group_id: i32, body: []const models.DeploymentTargetUpdateParameter) ![]const models.DeploymentMachine {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deployment_group_id: i32, body: []const models.DeploymentTargetUpdateParameter) !models.DeploymentMachineList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2272,7 +2272,7 @@ pub const Targets = struct {
             core.pager.logHttpError("Targets.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.DeploymentMachine, alloc, resp.body);
+        return try serde.json.fromSlice(models.DeploymentMachineList, alloc, resp.body);
     }
     /// Delete a deployment target in a deployment group. This deletes the agent from associated deployment pool too.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deployment_group_id: i32, target_id: i32) !void {
@@ -2359,7 +2359,7 @@ pub const Queues = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of agent queues by pool ids
-    pub fn getAgentQueuesForPools(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_ids: []const u8, project: []const u8, action_filter: ?enums.GetAgentQueuesForPoolsRequestActionFilter) ![]const models.TaskAgentQueue {
+    pub fn getAgentQueuesForPools(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_ids: []const u8, project: []const u8, action_filter: ?enums.GetAgentQueuesForPoolsRequestActionFilter) !models.TaskAgentQueueList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2399,7 +2399,7 @@ pub const Queues = struct {
             core.pager.logHttpError("Queues.getAgentQueuesForPools", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TaskAgentQueue, alloc, resp.body);
+        return try serde.json.fromSlice(models.TaskAgentQueueList, alloc, resp.body);
     }
     /// Create a new agent queue to connect a project to an agent pool.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, authorize_pipelines: ?bool, body: models.TaskAgentQueue) !models.TaskAgentQueue {
@@ -2523,7 +2523,7 @@ pub const Securefiles = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get secure files
-    pub fn getSecureFilesByNames(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, secure_file_names: []const u8, include_download_tickets: ?bool, action_filter: ?enums.GetSecureFilesByNamesRequestActionFilter) ![]const models.SecureFile {
+    pub fn getSecureFilesByNames(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, secure_file_names: []const u8, include_download_tickets: ?bool, action_filter: ?enums.GetSecureFilesByNamesRequestActionFilter) !models.SecureFileList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2568,10 +2568,10 @@ pub const Securefiles = struct {
             core.pager.logHttpError("Securefiles.getSecureFilesByNames", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SecureFile, alloc, resp.body);
+        return try serde.json.fromSlice(models.SecureFileList, alloc, resp.body);
     }
     /// Update properties and/or names of a set of secure files. Files are identified by their IDs. Properties provided override the existing one entirely, i.e. do not merge.
-    pub fn updateSecureFiles(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.SecureFile) ![]const models.SecureFile {
+    pub fn updateSecureFiles(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.SecureFile) !models.SecureFileList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2604,10 +2604,10 @@ pub const Securefiles = struct {
             core.pager.logHttpError("Securefiles.updateSecureFiles", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SecureFile, alloc, resp.body);
+        return try serde.json.fromSlice(models.SecureFileList, alloc, resp.body);
     }
     /// Query secure files using a name pattern and a condition on file properties.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name_pattern: ?[]const u8, body: []const u8) ![]const models.SecureFile {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, name_pattern: ?[]const u8, body: []const u8) !models.SecureFileList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2645,7 +2645,7 @@ pub const Securefiles = struct {
             core.pager.logHttpError("Securefiles.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SecureFile, alloc, resp.body);
+        return try serde.json.fromSlice(models.SecureFileList, alloc, resp.body);
     }
     /// Delete a secure file
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, secure_file_id: []const u8) !void {
@@ -2777,7 +2777,7 @@ pub const Taskgroups = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TaskGroup,
+            body: models.TaskGroupList,
         },
     };
     /// Create a task group.
@@ -2927,7 +2927,7 @@ pub const Taskgroups = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TaskGroup, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TaskGroupList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{

--- a/src/distributed_task/models.zig
+++ b/src/distributed_task/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `ElasticPool` as returned by Azure DevOps.
+pub const ElasticPoolList = struct {
+    count: ?i32 = null,
+    value: ?[]const ElasticPool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Data and settings for an elastic pool
 pub const ElasticPool = struct {
     /// Set whether agents should be configured to run with interactive UI
@@ -231,6 +241,16 @@ pub const ElasticPoolSettings = struct {
     };
 };
 
+/// A collection of `ElasticPoolLog` as returned by Azure DevOps.
+pub const ElasticPoolLogList = struct {
+    count: ?i32 = null,
+    value: ?[]const ElasticPoolLog = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Log data for an Elastic Pool
 pub const ElasticPoolLog = struct {
     /// Log Id
@@ -245,6 +265,16 @@ pub const ElasticPoolLog = struct {
     pool_id: ?i32 = null,
     /// Datetime that the log occurred
     timestamp: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ElasticNode` as returned by Azure DevOps.
+pub const ElasticNodeList = struct {
+    count: ?i32 = null,
+    value: ?[]const ElasticNode = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -339,6 +369,16 @@ pub const VssJsonCollectionWrapper = struct {
     count: ?i32 = null,
     /// The serialized item.
     value: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TimelineRecord` as returned by Azure DevOps.
+pub const TimelineRecordList = struct {
+    count: ?i32 = null,
+    value: ?[]const TimelineRecord = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -510,6 +550,16 @@ pub const VariableValue = struct {
     };
 };
 
+/// A collection of `TaskAgentCloud` as returned by Azure DevOps.
+pub const TaskAgentCloudList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskAgentCloud = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const TaskAgentCloud = struct {
     /// Gets or sets a AcquireAgentEndpoint using which a request can be made to acquire new agent
     acquire_agent_endpoint: ?[]const u8 = null,
@@ -527,6 +577,16 @@ pub const TaskAgentCloud = struct {
     shared_secret: ?[]const u8 = null,
     /// Gets or sets the type of the endpoint.
     type: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TaskAgentCloudRequest` as returned by Azure DevOps.
+pub const TaskAgentCloudRequestList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskAgentCloudRequest = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -596,6 +656,16 @@ pub const JToken = struct {
     root: ?*const JToken = null,
     /// Gets the node type for this JToken.
     type: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TaskAgentCloudType` as returned by Azure DevOps.
+pub const TaskAgentCloudTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskAgentCloudType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -729,6 +799,26 @@ pub const InputValue = struct {
 };
 
 pub const InputValueDatum = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TaskAgentPool` as returned by Azure DevOps.
+pub const TaskAgentPoolList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskAgentPool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TaskAgent` as returned by Azure DevOps.
+pub const TaskAgentList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskAgent = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };
@@ -989,7 +1079,27 @@ pub const VariableGroup = struct {
     };
 };
 
+/// A collection of `VariableGroup` as returned by Azure DevOps.
+pub const VariableGroupList = struct {
+    count: ?i32 = null,
+    value: ?[]const VariableGroup = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const GetResponse = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `DeploymentGroup` as returned by Azure DevOps.
+pub const DeploymentGroupList = struct {
+    count: ?i32 = null,
+    value: ?[]const DeploymentGroup = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };
@@ -1057,11 +1167,41 @@ pub const DeploymentGroupUpdateParameter = struct {
     };
 };
 
+/// A collection of `DeploymentMachine` as returned by Azure DevOps.
+pub const DeploymentMachineList = struct {
+    count: ?i32 = null,
+    value: ?[]const DeploymentMachine = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Deployment target update parameter.
 pub const DeploymentTargetUpdateParameter = struct {
     /// Identifier of the deployment target.
     id: ?i32 = null,
     tags: ?[]const []const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TaskAgentQueue` as returned by Azure DevOps.
+pub const TaskAgentQueueList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskAgentQueue = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `SecureFile` as returned by Azure DevOps.
+pub const SecureFileList = struct {
+    count: ?i32 = null,
+    value: ?[]const SecureFile = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1366,6 +1506,16 @@ pub const TaskSourceDefinition = struct {
     key_selector: ?[]const u8 = null,
     selector: ?[]const u8 = null,
     target: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TaskGroup` as returned by Azure DevOps.
+pub const TaskGroupList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskGroup = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/environments/clients.zig
+++ b/src/environments/clients.zig
@@ -151,7 +151,7 @@ pub const Environments = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.EnvironmentInstance,
+            body: models.EnvironmentInstanceList,
         },
     };
     /// Get all environments.
@@ -206,7 +206,7 @@ pub const Environments = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.EnvironmentInstance, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.EnvironmentInstanceList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -382,7 +382,7 @@ pub const Environmentdeploymentrecords = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.EnvironmentDeploymentExecutionRecord,
+            body: models.EnvironmentDeploymentExecutionRecordList,
         },
     };
     /// Get environment deployment execution history
@@ -432,7 +432,7 @@ pub const Environmentdeploymentrecords = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.EnvironmentDeploymentExecutionRecord, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.EnvironmentDeploymentExecutionRecordList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -613,7 +613,7 @@ pub const Vmresource = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.VirtualMachineResource,
+            body: models.VirtualMachineResourceList,
         },
     };
     /// Get Virtual Machine Resources
@@ -677,7 +677,7 @@ pub const Vmresource = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.VirtualMachineResource, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.VirtualMachineResourceList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{

--- a/src/environments/models.zig
+++ b/src/environments/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `EnvironmentInstance` as returned by Azure DevOps.
+pub const EnvironmentInstanceList = struct {
+    count: ?i32 = null,
+    value: ?[]const EnvironmentInstance = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Environment.
 pub const EnvironmentInstance = struct {
     created_by: ?IdentityRef = null,
@@ -105,6 +115,16 @@ pub const EnvironmentUpdateParameter = struct {
     description: ?[]const u8 = null,
     /// Name of the environment.
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `EnvironmentDeploymentExecutionRecord` as returned by Azure DevOps.
+pub const EnvironmentDeploymentExecutionRecordList = struct {
+    count: ?i32 = null,
+    value: ?[]const EnvironmentDeploymentExecutionRecord = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -214,6 +234,16 @@ pub const KubernetesResourceCreateParametersExistingEndpoint = struct {
     /// Tags of the kubernetes resource.
     tags: ?[]const []const u8 = null,
     service_endpoint_id: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `VirtualMachineResource` as returned by Azure DevOps.
+pub const VirtualMachineResourceList = struct {
+    count: ?i32 = null,
+    value: ?[]const VirtualMachineResource = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/extension_management/clients.zig
+++ b/src/extension_management/clients.zig
@@ -105,7 +105,7 @@ pub const InstalledExtensions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// List the installed extensions in the account / project collection.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_disabled_extensions: ?bool, include_errors: ?bool, asset_types: ?[]const u8, include_installation_issues: ?bool) ![]const models.InstalledExtension {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_disabled_extensions: ?bool, include_errors: ?bool, asset_types: ?[]const u8, include_installation_issues: ?bool) !models.InstalledExtensionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -154,7 +154,7 @@ pub const InstalledExtensions = struct {
             core.pager.logHttpError("InstalledExtensions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.InstalledExtension, alloc, resp.body);
+        return try serde.json.fromSlice(models.InstalledExtensionList, alloc, resp.body);
     }
     /// Update an installed extension. Typically this API is used to enable or disable an extension.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.InstalledExtension) !models.InstalledExtension {

--- a/src/extension_management/models.zig
+++ b/src/extension_management/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `InstalledExtension` as returned by Azure DevOps.
+pub const InstalledExtensionList = struct {
+    count: ?i32 = null,
+    value: ?[]const InstalledExtension = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a VSTS extension along with its installation state
 pub const InstalledExtension = struct {
     /// Uri used as base for other relative uri's defined in extension

--- a/src/favorite/clients.zig
+++ b/src/favorite/clients.zig
@@ -105,7 +105,7 @@ pub const Favorites = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn getFavorites(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, artifact_type: ?[]const u8, artifact_scope_type: ?[]const u8, artifact_scope_id: ?[]const u8, include_extended_details: ?bool) ![]const models.Favorite {
+    pub fn getFavorites(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, artifact_type: ?[]const u8, artifact_scope_type: ?[]const u8, artifact_scope_id: ?[]const u8, include_extended_details: ?bool) !models.FavoriteList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -158,7 +158,7 @@ pub const Favorites = struct {
             core.pager.logHttpError("Favorites.getFavorites", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Favorite, alloc, resp.body);
+        return try serde.json.fromSlice(models.FavoriteList, alloc, resp.body);
     }
 
     pub fn createFavorite(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.FavoriteCreateParameters) !models.Favorite {

--- a/src/favorite/models.zig
+++ b/src/favorite/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `Favorite` as returned by Azure DevOps.
+pub const FavoriteList = struct {
+    count: ?i32 = null,
+    value: ?[]const Favorite = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Implementation of Favorite contract following modern storage
 pub const Favorite = struct {
     links: ?ReferenceLinks = null,

--- a/src/git/clients.zig
+++ b/src/git/clients.zig
@@ -393,7 +393,7 @@ pub const Repositories = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve deleted git repositories.
-    pub fn getDeletedRepositories(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.GitDeletedRepository {
+    pub fn getDeletedRepositories(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.GitDeletedRepositoryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -422,10 +422,10 @@ pub const Repositories = struct {
             core.pager.logHttpError("Repositories.getDeletedRepositories", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitDeletedRepository, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitDeletedRepositoryList, alloc, resp.body);
     }
     /// Retrieve soft-deleted git repositories from the recycle bin.
-    pub fn getRecycleBinRepositories(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.GitDeletedRepository {
+    pub fn getRecycleBinRepositories(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.GitDeletedRepositoryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -454,7 +454,7 @@ pub const Repositories = struct {
             core.pager.logHttpError("Repositories.getRecycleBinRepositories", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitDeletedRepository, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitDeletedRepositoryList, alloc, resp.body);
     }
     /// Destroy (hard delete) a soft-deleted Git repository.
     pub fn deleteRepositoryFromRecycleBin(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8) !void {
@@ -528,7 +528,7 @@ pub const Repositories = struct {
         return try serde.json.fromSlice(models.GitRepository, alloc, resp.body);
     }
     /// Retrieve git repositories.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, include_links: ?bool, include_all_urls: ?bool, include_hidden: ?bool) ![]const models.GitRepository {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, include_links: ?bool, include_all_urls: ?bool, include_hidden: ?bool) !models.GitRepositoryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -572,7 +572,7 @@ pub const Repositories = struct {
             core.pager.logHttpError("Repositories.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitRepository, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitRepositoryList, alloc, resp.body);
     }
     /// Create a git repository in a team project.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, source_ref: ?[]const u8, body: models.GitRepositoryCreateOptions) !models.GitRepository {
@@ -729,7 +729,7 @@ pub const RefsFavorites = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets the refs favorites for a repo and an identity.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: ?[]const u8, identity_id: ?[]const u8) ![]const models.GitRefFavorite {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: ?[]const u8, identity_id: ?[]const u8) !models.GitRefFavoriteList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -772,7 +772,7 @@ pub const RefsFavorites = struct {
             core.pager.logHttpError("RefsFavorites.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitRefFavorite, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitRefFavoriteList, alloc, resp.body);
     }
     /// Creates a ref favorite
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.GitRefFavorite) !models.GitRefFavorite {
@@ -884,7 +884,7 @@ pub const RefsFavoritesForProject = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, identity_id: ?[]const u8) ![]const models.GitRefFavorite {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, identity_id: ?[]const u8) !models.GitRefFavoriteList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -920,7 +920,7 @@ pub const RefsFavoritesForProject = struct {
             core.pager.logHttpError("RefsFavoritesForProject.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitRefFavorite, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitRefFavoriteList, alloc, resp.body);
     }
 };
 
@@ -935,7 +935,7 @@ pub const PolicyConfigurations = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.PolicyConfiguration,
+            body: models.PolicyConfigurationList,
         },
     };
     /// Retrieve a list of policy configurations by a given set of scope/filtering criteria. Azure Repos uses two types of policies to protect your code: **Repository policies (push policies)** check every push to your repository. They validate things like file size limits, path restrictions, or commit requirements. When someone pushes code that violates these rules, the push gets rejected - no matter which branch they're pushing to. **Branch policies (PR policies)** protect specific branches by requiring pull requests. When you set a branch policy on `main`, for example, nobody can push directly to `main` anymore. They must create a pull request instead, which can then require reviews, builds, or other checks to pass first. ## How Policies Work with Your Project Structure Both types of policies can be defined at different levels in your project hierarchy. A policy defined at the project level affects all repositories in that project. A policy defined at the repository level affects just that repository. A branch policy can even be defined at the project level to protect all branches with the same name - like protecting all `main` branches across your entire project with one policy. ### Branch Patterns and Wildcards Branches in Git follow a folder-like structure. You might have branches like: - `refs/heads/main` - `refs/heads/releases/1.0.0` - `refs/heads/releases/2.0.0` - `refs/heads/features/new-login` You can create policies for specific branches or for groups of branches using wildcards. When you create a policy for `refs/heads/releases/*`, it protects all branches in the `releases` 'folder' - both the ones that exist now and any new release branches you create later. This pattern matching works recursively, so `refs/heads/releases/*` also covers branches like `refs/heads/releases/v1/hotfix`. This helps you set up consistent protection without creating the same policy over and over. For example, you can require two reviewers for all release branches with just one policy. ## Understanding Policy Inheritance When you query for policies, this endpoint shows you what policies are actually enforcing rules at your specified scope. This includes policies inherited from higher levels. For example, if you query for policies on a specific branch, you get: - Branch policies for that exact branch - Branch policies with wildcards that match your branch - Repository policies for that repo - Any applicable project-level policies Everything that protects that branch shows up in your results. ## How to Query for Policies The `repositoryId` and `refName` parameters let you focus on specific parts of your project. Here's what you get with different combinations: **Both `repositoryId` and `refName` specified:** - When `refName` is a specific branch name: You see all policies affecting that specific branch. This includes exact branch policies, wildcard branch policies that match, repository policies for that repo, and any project-level policies. - When `refName` is `~all`: You see every policy that affects any branch in that repository. This special value gives you the same results as if you called this API once for every single branch in the repo and then combined all the results (removing duplicates). You get all branch-specific policies, all wildcard policies, all repository policies, and all inherited project-level policies that apply to this repository. This helps you see the complete picture of what protects all your branches without making multiple API calls. **Only `repositoryId` specified:** You see policies that apply to the repository as a whole - repository policies and inherited project-level repository policies. Branch policies aren't included because they don't affect the whole repository. **Neither parameter specified:** You see only project-level repository policies. Branch policies defined at the project level aren't included, even though they exist at the project level. This happens because branch policies need a branch context to be meaningful - without specifying a repository or branch name, the API only returns policies that apply to repositories as a whole. **Only `refName` specified:** You see project-level branch policies for branches with that name (like all `main` branch policies defined at project level), plus project-level repository policies. You can add the `policyType` parameter to filter for a specific type of policy, such as 'Minimum number of reviewers' or 'File size restriction'. This parameter accepts the policy type ID and filters the results to show only that specific policy type. ## Common Scenarios - **'What protects my main branch?'** - Use `repositoryId` + `refName=refs/heads/main` - **'What protects all my release branches?'** - Use `repositoryId` + `refName=refs/heads/releases/*` - **'Show me every policy that affects any branch in this repository'** - Use `repositoryId` + `refName=~all` - **'What repository policies apply to this repo?'** - Use `repositoryId` only - **'What file size limits apply to this repository?'** - Use `repositoryId` with the `policyType` for file size restrictions - **'What project-wide repository policies do we have?'** - Don't specify `repositoryId` or `refName` - **'Which policies apply to develop branches across all repositories?'** - Use `refName=refs/heads/develop`
@@ -1004,7 +1004,7 @@ pub const PolicyConfigurations = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.PolicyConfiguration, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.PolicyConfigurationList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1026,7 +1026,7 @@ pub const PullRequests = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve all pull requests matching a specified criteria. Please note that description field will be truncated up to 400 symbols in the result.
-    pub fn getPullRequestsByProject(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, search_criteria_creator_id: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_labels: ?[]const []const u8, search_criteria_max_time: ?[]const u8, search_criteria_min_time: ?[]const u8, @"search_criteria.query_time_range_type": ?enums.GetPullRequestsByProjectRequestSearchCriteriaQueryTimeRangeType, search_criteria_repository_id: ?[]const u8, search_criteria_reviewer_id: ?[]const u8, search_criteria_source_ref_name: ?[]const u8, search_criteria_source_repository_id: ?[]const u8, @"search_criteria.status": ?enums.GetPullRequestsByProjectRequestSearchCriteriaStatus, @"search_criteria.tags_filter_operator": ?enums.GetPullRequestsByProjectRequestSearchCriteriaTagsFilterOperator, search_criteria_target_ref_name: ?[]const u8, search_criteria_title: ?[]const u8, max_comment_length: ?i32, @"$skip": ?i32, @"$top": ?i32) ![]const models.GitPullRequest {
+    pub fn getPullRequestsByProject(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, search_criteria_creator_id: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_labels: ?[]const []const u8, search_criteria_max_time: ?[]const u8, search_criteria_min_time: ?[]const u8, @"search_criteria.query_time_range_type": ?enums.GetPullRequestsByProjectRequestSearchCriteriaQueryTimeRangeType, search_criteria_repository_id: ?[]const u8, search_criteria_reviewer_id: ?[]const u8, search_criteria_source_ref_name: ?[]const u8, search_criteria_source_repository_id: ?[]const u8, @"search_criteria.status": ?enums.GetPullRequestsByProjectRequestSearchCriteriaStatus, @"search_criteria.tags_filter_operator": ?enums.GetPullRequestsByProjectRequestSearchCriteriaTagsFilterOperator, search_criteria_target_ref_name: ?[]const u8, search_criteria_title: ?[]const u8, max_comment_length: ?i32, @"$skip": ?i32, @"$top": ?i32) !models.GitPullRequestList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1174,7 +1174,7 @@ pub const PullRequests = struct {
             core.pager.logHttpError("PullRequests.getPullRequestsByProject", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitPullRequest, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitPullRequestList, alloc, resp.body);
     }
     /// Retrieve a pull request.
     pub fn getPullRequestById(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pull_request_id: i32, project: []const u8) !models.GitPullRequest {
@@ -1211,7 +1211,7 @@ pub const PullRequests = struct {
         return try serde.json.fromSlice(models.GitPullRequest, alloc, resp.body);
     }
     /// Retrieve all pull requests matching a specified criteria. Please note that description field will be truncated up to 400 symbols in the result.
-    pub fn getPullRequests(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, search_criteria_creator_id: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_labels: ?[]const []const u8, search_criteria_max_time: ?[]const u8, search_criteria_min_time: ?[]const u8, @"search_criteria.query_time_range_type": ?enums.GetPullRequestsRequestSearchCriteriaQueryTimeRangeType, search_criteria_repository_id: ?[]const u8, search_criteria_reviewer_id: ?[]const u8, search_criteria_source_ref_name: ?[]const u8, search_criteria_source_repository_id: ?[]const u8, @"search_criteria.status": ?enums.GetPullRequestsRequestSearchCriteriaStatus, @"search_criteria.tags_filter_operator": ?enums.GetPullRequestsRequestSearchCriteriaTagsFilterOperator, search_criteria_target_ref_name: ?[]const u8, search_criteria_title: ?[]const u8, max_comment_length: ?i32, @"$skip": ?i32, @"$top": ?i32) ![]const models.GitPullRequest {
+    pub fn getPullRequests(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, search_criteria_creator_id: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_labels: ?[]const []const u8, search_criteria_max_time: ?[]const u8, search_criteria_min_time: ?[]const u8, @"search_criteria.query_time_range_type": ?enums.GetPullRequestsRequestSearchCriteriaQueryTimeRangeType, search_criteria_repository_id: ?[]const u8, search_criteria_reviewer_id: ?[]const u8, search_criteria_source_ref_name: ?[]const u8, search_criteria_source_repository_id: ?[]const u8, @"search_criteria.status": ?enums.GetPullRequestsRequestSearchCriteriaStatus, @"search_criteria.tags_filter_operator": ?enums.GetPullRequestsRequestSearchCriteriaTagsFilterOperator, search_criteria_target_ref_name: ?[]const u8, search_criteria_title: ?[]const u8, max_comment_length: ?i32, @"$skip": ?i32, @"$top": ?i32) !models.GitPullRequestList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1361,7 +1361,7 @@ pub const PullRequests = struct {
             core.pager.logHttpError("PullRequests.getPullRequests", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitPullRequest, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitPullRequestList, alloc, resp.body);
     }
     /// Create a pull request.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, supports_iterations: ?bool, body: models.GitPullRequest) !models.GitPullRequest {
@@ -1876,7 +1876,7 @@ pub const Commits = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve a list of commits associated with a particular push.
-    pub fn getPushCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, push_id: i32, project: []const u8, top: ?i32, skip: ?i32, include_links: ?bool) ![]const models.GitCommitRef {
+    pub fn getPushCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, push_id: i32, project: []const u8, top: ?i32, skip: ?i32, include_links: ?bool) !models.GitCommitRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1924,7 +1924,7 @@ pub const Commits = struct {
             core.pager.logHttpError("Commits.getPushCommits", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitCommitRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitCommitRefList, alloc, resp.body);
     }
     /// Retrieve a particular commit.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, commit_id: []const u8, repository_id: []const u8, project: []const u8, change_count: ?i32) !models.GitCommit {
@@ -2014,7 +2014,7 @@ pub const Commits = struct {
         return try serde.json.fromSlice(models.GitCommitChanges, alloc, resp.body);
     }
     /// Retrieve git commits for a project matching the search criteria
-    pub fn getCommitsBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, @"$skip": ?i32, @"$top": ?i32, include_statuses: ?bool, body: models.GitQueryCommitsCriteria) ![]const models.GitCommitRef {
+    pub fn getCommitsBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, @"$skip": ?i32, @"$top": ?i32, include_statuses: ?bool, body: models.GitQueryCommitsCriteria) !models.GitCommitRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2064,7 +2064,7 @@ pub const Commits = struct {
             core.pager.logHttpError("Commits.getCommitsBatch", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitCommitRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitCommitRefList, alloc, resp.body);
     }
 };
 
@@ -2073,7 +2073,7 @@ pub const Statuses = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get statuses associated with the Git commit.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, commit_id: []const u8, repository_id: []const u8, project: []const u8, top: ?i32, skip: ?i32, latest_only: ?bool) ![]const models.GitStatus {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, commit_id: []const u8, repository_id: []const u8, project: []const u8, top: ?i32, skip: ?i32, latest_only: ?bool) !models.GitStatusList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2121,7 +2121,7 @@ pub const Statuses = struct {
             core.pager.logHttpError("Statuses.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitStatus, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitStatusList, alloc, resp.body);
     }
     /// Create Git commit status.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, commit_id: []const u8, repository_id: []const u8, project: []const u8, body: models.GitStatus) !models.GitStatus {
@@ -2267,7 +2267,7 @@ pub const ImportRequests = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve import requests for a repository.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8, include_abandoned: ?bool) ![]const models.GitImportRequest {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8, include_abandoned: ?bool) !models.GitImportRequestList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2303,7 +2303,7 @@ pub const ImportRequests = struct {
             core.pager.logHttpError("ImportRequests.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitImportRequest, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitImportRequestList, alloc, resp.body);
     }
     /// Create an import request.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8, body: models.GitImportRequest) !models.GitImportRequest {
@@ -2426,7 +2426,7 @@ pub const Items = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get Item Metadata and/or Content for a collection of items. The download parameter is to indicate whether the content should be available as a download or just sent as a stream in the response. Doesn't apply to zipped content which is always returned as a download.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, scope_path: ?[]const u8, recursion_level: ?enums.ListRequestRecursionLevel, include_content_metadata: ?bool, latest_processed_change: ?bool, download: ?bool, include_links: ?bool, @"$format": ?[]const u8, version_descriptor_version: ?[]const u8, @"version_descriptor.version_options": ?enums.ListRequestVersionDescriptorVersionOptions, @"version_descriptor.version_type": ?enums.ListRequestVersionDescriptorVersionType, zip_for_unix: ?bool) ![]const models.GitItem {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, scope_path: ?[]const u8, recursion_level: ?enums.ListRequestRecursionLevel, include_content_metadata: ?bool, latest_processed_change: ?bool, download: ?bool, include_links: ?bool, @"$format": ?[]const u8, version_descriptor_version: ?[]const u8, @"version_descriptor.version_options": ?enums.ListRequestVersionDescriptorVersionOptions, @"version_descriptor.version_type": ?enums.ListRequestVersionDescriptorVersionType, zip_for_unix: ?bool) !models.GitItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2524,7 +2524,7 @@ pub const Items = struct {
             core.pager.logHttpError("Items.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitItemList, alloc, resp.body);
     }
     /// Retrieves a batch of items in a repo / project for a given list of paths or a long path
     pub fn getItemsBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, body: models.GitItemRequestData) ![]const []const models.JsonValue {
@@ -2625,7 +2625,7 @@ pub const PullRequestAttachments = struct {
         },
     };
     /// Get a list of files attached to a given pull request.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) ![]const models.Attachment {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.AttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2658,7 +2658,7 @@ pub const PullRequestAttachments = struct {
             core.pager.logHttpError("PullRequestAttachments.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Attachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.AttachmentList, alloc, resp.body);
     }
     /// Delete a pull request attachment.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, file_name: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !void {
@@ -2805,7 +2805,7 @@ pub const PullRequestCommits = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.GitCommitRef,
+            body: models.GitCommitRefList,
         },
     };
     /// Get the commits for the specified pull request.
@@ -2857,7 +2857,7 @@ pub const PullRequestCommits = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.GitCommitRef, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.GitCommitRefList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -2873,7 +2873,7 @@ pub const PullRequestCommits = struct {
         }
     }
     /// Get the commits for the specified iteration of a pull request.
-    pub fn getPullRequestIterationCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8, top: ?i32, skip: ?i32) ![]const models.GitCommitRef {
+    pub fn getPullRequestIterationCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8, top: ?i32, skip: ?i32) !models.GitCommitRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2918,7 +2918,7 @@ pub const PullRequestCommits = struct {
             core.pager.logHttpError("PullRequestCommits.getPullRequestIterationCommits", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitCommitRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitCommitRefList, alloc, resp.body);
     }
 };
 
@@ -2927,7 +2927,7 @@ pub const PullRequestIterations = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get the list of iterations for the specified pull request.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, include_commits: ?bool) ![]const models.GitPullRequestIteration {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, include_commits: ?bool) !models.GitPullRequestIterationList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2965,7 +2965,7 @@ pub const PullRequestIterations = struct {
             core.pager.logHttpError("PullRequestIterations.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitPullRequestIteration, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitPullRequestIterationList, alloc, resp.body);
     }
     /// Get the specified iteration for a pull request.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8) !models.GitPullRequestIteration {
@@ -3071,7 +3071,7 @@ pub const PullRequestIterationStatuses = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all the statuses associated with a pull request iteration.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8) ![]const models.GitPullRequestStatus {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8) !models.GitPullRequestStatusList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3106,7 +3106,7 @@ pub const PullRequestIterationStatuses = struct {
             core.pager.logHttpError("PullRequestIterationStatuses.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitPullRequestStatus, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitPullRequestStatusList, alloc, resp.body);
     }
     /// Update pull request iteration statuses collection. The only supported operation type is `remove`. This operation allows to delete multiple statuses in one call. The path of the `remove` operation should refer to the ID of the pull request status. For example `path='/1'` refers to the pull request status with ID 1.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8, body: models.JsonPatchDocument) !void {
@@ -3277,7 +3277,7 @@ pub const PullRequestLabels = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all the labels (tags) assigned to a pull request.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, project_id: ?[]const u8) ![]const models.WebApiTagDefinition {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, project_id: ?[]const u8) !models.WebApiTagDefinitionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3317,7 +3317,7 @@ pub const PullRequestLabels = struct {
             core.pager.logHttpError("PullRequestLabels.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WebApiTagDefinition, alloc, resp.body);
+        return try serde.json.fromSlice(models.WebApiTagDefinitionList, alloc, resp.body);
     }
     /// Create a tag (if that does not exists yet) and add that as a label (tag) for a specified pull request. The only required field is the name of the new label (tag).
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, project_id: ?[]const u8, body: models.WebApiCreateTagRequestData) !models.WebApiTagDefinition {
@@ -3544,7 +3544,7 @@ pub const PullRequestReviewers = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve the reviewers for a pull request
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) ![]const models.IdentityRefWithVote {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.IdentityRefWithVoteList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3577,7 +3577,7 @@ pub const PullRequestReviewers = struct {
             core.pager.logHttpError("PullRequestReviewers.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.IdentityRefWithVote, alloc, resp.body);
+        return try serde.json.fromSlice(models.IdentityRefWithVoteList, alloc, resp.body);
     }
     /// Reset the votes of multiple reviewers on a pull request. NOTE: This endpoint only supports updating votes, but does not support updating required reviewers (use policy) or display names.
     pub fn updatePullRequestReviewers(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, body: []const models.IdentityRefWithVote) !void {
@@ -3619,7 +3619,7 @@ pub const PullRequestReviewers = struct {
         return;
     }
     /// Add reviewers to a pull request.
-    pub fn createPullRequestReviewers(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, body: []const models.IdentityRef) ![]const models.IdentityRefWithVote {
+    pub fn createPullRequestReviewers(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, body: []const models.IdentityRef) !models.IdentityRefWithVoteList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3656,7 +3656,7 @@ pub const PullRequestReviewers = struct {
             core.pager.logHttpError("PullRequestReviewers.createPullRequestReviewers", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.IdentityRefWithVote, alloc, resp.body);
+        return try serde.json.fromSlice(models.IdentityRefWithVoteList, alloc, resp.body);
     }
     /// Add an unmaterialized identity to the reviewers of a pull request.
     pub fn createUnmaterializedPullRequestReviewer(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, body: models.IdentityRefWithVote) !models.IdentityRefWithVote {
@@ -3909,7 +3909,7 @@ pub const PullRequestStatuses = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all the statuses associated with a pull request.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) ![]const models.GitPullRequestStatus {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.GitPullRequestStatusList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3942,7 +3942,7 @@ pub const PullRequestStatuses = struct {
             core.pager.logHttpError("PullRequestStatuses.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitPullRequestStatus, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitPullRequestStatusList, alloc, resp.body);
     }
     /// Update pull request statuses collection. The only supported operation type is `remove`. This operation allows to delete multiple statuses in one call. The path of the `remove` operation should refer to the ID of the pull request status. For example `path='/1'` refers to the pull request status with ID 1.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, body: models.JsonPatchDocument) !void {
@@ -4105,7 +4105,7 @@ pub const PullRequestThreads = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve all threads in a pull request.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, @"$iteration": ?i32, @"$base_iteration": ?i32) ![]const models.GitPullRequestCommentThread {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, @"$iteration": ?i32, @"$base_iteration": ?i32) !models.GitPullRequestCommentThreadList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4148,7 +4148,7 @@ pub const PullRequestThreads = struct {
             core.pager.logHttpError("PullRequestThreads.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitPullRequestCommentThread, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitPullRequestCommentThreadList, alloc, resp.body);
     }
     /// Create a thread in a pull request.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, body: models.GitPullRequestCommentThread) !models.GitPullRequestCommentThread {
@@ -4287,7 +4287,7 @@ pub const PullRequestThreadComments = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve all comments associated with a specific thread in a pull request.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, project: []const u8) ![]const models.Comment {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, project: []const u8) !models.CommentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4322,7 +4322,7 @@ pub const PullRequestThreadComments = struct {
             core.pager.logHttpError("PullRequestThreadComments.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Comment, alloc, resp.body);
+        return try serde.json.fromSlice(models.CommentList, alloc, resp.body);
     }
     /// Create a comment on a specific thread in a pull request (up to 500 comments can be created per thread).
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, project: []const u8, body: models.Comment) !models.Comment {
@@ -4535,7 +4535,7 @@ pub const PullRequestCommentLikes = struct {
         return;
     }
     /// Get likes for a comment.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, comment_id: i32, project: []const u8) ![]const models.IdentityRef {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, comment_id: i32, project: []const u8) !models.IdentityRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4572,7 +4572,7 @@ pub const PullRequestCommentLikes = struct {
             core.pager.logHttpError("PullRequestCommentLikes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.IdentityRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.IdentityRefList, alloc, resp.body);
     }
     /// Add a like on a comment.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, comment_id: i32, project: []const u8) !void {
@@ -4620,7 +4620,7 @@ pub const PullRequestWorkItems = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve a list of work items associated with a pull request.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) ![]const models.ResourceRef {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.ResourceRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4653,7 +4653,7 @@ pub const PullRequestWorkItems = struct {
             core.pager.logHttpError("PullRequestWorkItems.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ResourceRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.ResourceRefList, alloc, resp.body);
     }
 };
 
@@ -4662,7 +4662,7 @@ pub const Pushes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieves pushes associated with the specified repository.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, @"$skip": ?i32, @"$top": ?i32, search_criteria_from_date: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_include_ref_updates: ?bool, search_criteria_pusher_id: ?[]const u8, search_criteria_ref_name: ?[]const u8, search_criteria_to_date: ?[]const u8) ![]const models.GitPush {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, @"$skip": ?i32, @"$top": ?i32, search_criteria_from_date: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_include_ref_updates: ?bool, search_criteria_pusher_id: ?[]const u8, search_criteria_ref_name: ?[]const u8, search_criteria_to_date: ?[]const u8) !models.GitPushList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4741,7 +4741,7 @@ pub const Pushes = struct {
             core.pager.logHttpError("Pushes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitPush, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitPushList, alloc, resp.body);
     }
     /// Push changes to the repository.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, body: models.GitPush) !models.GitPush {
@@ -4840,7 +4840,7 @@ pub const Refs = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.GitRef,
+            body: models.GitRefList,
         },
     };
     /// Queries the provided repository for its refs and returns them.
@@ -4934,7 +4934,7 @@ pub const Refs = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.GitRef, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.GitRefList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -4999,7 +4999,7 @@ pub const Refs = struct {
         return try serde.json.fromSlice(models.GitRef, alloc, resp.body);
     }
     /// Creating, updating, or deleting refs(branches). Updating a ref means making it point at a different commit than it used to. You must specify both the old and new commit to avoid race conditions.
-    pub fn updateRefs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, project_id: ?[]const u8, body: []const models.GitRefUpdate) ![]const models.GitRefUpdateResult {
+    pub fn updateRefs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, project_id: ?[]const u8, body: []const models.GitRefUpdate) !models.GitRefUpdateResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -5041,7 +5041,7 @@ pub const Refs = struct {
             core.pager.logHttpError("Refs.updateRefs", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitRefUpdateResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitRefUpdateResultList, alloc, resp.body);
     }
 };
 
@@ -5168,7 +5168,7 @@ pub const Stats = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve statistics about all branches within a repository.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, base_version_descriptor_version: ?[]const u8, @"base_version_descriptor.version_options": ?enums.ListRequestBaseVersionDescriptorVersionOptions, @"base_version_descriptor.version_type": ?enums.ListRequestBaseVersionDescriptorVersionType) ![]const models.GitBranchStats {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, base_version_descriptor_version: ?[]const u8, @"base_version_descriptor.version_options": ?enums.ListRequestBaseVersionDescriptorVersionOptions, @"base_version_descriptor.version_type": ?enums.ListRequestBaseVersionDescriptorVersionType) !models.GitBranchStatsList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -5220,7 +5220,7 @@ pub const Stats = struct {
             core.pager.logHttpError("Stats.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitBranchStats, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitBranchStatsList, alloc, resp.body);
     }
 };
 
@@ -5229,7 +5229,7 @@ pub const Suggestions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve a pull request suggestion for a particular repository or team project.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, prefer_compare_branch: ?bool) ![]const models.GitSuggestion {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, prefer_compare_branch: ?bool) !models.GitSuggestionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -5265,7 +5265,7 @@ pub const Suggestions = struct {
             core.pager.logHttpError("Suggestions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitSuggestion, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitSuggestionList, alloc, resp.body);
     }
 };
 
@@ -5368,7 +5368,7 @@ pub const MergeBases = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Find the merge bases of two commits, optionally across forks. If otherRepositoryId is not specified, the merge bases will only be calculated within the context of the local repositoryNameOrId.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, commit_id: []const u8, other_commit_id: []const u8, project: []const u8, other_collection_id: ?[]const u8, other_repository_id: ?[]const u8) ![]const models.GitCommitRef {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, commit_id: []const u8, other_commit_id: []const u8, project: []const u8, other_collection_id: ?[]const u8, other_repository_id: ?[]const u8) !models.GitCommitRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -5419,7 +5419,7 @@ pub const MergeBases = struct {
             core.pager.logHttpError("MergeBases.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitCommitRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitCommitRefList, alloc, resp.body);
     }
 };
 
@@ -5428,7 +5428,7 @@ pub const Forks = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve all forks of a repository in the collection.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, collection_id: []const u8, project: []const u8, include_links: ?bool) ![]const models.GitRepositoryRef {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, collection_id: []const u8, project: []const u8, include_links: ?bool) !models.GitRepositoryRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -5466,10 +5466,10 @@ pub const Forks = struct {
             core.pager.logHttpError("Forks.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitRepositoryRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitRepositoryRefList, alloc, resp.body);
     }
     /// Retrieve all requested fork sync operations on this repository.
-    pub fn getForkSyncRequests(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, project: []const u8, include_abandoned: ?bool, include_links: ?bool) ![]const models.GitForkSyncRequest {
+    pub fn getForkSyncRequests(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, project: []const u8, include_abandoned: ?bool, include_links: ?bool) !models.GitForkSyncRequestList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -5510,7 +5510,7 @@ pub const Forks = struct {
             core.pager.logHttpError("Forks.getForkSyncRequests", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitForkSyncRequest, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitForkSyncRequestList, alloc, resp.body);
     }
     /// Request that another repository's refs be fetched into this one. It syncs two existing forks. To create a fork, please see the <a href='https://docs.microsoft.com/en-us/rest/api/vsts/git/repositories/create?view=azure-devops-rest-5.1'> repositories endpoint</a>
     pub fn createForkSyncRequest(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, project: []const u8, include_links: ?bool, body: models.GitForkSyncRequestParameters) !models.GitForkSyncRequest {

--- a/src/git/models.zig
+++ b/src/git/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `GitDeletedRepository` as returned by Azure DevOps.
+pub const GitDeletedRepositoryList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitDeletedRepository = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const GitDeletedRepository = struct {
     created_date: ?[]const u8 = null,
     deleted_by: ?IdentityRef = null,
@@ -165,10 +175,30 @@ pub const TeamProjectCollectionReference = struct {
     };
 };
 
+/// A collection of `GitRepository` as returned by Azure DevOps.
+pub const GitRepositoryList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitRepository = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const GitRepositoryCreateOptions = struct {
     name: ?[]const u8 = null,
     parent_repository: ?GitRepositoryRef = null,
     project: ?TeamProjectReference = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitRefFavorite` as returned by Azure DevOps.
+pub const GitRefFavoriteList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitRefFavorite = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -189,6 +219,16 @@ pub const GitRefFavorite = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `PolicyConfiguration` as returned by Azure DevOps.
+pub const PolicyConfigurationList = struct {
+    count: ?i32 = null,
+    value: ?[]const PolicyConfiguration = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 
@@ -232,6 +272,16 @@ pub const PolicyTypeRef = struct {
     id: ?[]const u8 = null,
     /// The URL where the policy type can be retrieved.
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitPullRequest` as returned by Azure DevOps.
+pub const GitPullRequestList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitPullRequest = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -705,6 +755,16 @@ pub const GitAsyncRefOperationSource = struct {
     };
 };
 
+/// A collection of `GitCommitRef` as returned by Azure DevOps.
+pub const GitCommitRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitCommitRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const GitCommit = struct {
     links: ?ReferenceLinks = null,
     author: ?GitUserDate = null,
@@ -806,6 +866,16 @@ pub const GitVersionDescriptor = struct {
     };
 };
 
+/// A collection of `GitStatus` as returned by Azure DevOps.
+pub const GitStatusList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitStatus = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const GitCommitDiffs = struct {
     ahead_count: ?i32 = null,
     all_changes_included: ?bool = null,
@@ -815,6 +885,16 @@ pub const GitCommitDiffs = struct {
     changes: ?[]const GitChange = null,
     common_commit: ?[]const u8 = null,
     target_commit: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitImportRequest` as returned by Azure DevOps.
+pub const GitImportRequestList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitImportRequest = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -890,6 +970,16 @@ pub const GitImportTfvcSource = struct {
     import_history_duration_in_days: ?i32 = null,
     /// Path which we want to import (this can be copied from Path Control in Explorer)
     path: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitItem` as returned by Azure DevOps.
+pub const GitItemList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitItem = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -994,6 +1084,16 @@ pub const GitPullRequestQueryInput = struct {
     };
 };
 
+/// A collection of `Attachment` as returned by Azure DevOps.
+pub const AttachmentList = struct {
+    count: ?i32 = null,
+    value: ?[]const Attachment = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Meta data for a file attached to an artifact.
 pub const Attachment = struct {
     links: ?ReferenceLinks = null,
@@ -1036,6 +1136,16 @@ pub const PropertiesCollection = struct {
 };
 
 pub const PropertiesCollectionItem = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitPullRequestIteration` as returned by Azure DevOps.
+pub const GitPullRequestIterationList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitPullRequestIteration = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };
@@ -1116,6 +1226,16 @@ pub const GitPullRequestIterationChanges = struct {
     };
 };
 
+/// A collection of `GitPullRequestStatus` as returned by Azure DevOps.
+pub const GitPullRequestStatusList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitPullRequestStatus = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// This class contains the metadata of a service/extension posting pull request status. Status can be associated with a pull request or an iteration.
 pub const GitPullRequestStatus = struct {
     links: ?ReferenceLinks = null,
@@ -1152,10 +1272,30 @@ pub const JsonPatchDocument = struct {
     };
 };
 
+/// A collection of `WebApiTagDefinition` as returned by Azure DevOps.
+pub const WebApiTagDefinitionList = struct {
+    count: ?i32 = null,
+    value: ?[]const WebApiTagDefinition = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// The representation of data needed to create a tag definition which is sent across the wire.
 pub const WebApiCreateTagRequestData = struct {
     /// Name of the tag definition that will be created.
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `IdentityRefWithVote` as returned by Azure DevOps.
+pub const IdentityRefWithVoteList = struct {
+    count: ?i32 = null,
+    value: ?[]const IdentityRefWithVote = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1168,6 +1308,16 @@ pub const ShareNotificationContext = struct {
     message: ?[]const u8 = null,
     /// Identities of users who will receive a share notification.
     receivers: ?[]const IdentityRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitPullRequestCommentThread` as returned by Azure DevOps.
+pub const GitPullRequestCommentThreadList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitPullRequestCommentThread = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1300,6 +1450,46 @@ pub const CommentTrackingCriteria = struct {
     };
 };
 
+/// A collection of `Comment` as returned by Azure DevOps.
+pub const CommentList = struct {
+    count: ?i32 = null,
+    value: ?[]const Comment = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `IdentityRef` as returned by Azure DevOps.
+pub const IdentityRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const IdentityRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ResourceRef` as returned by Azure DevOps.
+pub const ResourceRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const ResourceRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitPush` as returned by Azure DevOps.
+pub const GitPushList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitPush = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const GitPush = struct {
     links: ?ReferenceLinks = null,
     date: ?[]const u8 = null,
@@ -1330,6 +1520,16 @@ pub const GitRefUpdate = struct {
     };
 };
 
+/// A collection of `GitRef` as returned by Azure DevOps.
+pub const GitRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const GitRef = struct {
     links: ?ReferenceLinks = null,
     creator: ?IdentityRef = null,
@@ -1346,6 +1546,16 @@ pub const GitRef = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `GitRefUpdateResult` as returned by Azure DevOps.
+pub const GitRefUpdateResultList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitRefUpdateResult = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 
@@ -1391,6 +1601,16 @@ pub const GitRevert = struct {
     };
 };
 
+/// A collection of `GitBranchStats` as returned by Azure DevOps.
+pub const GitBranchStatsList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitBranchStats = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Ahead and behind counts for a particular ref.
 pub const GitBranchStats = struct {
     /// Number of commits ahead.
@@ -1402,6 +1622,16 @@ pub const GitBranchStats = struct {
     is_base_version: ?bool = null,
     /// Name of the ref.
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitSuggestion` as returned by Azure DevOps.
+pub const GitSuggestionList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitSuggestion = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1458,6 +1688,26 @@ pub const GitTreeEntryRef = struct {
     size: ?i64 = null,
     /// url to retrieve tree or blob
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitRepositoryRef` as returned by Azure DevOps.
+pub const GitRepositoryRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitRepositoryRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitForkSyncRequest` as returned by Azure DevOps.
+pub const GitForkSyncRequestList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitForkSyncRequest = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/graph/clients.zig
+++ b/src/graph/clients.zig
@@ -237,7 +237,7 @@ pub const Groups = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.GraphGroup,
+            body: models.GraphGroupList,
         },
     };
     /// Gets a list of all groups in the current scope (usually organization or account). The optional parameters are used to filter down the returned results. Returned results are in no guaranteed order. Since the list of groups may be large, results are returned in pages of groups. If there are more results than can be returned in a single page, the result set will contain a continuation token for retrieval of the next set of results.
@@ -292,7 +292,7 @@ pub const Groups = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.GraphGroup, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.GraphGroupList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -474,7 +474,7 @@ pub const Memberships = struct {
         },
     };
     /// Get all the memberships where this descriptor is a member in the relationship. The default value for direction is 'up' meaning return all memberships where the subject is a member (e.g. all groups the subject is a member of). Alternatively, passing the direction as 'down' will return all memberships where the subject is a container (e.g. all members of the subject group).
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subject_descriptor: []const u8, direction: ?enums.ListRequestDirection, depth: ?i32) ![]const models.GraphMembership {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subject_descriptor: []const u8, direction: ?enums.ListRequestDirection, depth: ?i32) !models.GraphMembershipList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -515,7 +515,7 @@ pub const Memberships = struct {
             core.pager.logHttpError("Memberships.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GraphMembership, alloc, resp.body);
+        return try serde.json.fromSlice(models.GraphMembershipList, alloc, resp.body);
     }
     /// Deletes a membership between a container and subject.
     pub fn removeMembership(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subject_descriptor: []const u8, container_descriptor: []const u8) !void {
@@ -756,7 +756,7 @@ pub const ServicePrincipals = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.GraphServicePrincipal,
+            body: models.GraphServicePrincipalList,
         },
     };
     /// Get a list of all service principals in a given scope. Since the list of service principals may be large, results are returned in pages of service principals. If there are more results than can be returned in a single page, the result set will contain a continuation token for retrieval of the next set of results. The only reliable way to know if there is no more service principals left is the lack of a continuation token.
@@ -804,7 +804,7 @@ pub const ServicePrincipals = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.GraphServicePrincipal, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.GraphServicePrincipalList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1008,7 +1008,7 @@ pub const SubjectQuery = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Search for Azure Devops users, or/and groups. Results will be returned in a batch with no more than 100 graph subjects.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.GraphSubjectQuery) ![]const models.GraphSubject {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.GraphSubjectQuery) !models.GraphSubjectList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1039,7 +1039,7 @@ pub const SubjectQuery = struct {
             core.pager.logHttpError("SubjectQuery.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GraphSubject, alloc, resp.body);
+        return try serde.json.fromSlice(models.GraphSubjectList, alloc, resp.body);
     }
 };
 
@@ -1172,7 +1172,7 @@ pub const Users = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.GraphUser,
+            body: models.GraphUserList,
         },
     };
     /// Get a list of all users in a given scope. Since the list of users may be large, results are returned in pages of users. If there are more results than can be returned in a single page, the result set will contain a continuation token for retrieval of the next set of results.
@@ -1227,7 +1227,7 @@ pub const Users = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.GraphUser, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.GraphUserList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{

--- a/src/graph/models.zig
+++ b/src/graph/models.zig
@@ -32,6 +32,16 @@ pub const ReferenceLinksLink = struct {
     };
 };
 
+/// A collection of `GraphGroup` as returned by Azure DevOps.
+pub const GraphGroupList = struct {
+    count: ?i32 = null,
+    value: ?[]const GraphGroup = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Graph group entity
 pub const GraphGroup = struct {
     links: ?ReferenceLinks = null,
@@ -83,6 +93,16 @@ pub const JsonPatchDocument = struct {
     };
 };
 
+/// A collection of `GraphMembership` as returned by Azure DevOps.
+pub const GraphMembershipList = struct {
+    count: ?i32 = null,
+    value: ?[]const GraphMembership = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Relationship between a container and a member
 pub const GraphMembership = struct {
     links: ?ReferenceLinks = null,
@@ -127,6 +147,16 @@ pub const JToken = struct {
     root: ?*const JToken = null,
     /// Gets the node type for this JToken.
     type: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GraphServicePrincipal` as returned by Azure DevOps.
+pub const GraphServicePrincipalList = struct {
+    count: ?i32 = null,
+    value: ?[]const GraphServicePrincipal = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -251,11 +281,31 @@ pub const GraphSubjectQuery = struct {
     };
 };
 
+/// A collection of `GraphSubject` as returned by Azure DevOps.
+pub const GraphSubjectList = struct {
+    count: ?i32 = null,
+    value: ?[]const GraphSubject = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const Avatar = struct {
     is_auto_generated: ?bool = null,
     size: ?enums.AvatarSize = null,
     time_stamp: ?[]const u8 = null,
     value: ?[]const []const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GraphUser` as returned by Azure DevOps.
+pub const GraphUserList = struct {
+    count: ?i32 = null,
+    value: ?[]const GraphUser = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/hooks/clients.zig
+++ b/src/hooks/clients.zig
@@ -137,7 +137,7 @@ pub const Consumers = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of available service hook consumer services. Optionally filter by consumers that support at least one event type from the specific publisher.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8) ![]const models.Consumer {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8) !models.ConsumerList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -171,7 +171,7 @@ pub const Consumers = struct {
             core.pager.logHttpError("Consumers.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Consumer, alloc, resp.body);
+        return try serde.json.fromSlice(models.ConsumerList, alloc, resp.body);
     }
     /// Get a specific consumer service. Optionally filter out consumer actions that do not support any event types for the specified publisher.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, consumer_id: []const u8, publisher_id: ?[]const u8) !models.Consumer {
@@ -213,7 +213,7 @@ pub const Consumers = struct {
         return try serde.json.fromSlice(models.Consumer, alloc, resp.body);
     }
     /// Get a list of consumer actions for a specific consumer.
-    pub fn listConsumerActions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, consumer_id: []const u8, publisher_id: ?[]const u8) ![]const models.ConsumerAction {
+    pub fn listConsumerActions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, consumer_id: []const u8, publisher_id: ?[]const u8) !models.ConsumerActionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -249,7 +249,7 @@ pub const Consumers = struct {
             core.pager.logHttpError("Consumers.listConsumerActions", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ConsumerAction, alloc, resp.body);
+        return try serde.json.fromSlice(models.ConsumerActionList, alloc, resp.body);
     }
     /// Get details about a specific consumer action.
     pub fn getConsumerAction(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, consumer_id: []const u8, consumer_action_id: []const u8, publisher_id: ?[]const u8) !models.ConsumerAction {
@@ -333,7 +333,7 @@ pub const Notifications = struct {
         return try serde.json.fromSlice(models.NotificationsQuery, alloc, resp.body);
     }
     /// Get a list of notifications for a specific subscription. A notification includes details about the event, the request to and the response from the consumer service.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subscription_id: []const u8, max_results: ?i32, status: ?enums.ListRequestStatus, result: ?enums.ListRequestResult) ![]const models.Notification {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subscription_id: []const u8, max_results: ?i32, status: ?enums.ListRequestStatus, result: ?enums.ListRequestResult) !models.NotificationList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -381,7 +381,7 @@ pub const Notifications = struct {
             core.pager.logHttpError("Notifications.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Notification, alloc, resp.body);
+        return try serde.json.fromSlice(models.NotificationList, alloc, resp.body);
     }
     /// Get a specific notification for a subscription.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subscription_id: []const u8, notification_id: i32) !models.Notification {
@@ -463,7 +463,7 @@ pub const Publishers = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of publishers.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.Publisher {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.PublisherList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -490,7 +490,7 @@ pub const Publishers = struct {
             core.pager.logHttpError("Publishers.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Publisher, alloc, resp.body);
+        return try serde.json.fromSlice(models.PublisherList, alloc, resp.body);
     }
     /// Get a specific service hooks publisher.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: []const u8) !models.Publisher {
@@ -525,7 +525,7 @@ pub const Publishers = struct {
         return try serde.json.fromSlice(models.Publisher, alloc, resp.body);
     }
     /// Get the event types for a specific publisher.
-    pub fn listEventTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: []const u8) ![]const models.EventTypeDescriptor {
+    pub fn listEventTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: []const u8) !models.EventTypeDescriptorList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -554,7 +554,7 @@ pub const Publishers = struct {
             core.pager.logHttpError("Publishers.listEventTypes", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.EventTypeDescriptor, alloc, resp.body);
+        return try serde.json.fromSlice(models.EventTypeDescriptorList, alloc, resp.body);
     }
     /// Get a specific event type.
     pub fn getEventType(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: []const u8, event_type_id: []const u8) !models.EventTypeDescriptor {
@@ -667,7 +667,7 @@ pub const Subscriptions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of subscriptions.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8, event_type: ?[]const u8, consumer_id: ?[]const u8, consumer_action_id: ?[]const u8) ![]const models.Subscription {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8, event_type: ?[]const u8, consumer_id: ?[]const u8, consumer_action_id: ?[]const u8) !models.SubscriptionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -722,7 +722,7 @@ pub const Subscriptions = struct {
             core.pager.logHttpError("Subscriptions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Subscription, alloc, resp.body);
+        return try serde.json.fromSlice(models.SubscriptionList, alloc, resp.body);
     }
     /// Create a subscription.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.Subscription) !models.Subscription {

--- a/src/hooks/models.zig
+++ b/src/hooks/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `Consumer` as returned by Azure DevOps.
+pub const ConsumerList = struct {
+    count: ?i32 = null,
+    value: ?[]const Consumer = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Defines the data contract of a consumer.
 pub const Consumer = struct {
     links: ?ReferenceLinks = null,
@@ -207,6 +217,16 @@ pub const ExternalConfigurationDescriptor = struct {
     edit_subscription_property_name: ?[]const u8 = null,
     /// True if the external configuration applies only to hosted.
     hosted_only: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ConsumerAction` as returned by Azure DevOps.
+pub const ConsumerActionList = struct {
+    count: ?i32 = null,
+    value: ?[]const ConsumerAction = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -482,6 +502,26 @@ pub const NotificationResultsSummaryDetail = struct {
     };
 };
 
+/// A collection of `Notification` as returned by Azure DevOps.
+pub const NotificationList = struct {
+    count: ?i32 = null,
+    value: ?[]const Notification = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Publisher` as returned by Azure DevOps.
+pub const PublisherList = struct {
+    count: ?i32 = null,
+    value: ?[]const Publisher = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Defines the data contract of an event publisher.
 pub const Publisher = struct {
     links: ?ReferenceLinks = null,
@@ -530,6 +570,16 @@ pub const EventTypeDescriptor = struct {
     };
 };
 
+/// A collection of `EventTypeDescriptor` as returned by Azure DevOps.
+pub const EventTypeDescriptorList = struct {
+    count: ?i32 = null,
+    value: ?[]const EventTypeDescriptor = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const InputValuesQuery = struct {
     current_values: ?std.json.ArrayHashMap([]const u8) = null,
     /// The input values to return on input, and the result from the consumer on output.
@@ -556,6 +606,16 @@ pub const PublishersQuery = struct {
     publisher_inputs: ?std.json.ArrayHashMap([]const u8) = null,
     /// Results from the query
     results: ?[]const Publisher = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Subscription` as returned by Azure DevOps.
+pub const SubscriptionList = struct {
+    count: ?i32 = null,
+    value: ?[]const Subscription = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/ims/clients.zig
+++ b/src/ims/clients.zig
@@ -105,7 +105,7 @@ pub const Identities = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Resolve legacy identity information for use with older APIs such as the Security APIs
-    pub fn readIdentities(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, descriptors: ?[]const u8, identity_ids: ?[]const u8, subject_descriptors: ?[]const u8, search_filter: ?[]const u8, filter_value: ?[]const u8, query_membership: ?enums.ReadIdentitiesRequestQueryMembership) ![]const models.Identity {
+    pub fn readIdentities(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, descriptors: ?[]const u8, identity_ids: ?[]const u8, subject_descriptors: ?[]const u8, search_filter: ?[]const u8, filter_value: ?[]const u8, query_membership: ?enums.ReadIdentitiesRequestQueryMembership) !models.IdentityList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -174,6 +174,6 @@ pub const Identities = struct {
             core.pager.logHttpError("Identities.readIdentities", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Identity, alloc, resp.body);
+        return try serde.json.fromSlice(models.IdentityList, alloc, resp.body);
     }
 };

--- a/src/ims/models.zig
+++ b/src/ims/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `Identity` as returned by Azure DevOps.
+pub const IdentityList = struct {
+    count: ?i32 = null,
+    value: ?[]const Identity = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const Identity = struct {
     /// The custom display name for the identity (if any). Setting this property to an empty string will clear the existing custom display name. Setting this property to null will not affect the existing persisted value (since null values do not get sent over the wire or to the database)
     custom_display_name: ?[]const u8 = null,

--- a/src/member_entitlement_management/clients.zig
+++ b/src/member_entitlement_management/clients.zig
@@ -145,7 +145,7 @@ pub const GroupEntitlements = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get the group entitlements for an account.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.GroupEntitlement {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.GroupEntitlementList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -172,7 +172,7 @@ pub const GroupEntitlements = struct {
             core.pager.logHttpError("GroupEntitlements.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GroupEntitlement, alloc, resp.body);
+        return try serde.json.fromSlice(models.GroupEntitlementList, alloc, resp.body);
     }
     /// Create a group entitlement with license rule, extension rule.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, rule_option: ?enums.AddRequestRuleOption, body: models.GroupEntitlement) !models.GroupEntitlementOperationReference {

--- a/src/member_entitlement_management/models.zig
+++ b/src/member_entitlement_management/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `GroupEntitlement` as returned by Azure DevOps.
+pub const GroupEntitlementList = struct {
+    count: ?i32 = null,
+    value: ?[]const GroupEntitlement = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// A group entity with additional properties including its license, extensions, and project membership
 pub const GroupEntitlement = struct {
     group: ?GraphGroup = null,

--- a/src/notification/clients.zig
+++ b/src/notification/clients.zig
@@ -144,7 +144,7 @@ pub const DiagnosticLogs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of diagnostic logs for this service.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, source: []const u8, organization: []const u8, entry_id: []const u8, start_time: ?[]const u8, end_time: ?[]const u8) ![]const models.INotificationDiagnosticLog {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, source: []const u8, organization: []const u8, entry_id: []const u8, start_time: ?[]const u8, end_time: ?[]const u8) !models.INotificationDiagnosticLogList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, source);
         defer alloc.free(encoded_path_0);
@@ -189,7 +189,7 @@ pub const DiagnosticLogs = struct {
             core.pager.logHttpError("DiagnosticLogs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.INotificationDiagnosticLog, alloc, resp.body);
+        return try serde.json.fromSlice(models.INotificationDiagnosticLogList, alloc, resp.body);
     }
 };
 
@@ -198,7 +198,7 @@ pub const EventTypes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// List available event types for this service. Optionally filter by only event types for the specified publisher.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8) ![]const models.NotificationEventType {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8) !models.NotificationEventTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -232,7 +232,7 @@ pub const EventTypes = struct {
             core.pager.logHttpError("EventTypes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.NotificationEventType, alloc, resp.body);
+        return try serde.json.fromSlice(models.NotificationEventTypeList, alloc, resp.body);
     }
     /// Get a specific event type.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, event_type: []const u8, organization: []const u8) !models.NotificationEventType {
@@ -417,7 +417,7 @@ pub const Subscriptions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Query for subscriptions. A subscription is returned if it matches one or more of the specified conditions.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.SubscriptionQuery) ![]const models.NotificationSubscription {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.SubscriptionQuery) !models.NotificationSubscriptionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -448,10 +448,10 @@ pub const Subscriptions = struct {
             core.pager.logHttpError("Subscriptions.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.NotificationSubscription, alloc, resp.body);
+        return try serde.json.fromSlice(models.NotificationSubscriptionList, alloc, resp.body);
     }
     /// Get a list of notification subscriptions, either by subscription IDs or by all subscriptions for a given user or group.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, target_id: ?[]const u8, ids: ?[]const u8, query_flags: ?enums.ListRequestQueryFlags) ![]const models.NotificationSubscription {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, target_id: ?[]const u8, ids: ?[]const u8, query_flags: ?enums.ListRequestQueryFlags) !models.NotificationSubscriptionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -499,7 +499,7 @@ pub const Subscriptions = struct {
             core.pager.logHttpError("Subscriptions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.NotificationSubscription, alloc, resp.body);
+        return try serde.json.fromSlice(models.NotificationSubscriptionList, alloc, resp.body);
     }
     /// Create a new subscription.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.NotificationSubscriptionCreateParameters) !models.NotificationSubscription {
@@ -680,7 +680,7 @@ pub const Subscriptions = struct {
         return try serde.json.fromSlice(models.SubscriptionUserSettings, alloc, resp.body);
     }
     /// Get available subscription templates.
-    pub fn getSubscriptionTemplates(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.NotificationSubscriptionTemplate {
+    pub fn getSubscriptionTemplates(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.NotificationSubscriptionTemplateList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -707,7 +707,7 @@ pub const Subscriptions = struct {
             core.pager.logHttpError("Subscriptions.getSubscriptionTemplates", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.NotificationSubscriptionTemplate, alloc, resp.body);
+        return try serde.json.fromSlice(models.NotificationSubscriptionTemplateList, alloc, resp.body);
     }
 };
 

--- a/src/notification/models.zig
+++ b/src/notification/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `INotificationDiagnosticLog` as returned by Azure DevOps.
+pub const INotificationDiagnosticLogList = struct {
+    count: ?i32 = null,
+    value: ?[]const INotificationDiagnosticLog = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Abstraction interface for the diagnostic log. Primarily for deserialization.
 pub const INotificationDiagnosticLog = struct {
     /// Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
@@ -34,6 +44,16 @@ pub const NotificationDiagnosticLogMessage = struct {
     level: ?i32 = null,
     message: ?[]const u8 = null,
     time: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `NotificationEventType` as returned by Azure DevOps.
+pub const NotificationEventTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const NotificationEventType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -284,6 +304,16 @@ pub const ISubscriptionFilter = struct {
     };
 };
 
+/// A collection of `NotificationSubscription` as returned by Azure DevOps.
+pub const NotificationSubscriptionList = struct {
+    count: ?i32 = null,
+    value: ?[]const NotificationSubscription = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// A subscription defines criteria for matching events and how the subscription's subscriber should be notified about those events.
 pub const NotificationSubscription = struct {
     links: ?ReferenceLinks = null,
@@ -469,6 +499,16 @@ pub const NotificationSubscriptionUpdateParameters = struct {
     /// Optional message that provides more details about the updated status.
     status_message: ?[]const u8 = null,
     user_settings: ?SubscriptionUserSettings = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `NotificationSubscriptionTemplate` as returned by Azure DevOps.
+pub const NotificationSubscriptionTemplateList = struct {
+    count: ?i32 = null,
+    value: ?[]const NotificationSubscriptionTemplate = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/permissions_report/clients.zig
+++ b/src/permissions_report/clients.zig
@@ -113,7 +113,7 @@ pub const PermissionsReportOperations = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of permissions reports
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.PermissionsReport {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.PermissionsReportList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -140,7 +140,7 @@ pub const PermissionsReportOperations = struct {
             core.pager.logHttpError("PermissionsReportOperations.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PermissionsReport, alloc, resp.body);
+        return try serde.json.fromSlice(models.PermissionsReportList, alloc, resp.body);
     }
     /// Request a permissions report to be created asyncronously
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.PermissionsReportRequest) !models.ReferenceLinks {

--- a/src/permissions_report/models.zig
+++ b/src/permissions_report/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `PermissionsReport` as returned by Azure DevOps.
+pub const PermissionsReportList = struct {
+    count: ?i32 = null,
+    value: ?[]const PermissionsReport = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Detailed report of permissions for a set of groups and users over a set of security namespaces
 pub const PermissionsReport = struct {
     /// Error if the report creation failed or empty if successful

--- a/src/pipelines/clients.zig
+++ b/src/pipelines/clients.zig
@@ -143,7 +143,7 @@ pub const Pipelines = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.Pipeline,
+            body: models.PipelineList,
         },
     };
     /// Get a list of pipelines.
@@ -198,7 +198,7 @@ pub const Pipelines = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.Pipeline, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.PipelineList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -344,7 +344,7 @@ pub const Runs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets top 10000 runs for a particular pipeline.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32) ![]const models.Run {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32) !models.RunList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -375,7 +375,7 @@ pub const Runs = struct {
             core.pager.logHttpError("Runs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Run, alloc, resp.body);
+        return try serde.json.fromSlice(models.RunList, alloc, resp.body);
     }
     /// Runs a pipeline.
     pub fn runPipeline(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, pipeline_version: ?i32, body: models.RunPipelineParameters) !models.Run {

--- a/src/pipelines/models.zig
+++ b/src/pipelines/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `Pipeline` as returned by Azure DevOps.
+pub const PipelineList = struct {
+    count: ?i32 = null,
+    value: ?[]const Pipeline = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Definition of a pipeline.
 pub const Pipeline = struct {
     /// Pipeline folder
@@ -158,6 +168,16 @@ pub const Variable = struct {
 
 pub const PreviewRun = struct {
     final_yaml: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Run` as returned by Azure DevOps.
+pub const RunList = struct {
+    count: ?i32 = null,
+    value: ?[]const Run = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/policy/clients.zig
+++ b/src/policy/clients.zig
@@ -135,7 +135,7 @@ pub const Configurations = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.PolicyConfiguration,
+            body: models.PolicyConfigurationList,
         },
     };
     /// Get a list of policy configurations in a project. The 'scope' parameter for this API should not be used, except for legacy compatability reasons. It returns specifically scoped policies and does not support heirarchical nesting. Instead, use the /_apis/git/policy/configurations API, which provides first class scope filtering support. The optional `policyType` parameter can be used to filter the set of policies returned from this method.
@@ -197,7 +197,7 @@ pub const Configurations = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.PolicyConfiguration, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.PolicyConfigurationList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -360,7 +360,7 @@ pub const Revisions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve all revisions for a given policy.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, configuration_id: i32, @"$top": ?i32, @"$skip": ?i32) ![]const models.PolicyConfiguration {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, configuration_id: i32, @"$top": ?i32, @"$skip": ?i32) !models.PolicyConfigurationList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -401,7 +401,7 @@ pub const Revisions = struct {
             core.pager.logHttpError("Revisions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PolicyConfiguration, alloc, resp.body);
+        return try serde.json.fromSlice(models.PolicyConfigurationList, alloc, resp.body);
     }
     /// Retrieve a specific revision of a given policy by ID.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, configuration_id: i32, revision_id: i32) !models.PolicyConfiguration {
@@ -446,7 +446,7 @@ pub const Evaluations = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieves a list of all the policy evaluation statuses for a specific pull request. Evaluations are retrieved using an artifact ID which uniquely identifies the pull request. To generate an artifact ID for a pull request, use this template: ``` vstfs:///CodeReview/CodeReviewId/{projectId}/{pullRequestId} ```
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, artifact_id: []const u8, include_not_applicable: ?bool, @"$top": ?i32, @"$skip": ?i32) ![]const models.PolicyEvaluationRecord {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, artifact_id: []const u8, include_not_applicable: ?bool, @"$top": ?i32, @"$skip": ?i32) !models.PolicyEvaluationRecordList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -494,7 +494,7 @@ pub const Evaluations = struct {
             core.pager.logHttpError("Evaluations.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PolicyEvaluationRecord, alloc, resp.body);
+        return try serde.json.fromSlice(models.PolicyEvaluationRecordList, alloc, resp.body);
     }
     /// Gets the present evaluation state of a policy. Each policy which applies to a pull request will have an evaluation state which is specific to that policy running in the context of that pull request. Each evaluation is uniquely identified via a Guid. You can find all the policy evaluations for a specific pull request using the List operation of this controller.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, evaluation_id: []const u8) !models.PolicyEvaluationRecord {
@@ -571,7 +571,7 @@ pub const Types = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieve all available policy types.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.PolicyType {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.PolicyTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -600,7 +600,7 @@ pub const Types = struct {
             core.pager.logHttpError("Types.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PolicyType, alloc, resp.body);
+        return try serde.json.fromSlice(models.PolicyTypeList, alloc, resp.body);
     }
     /// Retrieve a specific policy type by ID.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, type_id: []const u8) !models.PolicyType {

--- a/src/policy/models.zig
+++ b/src/policy/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `PolicyConfiguration` as returned by Azure DevOps.
+pub const PolicyConfigurationList = struct {
+    count: ?i32 = null,
+    value: ?[]const PolicyConfiguration = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// The full policy configuration with settings.
 pub const PolicyConfiguration = struct {
     /// The policy configuration ID.
@@ -108,6 +118,16 @@ pub const JObject = struct {
     };
 };
 
+/// A collection of `PolicyEvaluationRecord` as returned by Azure DevOps.
+pub const PolicyEvaluationRecordList = struct {
+    count: ?i32 = null,
+    value: ?[]const PolicyEvaluationRecord = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// This record encapsulates the current state of a policy as it applies to one specific pull request. Each pull request has a unique PolicyEvaluationRecord for each pull request which the policy applies to.
 pub const PolicyEvaluationRecord = struct {
     links: ?ReferenceLinks = null,
@@ -129,6 +149,16 @@ pub const PolicyEvaluationRecord = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `PolicyType` as returned by Azure DevOps.
+pub const PolicyTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const PolicyType = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 

--- a/src/processadmin/clients.zig
+++ b/src/processadmin/clients.zig
@@ -113,7 +113,7 @@ pub const Behaviors = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of behaviors for the process.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8) ![]const models.AdminBehavior {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8) !models.AdminBehaviorList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -142,7 +142,7 @@ pub const Behaviors = struct {
             core.pager.logHttpError("Behaviors.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AdminBehavior, alloc, resp.body);
+        return try serde.json.fromSlice(models.AdminBehaviorList, alloc, resp.body);
     }
 };
 

--- a/src/processadmin/models.zig
+++ b/src/processadmin/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `AdminBehavior` as returned by Azure DevOps.
+pub const AdminBehaviorList = struct {
+    count: ?i32 = null,
+    value: ?[]const AdminBehavior = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Describes an admin behavior for a process.
 pub const AdminBehavior = struct {
     /// Is the behavior abstract (i.e. can not be associated with any work item type).

--- a/src/processes/clients.zig
+++ b/src/processes/clients.zig
@@ -201,7 +201,7 @@ pub const Processes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get list of all processes including system and inherited.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"$expand": ?enums.ListRequestExpand) ![]const models.ProcessInfo {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"$expand": ?enums.ListRequestExpand) !models.ProcessInfoList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -235,7 +235,7 @@ pub const Processes = struct {
             core.pager.logHttpError("Processes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ProcessInfo, alloc, resp.body);
+        return try serde.json.fromSlice(models.ProcessInfoList, alloc, resp.body);
     }
     /// Creates a process.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.CreateProcessModel) !models.ProcessInfo {
@@ -384,7 +384,7 @@ pub const Behaviors = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of all behaviors in the process.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, @"$expand": ?enums.ListRequestExpand1) ![]const models.ProcessBehavior {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, @"$expand": ?enums.ListRequestExpand1) !models.ProcessBehaviorList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -420,7 +420,7 @@ pub const Behaviors = struct {
             core.pager.logHttpError("Behaviors.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ProcessBehavior, alloc, resp.body);
+        return try serde.json.fromSlice(models.ProcessBehaviorList, alloc, resp.body);
     }
     /// Creates a single behavior in the given process.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, body: models.ProcessBehaviorCreateRequest) !models.ProcessBehavior {
@@ -577,7 +577,7 @@ pub const WorkItemTypes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of all work item types in a process.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, @"$expand": ?enums.ListRequestExpand2) ![]const models.ProcessWorkItemType {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, @"$expand": ?enums.ListRequestExpand2) !models.ProcessWorkItemTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -613,7 +613,7 @@ pub const WorkItemTypes = struct {
             core.pager.logHttpError("WorkItemTypes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ProcessWorkItemType, alloc, resp.body);
+        return try serde.json.fromSlice(models.ProcessWorkItemTypeList, alloc, resp.body);
     }
     /// Creates a work item type in the process.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, body: models.CreateProcessWorkItemTypeRequest) !models.ProcessWorkItemType {
@@ -770,7 +770,7 @@ pub const Fields = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of all fields in a work item type.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) ![]const models.ProcessWorkItemTypeField {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.ProcessWorkItemTypeFieldList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -801,7 +801,7 @@ pub const Fields = struct {
             core.pager.logHttpError("Fields.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ProcessWorkItemTypeField, alloc, resp.body);
+        return try serde.json.fromSlice(models.ProcessWorkItemTypeFieldList, alloc, resp.body);
     }
     /// Adds a field to a work item type.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, body: models.AddProcessWorkItemTypeFieldRequest) !models.ProcessWorkItemTypeField {
@@ -1476,7 +1476,7 @@ pub const SystemControls = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets edited system controls for a work item type in a process. To get all system controls (base + edited) use layout API(s)
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) ![]const models.Control {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.ControlList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1507,10 +1507,10 @@ pub const SystemControls = struct {
             core.pager.logHttpError("SystemControls.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Control, alloc, resp.body);
+        return try serde.json.fromSlice(models.ControlList, alloc, resp.body);
     }
     /// Deletes a system control modification on the work item form.
-    pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, control_id: []const u8) ![]const models.Control {
+    pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, control_id: []const u8) !models.ControlList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1543,7 +1543,7 @@ pub const SystemControls = struct {
             core.pager.logHttpError("SystemControls.delete", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Control, alloc, resp.body);
+        return try serde.json.fromSlice(models.ControlList, alloc, resp.body);
     }
     /// Updates/adds a system control on the work item form.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, control_id: []const u8, body: models.Control) !models.Control {
@@ -1592,7 +1592,7 @@ pub const Rules = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of all rules in the work item type of the process.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) ![]const models.ProcessRule {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.ProcessRuleList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1623,7 +1623,7 @@ pub const Rules = struct {
             core.pager.logHttpError("Rules.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ProcessRule, alloc, resp.body);
+        return try serde.json.fromSlice(models.ProcessRuleList, alloc, resp.body);
     }
     /// Adds a rule to work item type in the process.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, body: models.CreateProcessRuleRequest) !models.ProcessRule {
@@ -1781,7 +1781,7 @@ pub const States = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of all state definitions in a work item type of the process.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) ![]const models.WorkItemStateResultModel {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.WorkItemStateResultModelList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1812,7 +1812,7 @@ pub const States = struct {
             core.pager.logHttpError("States.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemStateResultModel, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemStateResultModelList, alloc, resp.body);
     }
     /// Creates a state definition in the work item type of the process.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, body: models.WorkItemStateInputModel) !models.WorkItemStateResultModel {
@@ -2010,7 +2010,7 @@ pub const WorkItemTypesBehaviors = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of all behaviors for the work item type of the process.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name_for_behaviors: []const u8) ![]const models.WorkItemTypeBehavior {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name_for_behaviors: []const u8) !models.WorkItemTypeBehaviorList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2041,7 +2041,7 @@ pub const WorkItemTypesBehaviors = struct {
             core.pager.logHttpError("WorkItemTypesBehaviors.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemTypeBehavior, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemTypeBehaviorList, alloc, resp.body);
     }
     /// Updates a behavior for the work item type of the process.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name_for_behaviors: []const u8, body: models.WorkItemTypeBehavior) !models.WorkItemTypeBehavior {
@@ -2197,7 +2197,7 @@ pub const Lists = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns meta data of the picklist.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.PickListMetadata {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.PickListMetadataList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2224,7 +2224,7 @@ pub const Lists = struct {
             core.pager.logHttpError("Lists.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PickListMetadata, alloc, resp.body);
+        return try serde.json.fromSlice(models.PickListMetadataList, alloc, resp.body);
     }
     /// Creates a picklist.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.PickList) !models.PickList {

--- a/src/processes/models.zig
+++ b/src/processes/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `ProcessInfo` as returned by Azure DevOps.
+pub const ProcessInfoList = struct {
+    count: ?i32 = null,
+    value: ?[]const ProcessInfo = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Process.
 pub const ProcessInfo = struct {
     /// Indicates the type of customization on this process. System Process is default process. Inherited Process is modified process that was System process before.
@@ -71,6 +81,16 @@ pub const UpdateProcessModel = struct {
     is_enabled: ?bool = null,
     /// New name of the process
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ProcessBehavior` as returned by Azure DevOps.
+pub const ProcessBehaviorList = struct {
+    count: ?i32 = null,
+    value: ?[]const ProcessBehavior = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -150,6 +170,16 @@ pub const ProcessBehaviorUpdateRequest = struct {
     color: ?[]const u8 = null,
     /// Behavior Name.
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ProcessWorkItemType` as returned by Azure DevOps.
+pub const ProcessWorkItemTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const ProcessWorkItemType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -421,6 +451,16 @@ pub const UpdateProcessWorkItemTypeRequest = struct {
     };
 };
 
+/// A collection of `ProcessWorkItemTypeField` as returned by Azure DevOps.
+pub const ProcessWorkItemTypeFieldList = struct {
+    count: ?i32 = null,
+    value: ?[]const ProcessWorkItemTypeField = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Class that describes a field in a work item type and its properties.
 pub const ProcessWorkItemTypeField = struct {
     /// The list of field allowed values.
@@ -515,6 +555,26 @@ pub const UpdateProcessWorkItemTypeFieldRequestDefaultValue = struct {
     };
 };
 
+/// A collection of `Control` as returned by Azure DevOps.
+pub const ControlList = struct {
+    count: ?i32 = null,
+    value: ?[]const Control = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ProcessRule` as returned by Azure DevOps.
+pub const ProcessRuleList = struct {
+    count: ?i32 = null,
+    value: ?[]const ProcessRule = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Process Rule Response.
 pub const ProcessRule = struct {
     /// List of actions to take when the rule is triggered.
@@ -599,6 +659,16 @@ pub const UpdateProcessRuleRequest = struct {
     };
 };
 
+/// A collection of `WorkItemStateResultModel` as returned by Azure DevOps.
+pub const WorkItemStateResultModelList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemStateResultModel = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Class That represents a work item state input.
 pub const WorkItemStateInputModel = struct {
     /// Color of the state
@@ -619,6 +689,26 @@ pub const WorkItemStateInputModel = struct {
 pub const HideStateModel = struct {
     /// Returns 'true', if workitem state is hidden, 'false' otherwise.
     hidden: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemTypeBehavior` as returned by Azure DevOps.
+pub const WorkItemTypeBehaviorList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemTypeBehavior = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `PickListMetadata` as returned by Azure DevOps.
+pub const PickListMetadataList = struct {
+    count: ?i32 = null,
+    value: ?[]const PickListMetadata = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/release/clients.zig
+++ b/src/release/clients.zig
@@ -161,7 +161,7 @@ pub const Approvals = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of approvals
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, assigned_to_filter: ?[]const u8, status_filter: ?enums.ListRequestStatusFilter, release_ids_filter: ?[]const u8, type_filter: ?enums.ListRequestTypeFilter, top: ?i32, continuation_token: ?i32, query_order: ?enums.ListRequestQueryOrder, include_my_group_approvals: ?bool) ![]const models.ReleaseApproval {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, assigned_to_filter: ?[]const u8, status_filter: ?enums.ListRequestStatusFilter, release_ids_filter: ?[]const u8, type_filter: ?enums.ListRequestTypeFilter, top: ?i32, continuation_token: ?i32, query_order: ?enums.ListRequestQueryOrder, include_my_group_approvals: ?bool) !models.ReleaseApprovalList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -240,7 +240,7 @@ pub const Approvals = struct {
             core.pager.logHttpError("Approvals.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ReleaseApproval, alloc, resp.body);
+        return try serde.json.fromSlice(models.ReleaseApprovalList, alloc, resp.body);
     }
     /// Update status of an approval
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, approval_id: i32, body: models.ReleaseApproval) !models.ReleaseApproval {
@@ -293,7 +293,7 @@ pub const Definitions = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.ReleaseDefinition,
+            body: models.ReleaseDefinitionList,
         },
     };
 
@@ -429,7 +429,7 @@ pub const Definitions = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.ReleaseDefinition, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.ReleaseDefinitionList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -613,7 +613,7 @@ pub const Definitions = struct {
         return try serde.json.fromSlice(models.ReleaseDefinition, alloc, resp.body);
     }
     /// Get revision history for a release definition
-    pub fn getReleaseDefinitionHistory(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32) ![]const models.ReleaseDefinitionRevision {
+    pub fn getReleaseDefinitionHistory(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32) !models.ReleaseDefinitionRevisionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -644,7 +644,7 @@ pub const Definitions = struct {
             core.pager.logHttpError("Definitions.getReleaseDefinitionHistory", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ReleaseDefinitionRevision, alloc, resp.body);
+        return try serde.json.fromSlice(models.ReleaseDefinitionRevisionList, alloc, resp.body);
     }
     /// Get release definition for a given definitionId and revision
     pub fn getDefinitionRevision(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32, revision: i32) !GetDefinitionRevisionResult {
@@ -706,7 +706,7 @@ pub const Deployments = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of deployments
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: ?i32, definition_environment_id: ?i32, created_by: ?[]const u8, min_modified_time: ?[]const u8, max_modified_time: ?[]const u8, deployment_status: ?enums.ListRequestDeploymentStatus, operation_status: ?enums.ListRequestOperationStatus, latest_attempts_only: ?bool, query_order: ?enums.ListRequestQueryOrder2, @"$top": ?i32, continuation_token: ?i32, created_for: ?[]const u8, min_started_time: ?[]const u8, max_started_time: ?[]const u8, source_branch: ?[]const u8) ![]const models.Deployment {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: ?i32, definition_environment_id: ?i32, created_by: ?[]const u8, min_modified_time: ?[]const u8, max_modified_time: ?[]const u8, deployment_status: ?enums.ListRequestDeploymentStatus, operation_status: ?enums.ListRequestOperationStatus, latest_attempts_only: ?bool, query_order: ?enums.ListRequestQueryOrder2, @"$top": ?i32, continuation_token: ?i32, created_for: ?[]const u8, min_started_time: ?[]const u8, max_started_time: ?[]const u8, source_branch: ?[]const u8) !models.DeploymentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -830,7 +830,7 @@ pub const Deployments = struct {
             core.pager.logHttpError("Deployments.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Deployment, alloc, resp.body);
+        return try serde.json.fromSlice(models.DeploymentList, alloc, resp.body);
     }
 };
 
@@ -872,7 +872,7 @@ pub const Folders = struct {
         return;
     }
     /// Gets folders.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, path: []const u8, query_order: ?enums.ListRequestQueryOrder3) ![]const models.Folder {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, path: []const u8, query_order: ?enums.ListRequestQueryOrder3) !models.FolderList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -910,7 +910,7 @@ pub const Folders = struct {
             core.pager.logHttpError("Folders.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Folder, alloc, resp.body);
+        return try serde.json.fromSlice(models.FolderList, alloc, resp.body);
     }
     /// Updates an existing folder at given existing path.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, path: []const u8, body: models.Folder) !models.Folder {
@@ -1069,7 +1069,7 @@ pub const Releases = struct {
         },
     };
     /// Get a list of releases
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: ?i32, definition_environment_id: ?i32, search_text: ?[]const u8, created_by: ?[]const u8, status_filter: ?enums.ListRequestStatusFilter1, environment_status_filter: ?i32, min_created_time: ?[]const u8, max_created_time: ?[]const u8, query_order: ?enums.ListRequestQueryOrder4, @"$top": ?i32, continuation_token: ?i32, @"$expand": ?enums.ListRequestExpand1, artifact_type_id: ?[]const u8, source_id: ?[]const u8, artifact_version_id: ?[]const u8, source_branch_filter: ?[]const u8, is_deleted: ?bool, tag_filter: ?[]const u8, property_filters: ?[]const u8, release_id_filter: ?[]const u8, path: ?[]const u8) ![]const models.Release {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: ?i32, definition_environment_id: ?i32, search_text: ?[]const u8, created_by: ?[]const u8, status_filter: ?enums.ListRequestStatusFilter1, environment_status_filter: ?i32, min_created_time: ?[]const u8, max_created_time: ?[]const u8, query_order: ?enums.ListRequestQueryOrder4, @"$top": ?i32, continuation_token: ?i32, @"$expand": ?enums.ListRequestExpand1, artifact_type_id: ?[]const u8, source_id: ?[]const u8, artifact_version_id: ?[]const u8, source_branch_filter: ?[]const u8, is_deleted: ?bool, tag_filter: ?[]const u8, property_filters: ?[]const u8, release_id_filter: ?[]const u8, path: ?[]const u8) !models.ReleaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1233,7 +1233,7 @@ pub const Releases = struct {
             core.pager.logHttpError("Releases.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Release, alloc, resp.body);
+        return try serde.json.fromSlice(models.ReleaseList, alloc, resp.body);
     }
     /// Create a release.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.ReleaseStartMetadata) !models.Release {
@@ -1628,7 +1628,7 @@ pub const Attachments = struct {
         },
     };
     /// Get the release task attachments.
-    pub fn getReleaseTaskAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, environment_id: i32, attempt_id: i32, plan_id: []const u8, @"type": []const u8) ![]const models.ReleaseTaskAttachment {
+    pub fn getReleaseTaskAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, environment_id: i32, attempt_id: i32, plan_id: []const u8, @"type": []const u8) !models.ReleaseTaskAttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1667,7 +1667,7 @@ pub const Attachments = struct {
             core.pager.logHttpError("Attachments.getReleaseTaskAttachments", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ReleaseTaskAttachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.ReleaseTaskAttachmentList, alloc, resp.body);
     }
     /// Get a release task attachment.
     pub fn getReleaseTaskAttachmentContent(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, environment_id: i32, attempt_id: i32, plan_id: []const u8, timeline_id: []const u8, record_id: []const u8, @"type": []const u8, name: []const u8) !GetReleaseTaskAttachmentContentResult {
@@ -1735,7 +1735,7 @@ pub const Attachments = struct {
         }
     }
     /// GetTaskAttachments API is deprecated. Use GetReleaseTaskAttachments API instead.
-    pub fn getTaskAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, environment_id: i32, attempt_id: i32, timeline_id: []const u8, @"type": []const u8) ![]const models.ReleaseTaskAttachment {
+    pub fn getTaskAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, environment_id: i32, attempt_id: i32, timeline_id: []const u8, @"type": []const u8) !models.ReleaseTaskAttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1774,7 +1774,7 @@ pub const Attachments = struct {
             core.pager.logHttpError("Attachments.getTaskAttachments", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ReleaseTaskAttachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.ReleaseTaskAttachmentList, alloc, resp.body);
     }
     /// GetTaskAttachmentContent API is deprecated. Use GetReleaseTaskAttachmentContent API instead.
     pub fn getTaskAttachmentContent(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, environment_id: i32, attempt_id: i32, timeline_id: []const u8, record_id: []const u8, @"type": []const u8, name: []const u8) !GetTaskAttachmentContentResult {
@@ -1846,7 +1846,7 @@ pub const ManualInterventions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// List all manual interventions for a given release.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32) ![]const models.ManualIntervention {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32) !models.ManualInterventionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1877,7 +1877,7 @@ pub const ManualInterventions = struct {
             core.pager.logHttpError("ManualInterventions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ManualIntervention, alloc, resp.body);
+        return try serde.json.fromSlice(models.ManualInterventionList, alloc, resp.body);
     }
     /// Get manual intervention for a given release and manual intervention id.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, manual_intervention_id: i32) !models.ManualIntervention {

--- a/src/release/models.zig
+++ b/src/release/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `ReleaseApproval` as returned by Azure DevOps.
+pub const ReleaseApprovalList = struct {
+    count: ?i32 = null,
+    value: ?[]const ReleaseApproval = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const ReleaseApproval = struct {
     /// Gets or sets the type of approval.
     approval_type: ?enums.ReleaseApprovalApprovalType = null,
@@ -167,6 +177,16 @@ pub const ReleaseEnvironmentShallowReference = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `ReleaseDefinition` as returned by Azure DevOps.
+pub const ReleaseDefinitionList = struct {
+    count: ?i32 = null,
+    value: ?[]const ReleaseDefinition = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 
@@ -723,6 +743,16 @@ pub const ReleaseTriggerBase = struct {
     };
 };
 
+/// A collection of `ReleaseDefinitionRevision` as returned by Azure DevOps.
+pub const ReleaseDefinitionRevisionList = struct {
+    count: ?i32 = null,
+    value: ?[]const ReleaseDefinitionRevision = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const ReleaseDefinitionRevision = struct {
     /// Gets api-version for revision object.
     api_version: ?[]const u8 = null,
@@ -739,6 +769,16 @@ pub const ReleaseDefinitionRevision = struct {
     definition_url: ?[]const u8 = null,
     /// Get revision number of the definition.
     revision: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Deployment` as returned by Azure DevOps.
+pub const DeploymentList = struct {
+    count: ?i32 = null,
+    value: ?[]const Deployment = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -781,6 +821,16 @@ pub const Deployment = struct {
     scheduled_deployment_time: ?[]const u8 = null,
     /// Gets the date on which deployment is started.
     started_on: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Folder` as returned by Azure DevOps.
+pub const FolderList = struct {
+    count: ?i32 = null,
+    value: ?[]const Folder = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -915,6 +965,16 @@ pub const IgnoredGate = struct {
     last_modified_on: ?[]const u8 = null,
     /// Name of gate ignored.
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Release` as returned by Azure DevOps.
+pub const ReleaseList = struct {
+    count: ?i32 = null,
+    value: ?[]const Release = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1358,6 +1418,16 @@ pub const ReleaseEnvironmentUpdateMetadata = struct {
     };
 };
 
+/// A collection of `ReleaseTaskAttachment` as returned by Azure DevOps.
+pub const ReleaseTaskAttachmentList = struct {
+    count: ?i32 = null,
+    value: ?[]const ReleaseTaskAttachment = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const ReleaseTaskAttachment = struct {
     links: ?ReferenceLinks = null,
     /// Data and time when it created.
@@ -1379,6 +1449,16 @@ pub const ReleaseTaskAttachment = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `ManualIntervention` as returned by Azure DevOps.
+pub const ManualInterventionList = struct {
+    count: ?i32 = null,
+    value: ?[]const ManualIntervention = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 

--- a/src/security/clients.zig
+++ b/src/security/clients.zig
@@ -193,7 +193,7 @@ pub const AccessControlEntries = struct {
         }
     }
     /// Add or update ACEs in the ACL for the provided token. The request body contains the target token, a list of [ACEs](https://docs.microsoft.com/en-us/rest/api/azure/devops/security/access-control-entries/set-access-control-entries?#accesscontrolentry) and a optional merge parameter. In the case of a collision (by identity descriptor) with an existing ACE in the ACL, the 'merge' parameter determines the behavior. If set, the existing ACE has its allow and deny merged with the incoming ACE's allow and deny. If unset, the existing ACE is displaced. For optimal performance and reliability, it is strongly recommended to batch multiple ACEs in a single request rather than sending individual requests. Batching requests improves efficiency, reduces overhead, and helps ensure successful completion of your operations.
-    pub fn setAccessControlEntries(self: *@This(), alloc: std.mem.Allocator, security_namespace_id: []const u8, organization: []const u8, body: models.JObject) ![]const models.AccessControlEntry {
+    pub fn setAccessControlEntries(self: *@This(), alloc: std.mem.Allocator, security_namespace_id: []const u8, organization: []const u8, body: models.JObject) !models.AccessControlEntryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, security_namespace_id);
         defer alloc.free(encoded_path_0);
@@ -226,7 +226,7 @@ pub const AccessControlEntries = struct {
             core.pager.logHttpError("AccessControlEntries.setAccessControlEntries", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AccessControlEntry, alloc, resp.body);
+        return try serde.json.fromSlice(models.AccessControlEntryList, alloc, resp.body);
     }
 };
 
@@ -297,7 +297,7 @@ pub const AccessControlLists = struct {
         }
     }
     /// Return a list of access control lists for the specified security namespace and token. All ACLs in the security namespace will be retrieved if no optional parameters are provided. Note that the response will include all project IDs, including projects the current user does not have access to.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, security_namespace_id: []const u8, organization: []const u8, token: ?[]const u8, descriptors: ?[]const u8, include_extended_info: ?bool, recurse: ?bool) ![]const models.AccessControlList {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, security_namespace_id: []const u8, organization: []const u8, token: ?[]const u8, descriptors: ?[]const u8, include_extended_info: ?bool, recurse: ?bool) !models.AccessControlListList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, security_namespace_id);
         defer alloc.free(encoded_path_0);
@@ -350,7 +350,7 @@ pub const AccessControlLists = struct {
             core.pager.logHttpError("AccessControlLists.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AccessControlList, alloc, resp.body);
+        return try serde.json.fromSlice(models.AccessControlListList, alloc, resp.body);
     }
     /// Create or update one or more access control lists. All data that currently exists for the ACLs supplied will be overwritten.
     pub fn setAccessControlLists(self: *@This(), alloc: std.mem.Allocator, security_namespace_id: []const u8, organization: []const u8, body: models.VssJsonCollectionWrapper) !void {
@@ -532,7 +532,7 @@ pub const SecurityNamespaces = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// List all security namespaces or just the specified namespace.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, security_namespace_id: []const u8, local_only: ?bool) ![]const models.SecurityNamespaceDescription {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, security_namespace_id: []const u8, local_only: ?bool) !models.SecurityNamespaceDescriptionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -566,6 +566,6 @@ pub const SecurityNamespaces = struct {
             core.pager.logHttpError("SecurityNamespaces.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SecurityNamespaceDescription, alloc, resp.body);
+        return try serde.json.fromSlice(models.SecurityNamespaceDescriptionList, alloc, resp.body);
     }
 };

--- a/src/security/models.zig
+++ b/src/security/models.zig
@@ -14,6 +14,16 @@ pub const JObject = struct {
     };
 };
 
+/// A collection of `AccessControlEntry` as returned by Azure DevOps.
+pub const AccessControlEntryList = struct {
+    count: ?i32 = null,
+    value: ?[]const AccessControlEntry = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Class for encapsulating the allowed and denied permissions for a given IdentityDescriptor.
 pub const AccessControlEntry = struct {
     /// The set of permission bits that represent the actions that the associated descriptor is allowed to perform.
@@ -50,6 +60,16 @@ pub const AceExtendedInformation = struct {
     inherited_allow: ?i32 = null,
     /// These are the permissions that are inherited for this identity on this token. If the token does not inherit permissions this will be 0. Note that any permissions that have been explicitly set on this token for this identity, or any groups that this identity is a part of, are not included here.
     inherited_deny: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `AccessControlList` as returned by Azure DevOps.
+pub const AccessControlListList = struct {
+    count: ?i32 = null,
+    value: ?[]const AccessControlList = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -106,6 +126,16 @@ pub const PermissionEvaluation = struct {
     token: ?[]const u8 = null,
     /// Permission evaluation value.
     value: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `SecurityNamespaceDescription` as returned by Azure DevOps.
+pub const SecurityNamespaceDescriptionList = struct {
+    count: ?i32 = null,
+    value: ?[]const SecurityNamespaceDescription = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/security_roles/clients.zig
+++ b/src/security_roles/clients.zig
@@ -113,7 +113,7 @@ pub const Roleassignments = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get role assignments for the resource
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, resource_id: []const u8, organization: []const u8) ![]const models.RoleAssignment {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, resource_id: []const u8, organization: []const u8) !models.RoleAssignmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, scope_id);
         defer alloc.free(encoded_path_0);
@@ -144,7 +144,7 @@ pub const Roleassignments = struct {
             core.pager.logHttpError("Roleassignments.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.RoleAssignment, alloc, resp.body);
+        return try serde.json.fromSlice(models.RoleAssignmentList, alloc, resp.body);
     }
 
     pub fn removeRoleAssignments(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, resource_id: []const u8, organization: []const u8, body: []const []const u8) !void {
@@ -184,7 +184,7 @@ pub const Roleassignments = struct {
         return;
     }
     /// Set role assignments on a resource
-    pub fn setRoleAssignments(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, resource_id: []const u8, organization: []const u8, limit_to_caller_identity_domain: ?bool, body: []const models.UserRoleAssignmentRef) ![]const models.RoleAssignment {
+    pub fn setRoleAssignments(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, resource_id: []const u8, organization: []const u8, limit_to_caller_identity_domain: ?bool, body: []const models.UserRoleAssignmentRef) !models.RoleAssignmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, scope_id);
         defer alloc.free(encoded_path_0);
@@ -224,7 +224,7 @@ pub const Roleassignments = struct {
             core.pager.logHttpError("Roleassignments.setRoleAssignments", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.RoleAssignment, alloc, resp.body);
+        return try serde.json.fromSlice(models.RoleAssignmentList, alloc, resp.body);
     }
     /// Remove the role assignment on a resource
     pub fn removeRoleAssignment(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, resource_id: []const u8, identity_id: []const u8, organization: []const u8) !void {
@@ -308,7 +308,7 @@ pub const Roledefinitions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, organization: []const u8) ![]const models.SecurityRole {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, organization: []const u8) !models.SecurityRoleList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, scope_id);
         defer alloc.free(encoded_path_0);
@@ -337,6 +337,6 @@ pub const Roledefinitions = struct {
             core.pager.logHttpError("Roledefinitions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SecurityRole, alloc, resp.body);
+        return try serde.json.fromSlice(models.SecurityRoleList, alloc, resp.body);
     }
 };

--- a/src/security_roles/models.zig
+++ b/src/security_roles/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `RoleAssignment` as returned by Azure DevOps.
+pub const RoleAssignmentList = struct {
+    count: ?i32 = null,
+    value: ?[]const RoleAssignment = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const RoleAssignment = struct {
     /// Designates the role as explicitly assigned or inherited.
     access: ?enums.RoleAssignmentAccess = null,
@@ -93,6 +103,16 @@ pub const UserRoleAssignmentRef = struct {
     unique_name: ?[]const u8 = null,
     /// Unique id of the user given the role assignment.
     user_id: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `SecurityRole` as returned by Azure DevOps.
+pub const SecurityRoleList = struct {
+    count: ?i32 = null,
+    value: ?[]const SecurityRole = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/service_endpoint/clients.zig
+++ b/src/service_endpoint/clients.zig
@@ -163,7 +163,7 @@ pub const Endpoints = struct {
         return try serde.json.fromSlice(models.ServiceEndpoint, alloc, resp.body);
     }
     /// Update the service endpoints.
-    pub fn updateServiceEndpoints(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: []const models.ServiceEndpoint) ![]const models.ServiceEndpoint {
+    pub fn updateServiceEndpoints(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: []const models.ServiceEndpoint) !models.ServiceEndpointList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -194,7 +194,7 @@ pub const Endpoints = struct {
             core.pager.logHttpError("Endpoints.updateServiceEndpoints", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ServiceEndpoint, alloc, resp.body);
+        return try serde.json.fromSlice(models.ServiceEndpointList, alloc, resp.body);
     }
     /// Delete a service endpoint
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, endpoint_id: []const u8, project_ids: []const u8, deep: ?bool) !void {
@@ -315,7 +315,7 @@ pub const Endpoints = struct {
         return try serde.json.fromSlice(models.ServiceEndpoint, alloc, resp.body);
     }
     /// Get the service endpoints by name.
-    pub fn getServiceEndpointsByNames(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_names: []const u8, @"type": ?[]const u8, auth_schemes: ?[]const u8, owner: ?[]const u8, include_failed: ?bool, include_details: ?bool) ![]const models.ServiceEndpoint {
+    pub fn getServiceEndpointsByNames(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_names: []const u8, @"type": ?[]const u8, auth_schemes: ?[]const u8, owner: ?[]const u8, include_failed: ?bool, include_details: ?bool) !models.ServiceEndpointList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -379,10 +379,10 @@ pub const Endpoints = struct {
             core.pager.logHttpError("Endpoints.getServiceEndpointsByNames", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ServiceEndpoint, alloc, resp.body);
+        return try serde.json.fromSlice(models.ServiceEndpointList, alloc, resp.body);
     }
     /// Gets the service endpoints and patch new authorization parameters
-    pub fn getServiceEndpointsWithRefreshedAuthentication(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_ids: []const u8, body: []const models.RefreshAuthenticationParameters) ![]const models.ServiceEndpoint {
+    pub fn getServiceEndpointsWithRefreshedAuthentication(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_ids: []const u8, body: []const models.RefreshAuthenticationParameters) !models.ServiceEndpointList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -419,7 +419,7 @@ pub const Endpoints = struct {
             core.pager.logHttpError("Endpoints.getServiceEndpointsWithRefreshedAuthentication", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ServiceEndpoint, alloc, resp.body);
+        return try serde.json.fromSlice(models.ServiceEndpointList, alloc, resp.body);
     }
     /// Get the service endpoint details.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_id: []const u8, action_filter: ?enums.GetRequestActionFilter, load_confidential_data: ?bool) !models.ServiceEndpoint {
@@ -474,7 +474,7 @@ pub const Types = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get service endpoint types.
-    pub fn getServiceEndpointTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"type": ?[]const u8, scheme: ?[]const u8) ![]const models.ServiceEndpointType {
+    pub fn getServiceEndpointTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"type": ?[]const u8, scheme: ?[]const u8) !models.ServiceEndpointTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -515,10 +515,10 @@ pub const Types = struct {
             core.pager.logHttpError("Types.getServiceEndpointTypes", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ServiceEndpointType, alloc, resp.body);
+        return try serde.json.fromSlice(models.ServiceEndpointTypeList, alloc, resp.body);
     }
     /// Get service endpoint types with passed types filter.
-    pub fn getFilteredServiceEndpointTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: []const []const u8) ![]const models.ServiceEndpointType {
+    pub fn getFilteredServiceEndpointTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: []const []const u8) !models.ServiceEndpointTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -549,7 +549,7 @@ pub const Types = struct {
             core.pager.logHttpError("Types.getFilteredServiceEndpointTypes", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ServiceEndpointType, alloc, resp.body);
+        return try serde.json.fromSlice(models.ServiceEndpointTypeList, alloc, resp.body);
     }
 };
 
@@ -558,7 +558,7 @@ pub const Executionhistory = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get service endpoint execution records.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_id: []const u8, top: ?i32, continuation_token: ?i64) ![]const models.ServiceEndpointExecutionRecord {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_id: []const u8, top: ?i32, continuation_token: ?i64) !models.ServiceEndpointExecutionRecordList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -599,7 +599,7 @@ pub const Executionhistory = struct {
             core.pager.logHttpError("Executionhistory.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ServiceEndpointExecutionRecord, alloc, resp.body);
+        return try serde.json.fromSlice(models.ServiceEndpointExecutionRecordList, alloc, resp.body);
     }
 };
 

--- a/src/service_endpoint/models.zig
+++ b/src/service_endpoint/models.zig
@@ -163,6 +163,16 @@ pub const ProjectReference = struct {
     };
 };
 
+/// A collection of `ServiceEndpoint` as returned by Azure DevOps.
+pub const ServiceEndpointList = struct {
+    count: ?i32 = null,
+    value: ?[]const ServiceEndpoint = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Specify the properties for refreshing the endpoint authentication object being queried
 pub const RefreshAuthenticationParameters = struct {
     /// EndpointId which needs new authentication params
@@ -171,6 +181,16 @@ pub const RefreshAuthenticationParameters = struct {
     scope: ?[]const i32 = null,
     /// The requested endpoint authentication should be valid for _ minutes. Authentication params will not be refreshed if the token contained in endpoint already has active token.
     token_validity_in_minutes: ?i16 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ServiceEndpointType` as returned by Azure DevOps.
+pub const ServiceEndpointTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const ServiceEndpointType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -520,6 +540,16 @@ pub const HelpLink = struct {
     text: ?[]const u8 = null,
     /// Gets or sets the public url of the help documentation.
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ServiceEndpointExecutionRecord` as returned by Azure DevOps.
+pub const ServiceEndpointExecutionRecordList = struct {
+    count: ?i32 = null,
+    value: ?[]const ServiceEndpointExecutionRecord = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/symbol/clients.zig
+++ b/src/symbol/clients.zig
@@ -350,17 +350,17 @@ pub const Requests = struct {
         status_200: struct {
             status: u16 = 200,
             headers: struct {},
-            body: []const models.DebugEntry,
+            body: models.DebugEntryList,
         },
         status_400: struct {
             status: u16 = 400,
             headers: struct {},
-            body: []const models.DebugEntry,
+            body: models.DebugEntryList,
         },
         status_409: struct {
             status: u16 = 409,
             headers: struct {},
-            body: []const models.DebugEntry,
+            body: models.DebugEntryList,
         },
     };
     /// Delete a symbol request by request name.
@@ -748,7 +748,7 @@ pub const Requests = struct {
 
         switch (resp.status_code) {
             200 => {
-                const response_body = try serde.json.fromSlice([]const models.DebugEntry, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.DebugEntryList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{},
@@ -756,7 +756,7 @@ pub const Requests = struct {
                 } };
             },
             400 => {
-                const response_body = try serde.json.fromSlice([]const models.DebugEntry, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.DebugEntryList, alloc, resp.body);
                 return .{ .status_400 = .{
                     .status = resp.status_code,
                     .headers = .{},
@@ -764,7 +764,7 @@ pub const Requests = struct {
                 } };
             },
             409 => {
-                const response_body = try serde.json.fromSlice([]const models.DebugEntry, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.DebugEntryList, alloc, resp.body);
                 return .{ .status_409 = .{
                     .status = resp.status_code,
                     .headers = .{},

--- a/src/symbol/models.zig
+++ b/src/symbol/models.zig
@@ -122,3 +122,13 @@ pub const JsonBlobIdentifier = struct {
         .rename_all = .camel_case,
     };
 };
+
+/// A collection of `DebugEntry` as returned by Azure DevOps.
+pub const DebugEntryList = struct {
+    count: ?i32 = null,
+    value: ?[]const DebugEntry = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};

--- a/src/test/clients.zig
+++ b/src/test/clients.zig
@@ -185,7 +185,7 @@ pub const CodeCoverage = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get code coverage data for a build.
-    pub fn getBuildCodeCoverage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, flags: i32) ![]const models.BuildCoverage {
+    pub fn getBuildCodeCoverage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, flags: i32) !models.BuildCoverageList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -218,10 +218,10 @@ pub const CodeCoverage = struct {
             core.pager.logHttpError("CodeCoverage.getBuildCodeCoverage", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BuildCoverage, alloc, resp.body);
+        return try serde.json.fromSlice(models.BuildCoverageList, alloc, resp.body);
     }
     /// Get code coverage data for a test run
-    pub fn getTestRunCodeCoverage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, flags: i32) ![]const models.TestRunCoverage {
+    pub fn getTestRunCodeCoverage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, flags: i32) !models.TestRunCoverageList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -254,7 +254,7 @@ pub const CodeCoverage = struct {
             core.pager.logHttpError("CodeCoverage.getTestRunCodeCoverage", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestRunCoverage, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestRunCoverageList, alloc, resp.body);
     }
 };
 
@@ -263,7 +263,7 @@ pub const Points = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of test points.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, wit_fields: ?[]const u8, configuration_id: ?[]const u8, test_case_id: ?[]const u8, test_point_ids: ?[]const u8, include_point_details: ?bool, @"$skip": ?i32, @"$top": ?i32) ![]const models.TestPoint {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, wit_fields: ?[]const u8, configuration_id: ?[]const u8, test_case_id: ?[]const u8, test_point_ids: ?[]const u8, include_point_details: ?bool, @"$skip": ?i32, @"$top": ?i32) !models.TestPointList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -339,7 +339,7 @@ pub const Points = struct {
             core.pager.logHttpError("Points.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestPoint, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestPointList, alloc, resp.body);
     }
     /// Get a test point.
     pub fn getPoint(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, point_ids: i32, wit_fields: ?[]const u8) !models.TestPoint {
@@ -387,7 +387,7 @@ pub const Points = struct {
         return try serde.json.fromSlice(models.TestPoint, alloc, resp.body);
     }
     /// Update test points.
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, point_ids: []const u8, body: models.PointUpdateModel) ![]const models.TestPoint {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, point_ids: []const u8, body: models.PointUpdateModel) !models.TestPointList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -426,7 +426,7 @@ pub const Points = struct {
             core.pager.logHttpError("Points.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestPoint, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestPointList, alloc, resp.body);
     }
     /// Get test points using query.
     pub fn getPointsByQuery(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$skip": ?i32, @"$top": ?i32, body: models.TestPointsQuery) !models.TestPointsQuery {
@@ -481,7 +481,7 @@ pub const TestSuites = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all test cases in a suite.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32) ![]const models.SuiteTestCase {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32) !models.SuiteTestCaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -514,7 +514,7 @@ pub const TestSuites = struct {
             core.pager.logHttpError("TestSuites.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SuiteTestCase, alloc, resp.body);
+        return try serde.json.fromSlice(models.SuiteTestCaseList, alloc, resp.body);
     }
     /// The test points associated with the test cases are removed from the test suite. The test case work item is not deleted from the system. See test cases resource to delete a test case permanently.
     pub fn removeTestCasesFromSuiteUrl(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_case_ids: []const u8) !void {
@@ -592,7 +592,7 @@ pub const TestSuites = struct {
         return try serde.json.fromSlice(models.SuiteTestCase, alloc, resp.body);
     }
     /// Updates the properties of the test case association in a suite.
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_case_ids: []const u8, body: models.SuiteTestCaseUpdateModel) ![]const models.SuiteTestCase {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_case_ids: []const u8, body: models.SuiteTestCaseUpdateModel) !models.SuiteTestCaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -631,10 +631,10 @@ pub const TestSuites = struct {
             core.pager.logHttpError("TestSuites.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SuiteTestCase, alloc, resp.body);
+        return try serde.json.fromSlice(models.SuiteTestCaseList, alloc, resp.body);
     }
     /// Add test cases to suite.
-    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_case_ids: []const u8) ![]const models.SuiteTestCase {
+    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_case_ids: []const u8) !models.SuiteTestCaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -669,7 +669,7 @@ pub const TestSuites = struct {
             core.pager.logHttpError("TestSuites.add", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SuiteTestCase, alloc, resp.body);
+        return try serde.json.fromSlice(models.SuiteTestCaseList, alloc, resp.body);
     }
 };
 
@@ -794,7 +794,7 @@ pub const Runs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of test runs.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_uri: ?[]const u8, owner: ?[]const u8, tmi_run_id: ?[]const u8, plan_id: ?i32, include_run_details: ?bool, automated: ?bool, @"$skip": ?i32, @"$top": ?i32) ![]const models.TestRun {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_uri: ?[]const u8, owner: ?[]const u8, tmi_run_id: ?[]const u8, plan_id: ?i32, include_run_details: ?bool, automated: ?bool, @"$skip": ?i32, @"$top": ?i32) !models.TestRunList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -869,7 +869,7 @@ pub const Runs = struct {
             core.pager.logHttpError("Runs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestRun, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestRunList, alloc, resp.body);
     }
     /// Create new test run.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.RunCreateModel) !models.TestRun {
@@ -1078,7 +1078,7 @@ pub const Attachments = struct {
         },
     };
     /// Get list of test run attachments reference.
-    pub fn getTestRunAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) ![]const models.TestAttachment {
+    pub fn getTestRunAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) !models.TestAttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1109,7 +1109,7 @@ pub const Attachments = struct {
             core.pager.logHttpError("Attachments.getTestRunAttachments", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestAttachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestAttachmentList, alloc, resp.body);
     }
     /// Attach a file to a test run.
     pub fn createTestRunAttachment(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: models.TestAttachmentRequestModel) !models.TestAttachmentReference {
@@ -1203,7 +1203,7 @@ pub const Attachments = struct {
         }
     }
     /// Get list of test result attachments reference.
-    pub fn getTestResultAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) ![]const models.TestAttachment {
+    pub fn getTestResultAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) !models.TestAttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1236,7 +1236,7 @@ pub const Attachments = struct {
             core.pager.logHttpError("Attachments.getTestResultAttachments", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestAttachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestAttachmentList, alloc, resp.body);
     }
     /// Attach a file to a test result.
     pub fn createTestResultAttachment(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32, body: models.TestAttachmentRequestModel) !models.TestAttachmentReference {
@@ -1340,7 +1340,7 @@ pub const Results = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get test results for a test run.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, details_to_include: ?enums.ListRequestDetailsToInclude, @"$skip": ?i32, @"$top": ?i32, outcomes: ?[]const u8) ![]const models.TestCaseResult {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, details_to_include: ?enums.ListRequestDetailsToInclude, @"$skip": ?i32, @"$top": ?i32, outcomes: ?[]const u8) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1395,10 +1395,10 @@ pub const Results = struct {
             core.pager.logHttpError("Results.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
     /// Update test results in a test run.
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) ![]const models.TestCaseResult {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1433,10 +1433,10 @@ pub const Results = struct {
             core.pager.logHttpError("Results.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
     /// Add test results to a test run.
-    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) ![]const models.TestCaseResult {
+    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1471,7 +1471,7 @@ pub const Results = struct {
             core.pager.logHttpError("Results.add", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
     /// Get a test result for a test run.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32, details_to_include: ?enums.GetRequestDetailsToInclude) !models.TestCaseResult {
@@ -1523,7 +1523,7 @@ pub const Iterations = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get iterations for a result
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32, include_action_results: ?bool) ![]const models.TestIterationDetailsModel {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32, include_action_results: ?bool) !models.TestIterationDetailsModelList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1561,7 +1561,7 @@ pub const Iterations = struct {
             core.pager.logHttpError("Iterations.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestIterationDetailsModel, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestIterationDetailsModelList, alloc, resp.body);
     }
     /// Get iteration for a result
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32, iteration_id: i32, include_action_results: ?bool) !models.TestIterationDetailsModel {
@@ -1652,7 +1652,7 @@ pub const Session = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of test sessions
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, period: ?i32, all_sessions: ?bool, include_all_properties: ?bool, source: ?enums.ListRequestSource, include_only_completed_sessions: ?bool) ![]const models.TestSession {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, period: ?i32, all_sessions: ?bool, include_all_properties: ?bool, source: ?enums.ListRequestSource, include_only_completed_sessions: ?bool) !models.TestSessionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1710,7 +1710,7 @@ pub const Session = struct {
             core.pager.logHttpError("Session.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestSession, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestSessionList, alloc, resp.body);
     }
     /// Update a test session
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, body: models.TestSession) !models.TestSession {

--- a/src/test/models.zig
+++ b/src/test/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `BuildCoverage` as returned by Azure DevOps.
+pub const BuildCoverageList = struct {
+    count: ?i32 = null,
+    value: ?[]const BuildCoverage = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Build Coverage Detail
 pub const BuildCoverage = struct {
     /// Code Coverage File Url
@@ -111,6 +121,16 @@ pub const CoverageStatistics = struct {
     };
 };
 
+/// A collection of `TestRunCoverage` as returned by Azure DevOps.
+pub const TestRunCoverageList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestRunCoverage = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Test Run Code Coverage Details
 pub const TestRunCoverage = struct {
     /// Last Error
@@ -120,6 +140,16 @@ pub const TestRunCoverage = struct {
     /// State
     state: ?[]const u8 = null,
     test_run: ?ShallowReference = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestPoint` as returned by Azure DevOps.
+pub const TestPointList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestPoint = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -293,6 +323,16 @@ pub const PointsFilter = struct {
     testcase_ids: ?[]const i32 = null,
     /// List of tester for filtering.
     testers: ?[]const IdentityRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `SuiteTestCase` as returned by Azure DevOps.
+pub const SuiteTestCaseList = struct {
+    count: ?i32 = null,
+    value: ?[]const SuiteTestCase = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -726,6 +766,16 @@ pub const TestCaseResultIdentifier = struct {
     };
 };
 
+/// A collection of `TestRun` as returned by Azure DevOps.
+pub const TestRunList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestRun = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Test run details.
 pub const TestRun = struct {
     build: ?ShallowReference = null,
@@ -1097,6 +1147,16 @@ pub const TestRunStatistic = struct {
     };
 };
 
+/// A collection of `TestAttachment` as returned by Azure DevOps.
+pub const TestAttachmentList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestAttachment = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const TestAttachment = struct {
     /// Attachment type.
     attachment_type: ?enums.TestAttachmentAttachmentType = null,
@@ -1140,6 +1200,36 @@ pub const TestAttachmentReference = struct {
     id: ?i32 = null,
     /// Url to download the attachment.
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestCaseResult` as returned by Azure DevOps.
+pub const TestCaseResultList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestCaseResult = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestIterationDetailsModel` as returned by Azure DevOps.
+pub const TestIterationDetailsModelList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestIterationDetailsModel = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestSession` as returned by Azure DevOps.
+pub const TestSessionList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestSession = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/test_plan/clients.zig
+++ b/src/test_plan/clients.zig
@@ -207,11 +207,11 @@ pub const TestSuites = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestSuite,
+            body: models.TestSuiteList,
         },
     };
     /// Find the list of all test suites in which a given test case is present. This is helpful if you need to find out which test suites are using a test case, when you need to make changes to a test case.
-    pub fn getSuitesByTestCaseId(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, test_case_id: i32) ![]const models.TestSuite {
+    pub fn getSuitesByTestCaseId(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, test_case_id: i32) !models.TestSuiteList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -240,7 +240,7 @@ pub const TestSuites = struct {
             core.pager.logHttpError("TestSuites.getSuitesByTestCaseId", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestSuiteList, alloc, resp.body);
     }
     /// Get test suites for plan.
     pub fn getTestSuitesForPlan(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, expand: ?enums.GetTestSuitesForPlanRequestExpand, continuation_token: ?[]const u8, as_tree_view: ?bool) !GetTestSuitesForPlanResult {
@@ -296,7 +296,7 @@ pub const TestSuites = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestSuiteList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -480,7 +480,7 @@ pub const Configurations = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestConfiguration,
+            body: models.TestConfigurationList,
         },
     };
     /// Delete a test configuration by its ID.
@@ -556,7 +556,7 @@ pub const Configurations = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestConfiguration, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestConfigurationList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -692,7 +692,7 @@ pub const TestPlans = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestPlan,
+            body: models.TestPlanList,
         },
     };
     /// Get a list of test plans
@@ -752,7 +752,7 @@ pub const TestPlans = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestPlan, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestPlanList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -921,7 +921,7 @@ pub const SuiteTestCase = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestCase,
+            body: models.TestCaseList,
         },
     };
     /// Removes test cases from a suite based on the list of test case Ids provided. This API can be used to remove a larger number of test cases.
@@ -1050,7 +1050,7 @@ pub const SuiteTestCase = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestCase, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestCaseList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1066,7 +1066,7 @@ pub const SuiteTestCase = struct {
         }
     }
     /// Update the configurations for test cases
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, body: []const models.SuiteTestCaseCreateUpdateParameters) ![]const models.TestCase {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, body: []const models.SuiteTestCaseCreateUpdateParameters) !models.TestCaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1103,10 +1103,10 @@ pub const SuiteTestCase = struct {
             core.pager.logHttpError("SuiteTestCase.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCase, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseList, alloc, resp.body);
     }
     /// Add test cases to a suite with specified configurations
-    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, body: []const models.SuiteTestCaseCreateUpdateParameters) ![]const models.TestCase {
+    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, body: []const models.SuiteTestCaseCreateUpdateParameters) !models.TestCaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1143,10 +1143,10 @@ pub const SuiteTestCase = struct {
             core.pager.logHttpError("SuiteTestCase.add", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCase, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseList, alloc, resp.body);
     }
     /// Get a particular Test Case from a Suite.
-    pub fn getTestCase(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_case_id: []const u8, wit_fields: ?[]const u8, return_identity_ref: ?bool) ![]const models.TestCase {
+    pub fn getTestCase(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, test_case_id: []const u8, wit_fields: ?[]const u8, return_identity_ref: ?bool) !models.TestCaseList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1193,7 +1193,7 @@ pub const SuiteTestCase = struct {
             core.pager.logHttpError("SuiteTestCase.getTestCase", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCase, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseList, alloc, resp.body);
     }
 };
 
@@ -1202,7 +1202,7 @@ pub const TestPointOperations = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a particular Test Point from a suite.
-    pub fn getPoints(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, point_id: []const u8, return_identity_ref: ?bool, include_point_details: ?bool) ![]const models.TestPoint {
+    pub fn getPoints(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, point_id: []const u8, return_identity_ref: ?bool, include_point_details: ?bool) !models.TestPointList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1249,10 +1249,10 @@ pub const TestPointOperations = struct {
             core.pager.logHttpError("TestPointOperations.getPoints", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestPoint, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestPointList, alloc, resp.body);
     }
     /// Update Test Points. This is used to Reset test point to active, update the outcome of a test point or update the tester of a test point
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, include_point_details: ?bool, return_identity_ref: ?bool, body: []const models.TestPointUpdateParams) ![]const models.TestPoint {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, include_point_details: ?bool, return_identity_ref: ?bool, body: []const models.TestPointUpdateParams) !models.TestPointList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1299,7 +1299,7 @@ pub const TestPointOperations = struct {
             core.pager.logHttpError("TestPointOperations.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestPoint, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestPointList, alloc, resp.body);
     }
 };
 
@@ -1395,7 +1395,7 @@ pub const TestPlanRecycleBin = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestPlan,
+            body: models.TestPlanList,
         },
     };
     /// Get a list of deleted test plans
@@ -1438,7 +1438,7 @@ pub const TestPlanRecycleBin = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestPlan, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestPlanList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1503,7 +1503,7 @@ pub const TestSuiteRecycleBinOperations = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestSuite,
+            body: models.TestSuiteList,
         },
     };
 
@@ -1513,7 +1513,7 @@ pub const TestSuiteRecycleBinOperations = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestSuite,
+            body: models.TestSuiteList,
         },
     };
     /// Get Deleted Test Suites for a Test Plan.
@@ -1570,7 +1570,7 @@ pub const TestSuiteRecycleBinOperations = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestSuiteList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1637,7 +1637,7 @@ pub const TestSuiteRecycleBinOperations = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestSuite, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestSuiteList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1696,7 +1696,7 @@ pub const TestSuiteEntry = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of test suite entries in the test suite.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, suite_id: i32, suite_entry_type: ?enums.ListRequestSuiteEntryType) ![]const models.SuiteEntry {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, suite_id: i32, suite_entry_type: ?enums.ListRequestSuiteEntryType) !models.SuiteEntryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1734,10 +1734,10 @@ pub const TestSuiteEntry = struct {
             core.pager.logHttpError("TestSuiteEntry.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SuiteEntry, alloc, resp.body);
+        return try serde.json.fromSlice(models.SuiteEntryList, alloc, resp.body);
     }
     /// Reorder test suite entries in the test suite.
-    pub fn reorderSuiteEntries(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, suite_id: i32, body: []const models.SuiteEntryUpdateParams) ![]const models.SuiteEntry {
+    pub fn reorderSuiteEntries(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, suite_id: i32, body: []const models.SuiteEntryUpdateParams) !models.SuiteEntryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1772,7 +1772,7 @@ pub const TestSuiteEntry = struct {
             core.pager.logHttpError("TestSuiteEntry.reorderSuiteEntries", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SuiteEntry, alloc, resp.body);
+        return try serde.json.fromSlice(models.SuiteEntryList, alloc, resp.body);
     }
 };
 
@@ -1983,7 +1983,7 @@ pub const Variables = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TestVariable,
+            body: models.TestVariableList,
         },
     };
     /// Get a list of test variables.
@@ -2026,7 +2026,7 @@ pub const Variables = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TestVariable, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TestVariableList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{

--- a/src/test_plan/models.zig
+++ b/src/test_plan/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `TestSuite` as returned by Azure DevOps.
+pub const TestSuiteList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestSuite = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Test suite
 pub const TestSuite = struct {
     /// Test suite default configurations.
@@ -204,6 +214,16 @@ pub const TestSuiteUpdateParams = struct {
     };
 };
 
+/// A collection of `TestConfiguration` as returned by Azure DevOps.
+pub const TestConfigurationList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestConfiguration = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Test configuration
 pub const TestConfiguration = struct {
     /// Description of the configuration
@@ -249,6 +269,16 @@ pub const TestConfigurationCreateUpdateParameters = struct {
     state: ?enums.TestConfigurationState = null,
     /// Dictionary of Test Variable, Selected Value
     values: ?[]const NameValuePair = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestPlan` as returned by Azure DevOps.
+pub const TestPlanList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestPlan = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -420,6 +450,16 @@ pub const TestPlanUpdateParams = struct {
     };
 };
 
+/// A collection of `TestCase` as returned by Azure DevOps.
+pub const TestCaseList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestCase = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Test Case Class
 pub const TestCase = struct {
     links: ?ReferenceLinks = null,
@@ -497,6 +537,16 @@ pub const Configuration = struct {
 pub const WorkItem = struct {
     /// Id of the Work Item
     id: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestPoint` as returned by Azure DevOps.
+pub const TestPointList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestPoint = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -759,6 +809,16 @@ pub const TestPlanAndSuiteRestoreModel = struct {
     };
 };
 
+/// A collection of `SuiteEntry` as returned by Azure DevOps.
+pub const SuiteEntryList = struct {
+    count: ?i32 = null,
+    value: ?[]const SuiteEntry = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// A suite entry defines properties for a test suite.
 pub const SuiteEntry = struct {
     /// Id of the suite entry in the test suite: either a test case id or child suite id.
@@ -896,6 +956,16 @@ pub const SourceTestSuiteResponse = struct {
     project: ?TeamProjectReference = null,
     /// Id of suites to be cloned inside source Test Plan
     test_case_ids: ?[]const i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestVariable` as returned by Azure DevOps.
+pub const TestVariableList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestVariable = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/test_results/clients.zig
+++ b/src/test_results/clients.zig
@@ -501,7 +501,7 @@ pub const Codecoverage = struct {
         return;
     }
 
-    pub fn fetchSourceCodeCoverageReport(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) ![]const models.SourceViewBuildCoverage {
+    pub fn fetchSourceCodeCoverageReport(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) !models.SourceViewBuildCoverageList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -532,10 +532,10 @@ pub const Codecoverage = struct {
             core.pager.logHttpError("Codecoverage.fetchSourceCodeCoverageReport", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.SourceViewBuildCoverage, alloc, resp.body);
+        return try serde.json.fromSlice(models.SourceViewBuildCoverageList, alloc, resp.body);
     }
 
-    pub fn getTestRunCodeCoverage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, flags: i32) ![]const models.TestRunCoverage {
+    pub fn getTestRunCodeCoverage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, flags: i32) !models.TestRunCoverageList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -568,7 +568,7 @@ pub const Codecoverage = struct {
             core.pager.logHttpError("Codecoverage.getTestRunCodeCoverage", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestRunCoverage, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestRunCoverageList, alloc, resp.body);
     }
 };
 
@@ -718,7 +718,7 @@ pub const Extensionfields = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns List of custom test fields for the given custom test field scope.
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, scope_filter: enums.QueryRequestScopeFilter) ![]const models.CustomTestFieldDefinition {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, scope_filter: enums.QueryRequestScopeFilter) !models.CustomTestFieldDefinitionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -751,7 +751,7 @@ pub const Extensionfields = struct {
             core.pager.logHttpError("Extensionfields.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.CustomTestFieldDefinition, alloc, resp.body);
+        return try serde.json.fromSlice(models.CustomTestFieldDefinitionList, alloc, resp.body);
     }
     /// Returns details of the custom test field which is updated.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.CustomTestFieldUpdateDefinition) !models.CustomTestFieldDefinition {
@@ -790,7 +790,7 @@ pub const Extensionfields = struct {
         return try serde.json.fromSlice(models.CustomTestFieldDefinition, alloc, resp.body);
     }
     /// Creates custom test fields based on the data provided.
-    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.CustomTestFieldDefinition) ![]const models.CustomTestFieldDefinition {
+    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.CustomTestFieldDefinition) !models.CustomTestFieldDefinitionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -823,7 +823,7 @@ pub const Extensionfields = struct {
             core.pager.logHttpError("Extensionfields.add", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.CustomTestFieldDefinition, alloc, resp.body);
+        return try serde.json.fromSlice(models.CustomTestFieldDefinitionList, alloc, resp.body);
     }
     /// Returns details of the custom test field for the specified testExtensionFieldId.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, test_extension_field_id: i32) !void {
@@ -1102,7 +1102,7 @@ pub const Resultgroupsbybuild = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.FieldDetailsForTestResults,
+            body: models.FieldDetailsForTestResultsList,
         },
     };
 
@@ -1158,7 +1158,7 @@ pub const Resultgroupsbybuild = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.FieldDetailsForTestResults, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.FieldDetailsForTestResultsList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1186,7 +1186,7 @@ pub const Resultgroupsbyrelease = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.FieldDetailsForTestResults,
+            body: models.FieldDetailsForTestResultsList,
         },
     };
 
@@ -1247,7 +1247,7 @@ pub const Resultgroupsbyrelease = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.FieldDetailsForTestResults, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.FieldDetailsForTestResultsList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -1305,7 +1305,7 @@ pub const Results = struct {
         return try serde.json.fromSlice(models.TestResultsQuery, alloc, resp.body);
     }
 
-    pub fn getTestResultsByQueryWiql(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, include_result_details: ?bool, include_iteration_details: ?bool, @"$skip": ?i32, @"$top": ?i32, body: models.QueryModel) ![]const models.TestCaseResult {
+    pub fn getTestResultsByQueryWiql(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, include_result_details: ?bool, include_iteration_details: ?bool, @"$skip": ?i32, @"$top": ?i32, body: models.QueryModel) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1358,10 +1358,10 @@ pub const Results = struct {
             core.pager.logHttpError("Results.getTestResultsByQueryWiql", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
 
-    pub fn getTestResults(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, details_to_include: ?enums.GetTestResultsRequestDetailsToInclude, @"$skip": ?i32, @"$top": ?i32, outcomes: ?[]const u8, @"$new_tests_only": ?bool) ![]const models.TestCaseResult {
+    pub fn getTestResults(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, details_to_include: ?enums.GetTestResultsRequestDetailsToInclude, @"$skip": ?i32, @"$top": ?i32, outcomes: ?[]const u8, @"$new_tests_only": ?bool) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1421,10 +1421,10 @@ pub const Results = struct {
             core.pager.logHttpError("Results.getTestResults", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
 
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) ![]const models.TestCaseResult {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1459,10 +1459,10 @@ pub const Results = struct {
             core.pager.logHttpError("Results.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
 
-    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) ![]const models.TestCaseResult {
+    pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: []const models.TestCaseResult) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1497,7 +1497,7 @@ pub const Results = struct {
             core.pager.logHttpError("Results.add", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
 
     pub fn getTestResultById(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_result_id: i32, details_to_include: ?enums.GetTestResultByIdRequestDetailsToInclude) !models.TestCaseResult {
@@ -1591,7 +1591,7 @@ pub const ResultMetaData = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get list of test Result meta data details for corresponding testcasereferenceId
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, details_to_include: ?enums.QueryRequestDetailsToInclude, body: []const []const u8) ![]const models.TestResultMetaData {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, details_to_include: ?enums.QueryRequestDetailsToInclude, body: []const []const u8) !models.TestResultMetaDataList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1631,7 +1631,7 @@ pub const ResultMetaData = struct {
             core.pager.logHttpError("ResultMetaData.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestResultMetaData, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestResultMetaDataList, alloc, resp.body);
     }
     /// Update properties of test result meta data
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, test_case_reference_id: i32, body: models.TestResultMetaDataUpdateInput) !models.TestResultMetaData {
@@ -1728,7 +1728,7 @@ pub const Workitems = struct {
         },
     };
     /// Query Test Result WorkItems based on filter
-    pub fn queryTestResultWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_category: []const u8, automated_test_name: ?[]const u8, test_case_id: ?i32, max_complete_date: ?[]const u8, days: ?i32, @"$work_item_count": ?i32) ![]const models.WorkItemReference {
+    pub fn queryTestResultWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_category: []const u8, automated_test_name: ?[]const u8, test_case_id: ?i32, max_complete_date: ?[]const u8, days: ?i32, @"$work_item_count": ?i32) !models.WorkItemReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1790,10 +1790,10 @@ pub const Workitems = struct {
             core.pager.logHttpError("Workitems.queryTestResultWorkItems", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemReferenceList, alloc, resp.body);
     }
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) ![]const models.WorkItemReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) !models.WorkItemReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1826,7 +1826,7 @@ pub const Workitems = struct {
             core.pager.logHttpError("Workitems.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemReferenceList, alloc, resp.body);
     }
 
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, test_name: []const u8, work_item_id: i32) !DeleteResult {
@@ -1925,7 +1925,7 @@ pub const Resultsbybuild = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.ShallowTestCaseResult,
+            body: models.ShallowTestCaseResultList,
         },
     };
 
@@ -1989,7 +1989,7 @@ pub const Resultsbybuild = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.ShallowTestCaseResult, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.ShallowTestCaseResultList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -2011,7 +2011,7 @@ pub const Resultsbypipeline = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of results.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, stage_name: ?[]const u8, phase_name: ?[]const u8, job_name: ?[]const u8, outcomes: ?[]const u8, include_all_build_runs: ?bool, @"$top": ?i32, continuation_token: ?[]const u8) ![]const models.ShallowTestCaseResult {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, stage_name: ?[]const u8, phase_name: ?[]const u8, job_name: ?[]const u8, outcomes: ?[]const u8, include_all_build_runs: ?bool, @"$top": ?i32, continuation_token: ?[]const u8) !models.ShallowTestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2081,7 +2081,7 @@ pub const Resultsbypipeline = struct {
             core.pager.logHttpError("Resultsbypipeline.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ShallowTestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.ShallowTestCaseResultList, alloc, resp.body);
     }
 };
 
@@ -2096,7 +2096,7 @@ pub const Resultsbyrelease = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.ShallowTestCaseResult,
+            body: models.ShallowTestCaseResultList,
         },
     };
 
@@ -2165,7 +2165,7 @@ pub const Resultsbyrelease = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.ShallowTestCaseResult, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.ShallowTestCaseResultList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -2529,7 +2529,7 @@ pub const Resultsummarybyrelease = struct {
         return try serde.json.fromSlice(models.TestResultSummary, alloc, resp.body);
     }
 
-    pub fn queryTestResultsSummaryForReleases(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.ReleaseReference) ![]const models.TestResultSummary {
+    pub fn queryTestResultsSummaryForReleases(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.ReleaseReference) !models.TestResultSummaryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2562,7 +2562,7 @@ pub const Resultsummarybyrelease = struct {
             core.pager.logHttpError("Resultsummarybyrelease.queryTestResultsSummaryForReleases", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestResultSummary, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestResultSummaryList, alloc, resp.body);
     }
 };
 
@@ -2571,7 +2571,7 @@ pub const Resultsummarybyrequirement = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_ids: ?[]const u8, body: models.TestResultsContext) ![]const models.TestSummaryForWorkItem {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_ids: ?[]const u8, body: models.TestResultsContext) !models.TestSummaryForWorkItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2611,7 +2611,7 @@ pub const Resultsummarybyrequirement = struct {
             core.pager.logHttpError("Resultsummarybyrequirement.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestSummaryForWorkItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestSummaryForWorkItemList, alloc, resp.body);
     }
 };
 
@@ -2620,7 +2620,7 @@ pub const ResultTrendByBuild = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultTrendFilter) ![]const models.AggregatedDataForResultTrend {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultTrendFilter) !models.AggregatedDataForResultTrendList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2653,7 +2653,7 @@ pub const ResultTrendByBuild = struct {
             core.pager.logHttpError("ResultTrendByBuild.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AggregatedDataForResultTrend, alloc, resp.body);
+        return try serde.json.fromSlice(models.AggregatedDataForResultTrendList, alloc, resp.body);
     }
 };
 
@@ -2662,7 +2662,7 @@ pub const ResultTrendByRelease = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultTrendFilter) ![]const models.AggregatedDataForResultTrend {
+    pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultTrendFilter) !models.AggregatedDataForResultTrendList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2695,7 +2695,7 @@ pub const ResultTrendByRelease = struct {
             core.pager.logHttpError("ResultTrendByRelease.query", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AggregatedDataForResultTrend, alloc, resp.body);
+        return try serde.json.fromSlice(models.AggregatedDataForResultTrendList, alloc, resp.body);
     }
 };
 
@@ -2704,7 +2704,7 @@ pub const Runs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_uri: ?[]const u8, owner: ?[]const u8, tmi_run_id: ?[]const u8, plan_id: ?i32, include_run_details: ?bool, automated: ?bool, @"$skip": ?i32, @"$top": ?i32) ![]const models.TestRun {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_uri: ?[]const u8, owner: ?[]const u8, tmi_run_id: ?[]const u8, plan_id: ?i32, include_run_details: ?bool, automated: ?bool, @"$skip": ?i32, @"$top": ?i32) !models.TestRunList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2779,7 +2779,7 @@ pub const Runs = struct {
             core.pager.logHttpError("Runs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestRun, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestRunList, alloc, resp.body);
     }
 
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.RunCreateModel) !models.TestRun {
@@ -2959,7 +2959,7 @@ pub const Attachments = struct {
         },
     };
 
-    pub fn getTestRunAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) ![]const models.TestAttachment {
+    pub fn getTestRunAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) !models.TestAttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2990,7 +2990,7 @@ pub const Attachments = struct {
             core.pager.logHttpError("Attachments.getTestRunAttachments", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestAttachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestAttachmentList, alloc, resp.body);
     }
 
     pub fn createTestRunAttachment(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: models.TestAttachmentRequestModel) !models.TestAttachmentReference {
@@ -3119,7 +3119,7 @@ pub const Attachments = struct {
         }
     }
 
-    pub fn getTestResultAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) ![]const models.TestAttachment {
+    pub fn getTestResultAttachments(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) !models.TestAttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3152,7 +3152,7 @@ pub const Attachments = struct {
             core.pager.logHttpError("Attachments.getTestResultAttachments", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestAttachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestAttachmentList, alloc, resp.body);
     }
 
     pub fn createTestResultAttachment(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32, body: models.TestAttachmentRequestModel) !models.TestAttachmentReference {
@@ -3293,7 +3293,7 @@ pub const MessageLogs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get test run message logs
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) ![]const models.TestMessageLogDetails {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) !models.TestMessageLogDetailsList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3324,7 +3324,7 @@ pub const MessageLogs = struct {
             core.pager.logHttpError("MessageLogs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestMessageLogDetails, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestMessageLogDetailsList, alloc, resp.body);
     }
 };
 
@@ -3377,7 +3377,7 @@ pub const Testlog = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get list of test result attachments reference
-    pub fn getTestResultLogs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, result_id: i32, directory_path: ?[]const u8, file_name_prefix: ?[]const u8, fetch_meta_data: ?bool, top: ?i32, continuation_token: ?[]const u8) ![]const models.TestLog {
+    pub fn getTestResultLogs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, result_id: i32, directory_path: ?[]const u8, file_name_prefix: ?[]const u8, fetch_meta_data: ?bool, top: ?i32, continuation_token: ?[]const u8) !models.TestLogList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3439,10 +3439,10 @@ pub const Testlog = struct {
             core.pager.logHttpError("Testlog.getTestResultLogs", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestLog, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestLogList, alloc, resp.body);
     }
     /// Get list of test run attachments reference
-    pub fn getTestRunLogs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, directory_path: ?[]const u8, file_name_prefix: ?[]const u8, fetch_meta_data: ?bool, top: ?i32, continuation_token: ?[]const u8) ![]const models.TestLog {
+    pub fn getTestRunLogs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, directory_path: ?[]const u8, file_name_prefix: ?[]const u8, fetch_meta_data: ?bool, top: ?i32, continuation_token: ?[]const u8) !models.TestLogList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3502,10 +3502,10 @@ pub const Testlog = struct {
             core.pager.logHttpError("Testlog.getTestRunLogs", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestLog, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestLogList, alloc, resp.body);
     }
     /// Get list of build attachments reference
-    pub fn getTestLogsForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, directory_path: ?[]const u8, file_name_prefix: ?[]const u8, fetch_meta_data: ?bool, top: ?i32, continuation_token: ?[]const u8) ![]const models.TestLog {
+    pub fn getTestLogsForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, directory_path: ?[]const u8, file_name_prefix: ?[]const u8, fetch_meta_data: ?bool, top: ?i32, continuation_token: ?[]const u8) !models.TestLogList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3565,7 +3565,7 @@ pub const Testlog = struct {
             core.pager.logHttpError("Testlog.getTestLogsForBuild", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestLog, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestLogList, alloc, resp.body);
     }
 };
 
@@ -3841,7 +3841,7 @@ pub const Bugs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) ![]const models.WorkItemReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) !models.WorkItemReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3874,7 +3874,7 @@ pub const Bugs = struct {
             core.pager.logHttpError("Bugs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemReferenceList, alloc, resp.body);
     }
 };
 
@@ -3883,7 +3883,7 @@ pub const SimilarTestResults = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets the list of results whose failure matches with the provided one.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_result_id: i32, test_sub_result_id: i32, @"$top": ?i32, continuation_token: ?[]const u8) ![]const models.TestCaseResult {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_result_id: i32, test_sub_result_id: i32, @"$top": ?i32, continuation_token: ?[]const u8) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3924,7 +3924,7 @@ pub const SimilarTestResults = struct {
             core.pager.logHttpError("SimilarTestResults.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestCaseResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestCaseResultList, alloc, resp.body);
     }
 };
 
@@ -4013,7 +4013,7 @@ pub const Tags = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Update tags of a run, Tags can be Added and Deleted
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: models.TestTagsUpdateModel) ![]const models.TestTag {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: models.TestTagsUpdateModel) !models.TestTagList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4048,10 +4048,10 @@ pub const Tags = struct {
             core.pager.logHttpError("Tags.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestTag, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestTagList, alloc, resp.body);
     }
     /// Get all the tags in a build.
-    pub fn getTestTagsForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) ![]const models.TestTag {
+    pub fn getTestTagsForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) !models.TestTagList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4082,7 +4082,7 @@ pub const Tags = struct {
             core.pager.logHttpError("Tags.getTestTagsForBuild", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestTag, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestTagList, alloc, resp.body);
     }
 };
 
@@ -4128,7 +4128,7 @@ pub const Testattachments = struct {
         return;
     }
     /// Returns a list of attachments for the specified runId from the LogStore.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) ![]const models.TestLogStoreAttachment {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) !models.TestLogStoreAttachmentList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4159,7 +4159,7 @@ pub const Testattachments = struct {
             core.pager.logHttpError("Testattachments.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestLogStoreAttachment, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestLogStoreAttachmentList, alloc, resp.body);
     }
     /// Creates an attachment in the LogStore for the specified runId.
     pub fn createTestRunLogStoreAttachment(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: models.TestAttachmentRequestModel) !models.TestLogStoreAttachmentReference {
@@ -4424,7 +4424,7 @@ pub const Testfailuretype = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns the list of test failure types.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.TestResultFailureType {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.TestResultFailureTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -4453,7 +4453,7 @@ pub const Testfailuretype = struct {
             core.pager.logHttpError("Testfailuretype.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TestResultFailureType, alloc, resp.body);
+        return try serde.json.fromSlice(models.TestResultFailureTypeList, alloc, resp.body);
     }
     /// Creates a new test failure type
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultFailureTypeRequestModel) !models.TestResultFailureType {

--- a/src/test_results/models.zig
+++ b/src/test_results/models.zig
@@ -66,6 +66,16 @@ pub const CodeCoverageStatistics = struct {
     };
 };
 
+/// A collection of `SourceViewBuildCoverage` as returned by Azure DevOps.
+pub const SourceViewBuildCoverageList = struct {
+    count: ?i32 = null,
+    value: ?[]const SourceViewBuildCoverage = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const SourceViewBuildCoverage = struct {
     configuration: ?BuildConfiguration = null,
     folder_coverage_data: ?FolderCoverageData = null,
@@ -144,6 +154,16 @@ pub const FileCoverageData = struct {
     };
 };
 
+/// A collection of `TestRunCoverage` as returned by Azure DevOps.
+pub const TestRunCoverageList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestRunCoverage = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Test Run Code Coverage Details
 pub const TestRunCoverage = struct {
     /// Last Error
@@ -193,6 +213,16 @@ pub const FileCoverageRequest = struct {
     pull_request_id: ?i32 = null,
     pull_request_iteration_id: ?i32 = null,
     repo_id: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `CustomTestFieldDefinition` as returned by Azure DevOps.
+pub const CustomTestFieldDefinitionList = struct {
+    count: ?i32 = null,
+    value: ?[]const CustomTestFieldDefinition = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -816,6 +846,16 @@ pub const AggregatedResultsByOutcomeGroupByValue = struct {
     };
 };
 
+/// A collection of `FieldDetailsForTestResults` as returned by Azure DevOps.
+pub const FieldDetailsForTestResultsList = struct {
+    count: ?i32 = null,
+    value: ?[]const FieldDetailsForTestResults = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const FieldDetailsForTestResults = struct {
     /// Group by field name
     field_name: ?[]const u8 = null,
@@ -881,6 +921,16 @@ pub const QueryModel = struct {
     };
 };
 
+/// A collection of `TestCaseResult` as returned by Azure DevOps.
+pub const TestCaseResultList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestCaseResult = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const TestResultHistory = struct {
     group_by_field: ?[]const u8 = null,
     results_for_group: ?[]const TestResultHistoryDetailsForGroup = null,
@@ -900,6 +950,16 @@ pub const TestResultHistoryDetailsForGroup = struct {
 };
 
 pub const TestResultHistoryDetailsForGroupGroupByValue = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestResultMetaData` as returned by Azure DevOps.
+pub const TestResultMetaDataList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestResultMetaData = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };
@@ -991,6 +1051,16 @@ pub const TestResultHistoryForGroup = struct {
     };
 };
 
+/// A collection of `WorkItemReference` as returned by Azure DevOps.
+pub const WorkItemReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemReference = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// WorkItem reference Details.
 pub const WorkItemReference = struct {
     /// WorkItem Id.
@@ -1023,6 +1093,16 @@ pub const TestMethod = struct {
     container: ?[]const u8 = null,
     name: ?[]const u8 = null,
     test_result: ?TestCaseResult = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ShallowTestCaseResult` as returned by Azure DevOps.
+pub const ShallowTestCaseResultList = struct {
+    count: ?i32 = null,
+    value: ?[]const ShallowTestCaseResult = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1123,6 +1203,26 @@ pub const TestFailuresAnalysis = struct {
     };
 };
 
+/// A collection of `TestResultSummary` as returned by Azure DevOps.
+pub const TestResultSummaryList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestResultSummary = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestSummaryForWorkItem` as returned by Azure DevOps.
+pub const TestSummaryForWorkItemList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestSummaryForWorkItem = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const TestSummaryForWorkItem = struct {
     summary: ?AggregatedDataForResultTrend = null,
     work_item: ?WorkItemReference = null,
@@ -1154,6 +1254,26 @@ pub const TestResultTrendFilter = struct {
     publish_context: ?[]const u8 = null,
     test_run_titles: ?[]const []const u8 = null,
     trend_days: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `AggregatedDataForResultTrend` as returned by Azure DevOps.
+pub const AggregatedDataForResultTrendList = struct {
+    count: ?i32 = null,
+    value: ?[]const AggregatedDataForResultTrend = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestRun` as returned by Azure DevOps.
+pub const TestRunList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestRun = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1470,6 +1590,16 @@ pub const TestMessageLogDetails = struct {
     };
 };
 
+/// A collection of `TestAttachment` as returned by Azure DevOps.
+pub const TestAttachmentList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestAttachment = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const TestAttachment = struct {
     /// Attachment type.
     attachment_type: ?enums.TestAttachmentAttachmentType = null,
@@ -1519,6 +1649,16 @@ pub const TestAttachmentReference = struct {
     };
 };
 
+/// A collection of `TestMessageLogDetails` as returned by Azure DevOps.
+pub const TestMessageLogDetailsList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestMessageLogDetails = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const TestResultDocument = struct {
     operation_reference: ?TestOperationReference = null,
     payload: ?TestResultPayload = null,
@@ -1543,6 +1683,16 @@ pub const TestResultPayload = struct {
     comment: ?[]const u8 = null,
     name: ?[]const u8 = null,
     stream: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestLog` as returned by Azure DevOps.
+pub const TestLogList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestLog = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1627,6 +1777,26 @@ pub const TestTagsUpdateModel = struct {
 };
 
 pub const TestTagsUpdateModelTag = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestTag` as returned by Azure DevOps.
+pub const TestTagList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestTag = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestLogStoreAttachment` as returned by Azure DevOps.
+pub const TestLogStoreAttachmentList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestLogStoreAttachment = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };
@@ -1774,6 +1944,16 @@ pub const TestResultsUpdateSettings = struct {
 pub const TestTagSummary = struct {
     /// Dictionary which contains tags associated with a test run.
     tags_group_by_test_artifact: ?std.json.ArrayHashMap([]const TestTag) = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TestResultFailureType` as returned by Azure DevOps.
+pub const TestResultFailureTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const TestResultFailureType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/tfvc/clients.zig
+++ b/src/tfvc/clients.zig
@@ -143,7 +143,7 @@ pub const Changesets = struct {
             headers: struct {
                 x_ms_continuationtoken: ?[]const u8 = null,
             },
-            body: []const models.TfvcChange,
+            body: models.TfvcChangeList,
         },
     };
     /// Retrieve Tfvc changes for a given changeset.
@@ -196,7 +196,7 @@ pub const Changesets = struct {
                 else
                     null;
                 errdefer if (response_header_0) |value| alloc.free(value);
-                const response_body = try serde.json.fromSlice([]const models.TfvcChange, alloc, resp.body);
+                const response_body = try serde.json.fromSlice(models.TfvcChangeList, alloc, resp.body);
                 return .{ .status_200 = .{
                     .status = resp.status_code,
                     .headers = .{
@@ -212,7 +212,7 @@ pub const Changesets = struct {
         }
     }
     /// Retrieves the work items associated with a particular changeset.
-    pub fn getChangesetWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32) ![]const models.AssociatedWorkItem {
+    pub fn getChangesetWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32) !models.AssociatedWorkItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -241,10 +241,10 @@ pub const Changesets = struct {
             core.pager.logHttpError("Changesets.getChangesetWorkItems", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AssociatedWorkItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.AssociatedWorkItemList, alloc, resp.body);
     }
     /// Returns changesets for a given list of changeset Ids.
-    pub fn getBatchedChangesets(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.TfvcChangesetsRequestData) ![]const models.TfvcChangesetRef {
+    pub fn getBatchedChangesets(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.TfvcChangesetsRequestData) !models.TfvcChangesetRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -275,10 +275,10 @@ pub const Changesets = struct {
             core.pager.logHttpError("Changesets.getBatchedChangesets", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TfvcChangesetRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.TfvcChangesetRefList, alloc, resp.body);
     }
     /// Retrieve Tfvc Changesets Note: This is a new version of the GetChangesets API that doesn't expose the unneeded queryParams present in the 1.0 version of the API.
-    pub fn getChangesets(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, max_comment_length: ?i32, @"$skip": ?i32, @"$top": ?i32, @"$orderby": ?[]const u8, search_criteria_author: ?[]const u8, search_criteria_follow_renames: ?bool, search_criteria_from_date: ?[]const u8, search_criteria_from_id: ?i32, search_criteria_include_links: ?bool, search_criteria_item_path: ?[]const u8, search_criteria_mappings: ?[]const models.TfvcMappingFilter, search_criteria_to_date: ?[]const u8, search_criteria_to_id: ?i32) ![]const models.TfvcChangesetRef {
+    pub fn getChangesets(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, max_comment_length: ?i32, @"$skip": ?i32, @"$top": ?i32, @"$orderby": ?[]const u8, search_criteria_author: ?[]const u8, search_criteria_follow_renames: ?bool, search_criteria_from_date: ?[]const u8, search_criteria_from_id: ?i32, search_criteria_include_links: ?bool, search_criteria_item_path: ?[]const u8, search_criteria_mappings: ?[]const models.TfvcMappingFilter, search_criteria_to_date: ?[]const u8, search_criteria_to_id: ?i32) !models.TfvcChangesetRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -392,7 +392,7 @@ pub const Changesets = struct {
             core.pager.logHttpError("Changesets.getChangesets", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TfvcChangesetRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.TfvcChangesetRefList, alloc, resp.body);
     }
     /// Create a new changeset. Accepts TfvcChangeset as JSON body
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TfvcChangeset) !models.TfvcChangesetRef {
@@ -576,7 +576,7 @@ pub const Labels = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get items under a label.
-    pub fn getLabelItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, label_id: []const u8, @"$top": ?i32, @"$skip": ?i32) ![]const models.TfvcItem {
+    pub fn getLabelItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, label_id: []const u8, @"$top": ?i32, @"$skip": ?i32) !models.TfvcItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -615,10 +615,10 @@ pub const Labels = struct {
             core.pager.logHttpError("Labels.getLabelItems", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TfvcItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.TfvcItemList, alloc, resp.body);
     }
     /// Get a collection of shallow label references.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, request_data_include_links: ?bool, request_data_item_label_filter: ?[]const u8, request_data_label_scope: ?[]const u8, request_data_max_item_count: ?i32, request_data_name: ?[]const u8, request_data_owner: ?[]const u8, @"$top": ?i32, @"$skip": ?i32) ![]const models.TfvcLabelRef {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, request_data_include_links: ?bool, request_data_item_label_filter: ?[]const u8, request_data_label_scope: ?[]const u8, request_data_max_item_count: ?i32, request_data_name: ?[]const u8, request_data_owner: ?[]const u8, @"$top": ?i32, @"$skip": ?i32) !models.TfvcLabelRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -695,7 +695,7 @@ pub const Labels = struct {
             core.pager.logHttpError("Labels.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TfvcLabelRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.TfvcLabelRefList, alloc, resp.body);
     }
     /// Get a single deep label.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, label_id: []const u8, project: []const u8, request_data_include_links: ?bool, request_data_item_label_filter: ?[]const u8, request_data_label_scope: ?[]const u8, request_data_max_item_count: ?i32, request_data_name: ?[]const u8, request_data_owner: ?[]const u8) !models.TfvcLabel {
@@ -849,7 +849,7 @@ pub const Shelvesets = struct {
         return try serde.json.fromSlice(models.TfvcShelveset, alloc, resp.body);
     }
     /// Get changes included in a shelveset.
-    pub fn getShelvesetChanges(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, shelveset_id: []const u8, @"$top": ?i32, @"$skip": ?i32) ![]const models.TfvcChange {
+    pub fn getShelvesetChanges(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, shelveset_id: []const u8, @"$top": ?i32, @"$skip": ?i32) !models.TfvcChangeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -890,10 +890,10 @@ pub const Shelvesets = struct {
             core.pager.logHttpError("Shelvesets.getShelvesetChanges", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TfvcChange, alloc, resp.body);
+        return try serde.json.fromSlice(models.TfvcChangeList, alloc, resp.body);
     }
     /// Get work items associated with a shelveset.
-    pub fn getShelvesetWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, shelveset_id: []const u8) ![]const models.AssociatedWorkItem {
+    pub fn getShelvesetWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, shelveset_id: []const u8) !models.AssociatedWorkItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -924,7 +924,7 @@ pub const Shelvesets = struct {
             core.pager.logHttpError("Shelvesets.getShelvesetWorkItems", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AssociatedWorkItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.AssociatedWorkItemList, alloc, resp.body);
     }
 };
 
@@ -933,7 +933,7 @@ pub const Branches = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get branch hierarchies below the specified scopePath
-    pub fn getBranchRefs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_path: []const u8, project: []const u8, include_deleted: ?bool, include_links: ?bool) ![]const models.TfvcBranchRef {
+    pub fn getBranchRefs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_path: []const u8, project: []const u8, include_deleted: ?bool, include_links: ?bool) !models.TfvcBranchRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -976,7 +976,7 @@ pub const Branches = struct {
             core.pager.logHttpError("Branches.getBranchRefs", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TfvcBranchRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.TfvcBranchRefList, alloc, resp.body);
     }
 };
 
@@ -1047,7 +1047,7 @@ pub const Items = struct {
         }
     }
     /// Get a list of Tfvc items
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, scope_path: ?[]const u8, recursion_level: ?enums.ListRequestRecursionLevel, include_links: ?bool, version_descriptor_version: ?[]const u8, @"version_descriptor.version_option": ?enums.ListRequestVersionDescriptorVersionOption, @"version_descriptor.version_type": ?enums.ListRequestVersionDescriptorVersionType) ![]const models.TfvcItem {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, scope_path: ?[]const u8, recursion_level: ?enums.ListRequestRecursionLevel, include_links: ?bool, version_descriptor_version: ?[]const u8, @"version_descriptor.version_option": ?enums.ListRequestVersionDescriptorVersionOption, @"version_descriptor.version_type": ?enums.ListRequestVersionDescriptorVersionType) !models.TfvcItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1116,6 +1116,6 @@ pub const Items = struct {
             core.pager.logHttpError("Items.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TfvcItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.TfvcItemList, alloc, resp.body);
     }
 };

--- a/src/tfvc/models.zig
+++ b/src/tfvc/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `TfvcChange` as returned by Azure DevOps.
+pub const TfvcChangeList = struct {
+    count: ?i32 = null,
+    value: ?[]const TfvcChange = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// A change.
 pub const TfvcChange = struct {
     /// The type of change that was made to the item.
@@ -48,6 +58,16 @@ pub const TfvcMergeSource = struct {
     };
 };
 
+/// A collection of `AssociatedWorkItem` as returned by Azure DevOps.
+pub const AssociatedWorkItemList = struct {
+    count: ?i32 = null,
+    value: ?[]const AssociatedWorkItem = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const AssociatedWorkItem = struct {
     assigned_to: ?[]const u8 = null,
     /// Id of associated the work item.
@@ -72,6 +92,16 @@ pub const TfvcChangesetsRequestData = struct {
     comment_length: ?i32 = null,
     /// Whether to include the _links field on the shallow references
     include_links: ?bool = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TfvcChangesetRef` as returned by Azure DevOps.
+pub const TfvcChangesetRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const TfvcChangesetRef = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -235,6 +265,16 @@ pub const TfvcPolicyFailureInfo = struct {
     };
 };
 
+/// A collection of `TfvcItem` as returned by Azure DevOps.
+pub const TfvcItemList = struct {
+    count: ?i32 = null,
+    value: ?[]const TfvcItem = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Metadata for an item.
 pub const TfvcItem = struct {
     links: ?ReferenceLinks = null,
@@ -277,6 +317,16 @@ pub const FileContentMetadata = struct {
     is_binary: ?bool = null,
     is_image: ?bool = null,
     vs_link: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TfvcLabelRef` as returned by Azure DevOps.
+pub const TfvcLabelRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const TfvcLabelRef = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -364,6 +414,16 @@ pub const TfvcShelveset = struct {
         .rename = .{
             .links = "_links",
         },
+    };
+};
+
+/// A collection of `TfvcBranchRef` as returned by Azure DevOps.
+pub const TfvcBranchRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const TfvcBranchRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
     };
 };
 

--- a/src/wiki/clients.zig
+++ b/src/wiki/clients.zig
@@ -145,7 +145,7 @@ pub const Wikis = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets all wikis in a project or collection.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.WikiV2 {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WikiV2List {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -174,7 +174,7 @@ pub const Wikis = struct {
             core.pager.logHttpError("Wikis.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WikiV2, alloc, resp.body);
+        return try serde.json.fromSlice(models.WikiV2List, alloc, resp.body);
     }
     /// Creates the wiki resource.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.WikiCreateParametersV2) !models.WikiV2 {
@@ -1257,7 +1257,7 @@ pub const PagesBatch = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns pageable list of Wiki Pages
-    pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, wiki_identifier: []const u8, version_descriptor_version: ?[]const u8, @"version_descriptor.version_options": ?enums.GetRequestVersionDescriptorVersionOptions, @"version_descriptor.version_type": ?enums.GetRequestVersionDescriptorVersionType, body: models.WikiPagesBatchRequest) ![]const models.WikiPageDetail {
+    pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, wiki_identifier: []const u8, version_descriptor_version: ?[]const u8, @"version_descriptor.version_options": ?enums.GetRequestVersionDescriptorVersionOptions, @"version_descriptor.version_type": ?enums.GetRequestVersionDescriptorVersionType, body: models.WikiPagesBatchRequest) !models.WikiPageDetailList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1313,6 +1313,6 @@ pub const PagesBatch = struct {
             core.pager.logHttpError("PagesBatch.get", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WikiPageDetail, alloc, resp.body);
+        return try serde.json.fromSlice(models.WikiPageDetailList, alloc, resp.body);
     }
 };

--- a/src/wiki/models.zig
+++ b/src/wiki/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `WikiV2` as returned by Azure DevOps.
+pub const WikiV2List = struct {
+    count: ?i32 = null,
+    value: ?[]const WikiV2 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Defines a wiki resource.
 pub const WikiV2 = struct {
     /// Folder path inside repository which is shown as Wiki. Not required for ProjectWiki type.
@@ -190,6 +200,16 @@ pub const WikiPagesBatchRequest = struct {
     page_views_for_days: ?i32 = null,
     /// Total count of pages on a wiki to return.
     top: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WikiPageDetail` as returned by Azure DevOps.
+pub const WikiPageDetailList = struct {
+    count: ?i32 = null,
+    value: ?[]const WikiPageDetail = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/wit/clients.zig
+++ b/src/wit/clients.zig
@@ -353,7 +353,7 @@ pub const ArtifactLinkTypes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get the list of work item tracking outbound artifact link types.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.WorkArtifactLink {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.WorkArtifactLinkList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -380,7 +380,7 @@ pub const ArtifactLinkTypes = struct {
             core.pager.logHttpError("ArtifactLinkTypes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkArtifactLink, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkArtifactLinkList, alloc, resp.body);
     }
 };
 
@@ -399,7 +399,7 @@ pub const WorkItemIcons = struct {
         },
     };
     /// Get a list of all work item icons.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.WorkItemIcon {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.WorkItemIconList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -426,7 +426,7 @@ pub const WorkItemIcons = struct {
             core.pager.logHttpError("WorkItemIcons.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemIcon, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemIconList, alloc, resp.body);
     }
     /// Get a work item icon given the friendly name and icon color.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, icon: []const u8, organization: []const u8, color: ?[]const u8, v: ?i32) !GetResult {
@@ -495,7 +495,7 @@ pub const WorkItemRelationTypes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets the work item relation types.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.WorkItemRelationType {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.WorkItemRelationTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -522,7 +522,7 @@ pub const WorkItemRelationTypes = struct {
             core.pager.logHttpError("WorkItemRelationTypes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemRelationType, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemRelationTypeList, alloc, resp.body);
     }
     /// Gets the work item relation type definition.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, relation: []const u8) !models.WorkItemRelationType {
@@ -563,7 +563,7 @@ pub const WorkItemTransitions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns the next state on the given work item IDs.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, ids: []const u8, action: ?[]const u8) ![]const models.WorkItemNextStateOnTransition {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, ids: []const u8, action: ?[]const u8) !models.WorkItemNextStateOnTransitionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -601,7 +601,7 @@ pub const WorkItemTransitions = struct {
             core.pager.logHttpError("WorkItemTransitions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemNextStateOnTransition, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemNextStateOnTransitionList, alloc, resp.body);
     }
 };
 
@@ -610,7 +610,7 @@ pub const AccountMyWorkRecentActivity = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets recent work item activities
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) ![]const models.AccountRecentActivityWorkItemModel2 {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.AccountRecentActivityWorkItemModel2List {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -637,7 +637,7 @@ pub const AccountMyWorkRecentActivity = struct {
             core.pager.logHttpError("AccountMyWorkRecentActivity.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.AccountRecentActivityWorkItemModel2, alloc, resp.body);
+        return try serde.json.fromSlice(models.AccountRecentActivityWorkItemModel2List, alloc, resp.body);
     }
 };
 
@@ -646,7 +646,7 @@ pub const GithubConnections = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets a list of github connections
-    pub fn getGithubConnections(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.GitHubConnectionModel {
+    pub fn getGithubConnections(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.GitHubConnectionModelList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -675,10 +675,10 @@ pub const GithubConnections = struct {
             core.pager.logHttpError("GithubConnections.getGithubConnections", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitHubConnectionModel, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitHubConnectionModelList, alloc, resp.body);
     }
     /// Gets a list of repos within specified github connection.
-    pub fn getGithubConnectionRepositories(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, connection_id: []const u8) ![]const models.GitHubConnectionRepoModel {
+    pub fn getGithubConnectionRepositories(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, connection_id: []const u8) !models.GitHubConnectionRepoModelList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -709,10 +709,10 @@ pub const GithubConnections = struct {
             core.pager.logHttpError("GithubConnections.getGithubConnectionRepositories", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitHubConnectionRepoModel, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitHubConnectionRepoModelList, alloc, resp.body);
     }
     /// Add/remove list of repos within specified github connection.
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, connection_id: []const u8, body: models.GitHubConnectionReposBatchRequest) ![]const models.GitHubConnectionRepoModel {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, connection_id: []const u8, body: models.GitHubConnectionReposBatchRequest) !models.GitHubConnectionRepoModelList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -747,7 +747,7 @@ pub const GithubConnections = struct {
             core.pager.logHttpError("GithubConnections.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.GitHubConnectionRepoModel, alloc, resp.body);
+        return try serde.json.fromSlice(models.GitHubConnectionRepoModelList, alloc, resp.body);
     }
 };
 
@@ -1010,7 +1010,7 @@ pub const ClassificationNodes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets root classification nodes under the project.
-    pub fn getRootNodes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$depth": ?i32) ![]const models.WorkItemClassificationNode {
+    pub fn getRootNodes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$depth": ?i32) !models.WorkItemClassificationNodeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1044,7 +1044,7 @@ pub const ClassificationNodes = struct {
             core.pager.logHttpError("ClassificationNodes.getRootNodes", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemClassificationNode, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemClassificationNodeList, alloc, resp.body);
     }
     /// Delete an existing classification node.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, structure_group: enums.DeleteRequestStructureGroup, path: []const u8, @"$reclassify_id": ?i32) !void {
@@ -1214,7 +1214,7 @@ pub const Fields = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns information for all fields. The project ID/name parameter is optional.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.ListRequestExpand) ![]const models.WorkItemField2 {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.ListRequestExpand) !models.WorkItemField2List {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1250,7 +1250,7 @@ pub const Fields = struct {
             core.pager.logHttpError("Fields.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemField2, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemField2List, alloc, resp.body);
     }
     /// Create a new field.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.WorkItemField2) !models.WorkItemField2 {
@@ -1442,7 +1442,7 @@ pub const Queries = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets the root queries and their children
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.ListRequestExpand1, @"$depth": ?i32, @"$include_deleted": ?bool) ![]const models.QueryHierarchyItem {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.ListRequestExpand1, @"$depth": ?i32, @"$include_deleted": ?bool) !models.QueryHierarchyItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1488,7 +1488,7 @@ pub const Queries = struct {
             core.pager.logHttpError("Queries.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.QueryHierarchyItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.QueryHierarchyItemList, alloc, resp.body);
     }
     /// Delete a query or a folder. This deletes any permission change on the deleted query or folder and any of its descendants if it is a folder. It is important to note that the deleted permission changes cannot be recovered upon undeleting the query or folder.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, query: []const u8) !void {
@@ -1666,7 +1666,7 @@ pub const Queries = struct {
         return try serde.json.fromSlice(models.QueryHierarchyItem, alloc, resp.body);
     }
     /// Gets a list of queries by ids (Maximum 1000)
-    pub fn getQueriesBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.QueryBatchGetRequest) ![]const models.QueryHierarchyItem {
+    pub fn getQueriesBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.QueryBatchGetRequest) !models.QueryHierarchyItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1699,7 +1699,7 @@ pub const Queries = struct {
             core.pager.logHttpError("Queries.getQueriesBatch", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.QueryHierarchyItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.QueryHierarchyItemList, alloc, resp.body);
     }
 };
 
@@ -1708,7 +1708,7 @@ pub const Recyclebin = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets a list of the IDs and the URLs of the deleted the work items in the Recycle Bin.
-    pub fn getDeletedWorkItemShallowReferences(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.WorkItemDeleteShallowReference {
+    pub fn getDeletedWorkItemShallowReferences(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemDeleteShallowReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1737,7 +1737,7 @@ pub const Recyclebin = struct {
             core.pager.logHttpError("Recyclebin.getDeletedWorkItemShallowReferences", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemDeleteShallowReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemDeleteShallowReferenceList, alloc, resp.body);
     }
     /// Destroys the specified work item permanently from the Recycle Bin. This action can not be undone.
     pub fn destroyWorkItem(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, project: []const u8) !void {
@@ -2168,7 +2168,7 @@ pub const Tags = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all the tags for the project.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.WorkItemTagDefinition {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemTagDefinitionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2197,7 +2197,7 @@ pub const Tags = struct {
             core.pager.logHttpError("Tags.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemTagDefinition, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemTagDefinitionList, alloc, resp.body);
     }
     /// Delete the tag for the project. Please note, that the deleted tag will be removed from all Work Items as well as Pull Requests.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, tag_id_or_name: []const u8) !void {
@@ -2353,7 +2353,7 @@ pub const WorkItems = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns a list of work items (Maximum 200)
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, ids: []const u8, project: []const u8, fields: ?[]const u8, as_of: ?[]const u8, @"$expand": ?enums.ListRequestExpand2, error_policy: ?enums.ListRequestErrorPolicy) ![]const models.WorkItem {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, ids: []const u8, project: []const u8, fields: ?[]const u8, as_of: ?[]const u8, @"$expand": ?enums.ListRequestExpand2, error_policy: ?enums.ListRequestErrorPolicy) !models.WorkItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2414,7 +2414,7 @@ pub const WorkItems = struct {
             core.pager.logHttpError("WorkItems.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemList, alloc, resp.body);
     }
     /// Returns a single work item from a template.
     pub fn getWorkItemTemplate(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8, fields: ?[]const u8, as_of: ?[]const u8, @"$expand": ?enums.GetWorkItemTemplateRequestExpand) !models.WorkItem {
@@ -2686,7 +2686,7 @@ pub const WorkItems = struct {
         return try serde.json.fromSlice(models.WorkItem, alloc, resp.body);
     }
     /// Gets work items for a list of work item ids (Maximum 200)
-    pub fn getWorkItemsBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.WorkItemBatchGetRequest) ![]const models.WorkItem {
+    pub fn getWorkItemsBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.WorkItemBatchGetRequest) !models.WorkItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2719,7 +2719,7 @@ pub const WorkItems = struct {
             core.pager.logHttpError("WorkItems.getWorkItemsBatch", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemList, alloc, resp.body);
     }
     /// Deletes specified work items and sends them to the Recycle Bin, so that it can be restored back, if required. Optionally, if the destroy parameter has been set to true, it destroys the work item permanently. WARNING: If the destroy parameter is set to true, work items deleted by this command will NOT go to recycle-bin and there is no way to restore/recover them after deletion.
     pub fn deleteWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.WorkItemDeleteBatchRequest) !models.WorkItemDeleteBatch {
@@ -2764,7 +2764,7 @@ pub const Revisions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns the list of fully hydrated work item revisions, paged.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, project: []const u8, @"$top": ?i32, @"$skip": ?i32, @"$expand": ?enums.ListRequestExpand3) ![]const models.WorkItem {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, project: []const u8, @"$top": ?i32, @"$skip": ?i32, @"$expand": ?enums.ListRequestExpand3) !models.WorkItemList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2812,7 +2812,7 @@ pub const Revisions = struct {
             core.pager.logHttpError("Revisions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItem, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemList, alloc, resp.body);
     }
     /// Returns a fully hydrated work item for the requested revision
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, revision_number: i32, project: []const u8, @"$expand": ?enums.GetRequestExpand1) !models.WorkItem {
@@ -2864,7 +2864,7 @@ pub const Updates = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns the deltas between work item revisions
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, project: []const u8, @"$top": ?i32, @"$skip": ?i32) ![]const models.WorkItemUpdate {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, project: []const u8, @"$top": ?i32, @"$skip": ?i32) !models.WorkItemUpdateList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2905,7 +2905,7 @@ pub const Updates = struct {
             core.pager.logHttpError("Updates.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemUpdate, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemUpdateList, alloc, resp.body);
     }
     /// Returns a single update for a work item
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, update_number: i32, project: []const u8) !models.WorkItemUpdate {
@@ -3167,7 +3167,7 @@ pub const CommentsReactions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets reactions of a comment.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32) ![]const models.CommentReaction {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32) !models.CommentReactionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3200,7 +3200,7 @@ pub const CommentsReactions = struct {
             core.pager.logHttpError("CommentsReactions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.CommentReaction, alloc, resp.body);
+        return try serde.json.fromSlice(models.CommentReactionList, alloc, resp.body);
     }
     /// Deletes an existing reaction on a comment.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32, reaction_type: enums.DeleteRequestReactionType) !models.CommentReaction {
@@ -3285,7 +3285,7 @@ pub const CommentReactionsEngagedUsers = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get users who reacted on the comment.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32, reaction_type: enums.ListRequestReactionType, @"$top": ?i32, @"$skip": ?i32) ![]const models.IdentityRef {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32, reaction_type: enums.ListRequestReactionType, @"$top": ?i32, @"$skip": ?i32) !models.IdentityRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3330,7 +3330,7 @@ pub const CommentReactionsEngagedUsers = struct {
             core.pager.logHttpError("CommentReactionsEngagedUsers.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.IdentityRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.IdentityRefList, alloc, resp.body);
     }
 };
 
@@ -3339,7 +3339,7 @@ pub const CommentsVersions = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32) ![]const models.CommentVersion {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32) !models.CommentVersionList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3372,7 +3372,7 @@ pub const CommentsVersions = struct {
             core.pager.logHttpError("CommentsVersions.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.CommentVersion, alloc, resp.body);
+        return try serde.json.fromSlice(models.CommentVersionList, alloc, resp.body);
     }
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32, version: i32) !models.CommentVersion {
@@ -3419,7 +3419,7 @@ pub const WorkItemTypeCategories = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get all work item type categories.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.WorkItemTypeCategory {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemTypeCategoryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3448,7 +3448,7 @@ pub const WorkItemTypeCategories = struct {
             core.pager.logHttpError("WorkItemTypeCategories.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemTypeCategory, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemTypeCategoryList, alloc, resp.body);
     }
     /// Get specific work item type category by name.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, category: []const u8) !models.WorkItemTypeCategory {
@@ -3491,7 +3491,7 @@ pub const WorkItemTypes = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns the list of work item types
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.WorkItemType {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemTypeList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3520,7 +3520,7 @@ pub const WorkItemTypes = struct {
             core.pager.logHttpError("WorkItemTypes.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemType, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemTypeList, alloc, resp.body);
     }
     /// Returns a work item type definition.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8) !models.WorkItemType {
@@ -3563,7 +3563,7 @@ pub const WorkItemTypesField = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a list of fields for a work item type with detailed references.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8, @"$expand": ?enums.ListRequestExpand4) ![]const models.WorkItemTypeFieldWithReferences {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8, @"$expand": ?enums.ListRequestExpand4) !models.WorkItemTypeFieldWithReferencesList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3601,7 +3601,7 @@ pub const WorkItemTypesField = struct {
             core.pager.logHttpError("WorkItemTypesField.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemTypeFieldWithReferences, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemTypeFieldWithReferencesList, alloc, resp.body);
     }
     /// Get a field for a work item type with detailed references.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8, field: []const u8, @"$expand": ?enums.GetRequestExpand2) !models.WorkItemTypeFieldWithReferences {
@@ -3653,7 +3653,7 @@ pub const WorkItemTypeStates = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns the state names and colors for a work item type.
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8) ![]const models.WorkItemStateColor {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8) !models.WorkItemStateColorList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3684,7 +3684,7 @@ pub const WorkItemTypeStates = struct {
             core.pager.logHttpError("WorkItemTypeStates.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemStateColor, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemStateColorList, alloc, resp.body);
     }
 };
 
@@ -3693,7 +3693,7 @@ pub const Templates = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Gets template
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, workitemtypename: ?[]const u8) ![]const models.WorkItemTemplateReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, workitemtypename: ?[]const u8) !models.WorkItemTemplateReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -3731,7 +3731,7 @@ pub const Templates = struct {
             core.pager.logHttpError("Templates.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.WorkItemTemplateReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.WorkItemTemplateReferenceList, alloc, resp.body);
     }
     /// Creates a template
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, body: models.WorkItemTemplate) !models.WorkItemTemplate {

--- a/src/wit/models.zig
+++ b/src/wit/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `WorkArtifactLink` as returned by Azure DevOps.
+pub const WorkArtifactLinkList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkArtifactLink = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// A work artifact link describes an outbound artifact link type.
 pub const WorkArtifactLink = struct {
     /// Target artifact type.
@@ -17,12 +27,32 @@ pub const WorkArtifactLink = struct {
     };
 };
 
+/// A collection of `WorkItemIcon` as returned by Azure DevOps.
+pub const WorkItemIconList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemIcon = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Reference to a work item icon.
 pub const WorkItemIcon = struct {
     /// The identifier of the icon.
     id: ?[]const u8 = null,
     /// The REST URL of the resource.
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemRelationType` as returned by Azure DevOps.
+pub const WorkItemRelationTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemRelationType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -71,6 +101,16 @@ pub const WorkItemRelationTypeAttribute = struct {
     };
 };
 
+/// A collection of `WorkItemNextStateOnTransition` as returned by Azure DevOps.
+pub const WorkItemNextStateOnTransitionList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemNextStateOnTransition = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Describes the next state for a work item.
 pub const WorkItemNextStateOnTransition = struct {
     /// Error code if there is no next state transition possible.
@@ -81,6 +121,16 @@ pub const WorkItemNextStateOnTransition = struct {
     message: ?[]const u8 = null,
     /// Name of the next state on transition.
     state_on_transition: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `AccountRecentActivityWorkItemModel2` as returned by Azure DevOps.
+pub const AccountRecentActivityWorkItemModel2List = struct {
+    count: ?i32 = null,
+    value: ?[]const AccountRecentActivityWorkItemModel2 = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -147,6 +197,16 @@ pub const IdentityRef = struct {
     };
 };
 
+/// A collection of `GitHubConnectionModel` as returned by Azure DevOps.
+pub const GitHubConnectionModelList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitHubConnectionModel = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Describes Github connection.
 pub const GitHubConnectionModel = struct {
     /// Github connection authorization type (f. e. PAT, OAuth)
@@ -158,6 +218,16 @@ pub const GitHubConnectionModel = struct {
     is_connection_valid: ?bool = null,
     /// Github connection name (should contain organization/user name)
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `GitHubConnectionRepoModel` as returned by Azure DevOps.
+pub const GitHubConnectionRepoModelList = struct {
+    count: ?i32 = null,
+    value: ?[]const GitHubConnectionRepoModel = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -240,6 +310,16 @@ pub const DestroyedAttachment = struct {
     };
 };
 
+/// A collection of `WorkItemClassificationNode` as returned by Azure DevOps.
+pub const WorkItemClassificationNodeList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemClassificationNode = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Defines a classification node for work item tracking.
 pub const WorkItemClassificationNode = struct {
     /// REST URL for the resource.
@@ -271,6 +351,16 @@ pub const WorkItemClassificationNode = struct {
 };
 
 pub const WorkItemClassificationNodeAttribute = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemField2` as returned by Azure DevOps.
+pub const WorkItemField2List = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemField2 = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };
@@ -360,6 +450,16 @@ pub const ProcessMigrationResultModel = struct {
     process_id: ?[]const u8 = null,
     /// The ID of the project.
     project_id: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `QueryHierarchyItem` as returned by Azure DevOps.
+pub const QueryHierarchyItemList = struct {
+    count: ?i32 = null,
+    value: ?[]const QueryHierarchyItem = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -511,6 +611,16 @@ pub const QueryBatchGetRequest = struct {
     error_policy: ?enums.QueryBatchGetRequestErrorPolicy = null,
     /// The requested query ids
     ids: ?[]const []const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemDeleteShallowReference` as returned by Azure DevOps.
+pub const WorkItemDeleteShallowReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemDeleteShallowReference = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -732,6 +842,16 @@ pub const EmailRecipients = struct {
     };
 };
 
+/// A collection of `WorkItemTagDefinition` as returned by Azure DevOps.
+pub const WorkItemTagDefinitionList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemTagDefinition = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const WorkItemTagDefinition = struct {
     id: ?[]const u8 = null,
     last_updated: ?[]const u8 = null,
@@ -763,6 +883,16 @@ pub const TemporaryQueryRequestModel = struct {
 pub const TemporaryQueryResponseModel = struct {
     /// The id of the temporary query item.
     id: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItem` as returned by Azure DevOps.
+pub const WorkItemList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItem = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -812,6 +942,16 @@ pub const WorkItemDeleteBatchRequest = struct {
 pub const WorkItemDeleteBatch = struct {
     /// List of results for each work item
     results: ?[]const WorkItemDelete = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemUpdate` as returned by Azure DevOps.
+pub const WorkItemUpdateList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemUpdate = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1010,6 +1150,36 @@ pub const CommentUpdate = struct {
     };
 };
 
+/// A collection of `CommentReaction` as returned by Azure DevOps.
+pub const CommentReactionList = struct {
+    count: ?i32 = null,
+    value: ?[]const CommentReaction = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `IdentityRef` as returned by Azure DevOps.
+pub const IdentityRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const IdentityRef = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `CommentVersion` as returned by Azure DevOps.
+pub const CommentVersionList = struct {
+    count: ?i32 = null,
+    value: ?[]const CommentVersion = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a specific version of a comment on a work item.
 pub const CommentVersion = struct {
     /// REST URL for the resource.
@@ -1043,6 +1213,16 @@ pub const CommentVersion = struct {
     };
 };
 
+/// A collection of `WorkItemTypeCategory` as returned by Azure DevOps.
+pub const WorkItemTypeCategoryList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemTypeCategory = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Describes a work item type category.
 pub const WorkItemTypeCategory = struct {
     /// REST URL for the resource.
@@ -1070,6 +1250,16 @@ pub const WorkItemTypeReference = struct {
     url: ?[]const u8 = null,
     /// Name of the work item type.
     name: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemType` as returned by Azure DevOps.
+pub const WorkItemTypeList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -1161,6 +1351,16 @@ pub const WorkItemStateTransition = struct {
     };
 };
 
+/// A collection of `WorkItemTypeFieldWithReferences` as returned by Azure DevOps.
+pub const WorkItemTypeFieldWithReferencesList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemTypeFieldWithReferences = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Field Instance of a workItemype with detailed references.
 pub const WorkItemTypeFieldWithReferences = struct {
     /// The friendly name of the field.
@@ -1192,6 +1392,26 @@ pub const WorkItemTypeFieldWithReferencesAllowedValue = struct {
 };
 
 pub const WorkItemTypeFieldWithReferencesDefaultValue = struct {
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemStateColor` as returned by Azure DevOps.
+pub const WorkItemStateColorList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemStateColor = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `WorkItemTemplateReference` as returned by Azure DevOps.
+pub const WorkItemTemplateReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const WorkItemTemplateReference = null,
+
     pub const serde = .{
         .rename_all = .camel_case,
     };

--- a/src/work/clients.zig
+++ b/src/work/clients.zig
@@ -305,7 +305,7 @@ pub const Boardcolumns = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get available board columns in a project
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.BoardSuggestedValue {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BoardSuggestedValueList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -334,7 +334,7 @@ pub const Boardcolumns = struct {
             core.pager.logHttpError("Boardcolumns.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardSuggestedValue, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardSuggestedValueList, alloc, resp.body);
     }
 };
 
@@ -343,7 +343,7 @@ pub const Boardrows = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get available board rows in a project
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.BoardSuggestedValue {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BoardSuggestedValueList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -372,7 +372,7 @@ pub const Boardrows = struct {
             core.pager.logHttpError("Boardrows.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardSuggestedValue, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardSuggestedValueList, alloc, resp.body);
     }
 };
 
@@ -421,7 +421,7 @@ pub const Plans = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get the information for all the plans configured for the given team
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.Plan {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.PlanList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -450,7 +450,7 @@ pub const Plans = struct {
             core.pager.logHttpError("Plans.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.Plan, alloc, resp.body);
+        return try serde.json.fromSlice(models.PlanList, alloc, resp.body);
     }
     /// Add a new plan for the team
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.CreatePlan) !models.Plan {
@@ -659,7 +659,7 @@ pub const PredefinedQueries = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Retrieves the set of known queries
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) ![]const models.PredefinedQuery {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.PredefinedQueryList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -688,7 +688,7 @@ pub const PredefinedQueries = struct {
             core.pager.logHttpError("PredefinedQueries.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.PredefinedQuery, alloc, resp.body);
+        return try serde.json.fromSlice(models.PredefinedQueryList, alloc, resp.body);
     }
     /// Retrieves the specified predefined query including the query results
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, id: []const u8, @"$top": ?i32, include_completed: ?bool) !models.PredefinedQuery {
@@ -819,7 +819,7 @@ pub const Backlogs = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// List all backlog levels
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) ![]const models.BacklogLevelConfiguration {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.BacklogLevelConfigurationList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -850,7 +850,7 @@ pub const Backlogs = struct {
             core.pager.logHttpError("Backlogs.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BacklogLevelConfiguration, alloc, resp.body);
+        return try serde.json.fromSlice(models.BacklogLevelConfigurationList, alloc, resp.body);
     }
     /// Get a list of work items within a backlog level
     pub fn getBacklogLevelWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, backlog_id: []const u8) !models.BacklogLevelWorkItems {
@@ -931,7 +931,7 @@ pub const Boards = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get boards
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) ![]const models.BoardReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.BoardReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -962,7 +962,7 @@ pub const Boards = struct {
             core.pager.logHttpError("Boards.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardReferenceList, alloc, resp.body);
     }
     /// Get board
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, id: []const u8, team: []const u8) !models.Board {
@@ -1610,7 +1610,7 @@ pub const Charts = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get board charts
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) ![]const models.BoardChartReference {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardChartReferenceList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1643,7 +1643,7 @@ pub const Charts = struct {
             core.pager.logHttpError("Charts.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardChartReference, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardChartReferenceList, alloc, resp.body);
     }
     /// Get a board chart
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, name: []const u8, team: []const u8) !models.BoardChart {
@@ -1732,7 +1732,7 @@ pub const Columns = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get columns on a board
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) ![]const models.BoardColumn {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardColumnList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1765,10 +1765,10 @@ pub const Columns = struct {
             core.pager.logHttpError("Columns.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardColumn, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardColumnList, alloc, resp.body);
     }
     /// Update columns on a board
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8, body: []const models.BoardColumn) ![]const models.BoardColumn {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8, body: []const models.BoardColumn) !models.BoardColumnList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1805,7 +1805,7 @@ pub const Columns = struct {
             core.pager.logHttpError("Columns.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardColumn, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardColumnList, alloc, resp.body);
     }
 };
 
@@ -1814,7 +1814,7 @@ pub const Rows = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get rows on a board
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) ![]const models.BoardRow {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardRowList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1847,10 +1847,10 @@ pub const Rows = struct {
             core.pager.logHttpError("Rows.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardRow, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardRowList, alloc, resp.body);
     }
     /// Update rows on a board
-    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8, body: []const models.BoardRow) ![]const models.BoardRow {
+    pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8, body: []const models.BoardRow) !models.BoardRowList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1887,7 +1887,7 @@ pub const Rows = struct {
             core.pager.logHttpError("Rows.update", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.BoardRow, alloc, resp.body);
+        return try serde.json.fromSlice(models.BoardRowList, alloc, resp.body);
     }
 };
 
@@ -1896,7 +1896,7 @@ pub const Boardparents = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Returns the list of parent field filter model for the given list of workitem ids
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, child_backlog_context_category_ref_name: []const u8, workitem_ids: []const u8, team: []const u8) ![]const models.ParentChildWIMap {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, child_backlog_context_category_ref_name: []const u8, workitem_ids: []const u8, team: []const u8) !models.ParentChildWIMapList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1935,7 +1935,7 @@ pub const Boardparents = struct {
             core.pager.logHttpError("Boardparents.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ParentChildWIMap, alloc, resp.body);
+        return try serde.json.fromSlice(models.ParentChildWIMapList, alloc, resp.body);
     }
 };
 
@@ -1944,7 +1944,7 @@ pub const Workitemsorder = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Reorder Sprint Backlog/Taskboard Work Items
-    pub fn reorderIterationWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, iteration_id: []const u8, body: models.ReorderOperation) ![]const models.ReorderResult {
+    pub fn reorderIterationWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, iteration_id: []const u8, body: models.ReorderOperation) !models.ReorderResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -1981,10 +1981,10 @@ pub const Workitemsorder = struct {
             core.pager.logHttpError("Workitemsorder.reorderIterationWorkItems", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ReorderResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.ReorderResultList, alloc, resp.body);
     }
     /// Reorder Product Backlog/Boards Work Items
-    pub fn reorderBacklogWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, body: models.ReorderOperation) ![]const models.ReorderResult {
+    pub fn reorderBacklogWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, body: models.ReorderOperation) !models.ReorderResultList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2019,7 +2019,7 @@ pub const Workitemsorder = struct {
             core.pager.logHttpError("Workitemsorder.reorderBacklogWorkItems", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.ReorderResult, alloc, resp.body);
+        return try serde.json.fromSlice(models.ReorderResultList, alloc, resp.body);
     }
 };
 
@@ -2106,7 +2106,7 @@ pub const TaskboardWorkItems = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
 
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, iteration_id: []const u8) ![]const models.TaskboardWorkItemColumn {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, iteration_id: []const u8) !models.TaskboardWorkItemColumnList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2139,7 +2139,7 @@ pub const TaskboardWorkItems = struct {
             core.pager.logHttpError("TaskboardWorkItems.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TaskboardWorkItemColumn, alloc, resp.body);
+        return try serde.json.fromSlice(models.TaskboardWorkItemColumnList, alloc, resp.body);
     }
 
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, iteration_id: []const u8, work_item_id: i32, body: models.UpdateTaskboardWorkItemColumn) !void {
@@ -2267,7 +2267,7 @@ pub const Iterations = struct {
     api_version: []const u8,
     pipeline: core.pipeline.HttpPipeline,
     /// Get a team's iterations using timeframe filter
-    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, @"$timeframe": ?[]const u8) ![]const models.TeamSettingsIteration {
+    pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, @"$timeframe": ?[]const u8) !models.TeamSettingsIterationList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2305,7 +2305,7 @@ pub const Iterations = struct {
             core.pager.logHttpError("Iterations.list", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TeamSettingsIteration, alloc, resp.body);
+        return try serde.json.fromSlice(models.TeamSettingsIterationList, alloc, resp.body);
     }
     /// Add an iteration to the team
     pub fn postTeamIteration(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, body: models.TeamSettingsIteration) !models.TeamSettingsIteration {
@@ -2495,7 +2495,7 @@ pub const Capacities = struct {
         return try serde.json.fromSlice(models.TeamCapacity, alloc, resp.body);
     }
     /// Replace a team's capacity
-    pub fn replaceCapacitiesWithIdentityRef(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, iteration_id: []const u8, team: []const u8, body: []const models.TeamMemberCapacityIdentityRef) ![]const models.TeamMemberCapacityIdentityRef {
+    pub fn replaceCapacitiesWithIdentityRef(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, iteration_id: []const u8, team: []const u8, body: []const models.TeamMemberCapacityIdentityRef) !models.TeamMemberCapacityIdentityRefList {
         @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, organization);
         defer alloc.free(encoded_path_0);
@@ -2532,7 +2532,7 @@ pub const Capacities = struct {
             core.pager.logHttpError("Capacities.replaceCapacitiesWithIdentityRef", resp.status_code, resp.body);
             return error.AzureRequestFailed;
         }
-        return try serde.json.fromSlice([]const models.TeamMemberCapacityIdentityRef, alloc, resp.body);
+        return try serde.json.fromSlice(models.TeamMemberCapacityIdentityRefList, alloc, resp.body);
     }
     /// Get a team member's capacity
     pub fn getCapacityWithIdentityRef(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, iteration_id: []const u8, team_member_id: []const u8, team: []const u8) !models.TeamMemberCapacityIdentityRef {

--- a/src/work/models.zig
+++ b/src/work/models.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const enums = @import("enums.zig");
 
+/// A collection of `BoardSuggestedValue` as returned by Azure DevOps.
+pub const BoardSuggestedValueList = struct {
+    count: ?i32 = null,
+    value: ?[]const BoardSuggestedValue = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const BoardSuggestedValue = struct {
     name: ?[]const u8 = null,
 
@@ -27,6 +37,16 @@ pub const TeamCapacityTotals = struct {
     team_capacity_per_day: ?f64 = null,
     team_id: ?[]const u8 = null,
     team_total_days_off: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `Plan` as returned by Azure DevOps.
+pub const PlanList = struct {
+    count: ?i32 = null,
+    value: ?[]const Plan = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -351,6 +371,16 @@ pub const WorkItemColor = struct {
     };
 };
 
+/// A collection of `PredefinedQuery` as returned by Azure DevOps.
+pub const PredefinedQueryList = struct {
+    count: ?i32 = null,
+    value: ?[]const PredefinedQuery = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a single pre-defined query.
 pub const PredefinedQuery = struct {
     /// Whether or not the query returned the complete set of data or if the data was truncated.
@@ -575,6 +605,16 @@ pub const WorkItemTypeStateInfo = struct {
     };
 };
 
+/// A collection of `BacklogLevelConfiguration` as returned by Azure DevOps.
+pub const BacklogLevelConfigurationList = struct {
+    count: ?i32 = null,
+    value: ?[]const BacklogLevelConfiguration = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents work items in a backlog level
 pub const BacklogLevelWorkItems = struct {
     /// A list of work items within a backlog level
@@ -603,6 +643,16 @@ pub const WorkItemReference = struct {
     id: ?i32 = null,
     /// REST API URL of the resource
     url: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `BoardReference` as returned by Azure DevOps.
+pub const BoardReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const BoardReference = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -757,6 +807,16 @@ pub const FieldSetting = struct {
     };
 };
 
+/// A collection of `BoardChartReference` as returned by Azure DevOps.
+pub const BoardChartReferenceList = struct {
+    count: ?i32 = null,
+    value: ?[]const BoardChartReference = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 pub const BoardChartReference = struct {
     /// Name of the resource
     name: ?[]const u8 = null,
@@ -791,6 +851,36 @@ pub const BoardChartSetting = struct {
     };
 };
 
+/// A collection of `BoardColumn` as returned by Azure DevOps.
+pub const BoardColumnList = struct {
+    count: ?i32 = null,
+    value: ?[]const BoardColumn = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `BoardRow` as returned by Azure DevOps.
+pub const BoardRowList = struct {
+    count: ?i32 = null,
+    value: ?[]const BoardRow = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ParentChildWIMap` as returned by Azure DevOps.
+pub const ParentChildWIMapList = struct {
+    count: ?i32 = null,
+    value: ?[]const ParentChildWIMap = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents a reorder request for one or more work items.
 pub const ReorderOperation = struct {
     /// IDs of the work items to be reordered. Must be valid WorkItem Ids.
@@ -803,6 +893,16 @@ pub const ReorderOperation = struct {
     parent_id: ?i32 = null,
     /// ID of the work item that should be before the reordered items. Can use 0 to specify the beginning of the list.
     previous_id: ?i32 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `ReorderResult` as returned by Azure DevOps.
+pub const ReorderResultList = struct {
+    count: ?i32 = null,
+    value: ?[]const ReorderResult = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -881,6 +981,16 @@ pub const TaskboardColumnMapping = struct {
     state: ?[]const u8 = null,
     /// Work Item Type name who's state is mapped to the column
     work_item_type: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TaskboardWorkItemColumn` as returned by Azure DevOps.
+pub const TaskboardWorkItemColumnList = struct {
+    count: ?i32 = null,
+    value: ?[]const TaskboardWorkItemColumn = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -983,6 +1093,16 @@ pub const TeamSettingsPatch = struct {
     };
 };
 
+/// A collection of `TeamSettingsIteration` as returned by Azure DevOps.
+pub const TeamSettingsIterationList = struct {
+    count: ?i32 = null,
+    value: ?[]const TeamSettingsIteration = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
 /// Represents work items in an iteration backlog
 pub const IterationWorkItems = struct {
     links: ?ReferenceLinks = null,
@@ -1043,6 +1163,16 @@ pub const DateRange = struct {
     end: ?[]const u8 = null,
     /// Start of the date range.
     start: ?[]const u8 = null,
+
+    pub const serde = .{
+        .rename_all = .camel_case,
+    };
+};
+
+/// A collection of `TeamMemberCapacityIdentityRef` as returned by Azure DevOps.
+pub const TeamMemberCapacityIdentityRefList = struct {
+    count: ?i32 = null,
+    value: ?[]const TeamMemberCapacityIdentityRef = null,
 
     pub const serde = .{
         .rename_all = .camel_case,


### PR DESCRIPTION
Azure DevOps never returns a bare JSON array. Every collection comes back wrapped in an object with a `value` array and, on most endpoints, a `count`. The published Swagger declares the bare array, so every list operation in this package failed to deserialize with `WrongType` against the live service.

Verified against a real organization on `projects`, `processes`, `build definitions`, `builds`, `teams` and `repositories`. The first four send `count` and `value`; `teams` and `repositories` send `value` only, so `count` is optional. `azure-devops-rust-api` patches its specs with the same rule.

Regenerated from cataggar/vsts-rest-api-specs@a8ac46b8, which introduces one `<Item>List` model per collection element type. List operations now return that envelope instead of a slice, so callers read `.value`.

Also repins `azure_sdk_core` to pick up #379, which stops the transport sending duplicate `User-Agent` headers — Azure DevOps rejects those with `400 Invalid Header`.