### PR TITLE
Model Azure DevOps enums as extensible

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,6 +1,6 @@
 generator_commit=5ec3759d9bf33e1047fcbd884e8ad66519f60156
 source_repository=https://github.com/cataggar/vsts-rest-api-specs
-source_commit=a8ac46b877b40178b07457fbadde128bddfc513a
+source_commit=30b2105a165ce0f057e6adafe5f5e5b9b71502b7
 source_branch=typespec
 source_path=typespec/specs
 selected_api_version=7.2

--- a/src/account/enums.zig
+++ b/src/account/enums.zig
@@ -8,72 +8,71 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const AccountAccountStatus = enum {
+pub const AccountAccountStatus = union(enum) {
     none,
     enabled,
     disabled,
     deleted,
     moved,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .enabled => "enabled",
-            .disabled => "disabled",
-            .deleted => "deleted",
-            .moved => "moved",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        if (std.mem.eql(u8, s, "moved")) return .moved;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .enabled = "enabled",
+        .disabled = "disabled",
+        .deleted = "deleted",
+        .moved = "moved",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AccountAccountType = enum {
+pub const AccountAccountType = union(enum) {
     personal,
     organization,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .personal => "personal",
-            .organization => "organization",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "personal")) return .personal;
-        if (std.mem.eql(u8, s, "organization")) return .organization;
-        return null;
-    }
+    const wire_names = .{
+        .personal = "personal",
+        .organization = "organization",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/advanced_security/enums.zig
+++ b/src/advanced_security/enums.zig
@@ -8,79 +8,77 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const CombinedAlertFilterCriteriaAlertType = enum {
+pub const CombinedAlertFilterCriteriaAlertType = union(enum) {
     unknown,
     dependency,
     secret,
     code,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .dependency => "dependency",
-            .secret => "secret",
-            .code => "code",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "dependency")) return .dependency;
-        if (std.mem.eql(u8, s, "secret")) return .secret;
-        if (std.mem.eql(u8, s, "code")) return .code;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .dependency = "dependency",
+        .secret = "secret",
+        .code = "code",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CombinedAlertFilterCriteriaAlertValidityStatus = enum {
+pub const CombinedAlertFilterCriteriaAlertValidityStatus = union(enum) {
     none,
     unknown,
     active,
     inactive,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .unknown => "unknown",
-            .active => "active",
-            .inactive => "inactive",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "inactive")) return .inactive;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .unknown = "unknown",
+        .active = "active",
+        .inactive = "inactive",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CombinedAlertFilterCriteriaComponentType = enum {
+pub const CombinedAlertFilterCriteriaComponentType = union(enum) {
     unknown,
     nu_get,
     npm,
@@ -98,64 +96,50 @@ pub const CombinedAlertFilterCriteriaComponentType = enum {
     conda,
     docker_reference,
     vcpkg,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .nu_get => "nuGet",
-            .npm => "npm",
-            .maven => "maven",
-            .git => "git",
-            .other => "other",
-            .ruby_gems => "rubyGems",
-            .cargo => "cargo",
-            .pip => "pip",
-            .file => "file",
-            .go => "go",
-            .docker_image => "dockerImage",
-            .pod => "pod",
-            .linux => "linux",
-            .conda => "conda",
-            .docker_reference => "dockerReference",
-            .vcpkg => "vcpkg",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "nuGet")) return .nu_get;
-        if (std.mem.eql(u8, s, "npm")) return .npm;
-        if (std.mem.eql(u8, s, "maven")) return .maven;
-        if (std.mem.eql(u8, s, "git")) return .git;
-        if (std.mem.eql(u8, s, "other")) return .other;
-        if (std.mem.eql(u8, s, "rubyGems")) return .ruby_gems;
-        if (std.mem.eql(u8, s, "cargo")) return .cargo;
-        if (std.mem.eql(u8, s, "pip")) return .pip;
-        if (std.mem.eql(u8, s, "file")) return .file;
-        if (std.mem.eql(u8, s, "go")) return .go;
-        if (std.mem.eql(u8, s, "dockerImage")) return .docker_image;
-        if (std.mem.eql(u8, s, "pod")) return .pod;
-        if (std.mem.eql(u8, s, "linux")) return .linux;
-        if (std.mem.eql(u8, s, "conda")) return .conda;
-        if (std.mem.eql(u8, s, "dockerReference")) return .docker_reference;
-        if (std.mem.eql(u8, s, "vcpkg")) return .vcpkg;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .nu_get = "nuGet",
+        .npm = "npm",
+        .maven = "maven",
+        .git = "git",
+        .other = "other",
+        .ruby_gems = "rubyGems",
+        .cargo = "cargo",
+        .pip = "pip",
+        .file = "file",
+        .go = "go",
+        .docker_image = "dockerImage",
+        .pod = "pod",
+        .linux = "linux",
+        .conda = "conda",
+        .docker_reference = "dockerReference",
+        .vcpkg = "vcpkg",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CombinedAlertFilterCriteriaDismissalType = enum {
+pub const CombinedAlertFilterCriteriaDismissalType = union(enum) {
     unknown,
     fixed,
     accepted_risk,
@@ -163,44 +147,40 @@ pub const CombinedAlertFilterCriteriaDismissalType = enum {
     agreed_to_guidance,
     tool_upgrade,
     not_distributed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .fixed => "fixed",
-            .accepted_risk => "acceptedRisk",
-            .false_positive => "falsePositive",
-            .agreed_to_guidance => "agreedToGuidance",
-            .tool_upgrade => "toolUpgrade",
-            .not_distributed => "notDistributed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "acceptedRisk")) return .accepted_risk;
-        if (std.mem.eql(u8, s, "falsePositive")) return .false_positive;
-        if (std.mem.eql(u8, s, "agreedToGuidance")) return .agreed_to_guidance;
-        if (std.mem.eql(u8, s, "toolUpgrade")) return .tool_upgrade;
-        if (std.mem.eql(u8, s, "notDistributed")) return .not_distributed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .fixed = "fixed",
+        .accepted_risk = "acceptedRisk",
+        .false_positive = "falsePositive",
+        .agreed_to_guidance = "agreedToGuidance",
+        .tool_upgrade = "toolUpgrade",
+        .not_distributed = "notDistributed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CombinedAlertFilterCriteriaSeverity = enum {
+pub const CombinedAlertFilterCriteriaSeverity = union(enum) {
     low,
     medium,
     high,
@@ -209,72 +189,68 @@ pub const CombinedAlertFilterCriteriaSeverity = enum {
     warning,
     @"error",
     undefined,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .low => "low",
-            .medium => "medium",
-            .high => "high",
-            .critical => "critical",
-            .note => "note",
-            .warning => "warning",
-            .@"error" => "error",
-            .undefined => "undefined",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "low")) return .low;
-        if (std.mem.eql(u8, s, "medium")) return .medium;
-        if (std.mem.eql(u8, s, "high")) return .high;
-        if (std.mem.eql(u8, s, "critical")) return .critical;
-        if (std.mem.eql(u8, s, "note")) return .note;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        return null;
-    }
+    const wire_names = .{
+        .low = "low",
+        .medium = "medium",
+        .high = "high",
+        .critical = "critical",
+        .note = "note",
+        .warning = "warning",
+        .@"error" = "error",
+        .undefined = "undefined",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CombinedAlertFilterCriteriaState = enum {
+pub const CombinedAlertFilterCriteriaState = union(enum) {
     open,
     closed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .open => "open",
-            .closed => "closed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "open")) return .open;
-        if (std.mem.eql(u8, s, "closed")) return .closed;
-        return null;
-    }
+    const wire_names = .{
+        .open = "open",
+        .closed = "closed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -422,43 +398,42 @@ pub const ListRequestCriteriaState = enum {
     }
 };
 
-pub const DashboardAlertAlertType = enum {
+pub const DashboardAlertAlertType = union(enum) {
     unknown,
     dependency,
     secret,
     code,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .dependency => "dependency",
-            .secret => "secret",
-            .code => "code",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "dependency")) return .dependency;
-        if (std.mem.eql(u8, s, "secret")) return .secret;
-        if (std.mem.eql(u8, s, "code")) return .code;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .dependency = "dependency",
+        .secret = "secret",
+        .code = "code",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DashboardAlertSeverity = enum {
+pub const DashboardAlertSeverity = union(enum) {
     low,
     medium,
     high,
@@ -467,117 +442,109 @@ pub const DashboardAlertSeverity = enum {
     warning,
     @"error",
     undefined,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .low => "low",
-            .medium => "medium",
-            .high => "high",
-            .critical => "critical",
-            .note => "note",
-            .warning => "warning",
-            .@"error" => "error",
-            .undefined => "undefined",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "low")) return .low;
-        if (std.mem.eql(u8, s, "medium")) return .medium;
-        if (std.mem.eql(u8, s, "high")) return .high;
-        if (std.mem.eql(u8, s, "critical")) return .critical;
-        if (std.mem.eql(u8, s, "note")) return .note;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        return null;
-    }
+    const wire_names = .{
+        .low = "low",
+        .medium = "medium",
+        .high = "high",
+        .critical = "critical",
+        .note = "note",
+        .warning = "warning",
+        .@"error" = "error",
+        .undefined = "undefined",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DashboardAlertState = enum {
+pub const DashboardAlertState = union(enum) {
     unknown,
     active,
     dismissed,
     fixed,
     auto_dismissed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .active => "active",
-            .dismissed => "dismissed",
-            .fixed => "fixed",
-            .auto_dismissed => "autoDismissed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "dismissed")) return .dismissed;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "autoDismissed")) return .auto_dismissed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .active = "active",
+        .dismissed = "dismissed",
+        .fixed = "fixed",
+        .auto_dismissed = "autoDismissed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DashboardAlertValidityStatus = enum {
+pub const DashboardAlertValidityStatus = union(enum) {
     none,
     unknown,
     active,
     inactive,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .unknown => "unknown",
-            .active => "active",
-            .inactive => "inactive",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "inactive")) return .inactive;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .unknown = "unknown",
+        .active = "active",
+        .inactive = "inactive",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -641,73 +608,73 @@ pub const ListRequestExpand = enum {
     }
 };
 
-pub const AlertAlertType = enum {
+pub const AlertAlertType = union(enum) {
     unknown,
     dependency,
     secret,
     code,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .dependency => "dependency",
-            .secret => "secret",
-            .code => "code",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "dependency")) return .dependency;
-        if (std.mem.eql(u8, s, "secret")) return .secret;
-        if (std.mem.eql(u8, s, "code")) return .code;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .dependency = "dependency",
+        .secret = "secret",
+        .code = "code",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertConfidence = enum {
+pub const AlertConfidence = union(enum) {
     high,
     other,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .high => "high",
-            .other => "other",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "high")) return .high;
-        if (std.mem.eql(u8, s, "other")) return .other;
-        return null;
-    }
+    const wire_names = .{
+        .high = "high",
+        .other = "other",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DismissalDismissalType = enum {
+pub const DismissalDismissalType = union(enum) {
     unknown,
     fixed,
     accepted_risk,
@@ -715,113 +682,108 @@ pub const DismissalDismissalType = enum {
     agreed_to_guidance,
     tool_upgrade,
     not_distributed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .fixed => "fixed",
-            .accepted_risk => "acceptedRisk",
-            .false_positive => "falsePositive",
-            .agreed_to_guidance => "agreedToGuidance",
-            .tool_upgrade => "toolUpgrade",
-            .not_distributed => "notDistributed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "acceptedRisk")) return .accepted_risk;
-        if (std.mem.eql(u8, s, "falsePositive")) return .false_positive;
-        if (std.mem.eql(u8, s, "agreedToGuidance")) return .agreed_to_guidance;
-        if (std.mem.eql(u8, s, "toolUpgrade")) return .tool_upgrade;
-        if (std.mem.eql(u8, s, "notDistributed")) return .not_distributed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .fixed = "fixed",
+        .accepted_risk = "acceptedRisk",
+        .false_positive = "falsePositive",
+        .agreed_to_guidance = "agreedToGuidance",
+        .tool_upgrade = "toolUpgrade",
+        .not_distributed = "notDistributed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const LogicalLocationKind = enum {
+pub const LogicalLocationKind = union(enum) {
     unknown,
     root_dependency,
     component,
     vulnerable_dependency,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .root_dependency => "rootDependency",
-            .component => "component",
-            .vulnerable_dependency => "vulnerableDependency",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "rootDependency")) return .root_dependency;
-        if (std.mem.eql(u8, s, "component")) return .component;
-        if (std.mem.eql(u8, s, "vulnerableDependency")) return .vulnerable_dependency;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .root_dependency = "rootDependency",
+        .component = "component",
+        .vulnerable_dependency = "vulnerableDependency",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const LicenseState = enum {
+pub const LicenseState = union(enum) {
     unknown,
     not_harvested,
     harvested,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .not_harvested => "notHarvested",
-            .harvested => "harvested",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "notHarvested")) return .not_harvested;
-        if (std.mem.eql(u8, s, "harvested")) return .harvested;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .not_harvested = "notHarvested",
+        .harvested = "harvested",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const LicenseType = enum {
+pub const LicenseType = union(enum) {
     unknown,
     permissive,
     weak_copyleft,
@@ -829,44 +791,40 @@ pub const LicenseType = enum {
     network_copyleft,
     other,
     no_assertion,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .permissive => "permissive",
-            .weak_copyleft => "weakCopyleft",
-            .strong_copyleft => "strongCopyleft",
-            .network_copyleft => "networkCopyleft",
-            .other => "other",
-            .no_assertion => "noAssertion",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "permissive")) return .permissive;
-        if (std.mem.eql(u8, s, "weakCopyleft")) return .weak_copyleft;
-        if (std.mem.eql(u8, s, "strongCopyleft")) return .strong_copyleft;
-        if (std.mem.eql(u8, s, "networkCopyleft")) return .network_copyleft;
-        if (std.mem.eql(u8, s, "other")) return .other;
-        if (std.mem.eql(u8, s, "noAssertion")) return .no_assertion;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .permissive = "permissive",
+        .weak_copyleft = "weakCopyleft",
+        .strong_copyleft = "strongCopyleft",
+        .network_copyleft = "networkCopyleft",
+        .other = "other",
+        .no_assertion = "noAssertion",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertSeverity = enum {
+pub const AlertSeverity = union(enum) {
     low,
     medium,
     high,
@@ -875,159 +833,148 @@ pub const AlertSeverity = enum {
     warning,
     @"error",
     undefined,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .low => "low",
-            .medium => "medium",
-            .high => "high",
-            .critical => "critical",
-            .note => "note",
-            .warning => "warning",
-            .@"error" => "error",
-            .undefined => "undefined",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "low")) return .low;
-        if (std.mem.eql(u8, s, "medium")) return .medium;
-        if (std.mem.eql(u8, s, "high")) return .high;
-        if (std.mem.eql(u8, s, "critical")) return .critical;
-        if (std.mem.eql(u8, s, "note")) return .note;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        return null;
-    }
+    const wire_names = .{
+        .low = "low",
+        .medium = "medium",
+        .high = "high",
+        .critical = "critical",
+        .note = "note",
+        .warning = "warning",
+        .@"error" = "error",
+        .undefined = "undefined",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertState = enum {
+pub const AlertState = union(enum) {
     unknown,
     active,
     dismissed,
     fixed,
     auto_dismissed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .active => "active",
-            .dismissed => "dismissed",
-            .fixed => "fixed",
-            .auto_dismissed => "autoDismissed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "dismissed")) return .dismissed;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "autoDismissed")) return .auto_dismissed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .active = "active",
+        .dismissed = "dismissed",
+        .fixed = "fixed",
+        .auto_dismissed = "autoDismissed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ValidationFingerprintValidityResult = enum {
+pub const ValidationFingerprintValidityResult = union(enum) {
     none,
     exploitable,
     not_exploitable,
     inconclusive,
     validation_not_supported,
     transient_error,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .exploitable => "exploitable",
-            .not_exploitable => "notExploitable",
-            .inconclusive => "inconclusive",
-            .validation_not_supported => "validationNotSupported",
-            .transient_error => "transientError",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "exploitable")) return .exploitable;
-        if (std.mem.eql(u8, s, "notExploitable")) return .not_exploitable;
-        if (std.mem.eql(u8, s, "inconclusive")) return .inconclusive;
-        if (std.mem.eql(u8, s, "validationNotSupported")) return .validation_not_supported;
-        if (std.mem.eql(u8, s, "transientError")) return .transient_error;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .exploitable = "exploitable",
+        .not_exploitable = "notExploitable",
+        .inconclusive = "inconclusive",
+        .validation_not_supported = "validationNotSupported",
+        .transient_error = "transientError",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertValidityInfoValidityStatus = enum {
+pub const AlertValidityInfoValidityStatus = union(enum) {
     none,
     unknown,
     active,
     inactive,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .unknown => "unknown",
-            .active => "active",
-            .inactive => "inactive",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "inactive")) return .inactive;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .unknown = "unknown",
+        .active = "active",
+        .inactive = "inactive",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1061,7 +1008,7 @@ pub const GetRequestExpand = enum {
     }
 };
 
-pub const AlertStateUpdateDismissedReason = enum {
+pub const AlertStateUpdateDismissedReason = union(enum) {
     unknown,
     fixed,
     accepted_risk,
@@ -1069,113 +1016,108 @@ pub const AlertStateUpdateDismissedReason = enum {
     agreed_to_guidance,
     tool_upgrade,
     not_distributed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .fixed => "fixed",
-            .accepted_risk => "acceptedRisk",
-            .false_positive => "falsePositive",
-            .agreed_to_guidance => "agreedToGuidance",
-            .tool_upgrade => "toolUpgrade",
-            .not_distributed => "notDistributed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "acceptedRisk")) return .accepted_risk;
-        if (std.mem.eql(u8, s, "falsePositive")) return .false_positive;
-        if (std.mem.eql(u8, s, "agreedToGuidance")) return .agreed_to_guidance;
-        if (std.mem.eql(u8, s, "toolUpgrade")) return .tool_upgrade;
-        if (std.mem.eql(u8, s, "notDistributed")) return .not_distributed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .fixed = "fixed",
+        .accepted_risk = "acceptedRisk",
+        .false_positive = "falsePositive",
+        .agreed_to_guidance = "agreedToGuidance",
+        .tool_upgrade = "toolUpgrade",
+        .not_distributed = "notDistributed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertStateUpdateState = enum {
+pub const AlertStateUpdateState = union(enum) {
     unknown,
     active,
     dismissed,
     fixed,
     auto_dismissed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .active => "active",
-            .dismissed => "dismissed",
-            .fixed => "fixed",
-            .auto_dismissed => "autoDismissed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "dismissed")) return .dismissed;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "autoDismissed")) return .auto_dismissed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .active = "active",
+        .dismissed = "dismissed",
+        .fixed = "fixed",
+        .auto_dismissed = "autoDismissed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AnalysisConfigurationAnalysisConfigurationType = enum {
+pub const AnalysisConfigurationAnalysisConfigurationType = union(enum) {
     default,
     ado_pipeline,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .default => "default",
-            .ado_pipeline => "adoPipeline",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "default")) return .default;
-        if (std.mem.eql(u8, s, "adoPipeline")) return .ado_pipeline;
-        return null;
-    }
+    const wire_names = .{
+        .default = "default",
+        .ado_pipeline = "adoPipeline",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DependencyComponentType = enum {
+pub const DependencyComponentType = union(enum) {
     unknown,
     nu_get,
     npm,
@@ -1193,97 +1135,83 @@ pub const DependencyComponentType = enum {
     conda,
     docker_reference,
     vcpkg,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .nu_get => "nuGet",
-            .npm => "npm",
-            .maven => "maven",
-            .git => "git",
-            .other => "other",
-            .ruby_gems => "rubyGems",
-            .cargo => "cargo",
-            .pip => "pip",
-            .file => "file",
-            .go => "go",
-            .docker_image => "dockerImage",
-            .pod => "pod",
-            .linux => "linux",
-            .conda => "conda",
-            .docker_reference => "dockerReference",
-            .vcpkg => "vcpkg",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "nuGet")) return .nu_get;
-        if (std.mem.eql(u8, s, "npm")) return .npm;
-        if (std.mem.eql(u8, s, "maven")) return .maven;
-        if (std.mem.eql(u8, s, "git")) return .git;
-        if (std.mem.eql(u8, s, "other")) return .other;
-        if (std.mem.eql(u8, s, "rubyGems")) return .ruby_gems;
-        if (std.mem.eql(u8, s, "cargo")) return .cargo;
-        if (std.mem.eql(u8, s, "pip")) return .pip;
-        if (std.mem.eql(u8, s, "file")) return .file;
-        if (std.mem.eql(u8, s, "go")) return .go;
-        if (std.mem.eql(u8, s, "dockerImage")) return .docker_image;
-        if (std.mem.eql(u8, s, "pod")) return .pod;
-        if (std.mem.eql(u8, s, "linux")) return .linux;
-        if (std.mem.eql(u8, s, "conda")) return .conda;
-        if (std.mem.eql(u8, s, "dockerReference")) return .docker_reference;
-        if (std.mem.eql(u8, s, "vcpkg")) return .vcpkg;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .nu_get = "nuGet",
+        .npm = "npm",
+        .maven = "maven",
+        .git = "git",
+        .other = "other",
+        .ruby_gems = "rubyGems",
+        .cargo = "cargo",
+        .pip = "pip",
+        .file = "file",
+        .go = "go",
+        .docker_image = "dockerImage",
+        .pod = "pod",
+        .linux = "linux",
+        .conda = "conda",
+        .docker_reference = "dockerReference",
+        .vcpkg = "vcpkg",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ResultResultType = enum {
+pub const ResultResultType = union(enum) {
     unknown,
     dependency,
     version_control,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .dependency => "dependency",
-            .version_control => "versionControl",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "dependency")) return .dependency;
-        if (std.mem.eql(u8, s, "versionControl")) return .version_control;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .dependency = "dependency",
+        .version_control = "versionControl",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ResultSeverity = enum {
+pub const ResultSeverity = union(enum) {
     low,
     medium,
     high,
@@ -1292,219 +1220,210 @@ pub const ResultSeverity = enum {
     warning,
     @"error",
     undefined,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .low => "low",
-            .medium => "medium",
-            .high => "high",
-            .critical => "critical",
-            .note => "note",
-            .warning => "warning",
-            .@"error" => "error",
-            .undefined => "undefined",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "low")) return .low;
-        if (std.mem.eql(u8, s, "medium")) return .medium;
-        if (std.mem.eql(u8, s, "high")) return .high;
-        if (std.mem.eql(u8, s, "critical")) return .critical;
-        if (std.mem.eql(u8, s, "note")) return .note;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        return null;
-    }
+    const wire_names = .{
+        .low = "low",
+        .medium = "medium",
+        .high = "high",
+        .critical = "critical",
+        .note = "note",
+        .warning = "warning",
+        .@"error" = "error",
+        .undefined = "undefined",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AnalysisResultState = enum {
+pub const AnalysisResultState = union(enum) {
     unknown,
     active,
     dismissed,
     fixed,
     auto_dismissed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .active => "active",
-            .dismissed => "dismissed",
-            .fixed => "fixed",
-            .auto_dismissed => "autoDismissed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "dismissed")) return .dismissed;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "autoDismissed")) return .auto_dismissed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .active = "active",
+        .dismissed = "dismissed",
+        .fixed = "fixed",
+        .auto_dismissed = "autoDismissed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertAnalysisInstanceState = enum {
+pub const AlertAnalysisInstanceState = union(enum) {
     unknown,
     active,
     dismissed,
     fixed,
     auto_dismissed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .active => "active",
-            .dismissed => "dismissed",
-            .fixed => "fixed",
-            .auto_dismissed => "autoDismissed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "dismissed")) return .dismissed;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "autoDismissed")) return .auto_dismissed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .active = "active",
+        .dismissed = "dismissed",
+        .fixed = "fixed",
+        .auto_dismissed = "autoDismissed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const MetadataOp = enum {
+pub const MetadataOp = union(enum) {
     none,
     add,
     remove,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .add => "add",
-            .remove => "remove",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "add")) return .add;
-        if (std.mem.eql(u8, s, "remove")) return .remove;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .add = "add",
+        .remove = "remove",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertMetadataBatchRequestErrorPolicy = enum {
+pub const AlertMetadataBatchRequestErrorPolicy = union(enum) {
     fail,
     omit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .fail => "fail",
-            .omit => "omit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "fail")) return .fail;
-        if (std.mem.eql(u8, s, "omit")) return .omit;
-        return null;
-    }
+    const wire_names = .{
+        .fail = "fail",
+        .omit = "omit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AlertBatchRequestAlertType = enum {
+pub const AlertBatchRequestAlertType = union(enum) {
     unknown,
     dependency,
     secret,
     code,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .dependency => "dependency",
-            .secret => "secret",
-            .code => "code",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "dependency")) return .dependency;
-        if (std.mem.eql(u8, s, "secret")) return .secret;
-        if (std.mem.eql(u8, s, "code")) return .code;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .dependency = "dependency",
+        .secret = "secret",
+        .code = "code",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/approvals_and_checks/enums.zig
+++ b/src/approvals_and_checks/enums.zig
@@ -65,33 +65,34 @@ pub const ListRequestExpand = enum {
     }
 };
 
-pub const CheckIssueType = enum {
+pub const CheckIssueType = union(enum) {
     @"error",
     warning,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .@"error" => "error",
-            .warning => "warning",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        return null;
-    }
+    const wire_names = .{
+        .@"error" = "error",
+        .warning = "warning",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -185,7 +186,7 @@ pub const EvaluateRequestExpand = enum {
     }
 };
 
-pub const CheckRunStatus = enum {
+pub const CheckRunStatus = union(enum) {
     none,
     queued,
     running,
@@ -199,56 +200,46 @@ pub const CheckRunStatus = enum {
     failed,
     completed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .queued => "queued",
-            .running => "running",
-            .approved => "approved",
-            .rejected => "rejected",
-            .canceled => "canceled",
-            .timed_out => "timedOut",
-            .rerunning => "rerunning",
-            .bypassed => "bypassed",
-            .deferred => "deferred",
-            .failed => "failed",
-            .completed => "completed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "running")) return .running;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "rerunning")) return .rerunning;
-        if (std.mem.eql(u8, s, "bypassed")) return .bypassed;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .queued = "queued",
+        .running = "running",
+        .approved = "approved",
+        .rejected = "rejected",
+        .canceled = "canceled",
+        .timed_out = "timedOut",
+        .rerunning = "rerunning",
+        .bypassed = "bypassed",
+        .deferred = "deferred",
+        .failed = "failed",
+        .completed = "completed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CheckRunEvaluationOrder = enum {
+pub const CheckRunEvaluationOrder = union(enum) {
     system,
     sanity_checks,
     pre_checks,
@@ -259,50 +250,43 @@ pub const CheckRunEvaluationOrder = enum {
     post_checks,
     proof_of_presence_temp,
     final,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .sanity_checks => "sanityChecks",
-            .pre_checks => "preChecks",
-            .production_readiness_check => "productionReadinessCheck",
-            .proof_of_presence => "proofOfPresence",
-            .production_readiness_check_deprecated => "productionReadinessCheckDeprecated",
-            .main => "main",
-            .post_checks => "postChecks",
-            .proof_of_presence_temp => "proofOfPresenceTemp",
-            .final => "final",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "sanityChecks")) return .sanity_checks;
-        if (std.mem.eql(u8, s, "preChecks")) return .pre_checks;
-        if (std.mem.eql(u8, s, "productionReadinessCheck")) return .production_readiness_check;
-        if (std.mem.eql(u8, s, "proofOfPresence")) return .proof_of_presence;
-        if (std.mem.eql(u8, s, "productionReadinessCheckDeprecated")) return .production_readiness_check_deprecated;
-        if (std.mem.eql(u8, s, "main")) return .main;
-        if (std.mem.eql(u8, s, "postChecks")) return .post_checks;
-        if (std.mem.eql(u8, s, "proofOfPresenceTemp")) return .proof_of_presence_temp;
-        if (std.mem.eql(u8, s, "final")) return .final;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .sanity_checks = "sanityChecks",
+        .pre_checks = "preChecks",
+        .production_readiness_check = "productionReadinessCheck",
+        .proof_of_presence = "proofOfPresence",
+        .production_readiness_check_deprecated = "productionReadinessCheckDeprecated",
+        .main = "main",
+        .post_checks = "postChecks",
+        .proof_of_presence_temp = "proofOfPresenceTemp",
+        .final = "final",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CheckRunUpdateStatus = enum {
+pub const CheckRunUpdateStatus = union(enum) {
     none,
     queued,
     running,
@@ -316,56 +300,46 @@ pub const CheckRunUpdateStatus = enum {
     failed,
     completed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .queued => "queued",
-            .running => "running",
-            .approved => "approved",
-            .rejected => "rejected",
-            .canceled => "canceled",
-            .timed_out => "timedOut",
-            .rerunning => "rerunning",
-            .bypassed => "bypassed",
-            .deferred => "deferred",
-            .failed => "failed",
-            .completed => "completed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "running")) return .running;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "rerunning")) return .rerunning;
-        if (std.mem.eql(u8, s, "bypassed")) return .bypassed;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .queued = "queued",
+        .running = "running",
+        .approved = "approved",
+        .rejected = "rejected",
+        .canceled = "canceled",
+        .timed_out = "timedOut",
+        .rerunning = "rerunning",
+        .bypassed = "bypassed",
+        .deferred = "deferred",
+        .failed = "failed",
+        .completed = "completed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CheckSuiteStatus = enum {
+pub const CheckSuiteStatus = union(enum) {
     none,
     queued,
     running,
@@ -379,52 +353,42 @@ pub const CheckSuiteStatus = enum {
     failed,
     completed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .queued => "queued",
-            .running => "running",
-            .approved => "approved",
-            .rejected => "rejected",
-            .canceled => "canceled",
-            .timed_out => "timedOut",
-            .rerunning => "rerunning",
-            .bypassed => "bypassed",
-            .deferred => "deferred",
-            .failed => "failed",
-            .completed => "completed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "running")) return .running;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "rerunning")) return .rerunning;
-        if (std.mem.eql(u8, s, "bypassed")) return .bypassed;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .queued = "queued",
+        .running = "running",
+        .approved = "approved",
+        .rejected = "rejected",
+        .canceled = "canceled",
+        .timed_out = "timedOut",
+        .rerunning = "rerunning",
+        .bypassed = "bypassed",
+        .deferred = "deferred",
+        .failed = "failed",
+        .completed = "completed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -488,36 +452,36 @@ pub const UpdateRequestExpand = enum {
     }
 };
 
-pub const CheckSuiteUpdateParameterAction = enum {
+pub const CheckSuiteUpdateParameterAction = union(enum) {
     rerun,
     bypass,
     @"defer",
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .rerun => "rerun",
-            .bypass => "bypass",
-            .@"defer" => "defer",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "rerun")) return .rerun;
-        if (std.mem.eql(u8, s, "bypass")) return .bypass;
-        if (std.mem.eql(u8, s, "defer")) return .@"defer";
-        return null;
-    }
+    const wire_names = .{
+        .rerun = "rerun",
+        .bypass = "bypass",
+        .@"defer" = "defer",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -581,79 +545,77 @@ pub const QueryRequestState = enum {
     }
 };
 
-pub const ApprovalExecutionOrder = enum {
+pub const ApprovalExecutionOrder = union(enum) {
     any_order,
     in_sequence,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .any_order => "anyOrder",
-            .in_sequence => "inSequence",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "anyOrder")) return .any_order;
-        if (std.mem.eql(u8, s, "inSequence")) return .in_sequence;
-        return null;
-    }
+    const wire_names = .{
+        .any_order = "anyOrder",
+        .in_sequence = "inSequence",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ApprovalPermissions = enum {
+pub const ApprovalPermissions = union(enum) {
     none,
     view,
     update,
     reassign,
     resource_admin,
     queue_build,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .view => "view",
-            .update => "update",
-            .reassign => "reassign",
-            .resource_admin => "resourceAdmin",
-            .queue_build => "queueBuild",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "view")) return .view;
-        if (std.mem.eql(u8, s, "update")) return .update;
-        if (std.mem.eql(u8, s, "reassign")) return .reassign;
-        if (std.mem.eql(u8, s, "resourceAdmin")) return .resource_admin;
-        if (std.mem.eql(u8, s, "queueBuild")) return .queue_build;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .view = "view",
+        .update = "update",
+        .reassign = "reassign",
+        .resource_admin = "resourceAdmin",
+        .queue_build = "queueBuild",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ApprovalStatus = enum {
+pub const ApprovalStatus = union(enum) {
     undefined,
     uninitiated,
     pending,
@@ -666,96 +628,84 @@ pub const ApprovalStatus = enum {
     failed,
     completed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .uninitiated => "uninitiated",
-            .pending => "pending",
-            .approved => "approved",
-            .rejected => "rejected",
-            .skipped => "skipped",
-            .canceled => "canceled",
-            .timed_out => "timedOut",
-            .deferred => "deferred",
-            .failed => "failed",
-            .completed => "completed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "uninitiated")) return .uninitiated;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .uninitiated = "uninitiated",
+        .pending = "pending",
+        .approved = "approved",
+        .rejected = "rejected",
+        .skipped = "skipped",
+        .canceled = "canceled",
+        .timed_out = "timedOut",
+        .deferred = "deferred",
+        .failed = "failed",
+        .completed = "completed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ApprovalStepPermissions = enum {
+pub const ApprovalStepPermissions = union(enum) {
     none,
     view,
     update,
     reassign,
     resource_admin,
     queue_build,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .view => "view",
-            .update => "update",
-            .reassign => "reassign",
-            .resource_admin => "resourceAdmin",
-            .queue_build => "queueBuild",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "view")) return .view;
-        if (std.mem.eql(u8, s, "update")) return .update;
-        if (std.mem.eql(u8, s, "reassign")) return .reassign;
-        if (std.mem.eql(u8, s, "resourceAdmin")) return .resource_admin;
-        if (std.mem.eql(u8, s, "queueBuild")) return .queue_build;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .view = "view",
+        .update = "update",
+        .reassign = "reassign",
+        .resource_admin = "resourceAdmin",
+        .queue_build = "queueBuild",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ApprovalStepStatus = enum {
+pub const ApprovalStepStatus = union(enum) {
     undefined,
     uninitiated,
     pending,
@@ -768,54 +718,45 @@ pub const ApprovalStepStatus = enum {
     failed,
     completed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .uninitiated => "uninitiated",
-            .pending => "pending",
-            .approved => "approved",
-            .rejected => "rejected",
-            .skipped => "skipped",
-            .canceled => "canceled",
-            .timed_out => "timedOut",
-            .deferred => "deferred",
-            .failed => "failed",
-            .completed => "completed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "uninitiated")) return .uninitiated;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .uninitiated = "uninitiated",
+        .pending = "pending",
+        .approved = "approved",
+        .rejected = "rejected",
+        .skipped = "skipped",
+        .canceled = "canceled",
+        .timed_out = "timedOut",
+        .deferred = "deferred",
+        .failed = "failed",
+        .completed = "completed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ApprovalUpdateParametersStatus = enum {
+pub const ApprovalUpdateParametersStatus = union(enum) {
     undefined,
     uninitiated,
     pending,
@@ -828,49 +769,40 @@ pub const ApprovalUpdateParametersStatus = enum {
     failed,
     completed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .uninitiated => "uninitiated",
-            .pending => "pending",
-            .approved => "approved",
-            .rejected => "rejected",
-            .skipped => "skipped",
-            .canceled => "canceled",
-            .timed_out => "timedOut",
-            .deferred => "deferred",
-            .failed => "failed",
-            .completed => "completed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "uninitiated")) return .uninitiated;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .uninitiated = "uninitiated",
+        .pending = "pending",
+        .approved = "approved",
+        .rejected = "rejected",
+        .skipped = "skipped",
+        .canceled = "canceled",
+        .timed_out = "timedOut",
+        .deferred = "deferred",
+        .failed = "failed",
+        .completed = "completed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };

--- a/src/artifacts/enums.zig
+++ b/src/artifacts/enums.zig
@@ -8,312 +8,308 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const GlobalPermissionRole = enum {
+pub const GlobalPermissionRole = union(enum) {
     custom,
     none,
     feed_creator,
     administrator,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .custom => "custom",
-            .none => "none",
-            .feed_creator => "feedCreator",
-            .administrator => "administrator",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "feedCreator")) return .feed_creator;
-        if (std.mem.eql(u8, s, "administrator")) return .administrator;
-        return null;
-    }
+    const wire_names = .{
+        .custom = "custom",
+        .none = "none",
+        .feed_creator = "feedCreator",
+        .administrator = "administrator",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const FeedChangeChangeType = enum {
+pub const FeedChangeChangeType = union(enum) {
     add_or_update,
     delete,
     permanent_delete,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .add_or_update => "addOrUpdate",
-            .delete => "delete",
-            .permanent_delete => "permanentDelete",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "addOrUpdate")) return .add_or_update;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        return null;
-    }
+    const wire_names = .{
+        .add_or_update = "addOrUpdate",
+        .delete = "delete",
+        .permanent_delete = "permanentDelete",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const FeedCapabilities = enum {
+pub const FeedCapabilities = union(enum) {
     none,
     upstream_v2,
     under_maintenance,
     default_capabilities,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .upstream_v2 => "upstreamV2",
-            .under_maintenance => "underMaintenance",
-            .default_capabilities => "defaultCapabilities",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "upstreamV2")) return .upstream_v2;
-        if (std.mem.eql(u8, s, "underMaintenance")) return .under_maintenance;
-        if (std.mem.eql(u8, s, "defaultCapabilities")) return .default_capabilities;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .upstream_v2 = "upstreamV2",
+        .under_maintenance = "underMaintenance",
+        .default_capabilities = "defaultCapabilities",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const UpstreamSourceStatus = enum {
+pub const UpstreamSourceStatus = union(enum) {
     ok,
     disabled,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .ok => "ok",
-            .disabled => "disabled",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "ok")) return .ok;
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        return null;
-    }
+    const wire_names = .{
+        .ok = "ok",
+        .disabled = "disabled",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const UpstreamSourceUpstreamSourceType = enum {
+pub const UpstreamSourceUpstreamSourceType = union(enum) {
     public,
     internal,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .public => "public",
-            .internal => "internal",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "public")) return .public;
-        if (std.mem.eql(u8, s, "internal")) return .internal;
-        return null;
-    }
+    const wire_names = .{
+        .public = "public",
+        .internal = "internal",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const FeedViewType = enum {
+pub const FeedViewType = union(enum) {
     none,
     release,
     implicit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .release => "release",
-            .implicit => "implicit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "release")) return .release;
-        if (std.mem.eql(u8, s, "implicit")) return .implicit;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .release = "release",
+        .implicit = "implicit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const FeedViewVisibility = enum {
+pub const FeedViewVisibility = union(enum) {
     private,
     collection,
     organization,
     aad_tenant,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .private => "private",
-            .collection => "collection",
-            .organization => "organization",
-            .aad_tenant => "aadTenant",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "private")) return .private;
-        if (std.mem.eql(u8, s, "collection")) return .collection;
-        if (std.mem.eql(u8, s, "organization")) return .organization;
-        if (std.mem.eql(u8, s, "aadTenant")) return .aad_tenant;
-        return null;
-    }
+    const wire_names = .{
+        .private = "private",
+        .collection = "collection",
+        .organization = "organization",
+        .aad_tenant = "aadTenant",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const FeedPermissionRole = enum {
+pub const FeedPermissionRole = union(enum) {
     custom,
     none,
     reader,
     contributor,
     administrator,
     collaborator,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .custom => "custom",
-            .none => "none",
-            .reader => "reader",
-            .contributor => "contributor",
-            .administrator => "administrator",
-            .collaborator => "collaborator",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "reader")) return .reader;
-        if (std.mem.eql(u8, s, "contributor")) return .contributor;
-        if (std.mem.eql(u8, s, "administrator")) return .administrator;
-        if (std.mem.eql(u8, s, "collaborator")) return .collaborator;
-        return null;
-    }
+    const wire_names = .{
+        .custom = "custom",
+        .none = "none",
+        .reader = "reader",
+        .contributor = "contributor",
+        .administrator = "administrator",
+        .collaborator = "collaborator",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const PackageVersionChangeChangeType = enum {
+pub const PackageVersionChangeChangeType = union(enum) {
     add_or_update,
     delete,
     permanent_delete,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .add_or_update => "addOrUpdate",
-            .delete => "delete",
-            .permanent_delete => "permanentDelete",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "addOrUpdate")) return .add_or_update;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        return null;
-    }
+    const wire_names = .{
+        .add_or_update = "addOrUpdate",
+        .delete = "delete",
+        .permanent_delete = "permanentDelete",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -359,45 +355,42 @@ pub const GetFeedsRequestFeedRole = enum {
     }
 };
 
-pub const OperationReferenceStatus = enum {
+pub const OperationReferenceStatus = union(enum) {
     not_set,
     queued,
     in_progress,
     cancelled,
     succeeded,
     failed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .cancelled => "cancelled",
-            .succeeded => "succeeded",
-            .failed => "failed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "cancelled")) return .cancelled;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .cancelled = "cancelled",
+        .succeeded = "succeeded",
+        .failed = "failed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/artifacts_package_types/enums.zig
+++ b/src/artifacts_package_types/enums.zig
@@ -8,144 +8,141 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const UpstreamingBehaviorVersionsFromExternalUpstreams = enum {
+pub const UpstreamingBehaviorVersionsFromExternalUpstreams = union(enum) {
     auto,
     allow_external_versions,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .auto => "auto",
-            .allow_external_versions => "allowExternalVersions",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "auto")) return .auto;
-        if (std.mem.eql(u8, s, "allowExternalVersions")) return .allow_external_versions;
-        return null;
-    }
+    const wire_names = .{
+        .auto = "auto",
+        .allow_external_versions = "allowExternalVersions",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const UpstreamSourceInfoSourceType = enum {
+pub const UpstreamSourceInfoSourceType = union(enum) {
     public,
     internal,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .public => "public",
-            .internal => "internal",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "public")) return .public;
-        if (std.mem.eql(u8, s, "internal")) return .internal;
-        return null;
-    }
+    const wire_names = .{
+        .public = "public",
+        .internal = "internal",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const JsonPatchOperationOp = enum {
+pub const JsonPatchOperationOp = union(enum) {
     add,
     remove,
     replace,
     move,
     copy,
     @"test",
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .add => "add",
-            .remove => "remove",
-            .replace => "replace",
-            .move => "move",
-            .copy => "copy",
-            .@"test" => "test",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "add")) return .add;
-        if (std.mem.eql(u8, s, "remove")) return .remove;
-        if (std.mem.eql(u8, s, "replace")) return .replace;
-        if (std.mem.eql(u8, s, "move")) return .move;
-        if (std.mem.eql(u8, s, "copy")) return .copy;
-        if (std.mem.eql(u8, s, "test")) return .@"test";
-        return null;
-    }
+    const wire_names = .{
+        .add = "add",
+        .remove = "remove",
+        .replace = "replace",
+        .move = "move",
+        .copy = "copy",
+        .@"test" = "test",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CargoPackagesBatchRequestOperation = enum {
+pub const CargoPackagesBatchRequestOperation = union(enum) {
     promote,
     delete,
     permanent_delete,
     restore_to_feed,
     yank,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .promote => "promote",
-            .delete => "delete",
-            .permanent_delete => "permanentDelete",
-            .restore_to_feed => "restoreToFeed",
-            .yank => "yank",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "promote")) return .promote;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        if (std.mem.eql(u8, s, "restoreToFeed")) return .restore_to_feed;
-        if (std.mem.eql(u8, s, "yank")) return .yank;
-        return null;
-    }
+    const wire_names = .{
+        .promote = "promote",
+        .delete = "delete",
+        .permanent_delete = "permanentDelete",
+        .restore_to_feed = "restoreToFeed",
+        .yank = "yank",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -176,191 +173,183 @@ pub const ServiceApiVersions = enum {
     }
 };
 
-pub const MavenPackagesBatchRequestOperation = enum {
+pub const MavenPackagesBatchRequestOperation = union(enum) {
     promote,
     delete,
     permanent_delete,
     restore_to_feed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .promote => "promote",
-            .delete => "delete",
-            .permanent_delete => "permanentDelete",
-            .restore_to_feed => "restoreToFeed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "promote")) return .promote;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        if (std.mem.eql(u8, s, "restoreToFeed")) return .restore_to_feed;
-        return null;
-    }
+    const wire_names = .{
+        .promote = "promote",
+        .delete = "delete",
+        .permanent_delete = "permanentDelete",
+        .restore_to_feed = "restoreToFeed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NpmPackagesBatchRequestOperation = enum {
+pub const NpmPackagesBatchRequestOperation = union(enum) {
     promote,
     deprecate,
     unpublish,
     permanent_delete,
     restore_to_feed,
     delete,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .promote => "promote",
-            .deprecate => "deprecate",
-            .unpublish => "unpublish",
-            .permanent_delete => "permanentDelete",
-            .restore_to_feed => "restoreToFeed",
-            .delete => "delete",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "promote")) return .promote;
-        if (std.mem.eql(u8, s, "deprecate")) return .deprecate;
-        if (std.mem.eql(u8, s, "unpublish")) return .unpublish;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        if (std.mem.eql(u8, s, "restoreToFeed")) return .restore_to_feed;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        return null;
-    }
+    const wire_names = .{
+        .promote = "promote",
+        .deprecate = "deprecate",
+        .unpublish = "unpublish",
+        .permanent_delete = "permanentDelete",
+        .restore_to_feed = "restoreToFeed",
+        .delete = "delete",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NuGetPackagesBatchRequestOperation = enum {
+pub const NuGetPackagesBatchRequestOperation = union(enum) {
     promote,
     list,
     delete,
     permanent_delete,
     restore_to_feed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .promote => "promote",
-            .list => "list",
-            .delete => "delete",
-            .permanent_delete => "permanentDelete",
-            .restore_to_feed => "restoreToFeed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "promote")) return .promote;
-        if (std.mem.eql(u8, s, "list")) return .list;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        if (std.mem.eql(u8, s, "restoreToFeed")) return .restore_to_feed;
-        return null;
-    }
+    const wire_names = .{
+        .promote = "promote",
+        .list = "list",
+        .delete = "delete",
+        .permanent_delete = "permanentDelete",
+        .restore_to_feed = "restoreToFeed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const PyPiPackagesBatchRequestOperation = enum {
+pub const PyPiPackagesBatchRequestOperation = union(enum) {
     promote,
     delete,
     permanent_delete,
     restore_to_feed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .promote => "promote",
-            .delete => "delete",
-            .permanent_delete => "permanentDelete",
-            .restore_to_feed => "restoreToFeed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "promote")) return .promote;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        if (std.mem.eql(u8, s, "restoreToFeed")) return .restore_to_feed;
-        return null;
-    }
+    const wire_names = .{
+        .promote = "promote",
+        .delete = "delete",
+        .permanent_delete = "permanentDelete",
+        .restore_to_feed = "restoreToFeed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const UPackPackagesBatchRequestOperation = enum {
+pub const UPackPackagesBatchRequestOperation = union(enum) {
     promote,
     delete,
     permanent_delete,
     restore_to_feed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .promote => "promote",
-            .delete => "delete",
-            .permanent_delete => "permanentDelete",
-            .restore_to_feed => "restoreToFeed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "promote")) return .promote;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "permanentDelete")) return .permanent_delete;
-        if (std.mem.eql(u8, s, "restoreToFeed")) return .restore_to_feed;
-        return null;
-    }
+    const wire_names = .{
+        .promote = "promote",
+        .delete = "delete",
+        .permanent_delete = "permanentDelete",
+        .restore_to_feed = "restoreToFeed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };

--- a/src/audit/enums.zig
+++ b/src/audit/enums.zig
@@ -8,168 +8,157 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const AuditActionInfoCategory = enum {
+pub const AuditActionInfoCategory = union(enum) {
     unknown,
     modify,
     remove,
     create,
     access,
     execute,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .modify => "modify",
-            .remove => "remove",
-            .create => "create",
-            .access => "access",
-            .execute => "execute",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "modify")) return .modify;
-        if (std.mem.eql(u8, s, "remove")) return .remove;
-        if (std.mem.eql(u8, s, "create")) return .create;
-        if (std.mem.eql(u8, s, "access")) return .access;
-        if (std.mem.eql(u8, s, "execute")) return .execute;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .modify = "modify",
+        .remove = "remove",
+        .create = "create",
+        .access = "access",
+        .execute = "execute",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DecoratedAuditLogEntryCategory = enum {
+pub const DecoratedAuditLogEntryCategory = union(enum) {
     unknown,
     modify,
     remove,
     create,
     access,
     execute,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .modify => "modify",
-            .remove => "remove",
-            .create => "create",
-            .access => "access",
-            .execute => "execute",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "modify")) return .modify;
-        if (std.mem.eql(u8, s, "remove")) return .remove;
-        if (std.mem.eql(u8, s, "create")) return .create;
-        if (std.mem.eql(u8, s, "access")) return .access;
-        if (std.mem.eql(u8, s, "execute")) return .execute;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .modify = "modify",
+        .remove = "remove",
+        .create = "create",
+        .access = "access",
+        .execute = "execute",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DecoratedAuditLogEntryScopeType = enum {
+pub const DecoratedAuditLogEntryScopeType = union(enum) {
     unknown,
     deployment,
     enterprise,
     organization,
     project,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .deployment => "deployment",
-            .enterprise => "enterprise",
-            .organization => "organization",
-            .project => "project",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "deployment")) return .deployment;
-        if (std.mem.eql(u8, s, "enterprise")) return .enterprise;
-        if (std.mem.eql(u8, s, "organization")) return .organization;
-        if (std.mem.eql(u8, s, "project")) return .project;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .deployment = "deployment",
+        .enterprise = "enterprise",
+        .organization = "organization",
+        .project = "project",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AuditStreamStatus = enum {
+pub const AuditStreamStatus = union(enum) {
     unknown,
     enabled,
     disabled_by_user,
     disabled_by_system,
     deleted,
     backfilling,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .enabled => "enabled",
-            .disabled_by_user => "disabledByUser",
-            .disabled_by_system => "disabledBySystem",
-            .deleted => "deleted",
-            .backfilling => "backfilling",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        if (std.mem.eql(u8, s, "disabledByUser")) return .disabled_by_user;
-        if (std.mem.eql(u8, s, "disabledBySystem")) return .disabled_by_system;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        if (std.mem.eql(u8, s, "backfilling")) return .backfilling;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .enabled = "enabled",
+        .disabled_by_user = "disabledByUser",
+        .disabled_by_system = "disabledBySystem",
+        .deleted = "deleted",
+        .backfilling = "backfilling",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/build/enums.zig
+++ b/src/build/enums.zig
@@ -8,36 +8,36 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const BuildControllerStatus = enum {
+pub const BuildControllerStatus = union(enum) {
     unavailable,
     available,
     offline,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unavailable => "unavailable",
-            .available => "available",
-            .offline => "offline",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unavailable")) return .unavailable;
-        if (std.mem.eql(u8, s, "available")) return .available;
-        if (std.mem.eql(u8, s, "offline")) return .offline;
-        return null;
-    }
+    const wire_names = .{
+        .unavailable = "unavailable",
+        .available = "available",
+        .offline = "offline",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -269,7 +269,7 @@ pub const ListRequestQueryOrder = enum {
     }
 };
 
-pub const TeamProjectReferenceState = enum {
+pub const TeamProjectReferenceState = union(enum) {
     deleting,
     new,
     well_formed,
@@ -277,206 +277,203 @@ pub const TeamProjectReferenceState = enum {
     all,
     unchanged,
     deleted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .deleting => "deleting",
-            .new => "new",
-            .well_formed => "wellFormed",
-            .create_pending => "createPending",
-            .all => "all",
-            .unchanged => "unchanged",
-            .deleted => "deleted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "deleting")) return .deleting;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "wellFormed")) return .well_formed;
-        if (std.mem.eql(u8, s, "createPending")) return .create_pending;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        if (std.mem.eql(u8, s, "unchanged")) return .unchanged;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        return null;
-    }
+    const wire_names = .{
+        .deleting = "deleting",
+        .new = "new",
+        .well_formed = "wellFormed",
+        .create_pending = "createPending",
+        .all = "all",
+        .unchanged = "unchanged",
+        .deleted = "deleted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamProjectReferenceVisibility = enum {
+pub const TeamProjectReferenceVisibility = union(enum) {
     private,
     public,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .private => "private",
-            .public => "public",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "private")) return .private;
-        if (std.mem.eql(u8, s, "public")) return .public;
-        return null;
-    }
+    const wire_names = .{
+        .private = "private",
+        .public = "public",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DefinitionReferenceQueueStatus = enum {
+pub const DefinitionReferenceQueueStatus = union(enum) {
     enabled,
     paused,
     disabled,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .enabled => "enabled",
-            .paused => "paused",
-            .disabled => "disabled",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        return null;
-    }
+    const wire_names = .{
+        .enabled = "enabled",
+        .paused = "paused",
+        .disabled = "disabled",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DefinitionReferenceType = enum {
+pub const DefinitionReferenceType = union(enum) {
     xaml,
     build,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .xaml => "xaml",
-            .build => "build",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "xaml")) return .xaml;
-        if (std.mem.eql(u8, s, "build")) return .build;
-        return null;
-    }
+    const wire_names = .{
+        .xaml = "xaml",
+        .build = "build",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildPriority = enum {
+pub const BuildPriority = union(enum) {
     low,
     below_normal,
     normal,
     above_normal,
     high,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .low => "low",
-            .below_normal => "belowNormal",
-            .normal => "normal",
-            .above_normal => "aboveNormal",
-            .high => "high",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "low")) return .low;
-        if (std.mem.eql(u8, s, "belowNormal")) return .below_normal;
-        if (std.mem.eql(u8, s, "normal")) return .normal;
-        if (std.mem.eql(u8, s, "aboveNormal")) return .above_normal;
-        if (std.mem.eql(u8, s, "high")) return .high;
-        return null;
-    }
+    const wire_names = .{
+        .low = "low",
+        .below_normal = "belowNormal",
+        .normal = "normal",
+        .above_normal = "aboveNormal",
+        .high = "high",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildQueueOptions = enum {
+pub const BuildQueueOptions = union(enum) {
     none,
     do_not_run,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .do_not_run => "doNotRun",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "doNotRun")) return .do_not_run;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .do_not_run = "doNotRun",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildReason = enum {
+pub const BuildReason = union(enum) {
     none,
     manual,
     individual_ci,
@@ -491,97 +488,84 @@ pub const BuildReason = enum {
     resource_trigger,
     triggered,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .manual => "manual",
-            .individual_ci => "individualCI",
-            .batched_ci => "batchedCI",
-            .schedule => "schedule",
-            .schedule_forced => "scheduleForced",
-            .user_created => "userCreated",
-            .validate_shelveset => "validateShelveset",
-            .check_in_shelveset => "checkInShelveset",
-            .pull_request => "pullRequest",
-            .build_completion => "buildCompletion",
-            .resource_trigger => "resourceTrigger",
-            .triggered => "triggered",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "individualCI")) return .individual_ci;
-        if (std.mem.eql(u8, s, "batchedCI")) return .batched_ci;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "scheduleForced")) return .schedule_forced;
-        if (std.mem.eql(u8, s, "userCreated")) return .user_created;
-        if (std.mem.eql(u8, s, "validateShelveset")) return .validate_shelveset;
-        if (std.mem.eql(u8, s, "checkInShelveset")) return .check_in_shelveset;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        if (std.mem.eql(u8, s, "buildCompletion")) return .build_completion;
-        if (std.mem.eql(u8, s, "resourceTrigger")) return .resource_trigger;
-        if (std.mem.eql(u8, s, "triggered")) return .triggered;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .manual = "manual",
+        .individual_ci = "individualCI",
+        .batched_ci = "batchedCI",
+        .schedule = "schedule",
+        .schedule_forced = "scheduleForced",
+        .user_created = "userCreated",
+        .validate_shelveset = "validateShelveset",
+        .check_in_shelveset = "checkInShelveset",
+        .pull_request = "pullRequest",
+        .build_completion = "buildCompletion",
+        .resource_trigger = "resourceTrigger",
+        .triggered = "triggered",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildResult = enum {
+pub const BuildResult = union(enum) {
     none,
     succeeded,
     partially_succeeded,
     failed,
     canceled,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .succeeded => "succeeded",
-            .partially_succeeded => "partiallySucceeded",
-            .failed => "failed",
-            .canceled => "canceled",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .succeeded = "succeeded",
+        .partially_succeeded = "partiallySucceeded",
+        .failed = "failed",
+        .canceled = "canceled",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildStatus = enum {
+pub const BuildStatus = union(enum) {
     none,
     in_progress,
     completed,
@@ -590,142 +574,138 @@ pub const BuildStatus = enum {
     abandoned,
     not_started,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .in_progress => "inProgress",
-            .completed => "completed",
-            .cancelling => "cancelling",
-            .postponed => "postponed",
-            .abandoned => "abandoned",
-            .not_started => "notStarted",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "cancelling")) return .cancelling;
-        if (std.mem.eql(u8, s, "postponed")) return .postponed;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        if (std.mem.eql(u8, s, "notStarted")) return .not_started;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .in_progress = "inProgress",
+        .completed = "completed",
+        .cancelling = "cancelling",
+        .postponed = "postponed",
+        .abandoned = "abandoned",
+        .not_started = "notStarted",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildRequestValidationResultResult = enum {
+pub const BuildRequestValidationResultResult = union(enum) {
     ok,
     warning,
     @"error",
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .ok => "ok",
-            .warning => "warning",
-            .@"error" => "error",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "ok")) return .ok;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        return null;
-    }
+    const wire_names = .{
+        .ok = "ok",
+        .warning = "warning",
+        .@"error" = "error",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const UpdateStageParametersState = enum {
+pub const UpdateStageParametersState = union(enum) {
     cancel,
     retry,
     run,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .cancel => "cancel",
-            .retry => "retry",
-            .run => "run",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "cancel")) return .cancel;
-        if (std.mem.eql(u8, s, "retry")) return .retry;
-        if (std.mem.eql(u8, s, "run")) return .run;
-        return null;
-    }
+    const wire_names = .{
+        .cancel = "cancel",
+        .retry = "retry",
+        .run = "run",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const IssueType = enum {
+pub const IssueType = union(enum) {
     @"error",
     warning,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .@"error" => "error",
-            .warning => "warning",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        return null;
-    }
+    const wire_names = .{
+        .@"error" = "error",
+        .warning = "warning",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TimelineRecordResult = enum {
+pub const TimelineRecordResult = union(enum) {
     succeeded,
     succeeded_with_issues,
     failed,
@@ -734,75 +714,70 @@ pub const TimelineRecordResult = enum {
     abandoned,
     manually_queued,
     dependent_on_manual_queue,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .succeeded => "succeeded",
-            .succeeded_with_issues => "succeededWithIssues",
-            .failed => "failed",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .abandoned => "abandoned",
-            .manually_queued => "manuallyQueued",
-            .dependent_on_manual_queue => "dependentOnManualQueue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "succeededWithIssues")) return .succeeded_with_issues;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        if (std.mem.eql(u8, s, "manuallyQueued")) return .manually_queued;
-        if (std.mem.eql(u8, s, "dependentOnManualQueue")) return .dependent_on_manual_queue;
-        return null;
-    }
+    const wire_names = .{
+        .succeeded = "succeeded",
+        .succeeded_with_issues = "succeededWithIssues",
+        .failed = "failed",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .abandoned = "abandoned",
+        .manually_queued = "manuallyQueued",
+        .dependent_on_manual_queue = "dependentOnManualQueue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TimelineRecordState = enum {
+pub const TimelineRecordState = union(enum) {
     pending,
     in_progress,
     completed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .pending => "pending",
-            .in_progress => "inProgress",
-            .completed => "completed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        return null;
-    }
+    const wire_names = .{
+        .pending = "pending",
+        .in_progress = "inProgress",
+        .completed = "completed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -845,67 +820,69 @@ pub const ListRequestQueryOrder1 = enum {
     }
 };
 
-pub const BuildDefinitionReferenceQuality = enum {
+pub const BuildDefinitionReferenceQuality = union(enum) {
     definition,
     draft,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .definition => "definition",
-            .draft => "draft",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "definition")) return .definition;
-        if (std.mem.eql(u8, s, "draft")) return .draft;
-        return null;
-    }
+    const wire_names = .{
+        .definition = "definition",
+        .draft = "draft",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildDefinitionJobAuthorizationScope = enum {
+pub const BuildDefinitionJobAuthorizationScope = union(enum) {
     project_collection,
     project,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .project_collection => "projectCollection",
-            .project => "project",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "projectCollection")) return .project_collection;
-        if (std.mem.eql(u8, s, "project")) return .project;
-        return null;
-    }
+    const wire_names = .{
+        .project_collection = "projectCollection",
+        .project = "project",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildTriggerTriggerType = enum {
+pub const BuildTriggerTriggerType = union(enum) {
     none,
     continuous_integration,
     batched_continuous_integration,
@@ -915,77 +892,71 @@ pub const BuildTriggerTriggerType = enum {
     pull_request,
     build_completion,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .continuous_integration => "continuousIntegration",
-            .batched_continuous_integration => "batchedContinuousIntegration",
-            .schedule => "schedule",
-            .gated_check_in => "gatedCheckIn",
-            .batched_gated_check_in => "batchedGatedCheckIn",
-            .pull_request => "pullRequest",
-            .build_completion => "buildCompletion",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "continuousIntegration")) return .continuous_integration;
-        if (std.mem.eql(u8, s, "batchedContinuousIntegration")) return .batched_continuous_integration;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "gatedCheckIn")) return .gated_check_in;
-        if (std.mem.eql(u8, s, "batchedGatedCheckIn")) return .batched_gated_check_in;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        if (std.mem.eql(u8, s, "buildCompletion")) return .build_completion;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .continuous_integration = "continuousIntegration",
+        .batched_continuous_integration = "batchedContinuousIntegration",
+        .schedule = "schedule",
+        .gated_check_in = "gatedCheckIn",
+        .batched_gated_check_in = "batchedGatedCheckIn",
+        .pull_request = "pullRequest",
+        .build_completion = "buildCompletion",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BuildDefinitionRevisionChangeType = enum {
+pub const BuildDefinitionRevisionChangeType = union(enum) {
     add,
     update,
     delete,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .add => "add",
-            .update => "update",
-            .delete => "delete",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "add")) return .add;
-        if (std.mem.eql(u8, s, "update")) return .update;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        return null;
-    }
+    const wire_names = .{
+        .add = "add",
+        .update = "update",
+        .delete = "delete",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1022,7 +993,7 @@ pub const ListRequestQueryOrder2 = enum {
     }
 };
 
-pub const BuildOptionInputDefinitionType = enum {
+pub const BuildOptionInputDefinitionType = union(enum) {
     string,
     boolean,
     string_list,
@@ -1030,77 +1001,73 @@ pub const BuildOptionInputDefinitionType = enum {
     pick_list,
     multi_line,
     branch_filter,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .string => "string",
-            .boolean => "boolean",
-            .string_list => "stringList",
-            .radio => "radio",
-            .pick_list => "pickList",
-            .multi_line => "multiLine",
-            .branch_filter => "branchFilter",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "stringList")) return .string_list;
-        if (std.mem.eql(u8, s, "radio")) return .radio;
-        if (std.mem.eql(u8, s, "pickList")) return .pick_list;
-        if (std.mem.eql(u8, s, "multiLine")) return .multi_line;
-        if (std.mem.eql(u8, s, "branchFilter")) return .branch_filter;
-        return null;
-    }
+    const wire_names = .{
+        .string = "string",
+        .boolean = "boolean",
+        .string_list = "stringList",
+        .radio = "radio",
+        .pick_list = "pickList",
+        .multi_line = "multiLine",
+        .branch_filter = "branchFilter",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const SupportedTriggerSupportedCapability = enum {
+pub const SupportedTriggerSupportedCapability = union(enum) {
     unsupported,
     supported,
     required,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unsupported => "unsupported",
-            .supported => "supported",
-            .required => "required",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unsupported")) return .unsupported;
-        if (std.mem.eql(u8, s, "supported")) return .supported;
-        if (std.mem.eql(u8, s, "required")) return .required;
-        return null;
-    }
+    const wire_names = .{
+        .unsupported = "unsupported",
+        .supported = "supported",
+        .required = "required",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const SupportedTriggerType = enum {
+pub const SupportedTriggerType = union(enum) {
     none,
     continuous_integration,
     batched_continuous_integration,
@@ -1110,44 +1077,38 @@ pub const SupportedTriggerType = enum {
     pull_request,
     build_completion,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .continuous_integration => "continuousIntegration",
-            .batched_continuous_integration => "batchedContinuousIntegration",
-            .schedule => "schedule",
-            .gated_check_in => "gatedCheckIn",
-            .batched_gated_check_in => "batchedGatedCheckIn",
-            .pull_request => "pullRequest",
-            .build_completion => "buildCompletion",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "continuousIntegration")) return .continuous_integration;
-        if (std.mem.eql(u8, s, "batchedContinuousIntegration")) return .batched_continuous_integration;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "gatedCheckIn")) return .gated_check_in;
-        if (std.mem.eql(u8, s, "batchedGatedCheckIn")) return .batched_gated_check_in;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        if (std.mem.eql(u8, s, "buildCompletion")) return .build_completion;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .continuous_integration = "continuousIntegration",
+        .batched_continuous_integration = "batchedContinuousIntegration",
+        .schedule = "schedule",
+        .gated_check_in = "gatedCheckIn",
+        .batched_gated_check_in = "batchedGatedCheckIn",
+        .pull_request = "pullRequest",
+        .build_completion = "buildCompletion",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1181,7 +1142,7 @@ pub const ListRepositoriesRequestResultSet = enum {
     }
 };
 
-pub const RepositoryWebhookType = enum {
+pub const RepositoryWebhookType = union(enum) {
     none,
     continuous_integration,
     batched_continuous_integration,
@@ -1191,44 +1152,38 @@ pub const RepositoryWebhookType = enum {
     pull_request,
     build_completion,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .continuous_integration => "continuousIntegration",
-            .batched_continuous_integration => "batchedContinuousIntegration",
-            .schedule => "schedule",
-            .gated_check_in => "gatedCheckIn",
-            .batched_gated_check_in => "batchedGatedCheckIn",
-            .pull_request => "pullRequest",
-            .build_completion => "buildCompletion",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "continuousIntegration")) return .continuous_integration;
-        if (std.mem.eql(u8, s, "batchedContinuousIntegration")) return .batched_continuous_integration;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "gatedCheckIn")) return .gated_check_in;
-        if (std.mem.eql(u8, s, "batchedGatedCheckIn")) return .batched_gated_check_in;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        if (std.mem.eql(u8, s, "buildCompletion")) return .build_completion;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .continuous_integration = "continuousIntegration",
+        .batched_continuous_integration = "batchedContinuousIntegration",
+        .schedule = "schedule",
+        .gated_check_in = "gatedCheckIn",
+        .batched_gated_check_in = "batchedGatedCheckIn",
+        .pull_request = "pullRequest",
+        .build_completion = "buildCompletion",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/core/enums.zig
+++ b/src/core/enums.zig
@@ -8,36 +8,36 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const ProcessType = enum {
+pub const ProcessType = union(enum) {
     system,
     custom,
     inherited,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .custom => "custom",
-            .inherited => "inherited",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .custom = "custom",
+        .inherited = "inherited",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -86,7 +86,7 @@ pub const ListRequestStateFilter = enum {
     }
 };
 
-pub const TeamProjectReferenceState = enum {
+pub const TeamProjectReferenceState = union(enum) {
     deleting,
     new,
     well_formed,
@@ -94,112 +94,106 @@ pub const TeamProjectReferenceState = enum {
     all,
     unchanged,
     deleted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .deleting => "deleting",
-            .new => "new",
-            .well_formed => "wellFormed",
-            .create_pending => "createPending",
-            .all => "all",
-            .unchanged => "unchanged",
-            .deleted => "deleted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "deleting")) return .deleting;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "wellFormed")) return .well_formed;
-        if (std.mem.eql(u8, s, "createPending")) return .create_pending;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        if (std.mem.eql(u8, s, "unchanged")) return .unchanged;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        return null;
-    }
+    const wire_names = .{
+        .deleting = "deleting",
+        .new = "new",
+        .well_formed = "wellFormed",
+        .create_pending = "createPending",
+        .all = "all",
+        .unchanged = "unchanged",
+        .deleted = "deleted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamProjectReferenceVisibility = enum {
+pub const TeamProjectReferenceVisibility = union(enum) {
     private,
     public,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .private => "private",
-            .public => "public",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "private")) return .private;
-        if (std.mem.eql(u8, s, "public")) return .public;
-        return null;
-    }
+    const wire_names = .{
+        .private = "private",
+        .public = "public",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const OperationReferenceStatus = enum {
+pub const OperationReferenceStatus = union(enum) {
     not_set,
     queued,
     in_progress,
     cancelled,
     succeeded,
     failed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .cancelled => "cancelled",
-            .succeeded => "succeeded",
-            .failed => "failed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "cancelled")) return .cancelled;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .cancelled = "cancelled",
+        .succeeded = "succeeded",
+        .failed = "failed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/dashboard/enums.zig
+++ b/src/dashboard/enums.zig
@@ -38,144 +38,141 @@ pub const GetWidgetTypesRequestScope = enum {
     }
 };
 
-pub const WidgetMetadataSupportedScope = enum {
+pub const WidgetMetadataSupportedScope = union(enum) {
     collection_user,
     project_team,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .collection_user => "collection_User",
-            .project_team => "project_Team",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "collection_User")) return .collection_user;
-        if (std.mem.eql(u8, s, "project_Team")) return .project_team;
-        return null;
-    }
+    const wire_names = .{
+        .collection_user = "collection_User",
+        .project_team = "project_Team",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DashboardDashboardScope = enum {
+pub const DashboardDashboardScope = union(enum) {
     collection_user,
     project_team,
     project,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .collection_user => "collection_User",
-            .project_team => "project_Team",
-            .project => "project",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "collection_User")) return .collection_user;
-        if (std.mem.eql(u8, s, "project_Team")) return .project_team;
-        if (std.mem.eql(u8, s, "project")) return .project;
-        return null;
-    }
+    const wire_names = .{
+        .collection_user = "collection_User",
+        .project_team = "project_Team",
+        .project = "project",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DashboardGroupPermission = enum {
+pub const DashboardGroupPermission = union(enum) {
     none,
     edit,
     manage,
     manage_permissions,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .edit => "edit",
-            .manage => "manage",
-            .manage_permissions => "managePermissions",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "edit")) return .edit;
-        if (std.mem.eql(u8, s, "manage")) return .manage;
-        if (std.mem.eql(u8, s, "managePermissions")) return .manage_permissions;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .edit = "edit",
+        .manage = "manage",
+        .manage_permissions = "managePermissions",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DashboardGroupTeamDashboardPermission = enum {
+pub const DashboardGroupTeamDashboardPermission = union(enum) {
     none,
     read,
     create,
     edit,
     delete,
     manage_permissions,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .read => "read",
-            .create => "create",
-            .edit => "edit",
-            .delete => "delete",
-            .manage_permissions => "managePermissions",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "read")) return .read;
-        if (std.mem.eql(u8, s, "create")) return .create;
-        if (std.mem.eql(u8, s, "edit")) return .edit;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "managePermissions")) return .manage_permissions;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .read = "read",
+        .create = "create",
+        .edit = "edit",
+        .delete = "delete",
+        .manage_permissions = "managePermissions",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/delegated_auth/enums.zig
+++ b/src/delegated_auth/enums.zig
@@ -8,45 +8,42 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const RegistrationClientType = enum {
+pub const RegistrationClientType = union(enum) {
     confidential,
     public,
     medium_trust,
     high_trust,
     full_trust,
     application,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .confidential => "confidential",
-            .public => "public",
-            .medium_trust => "mediumTrust",
-            .high_trust => "highTrust",
-            .full_trust => "fullTrust",
-            .application => "application",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "confidential")) return .confidential;
-        if (std.mem.eql(u8, s, "public")) return .public;
-        if (std.mem.eql(u8, s, "mediumTrust")) return .medium_trust;
-        if (std.mem.eql(u8, s, "highTrust")) return .high_trust;
-        if (std.mem.eql(u8, s, "fullTrust")) return .full_trust;
-        if (std.mem.eql(u8, s, "application")) return .application;
-        return null;
-    }
+    const wire_names = .{
+        .confidential = "confidential",
+        .public = "public",
+        .medium_trust = "mediumTrust",
+        .high_trust = "highTrust",
+        .full_trust = "fullTrust",
+        .application = "application",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/distributed_task/enums.zig
+++ b/src/distributed_task/enums.zig
@@ -8,297 +8,298 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const ElasticPoolOrchestrationType = enum {
+pub const ElasticPoolOrchestrationType = union(enum) {
     uniform,
     flexible,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .uniform => "uniform",
-            .flexible => "flexible",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "uniform")) return .uniform;
-        if (std.mem.eql(u8, s, "flexible")) return .flexible;
-        return null;
-    }
+    const wire_names = .{
+        .uniform = "uniform",
+        .flexible = "flexible",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticPoolOsType = enum {
+pub const ElasticPoolOsType = union(enum) {
     windows,
     linux,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .windows => "windows",
-            .linux => "linux",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "windows")) return .windows;
-        if (std.mem.eql(u8, s, "linux")) return .linux;
-        return null;
-    }
+    const wire_names = .{
+        .windows = "windows",
+        .linux = "linux",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticPoolState = enum {
+pub const ElasticPoolState = union(enum) {
     online,
     offline,
     unhealthy,
     new,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .online => "online",
-            .offline => "offline",
-            .unhealthy => "unhealthy",
-            .new => "new",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "online")) return .online;
-        if (std.mem.eql(u8, s, "offline")) return .offline;
-        if (std.mem.eql(u8, s, "unhealthy")) return .unhealthy;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        return null;
-    }
+    const wire_names = .{
+        .online = "online",
+        .offline = "offline",
+        .unhealthy = "unhealthy",
+        .new = "new",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentPoolOptions = enum {
+pub const TaskAgentPoolOptions = union(enum) {
     none,
     elastic_pool,
     single_use_agents,
     preserve_agent_on_job_failure,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .elastic_pool => "elasticPool",
-            .single_use_agents => "singleUseAgents",
-            .preserve_agent_on_job_failure => "preserveAgentOnJobFailure",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "elasticPool")) return .elastic_pool;
-        if (std.mem.eql(u8, s, "singleUseAgents")) return .single_use_agents;
-        if (std.mem.eql(u8, s, "preserveAgentOnJobFailure")) return .preserve_agent_on_job_failure;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .elastic_pool = "elasticPool",
+        .single_use_agents = "singleUseAgents",
+        .preserve_agent_on_job_failure = "preserveAgentOnJobFailure",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentPoolPoolType = enum {
+pub const TaskAgentPoolPoolType = union(enum) {
     automation,
     deployment,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .automation => "automation",
-            .deployment => "deployment",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "automation")) return .automation;
-        if (std.mem.eql(u8, s, "deployment")) return .deployment;
-        return null;
-    }
+    const wire_names = .{
+        .automation = "automation",
+        .deployment = "deployment",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticPoolSettingsOrchestrationType = enum {
+pub const ElasticPoolSettingsOrchestrationType = union(enum) {
     uniform,
     flexible,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .uniform => "uniform",
-            .flexible => "flexible",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "uniform")) return .uniform;
-        if (std.mem.eql(u8, s, "flexible")) return .flexible;
-        return null;
-    }
+    const wire_names = .{
+        .uniform = "uniform",
+        .flexible = "flexible",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticPoolSettingsOsType = enum {
+pub const ElasticPoolSettingsOsType = union(enum) {
     windows,
     linux,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .windows => "windows",
-            .linux => "linux",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "windows")) return .windows;
-        if (std.mem.eql(u8, s, "linux")) return .linux;
-        return null;
-    }
+    const wire_names = .{
+        .windows = "windows",
+        .linux = "linux",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticPoolLogLevel = enum {
+pub const ElasticPoolLogLevel = union(enum) {
     @"error",
     warning,
     info,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .@"error" => "error",
-            .warning => "warning",
-            .info => "info",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "info")) return .info;
-        return null;
-    }
+    const wire_names = .{
+        .@"error" = "error",
+        .warning = "warning",
+        .info = "info",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticPoolLogOperation = enum {
+pub const ElasticPoolLogOperation = union(enum) {
     configuration_job,
     sizing_job,
     increase_capacity,
     reimage,
     delete_v_ms,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .configuration_job => "configurationJob",
-            .sizing_job => "sizingJob",
-            .increase_capacity => "increaseCapacity",
-            .reimage => "reimage",
-            .delete_v_ms => "deleteVMs",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "configurationJob")) return .configuration_job;
-        if (std.mem.eql(u8, s, "sizingJob")) return .sizing_job;
-        if (std.mem.eql(u8, s, "increaseCapacity")) return .increase_capacity;
-        if (std.mem.eql(u8, s, "reimage")) return .reimage;
-        if (std.mem.eql(u8, s, "deleteVMs")) return .delete_v_ms;
-        return null;
-    }
+    const wire_names = .{
+        .configuration_job = "configurationJob",
+        .sizing_job = "sizingJob",
+        .increase_capacity = "increaseCapacity",
+        .reimage = "reimage",
+        .delete_v_ms = "deleteVMs",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -395,43 +396,42 @@ pub const ListRequestState = enum {
     }
 };
 
-pub const ElasticNodeAgentState = enum {
+pub const ElasticNodeAgentState = union(enum) {
     none,
     enabled,
     online,
     assigned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .enabled => "enabled",
-            .online => "online",
-            .assigned => "assigned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        if (std.mem.eql(u8, s, "online")) return .online;
-        if (std.mem.eql(u8, s, "assigned")) return .assigned;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .enabled = "enabled",
+        .online = "online",
+        .assigned = "assigned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticNodeComputeState = enum {
+pub const ElasticNodeComputeState = union(enum) {
     none,
     healthy,
     creating,
@@ -441,48 +441,42 @@ pub const ElasticNodeComputeState = enum {
     reimaging,
     unhealthy_vm,
     unhealthy_vmss_vm,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .healthy => "healthy",
-            .creating => "creating",
-            .deleting => "deleting",
-            .failed => "failed",
-            .stopped => "stopped",
-            .reimaging => "reimaging",
-            .unhealthy_vm => "unhealthyVm",
-            .unhealthy_vmss_vm => "unhealthyVmssVm",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "healthy")) return .healthy;
-        if (std.mem.eql(u8, s, "creating")) return .creating;
-        if (std.mem.eql(u8, s, "deleting")) return .deleting;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "stopped")) return .stopped;
-        if (std.mem.eql(u8, s, "reimaging")) return .reimaging;
-        if (std.mem.eql(u8, s, "unhealthyVm")) return .unhealthy_vm;
-        if (std.mem.eql(u8, s, "unhealthyVmssVm")) return .unhealthy_vmss_vm;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .healthy = "healthy",
+        .creating = "creating",
+        .deleting = "deleting",
+        .failed = "failed",
+        .stopped = "stopped",
+        .reimaging = "reimaging",
+        .unhealthy_vm = "unhealthyVm",
+        .unhealthy_vmss_vm = "unhealthyVmssVm",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticNodeDesiredState = enum {
+pub const ElasticNodeDesiredState = union(enum) {
     none,
     new,
     creating_compute,
@@ -506,76 +500,56 @@ pub const ElasticNodeDesiredState = enum {
     unhealthy_vm,
     unhealthy_vm_pending_delete,
     pending_reimage_candidate,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .new => "new",
-            .creating_compute => "creatingCompute",
-            .starting_agent => "startingAgent",
-            .idle => "idle",
-            .assigned => "assigned",
-            .offline => "offline",
-            .pending_reimage => "pendingReimage",
-            .pending_delete => "pendingDelete",
-            .saved => "saved",
-            .deleting_compute => "deletingCompute",
-            .deleted => "deleted",
-            .lost => "lost",
-            .reimaging_compute => "reimagingCompute",
-            .restarting_agent => "restartingAgent",
-            .failed_to_start_pending_delete => "failedToStartPendingDelete",
-            .failed_to_restart_pending_delete => "failedToRestartPendingDelete",
-            .failed_vm_pending_delete => "failedVMPendingDelete",
-            .assigned_pending_delete => "assignedPendingDelete",
-            .retry_delete => "retryDelete",
-            .unhealthy_vm => "unhealthyVm",
-            .unhealthy_vm_pending_delete => "unhealthyVmPendingDelete",
-            .pending_reimage_candidate => "pendingReimageCandidate",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "creatingCompute")) return .creating_compute;
-        if (std.mem.eql(u8, s, "startingAgent")) return .starting_agent;
-        if (std.mem.eql(u8, s, "idle")) return .idle;
-        if (std.mem.eql(u8, s, "assigned")) return .assigned;
-        if (std.mem.eql(u8, s, "offline")) return .offline;
-        if (std.mem.eql(u8, s, "pendingReimage")) return .pending_reimage;
-        if (std.mem.eql(u8, s, "pendingDelete")) return .pending_delete;
-        if (std.mem.eql(u8, s, "saved")) return .saved;
-        if (std.mem.eql(u8, s, "deletingCompute")) return .deleting_compute;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        if (std.mem.eql(u8, s, "lost")) return .lost;
-        if (std.mem.eql(u8, s, "reimagingCompute")) return .reimaging_compute;
-        if (std.mem.eql(u8, s, "restartingAgent")) return .restarting_agent;
-        if (std.mem.eql(u8, s, "failedToStartPendingDelete")) return .failed_to_start_pending_delete;
-        if (std.mem.eql(u8, s, "failedToRestartPendingDelete")) return .failed_to_restart_pending_delete;
-        if (std.mem.eql(u8, s, "failedVMPendingDelete")) return .failed_vm_pending_delete;
-        if (std.mem.eql(u8, s, "assignedPendingDelete")) return .assigned_pending_delete;
-        if (std.mem.eql(u8, s, "retryDelete")) return .retry_delete;
-        if (std.mem.eql(u8, s, "unhealthyVm")) return .unhealthy_vm;
-        if (std.mem.eql(u8, s, "unhealthyVmPendingDelete")) return .unhealthy_vm_pending_delete;
-        if (std.mem.eql(u8, s, "pendingReimageCandidate")) return .pending_reimage_candidate;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .new = "new",
+        .creating_compute = "creatingCompute",
+        .starting_agent = "startingAgent",
+        .idle = "idle",
+        .assigned = "assigned",
+        .offline = "offline",
+        .pending_reimage = "pendingReimage",
+        .pending_delete = "pendingDelete",
+        .saved = "saved",
+        .deleting_compute = "deletingCompute",
+        .deleted = "deleted",
+        .lost = "lost",
+        .reimaging_compute = "reimagingCompute",
+        .restarting_agent = "restartingAgent",
+        .failed_to_start_pending_delete = "failedToStartPendingDelete",
+        .failed_to_restart_pending_delete = "failedToRestartPendingDelete",
+        .failed_vm_pending_delete = "failedVMPendingDelete",
+        .assigned_pending_delete = "assignedPendingDelete",
+        .retry_delete = "retryDelete",
+        .unhealthy_vm = "unhealthyVm",
+        .unhealthy_vm_pending_delete = "unhealthyVmPendingDelete",
+        .pending_reimage_candidate = "pendingReimageCandidate",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticNodeState = enum {
+pub const ElasticNodeState = union(enum) {
     none,
     new,
     creating_compute,
@@ -599,76 +573,56 @@ pub const ElasticNodeState = enum {
     unhealthy_vm,
     unhealthy_vm_pending_delete,
     pending_reimage_candidate,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .new => "new",
-            .creating_compute => "creatingCompute",
-            .starting_agent => "startingAgent",
-            .idle => "idle",
-            .assigned => "assigned",
-            .offline => "offline",
-            .pending_reimage => "pendingReimage",
-            .pending_delete => "pendingDelete",
-            .saved => "saved",
-            .deleting_compute => "deletingCompute",
-            .deleted => "deleted",
-            .lost => "lost",
-            .reimaging_compute => "reimagingCompute",
-            .restarting_agent => "restartingAgent",
-            .failed_to_start_pending_delete => "failedToStartPendingDelete",
-            .failed_to_restart_pending_delete => "failedToRestartPendingDelete",
-            .failed_vm_pending_delete => "failedVMPendingDelete",
-            .assigned_pending_delete => "assignedPendingDelete",
-            .retry_delete => "retryDelete",
-            .unhealthy_vm => "unhealthyVm",
-            .unhealthy_vm_pending_delete => "unhealthyVmPendingDelete",
-            .pending_reimage_candidate => "pendingReimageCandidate",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "creatingCompute")) return .creating_compute;
-        if (std.mem.eql(u8, s, "startingAgent")) return .starting_agent;
-        if (std.mem.eql(u8, s, "idle")) return .idle;
-        if (std.mem.eql(u8, s, "assigned")) return .assigned;
-        if (std.mem.eql(u8, s, "offline")) return .offline;
-        if (std.mem.eql(u8, s, "pendingReimage")) return .pending_reimage;
-        if (std.mem.eql(u8, s, "pendingDelete")) return .pending_delete;
-        if (std.mem.eql(u8, s, "saved")) return .saved;
-        if (std.mem.eql(u8, s, "deletingCompute")) return .deleting_compute;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        if (std.mem.eql(u8, s, "lost")) return .lost;
-        if (std.mem.eql(u8, s, "reimagingCompute")) return .reimaging_compute;
-        if (std.mem.eql(u8, s, "restartingAgent")) return .restarting_agent;
-        if (std.mem.eql(u8, s, "failedToStartPendingDelete")) return .failed_to_start_pending_delete;
-        if (std.mem.eql(u8, s, "failedToRestartPendingDelete")) return .failed_to_restart_pending_delete;
-        if (std.mem.eql(u8, s, "failedVMPendingDelete")) return .failed_vm_pending_delete;
-        if (std.mem.eql(u8, s, "assignedPendingDelete")) return .assigned_pending_delete;
-        if (std.mem.eql(u8, s, "retryDelete")) return .retry_delete;
-        if (std.mem.eql(u8, s, "unhealthyVm")) return .unhealthy_vm;
-        if (std.mem.eql(u8, s, "unhealthyVmPendingDelete")) return .unhealthy_vm_pending_delete;
-        if (std.mem.eql(u8, s, "pendingReimageCandidate")) return .pending_reimage_candidate;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .new = "new",
+        .creating_compute = "creatingCompute",
+        .starting_agent = "startingAgent",
+        .idle = "idle",
+        .assigned = "assigned",
+        .offline = "offline",
+        .pending_reimage = "pendingReimage",
+        .pending_delete = "pendingDelete",
+        .saved = "saved",
+        .deleting_compute = "deletingCompute",
+        .deleted = "deleted",
+        .lost = "lost",
+        .reimaging_compute = "reimagingCompute",
+        .restarting_agent = "restartingAgent",
+        .failed_to_start_pending_delete = "failedToStartPendingDelete",
+        .failed_to_restart_pending_delete = "failedToRestartPendingDelete",
+        .failed_vm_pending_delete = "failedVMPendingDelete",
+        .assigned_pending_delete = "assignedPendingDelete",
+        .retry_delete = "retryDelete",
+        .unhealthy_vm = "unhealthyVm",
+        .unhealthy_vm_pending_delete = "unhealthyVmPendingDelete",
+        .pending_reimage_candidate = "pendingReimageCandidate",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ElasticNodeSettingsState = enum {
+pub const ElasticNodeSettingsState = union(enum) {
     none,
     new,
     creating_compute,
@@ -692,72 +646,52 @@ pub const ElasticNodeSettingsState = enum {
     unhealthy_vm,
     unhealthy_vm_pending_delete,
     pending_reimage_candidate,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .new => "new",
-            .creating_compute => "creatingCompute",
-            .starting_agent => "startingAgent",
-            .idle => "idle",
-            .assigned => "assigned",
-            .offline => "offline",
-            .pending_reimage => "pendingReimage",
-            .pending_delete => "pendingDelete",
-            .saved => "saved",
-            .deleting_compute => "deletingCompute",
-            .deleted => "deleted",
-            .lost => "lost",
-            .reimaging_compute => "reimagingCompute",
-            .restarting_agent => "restartingAgent",
-            .failed_to_start_pending_delete => "failedToStartPendingDelete",
-            .failed_to_restart_pending_delete => "failedToRestartPendingDelete",
-            .failed_vm_pending_delete => "failedVMPendingDelete",
-            .assigned_pending_delete => "assignedPendingDelete",
-            .retry_delete => "retryDelete",
-            .unhealthy_vm => "unhealthyVm",
-            .unhealthy_vm_pending_delete => "unhealthyVmPendingDelete",
-            .pending_reimage_candidate => "pendingReimageCandidate",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "creatingCompute")) return .creating_compute;
-        if (std.mem.eql(u8, s, "startingAgent")) return .starting_agent;
-        if (std.mem.eql(u8, s, "idle")) return .idle;
-        if (std.mem.eql(u8, s, "assigned")) return .assigned;
-        if (std.mem.eql(u8, s, "offline")) return .offline;
-        if (std.mem.eql(u8, s, "pendingReimage")) return .pending_reimage;
-        if (std.mem.eql(u8, s, "pendingDelete")) return .pending_delete;
-        if (std.mem.eql(u8, s, "saved")) return .saved;
-        if (std.mem.eql(u8, s, "deletingCompute")) return .deleting_compute;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        if (std.mem.eql(u8, s, "lost")) return .lost;
-        if (std.mem.eql(u8, s, "reimagingCompute")) return .reimaging_compute;
-        if (std.mem.eql(u8, s, "restartingAgent")) return .restarting_agent;
-        if (std.mem.eql(u8, s, "failedToStartPendingDelete")) return .failed_to_start_pending_delete;
-        if (std.mem.eql(u8, s, "failedToRestartPendingDelete")) return .failed_to_restart_pending_delete;
-        if (std.mem.eql(u8, s, "failedVMPendingDelete")) return .failed_vm_pending_delete;
-        if (std.mem.eql(u8, s, "assignedPendingDelete")) return .assigned_pending_delete;
-        if (std.mem.eql(u8, s, "retryDelete")) return .retry_delete;
-        if (std.mem.eql(u8, s, "unhealthyVm")) return .unhealthy_vm;
-        if (std.mem.eql(u8, s, "unhealthyVmPendingDelete")) return .unhealthy_vm_pending_delete;
-        if (std.mem.eql(u8, s, "pendingReimageCandidate")) return .pending_reimage_candidate;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .new = "new",
+        .creating_compute = "creatingCompute",
+        .starting_agent = "startingAgent",
+        .idle = "idle",
+        .assigned = "assigned",
+        .offline = "offline",
+        .pending_reimage = "pendingReimage",
+        .pending_delete = "pendingDelete",
+        .saved = "saved",
+        .deleting_compute = "deletingCompute",
+        .deleted = "deleted",
+        .lost = "lost",
+        .reimaging_compute = "reimagingCompute",
+        .restarting_agent = "restartingAgent",
+        .failed_to_start_pending_delete = "failedToStartPendingDelete",
+        .failed_to_restart_pending_delete = "failedToRestartPendingDelete",
+        .failed_vm_pending_delete = "failedVMPendingDelete",
+        .assigned_pending_delete = "assignedPendingDelete",
+        .retry_delete = "retryDelete",
+        .unhealthy_vm = "unhealthyVm",
+        .unhealthy_vm_pending_delete = "unhealthyVmPendingDelete",
+        .pending_reimage_candidate = "pendingReimageCandidate",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -788,37 +722,38 @@ pub const ServiceApiVersions = enum {
     }
 };
 
-pub const IssueType = enum {
+pub const IssueType = union(enum) {
     @"error",
     warning,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .@"error" => "error",
-            .warning => "warning",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        return null;
-    }
+    const wire_names = .{
+        .@"error" = "error",
+        .warning = "warning",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TimelineRecordResult = enum {
+pub const TimelineRecordResult = union(enum) {
     succeeded,
     succeeded_with_issues,
     failed,
@@ -827,175 +762,171 @@ pub const TimelineRecordResult = enum {
     abandoned,
     manually_queued,
     dependent_on_manual_queue,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .succeeded => "succeeded",
-            .succeeded_with_issues => "succeededWithIssues",
-            .failed => "failed",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .abandoned => "abandoned",
-            .manually_queued => "manuallyQueued",
-            .dependent_on_manual_queue => "dependentOnManualQueue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "succeededWithIssues")) return .succeeded_with_issues;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        if (std.mem.eql(u8, s, "manuallyQueued")) return .manually_queued;
-        if (std.mem.eql(u8, s, "dependentOnManualQueue")) return .dependent_on_manual_queue;
-        return null;
-    }
+    const wire_names = .{
+        .succeeded = "succeeded",
+        .succeeded_with_issues = "succeededWithIssues",
+        .failed = "failed",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .abandoned = "abandoned",
+        .manually_queued = "manuallyQueued",
+        .dependent_on_manual_queue = "dependentOnManualQueue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TimelineRecordState = enum {
+pub const TimelineRecordState = union(enum) {
     pending,
     in_progress,
     completed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .pending => "pending",
-            .in_progress => "inProgress",
-            .completed => "completed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        return null;
-    }
+    const wire_names = .{
+        .pending = "pending",
+        .in_progress = "inProgress",
+        .completed = "completed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentReferenceStatus = enum {
+pub const TaskAgentReferenceStatus = union(enum) {
     offline,
     online,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .offline => "offline",
-            .online => "online",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "offline")) return .offline;
-        if (std.mem.eql(u8, s, "online")) return .online;
-        return null;
-    }
+    const wire_names = .{
+        .offline = "offline",
+        .online = "online",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentPoolReferenceOptions = enum {
+pub const TaskAgentPoolReferenceOptions = union(enum) {
     none,
     elastic_pool,
     single_use_agents,
     preserve_agent_on_job_failure,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .elastic_pool => "elasticPool",
-            .single_use_agents => "singleUseAgents",
-            .preserve_agent_on_job_failure => "preserveAgentOnJobFailure",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "elasticPool")) return .elastic_pool;
-        if (std.mem.eql(u8, s, "singleUseAgents")) return .single_use_agents;
-        if (std.mem.eql(u8, s, "preserveAgentOnJobFailure")) return .preserve_agent_on_job_failure;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .elastic_pool = "elasticPool",
+        .single_use_agents = "singleUseAgents",
+        .preserve_agent_on_job_failure = "preserveAgentOnJobFailure",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentPoolReferencePoolType = enum {
+pub const TaskAgentPoolReferencePoolType = union(enum) {
     automation,
     deployment,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .automation => "automation",
-            .deployment => "deployment",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "automation")) return .automation;
-        if (std.mem.eql(u8, s, "deployment")) return .deployment;
-        return null;
-    }
+    const wire_names = .{
+        .automation = "automation",
+        .deployment = "deployment",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const InputDescriptorInputMode = enum {
+pub const InputDescriptorInputMode = union(enum) {
     none,
     text_box,
     password_box,
@@ -1003,82 +934,75 @@ pub const InputDescriptorInputMode = enum {
     radio_buttons,
     check_box,
     text_area,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .text_box => "textBox",
-            .password_box => "passwordBox",
-            .combo => "combo",
-            .radio_buttons => "radioButtons",
-            .check_box => "checkBox",
-            .text_area => "textArea",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "textBox")) return .text_box;
-        if (std.mem.eql(u8, s, "passwordBox")) return .password_box;
-        if (std.mem.eql(u8, s, "combo")) return .combo;
-        if (std.mem.eql(u8, s, "radioButtons")) return .radio_buttons;
-        if (std.mem.eql(u8, s, "checkBox")) return .check_box;
-        if (std.mem.eql(u8, s, "textArea")) return .text_area;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .text_box = "textBox",
+        .password_box = "passwordBox",
+        .combo = "combo",
+        .radio_buttons = "radioButtons",
+        .check_box = "checkBox",
+        .text_area = "textArea",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const InputValidationDataType = enum {
+pub const InputValidationDataType = union(enum) {
     none,
     string,
     number,
     boolean,
     guid,
     uri,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .string => "string",
-            .number => "number",
-            .boolean => "boolean",
-            .guid => "guid",
-            .uri => "uri",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "number")) return .number;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        if (std.mem.eql(u8, s, "uri")) return .uri;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .string = "string",
+        .number = "number",
+        .boolean = "boolean",
+        .guid = "guid",
+        .uri = "uri",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1148,7 +1072,7 @@ pub const GetRequestActionFilter = enum {
     }
 };
 
-pub const TaskAgentJobRequestResult = enum {
+pub const TaskAgentJobRequestResult = union(enum) {
     succeeded,
     succeeded_with_issues,
     failed,
@@ -1157,75 +1081,70 @@ pub const TaskAgentJobRequestResult = enum {
     abandoned,
     manually_queued,
     dependent_on_manual_queue,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .succeeded => "succeeded",
-            .succeeded_with_issues => "succeededWithIssues",
-            .failed => "failed",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .abandoned => "abandoned",
-            .manually_queued => "manuallyQueued",
-            .dependent_on_manual_queue => "dependentOnManualQueue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "succeededWithIssues")) return .succeeded_with_issues;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        if (std.mem.eql(u8, s, "manuallyQueued")) return .manually_queued;
-        if (std.mem.eql(u8, s, "dependentOnManualQueue")) return .dependent_on_manual_queue;
-        return null;
-    }
+    const wire_names = .{
+        .succeeded = "succeeded",
+        .succeeded_with_issues = "succeededWithIssues",
+        .failed = "failed",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .abandoned = "abandoned",
+        .manually_queued = "manuallyQueued",
+        .dependent_on_manual_queue = "dependentOnManualQueue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentUpdateReasonCode = enum {
+pub const TaskAgentUpdateReasonCode = union(enum) {
     manual,
     min_agent_version_required,
     downgrade,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .manual => "manual",
-            .min_agent_version_required => "minAgentVersionRequired",
-            .downgrade => "downgrade",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "minAgentVersionRequired")) return .min_agent_version_required;
-        if (std.mem.eql(u8, s, "downgrade")) return .downgrade;
-        return null;
-    }
+    const wire_names = .{
+        .manual = "manual",
+        .min_agent_version_required = "minAgentVersionRequired",
+        .downgrade = "downgrade",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1634,33 +1553,34 @@ pub const GetRequestActionFilter3 = enum {
     }
 };
 
-pub const TaskCommandRestrictionsMode = enum {
+pub const TaskCommandRestrictionsMode = union(enum) {
     any,
     restricted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .any => "any",
-            .restricted => "restricted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "any")) return .any;
-        if (std.mem.eql(u8, s, "restricted")) return .restricted;
-        return null;
-    }
+    const wire_names = .{
+        .any = "any",
+        .restricted = "restricted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/environments/enums.zig
+++ b/src/environments/enums.zig
@@ -8,39 +8,38 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const EnvironmentResourceReferenceType = enum {
+pub const EnvironmentResourceReferenceType = union(enum) {
     undefined,
     generic,
     virtual_machine,
     kubernetes,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .generic => "generic",
-            .virtual_machine => "virtualMachine",
-            .kubernetes => "kubernetes",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "generic")) return .generic;
-        if (std.mem.eql(u8, s, "virtualMachine")) return .virtual_machine;
-        if (std.mem.eql(u8, s, "kubernetes")) return .kubernetes;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .generic = "generic",
+        .virtual_machine = "virtualMachine",
+        .kubernetes = "kubernetes",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -74,7 +73,7 @@ pub const GetRequestExpands = enum {
     }
 };
 
-pub const EnvironmentDeploymentExecutionRecordResult = enum {
+pub const EnvironmentDeploymentExecutionRecordResult = union(enum) {
     succeeded,
     succeeded_with_issues,
     failed,
@@ -83,178 +82,173 @@ pub const EnvironmentDeploymentExecutionRecordResult = enum {
     abandoned,
     manually_queued,
     dependent_on_manual_queue,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .succeeded => "succeeded",
-            .succeeded_with_issues => "succeededWithIssues",
-            .failed => "failed",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .abandoned => "abandoned",
-            .manually_queued => "manuallyQueued",
-            .dependent_on_manual_queue => "dependentOnManualQueue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "succeededWithIssues")) return .succeeded_with_issues;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        if (std.mem.eql(u8, s, "manuallyQueued")) return .manually_queued;
-        if (std.mem.eql(u8, s, "dependentOnManualQueue")) return .dependent_on_manual_queue;
-        return null;
-    }
+    const wire_names = .{
+        .succeeded = "succeeded",
+        .succeeded_with_issues = "succeededWithIssues",
+        .failed = "failed",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .abandoned = "abandoned",
+        .manually_queued = "manuallyQueued",
+        .dependent_on_manual_queue = "dependentOnManualQueue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const KubernetesResourceType = enum {
+pub const KubernetesResourceType = union(enum) {
     undefined,
     generic,
     virtual_machine,
     kubernetes,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .generic => "generic",
-            .virtual_machine => "virtualMachine",
-            .kubernetes => "kubernetes",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "generic")) return .generic;
-        if (std.mem.eql(u8, s, "virtualMachine")) return .virtual_machine;
-        if (std.mem.eql(u8, s, "kubernetes")) return .kubernetes;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .generic = "generic",
+        .virtual_machine = "virtualMachine",
+        .kubernetes = "kubernetes",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentStatus = enum {
+pub const TaskAgentStatus = union(enum) {
     offline,
     online,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .offline => "offline",
-            .online => "online",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "offline")) return .offline;
-        if (std.mem.eql(u8, s, "online")) return .online;
-        return null;
-    }
+    const wire_names = .{
+        .offline = "offline",
+        .online = "online",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentPoolReferenceOptions = enum {
+pub const TaskAgentPoolReferenceOptions = union(enum) {
     none,
     elastic_pool,
     single_use_agents,
     preserve_agent_on_job_failure,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .elastic_pool => "elasticPool",
-            .single_use_agents => "singleUseAgents",
-            .preserve_agent_on_job_failure => "preserveAgentOnJobFailure",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "elasticPool")) return .elastic_pool;
-        if (std.mem.eql(u8, s, "singleUseAgents")) return .single_use_agents;
-        if (std.mem.eql(u8, s, "preserveAgentOnJobFailure")) return .preserve_agent_on_job_failure;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .elastic_pool = "elasticPool",
+        .single_use_agents = "singleUseAgents",
+        .preserve_agent_on_job_failure = "preserveAgentOnJobFailure",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentPoolReferencePoolType = enum {
+pub const TaskAgentPoolReferencePoolType = union(enum) {
     automation,
     deployment,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .automation => "automation",
-            .deployment => "deployment",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "automation")) return .automation;
-        if (std.mem.eql(u8, s, "deployment")) return .deployment;
-        return null;
-    }
+    const wire_names = .{
+        .automation = "automation",
+        .deployment = "deployment",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentJobRequestResult = enum {
+pub const TaskAgentJobRequestResult = union(enum) {
     succeeded,
     succeeded_with_issues,
     failed,
@@ -263,75 +257,70 @@ pub const TaskAgentJobRequestResult = enum {
     abandoned,
     manually_queued,
     dependent_on_manual_queue,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .succeeded => "succeeded",
-            .succeeded_with_issues => "succeededWithIssues",
-            .failed => "failed",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .abandoned => "abandoned",
-            .manually_queued => "manuallyQueued",
-            .dependent_on_manual_queue => "dependentOnManualQueue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "succeededWithIssues")) return .succeeded_with_issues;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        if (std.mem.eql(u8, s, "manuallyQueued")) return .manually_queued;
-        if (std.mem.eql(u8, s, "dependentOnManualQueue")) return .dependent_on_manual_queue;
-        return null;
-    }
+    const wire_names = .{
+        .succeeded = "succeeded",
+        .succeeded_with_issues = "succeededWithIssues",
+        .failed = "failed",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .abandoned = "abandoned",
+        .manually_queued = "manuallyQueued",
+        .dependent_on_manual_queue = "dependentOnManualQueue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TaskAgentUpdateReasonCode = enum {
+pub const TaskAgentUpdateReasonCode = union(enum) {
     manual,
     min_agent_version_required,
     downgrade,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .manual => "manual",
-            .min_agent_version_required => "minAgentVersionRequired",
-            .downgrade => "downgrade",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "minAgentVersionRequired")) return .min_agent_version_required;
-        if (std.mem.eql(u8, s, "downgrade")) return .downgrade;
-        return null;
-    }
+    const wire_names = .{
+        .manual = "manual",
+        .min_agent_version_required = "minAgentVersionRequired",
+        .downgrade = "downgrade",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/extension_management/enums.zig
+++ b/src/extension_management/enums.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const ContributionPropertyDescriptionType = enum {
+pub const ContributionPropertyDescriptionType = union(enum) {
     unknown,
     string,
     uri,
@@ -20,115 +20,108 @@ pub const ContributionPropertyDescriptionType = enum {
     dictionary,
     array,
     object,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .string => "string",
-            .uri => "uri",
-            .guid => "guid",
-            .boolean => "boolean",
-            .integer => "integer",
-            .double => "double",
-            .date_time => "dateTime",
-            .dictionary => "dictionary",
-            .array => "array",
-            .object => "object",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "uri")) return .uri;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "integer")) return .integer;
-        if (std.mem.eql(u8, s, "double")) return .double;
-        if (std.mem.eql(u8, s, "dateTime")) return .date_time;
-        if (std.mem.eql(u8, s, "dictionary")) return .dictionary;
-        if (std.mem.eql(u8, s, "array")) return .array;
-        if (std.mem.eql(u8, s, "object")) return .object;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .string = "string",
+        .uri = "uri",
+        .guid = "guid",
+        .boolean = "boolean",
+        .integer = "integer",
+        .double = "double",
+        .date_time = "dateTime",
+        .dictionary = "dictionary",
+        .array = "array",
+        .object = "object",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const LicensingOverrideBehavior = enum {
+pub const LicensingOverrideBehavior = union(enum) {
     only_if_licensed,
     only_if_unlicensed,
     always_include,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .only_if_licensed => "onlyIfLicensed",
-            .only_if_unlicensed => "onlyIfUnlicensed",
-            .always_include => "alwaysInclude",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "onlyIfLicensed")) return .only_if_licensed;
-        if (std.mem.eql(u8, s, "onlyIfUnlicensed")) return .only_if_unlicensed;
-        if (std.mem.eql(u8, s, "alwaysInclude")) return .always_include;
-        return null;
-    }
+    const wire_names = .{
+        .only_if_licensed = "onlyIfLicensed",
+        .only_if_unlicensed = "onlyIfUnlicensed",
+        .always_include = "alwaysInclude",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const InstalledExtensionFlags = enum {
+pub const InstalledExtensionFlags = union(enum) {
     built_in,
     trusted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .built_in => "builtIn",
-            .trusted => "trusted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "builtIn")) return .built_in;
-        if (std.mem.eql(u8, s, "trusted")) return .trusted;
-        return null;
-    }
+    const wire_names = .{
+        .built_in = "builtIn",
+        .trusted = "trusted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const InstalledExtensionStateFlags = enum {
+pub const InstalledExtensionStateFlags = union(enum) {
     none,
     disabled,
     built_in,
@@ -141,80 +134,72 @@ pub const InstalledExtensionStateFlags = enum {
     auto_upgrade_error,
     warning,
     unpublished,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .disabled => "disabled",
-            .built_in => "builtIn",
-            .multi_version => "multiVersion",
-            .un_installed => "unInstalled",
-            .version_check_error => "versionCheckError",
-            .trusted => "trusted",
-            .@"error" => "error",
-            .needs_reauthorization => "needsReauthorization",
-            .auto_upgrade_error => "autoUpgradeError",
-            .warning => "warning",
-            .unpublished => "unpublished",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        if (std.mem.eql(u8, s, "builtIn")) return .built_in;
-        if (std.mem.eql(u8, s, "multiVersion")) return .multi_version;
-        if (std.mem.eql(u8, s, "unInstalled")) return .un_installed;
-        if (std.mem.eql(u8, s, "versionCheckError")) return .version_check_error;
-        if (std.mem.eql(u8, s, "trusted")) return .trusted;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "needsReauthorization")) return .needs_reauthorization;
-        if (std.mem.eql(u8, s, "autoUpgradeError")) return .auto_upgrade_error;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "unpublished")) return .unpublished;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .disabled = "disabled",
+        .built_in = "builtIn",
+        .multi_version = "multiVersion",
+        .un_installed = "unInstalled",
+        .version_check_error = "versionCheckError",
+        .trusted = "trusted",
+        .@"error" = "error",
+        .needs_reauthorization = "needsReauthorization",
+        .auto_upgrade_error = "autoUpgradeError",
+        .warning = "warning",
+        .unpublished = "unpublished",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const InstalledExtensionStateIssueType = enum {
+pub const InstalledExtensionStateIssueType = union(enum) {
     warning,
     @"error",
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .warning => "warning",
-            .@"error" => "error",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        return null;
-    }
+    const wire_names = .{
+        .warning = "warning",
+        .@"error" = "error",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/git/enums.zig
+++ b/src/git/enums.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const TeamProjectReferenceState = enum {
+pub const TeamProjectReferenceState = union(enum) {
     deleting,
     new,
     well_formed,
@@ -16,103 +16,100 @@ pub const TeamProjectReferenceState = enum {
     all,
     unchanged,
     deleted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .deleting => "deleting",
-            .new => "new",
-            .well_formed => "wellFormed",
-            .create_pending => "createPending",
-            .all => "all",
-            .unchanged => "unchanged",
-            .deleted => "deleted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "deleting")) return .deleting;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "wellFormed")) return .well_formed;
-        if (std.mem.eql(u8, s, "createPending")) return .create_pending;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        if (std.mem.eql(u8, s, "unchanged")) return .unchanged;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        return null;
-    }
+    const wire_names = .{
+        .deleting = "deleting",
+        .new = "new",
+        .well_formed = "wellFormed",
+        .create_pending = "createPending",
+        .all = "all",
+        .unchanged = "unchanged",
+        .deleted = "deleted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamProjectReferenceVisibility = enum {
+pub const TeamProjectReferenceVisibility = union(enum) {
     private,
     public,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .private => "private",
-            .public => "public",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "private")) return .private;
-        if (std.mem.eql(u8, s, "public")) return .public;
-        return null;
-    }
+    const wire_names = .{
+        .private = "private",
+        .public = "public",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitRefFavoriteType = enum {
+pub const GitRefFavoriteType = union(enum) {
     invalid,
     folder,
     ref,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .invalid => "invalid",
-            .folder => "folder",
-            .ref => "ref",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "invalid")) return .invalid;
-        if (std.mem.eql(u8, s, "folder")) return .folder;
-        if (std.mem.eql(u8, s, "ref")) return .ref;
-        return null;
-    }
+    const wire_names = .{
+        .invalid = "invalid",
+        .folder = "folder",
+        .ref = "ref",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -215,7 +212,7 @@ pub const GetPullRequestsByProjectRequestSearchCriteriaTagsFilterOperator = enum
     }
 };
 
-pub const GitChangeChangeType = enum {
+pub const GitChangeChangeType = union(enum) {
     none,
     add,
     edit,
@@ -231,90 +228,79 @@ pub const GitChangeChangeType = enum {
     target_rename,
     property,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .add => "add",
-            .edit => "edit",
-            .encoding => "encoding",
-            .rename => "rename",
-            .delete => "delete",
-            .undelete => "undelete",
-            .branch => "branch",
-            .merge => "merge",
-            .lock => "lock",
-            .rollback => "rollback",
-            .source_rename => "sourceRename",
-            .target_rename => "targetRename",
-            .property => "property",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "add")) return .add;
-        if (std.mem.eql(u8, s, "edit")) return .edit;
-        if (std.mem.eql(u8, s, "encoding")) return .encoding;
-        if (std.mem.eql(u8, s, "rename")) return .rename;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "undelete")) return .undelete;
-        if (std.mem.eql(u8, s, "branch")) return .branch;
-        if (std.mem.eql(u8, s, "merge")) return .merge;
-        if (std.mem.eql(u8, s, "lock")) return .lock;
-        if (std.mem.eql(u8, s, "rollback")) return .rollback;
-        if (std.mem.eql(u8, s, "sourceRename")) return .source_rename;
-        if (std.mem.eql(u8, s, "targetRename")) return .target_rename;
-        if (std.mem.eql(u8, s, "property")) return .property;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .add = "add",
+        .edit = "edit",
+        .encoding = "encoding",
+        .rename = "rename",
+        .delete = "delete",
+        .undelete = "undelete",
+        .branch = "branch",
+        .merge = "merge",
+        .lock = "lock",
+        .rollback = "rollback",
+        .source_rename = "sourceRename",
+        .target_rename = "targetRename",
+        .property = "property",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ItemContentContentType = enum {
+pub const ItemContentContentType = union(enum) {
     raw_text,
     base64encoded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .raw_text => "rawText",
-            .base64encoded => "base64Encoded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "rawText")) return .raw_text;
-        if (std.mem.eql(u8, s, "base64Encoded")) return .base64encoded;
-        return null;
-    }
+    const wire_names = .{
+        .raw_text = "rawText",
+        .base64encoded = "base64Encoded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitStatusState = enum {
+pub const GitStatusState = union(enum) {
     not_set,
     pending,
     succeeded,
@@ -322,193 +308,182 @@ pub const GitStatusState = enum {
     @"error",
     not_applicable,
     partially_succeeded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .pending => "pending",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .@"error" => "error",
-            .not_applicable => "notApplicable",
-            .partially_succeeded => "partiallySucceeded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .pending = "pending",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .@"error" = "error",
+        .not_applicable = "notApplicable",
+        .partially_succeeded = "partiallySucceeded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestCompletionOptionsMergeStrategy = enum {
+pub const GitPullRequestCompletionOptionsMergeStrategy = union(enum) {
     no_fast_forward,
     squash,
     rebase,
     rebase_merge,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .no_fast_forward => "noFastForward",
-            .squash => "squash",
-            .rebase => "rebase",
-            .rebase_merge => "rebaseMerge",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "noFastForward")) return .no_fast_forward;
-        if (std.mem.eql(u8, s, "squash")) return .squash;
-        if (std.mem.eql(u8, s, "rebase")) return .rebase;
-        if (std.mem.eql(u8, s, "rebaseMerge")) return .rebase_merge;
-        return null;
-    }
+    const wire_names = .{
+        .no_fast_forward = "noFastForward",
+        .squash = "squash",
+        .rebase = "rebase",
+        .rebase_merge = "rebaseMerge",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestMergeFailureType = enum {
+pub const GitPullRequestMergeFailureType = union(enum) {
     none,
     unknown,
     case_sensitive,
     object_too_large,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .unknown => "unknown",
-            .case_sensitive => "caseSensitive",
-            .object_too_large => "objectTooLarge",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "caseSensitive")) return .case_sensitive;
-        if (std.mem.eql(u8, s, "objectTooLarge")) return .object_too_large;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .unknown = "unknown",
+        .case_sensitive = "caseSensitive",
+        .object_too_large = "objectTooLarge",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestMergeStatus = enum {
+pub const GitPullRequestMergeStatus = union(enum) {
     not_set,
     queued,
     conflicts,
     succeeded,
     rejected_by_policy,
     failure,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .queued => "queued",
-            .conflicts => "conflicts",
-            .succeeded => "succeeded",
-            .rejected_by_policy => "rejectedByPolicy",
-            .failure => "failure",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "conflicts")) return .conflicts;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "rejectedByPolicy")) return .rejected_by_policy;
-        if (std.mem.eql(u8, s, "failure")) return .failure;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .queued = "queued",
+        .conflicts = "conflicts",
+        .succeeded = "succeeded",
+        .rejected_by_policy = "rejectedByPolicy",
+        .failure = "failure",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestStatus1 = enum {
+pub const GitPullRequestStatus1 = union(enum) {
     not_set,
     active,
     abandoned,
     completed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .active => "active",
-            .abandoned => "abandoned",
-            .completed => "completed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .active = "active",
+        .abandoned = "abandoned",
+        .completed = "completed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -611,7 +586,7 @@ pub const GetPullRequestsRequestSearchCriteriaTagsFilterOperator = enum {
     }
 };
 
-pub const GitObjectObjectType = enum {
+pub const GitObjectObjectType = union(enum) {
     bad,
     commit,
     tree,
@@ -620,46 +595,41 @@ pub const GitObjectObjectType = enum {
     ext2,
     ofs_delta,
     ref_delta,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .bad => "bad",
-            .commit => "commit",
-            .tree => "tree",
-            .blob => "blob",
-            .tag => "tag",
-            .ext2 => "ext2",
-            .ofs_delta => "ofsDelta",
-            .ref_delta => "refDelta",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "bad")) return .bad;
-        if (std.mem.eql(u8, s, "commit")) return .commit;
-        if (std.mem.eql(u8, s, "tree")) return .tree;
-        if (std.mem.eql(u8, s, "blob")) return .blob;
-        if (std.mem.eql(u8, s, "tag")) return .tag;
-        if (std.mem.eql(u8, s, "ext2")) return .ext2;
-        if (std.mem.eql(u8, s, "ofsDelta")) return .ofs_delta;
-        if (std.mem.eql(u8, s, "refDelta")) return .ref_delta;
-        return null;
-    }
+    const wire_names = .{
+        .bad = "bad",
+        .commit = "commit",
+        .tree = "tree",
+        .blob = "blob",
+        .tag = "tag",
+        .ext2 = "ext2",
+        .ofs_delta = "ofsDelta",
+        .ref_delta = "refDelta",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitAsyncRefOperationDetailStatus = enum {
+pub const GitAsyncRefOperationDetailStatus = union(enum) {
     none,
     invalid_ref_name,
     ref_name_conflict,
@@ -671,189 +641,178 @@ pub const GitAsyncRefOperationDetailStatus = enum {
     async_operation_not_found,
     other,
     empty_committer_signature,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .invalid_ref_name => "invalidRefName",
-            .ref_name_conflict => "refNameConflict",
-            .create_branch_permission_required => "createBranchPermissionRequired",
-            .write_permission_required => "writePermissionRequired",
-            .target_branch_deleted => "targetBranchDeleted",
-            .git_object_too_large => "gitObjectTooLarge",
-            .operation_indentity_not_found => "operationIndentityNotFound",
-            .async_operation_not_found => "asyncOperationNotFound",
-            .other => "other",
-            .empty_committer_signature => "emptyCommitterSignature",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "invalidRefName")) return .invalid_ref_name;
-        if (std.mem.eql(u8, s, "refNameConflict")) return .ref_name_conflict;
-        if (std.mem.eql(u8, s, "createBranchPermissionRequired")) return .create_branch_permission_required;
-        if (std.mem.eql(u8, s, "writePermissionRequired")) return .write_permission_required;
-        if (std.mem.eql(u8, s, "targetBranchDeleted")) return .target_branch_deleted;
-        if (std.mem.eql(u8, s, "gitObjectTooLarge")) return .git_object_too_large;
-        if (std.mem.eql(u8, s, "operationIndentityNotFound")) return .operation_indentity_not_found;
-        if (std.mem.eql(u8, s, "asyncOperationNotFound")) return .async_operation_not_found;
-        if (std.mem.eql(u8, s, "other")) return .other;
-        if (std.mem.eql(u8, s, "emptyCommitterSignature")) return .empty_committer_signature;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .invalid_ref_name = "invalidRefName",
+        .ref_name_conflict = "refNameConflict",
+        .create_branch_permission_required = "createBranchPermissionRequired",
+        .write_permission_required = "writePermissionRequired",
+        .target_branch_deleted = "targetBranchDeleted",
+        .git_object_too_large = "gitObjectTooLarge",
+        .operation_indentity_not_found = "operationIndentityNotFound",
+        .async_operation_not_found = "asyncOperationNotFound",
+        .other = "other",
+        .empty_committer_signature = "emptyCommitterSignature",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitCherryPickStatus = enum {
+pub const GitCherryPickStatus = union(enum) {
     queued,
     in_progress,
     completed,
     failed,
     abandoned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .completed => "completed",
-            .failed => "failed",
-            .abandoned => "abandoned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        return null;
-    }
+    const wire_names = .{
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .completed = "completed",
+        .failed = "failed",
+        .abandoned = "abandoned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitVersionDescriptorVersionOptions = enum {
+pub const GitVersionDescriptorVersionOptions = union(enum) {
     none,
     previous_change,
     first_parent,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .previous_change => "previousChange",
-            .first_parent => "firstParent",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "previousChange")) return .previous_change;
-        if (std.mem.eql(u8, s, "firstParent")) return .first_parent;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .previous_change = "previousChange",
+        .first_parent = "firstParent",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitVersionDescriptorVersionType = enum {
+pub const GitVersionDescriptorVersionType = union(enum) {
     branch,
     tag,
     commit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .branch => "branch",
-            .tag => "tag",
-            .commit => "commit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "branch")) return .branch;
-        if (std.mem.eql(u8, s, "tag")) return .tag;
-        if (std.mem.eql(u8, s, "commit")) return .commit;
-        return null;
-    }
+    const wire_names = .{
+        .branch = "branch",
+        .tag = "tag",
+        .commit = "commit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitQueryCommitsCriteriaHistoryMode = enum {
+pub const GitQueryCommitsCriteriaHistoryMode = union(enum) {
     simplified_history,
     first_parent,
     full_history,
     full_history_simplify_merges,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .simplified_history => "simplifiedHistory",
-            .first_parent => "firstParent",
-            .full_history => "fullHistory",
-            .full_history_simplify_merges => "fullHistorySimplifyMerges",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "simplifiedHistory")) return .simplified_history;
-        if (std.mem.eql(u8, s, "firstParent")) return .first_parent;
-        if (std.mem.eql(u8, s, "fullHistory")) return .full_history;
-        if (std.mem.eql(u8, s, "fullHistorySimplifyMerges")) return .full_history_simplify_merges;
-        return null;
-    }
+    const wire_names = .{
+        .simplified_history = "simplifiedHistory",
+        .first_parent = "firstParent",
+        .full_history = "fullHistory",
+        .full_history_simplify_merges = "fullHistorySimplifyMerges",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -989,42 +948,40 @@ pub const GetRequestTargetVersionType = enum {
     }
 };
 
-pub const GitImportRequestStatus = enum {
+pub const GitImportRequestStatus = union(enum) {
     queued,
     in_progress,
     completed,
     failed,
     abandoned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .completed => "completed",
-            .failed => "failed",
-            .abandoned => "abandoned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        return null;
-    }
+    const wire_names = .{
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .completed = "completed",
+        .failed = "failed",
+        .abandoned = "abandoned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1130,7 +1087,7 @@ pub const ListRequestVersionDescriptorVersionType = enum {
     }
 };
 
-pub const GitItemGitObjectType = enum {
+pub const GitItemGitObjectType = union(enum) {
     bad,
     commit,
     tree,
@@ -1139,211 +1096,206 @@ pub const GitItemGitObjectType = enum {
     ext2,
     ofs_delta,
     ref_delta,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .bad => "bad",
-            .commit => "commit",
-            .tree => "tree",
-            .blob => "blob",
-            .tag => "tag",
-            .ext2 => "ext2",
-            .ofs_delta => "ofsDelta",
-            .ref_delta => "refDelta",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "bad")) return .bad;
-        if (std.mem.eql(u8, s, "commit")) return .commit;
-        if (std.mem.eql(u8, s, "tree")) return .tree;
-        if (std.mem.eql(u8, s, "blob")) return .blob;
-        if (std.mem.eql(u8, s, "tag")) return .tag;
-        if (std.mem.eql(u8, s, "ext2")) return .ext2;
-        if (std.mem.eql(u8, s, "ofsDelta")) return .ofs_delta;
-        if (std.mem.eql(u8, s, "refDelta")) return .ref_delta;
-        return null;
-    }
+    const wire_names = .{
+        .bad = "bad",
+        .commit = "commit",
+        .tree = "tree",
+        .blob = "blob",
+        .tag = "tag",
+        .ext2 = "ext2",
+        .ofs_delta = "ofsDelta",
+        .ref_delta = "refDelta",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitItemDescriptorRecursionLevel = enum {
+pub const GitItemDescriptorRecursionLevel = union(enum) {
     none,
     one_level,
     one_level_plus_nested_empty_folders,
     full,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .one_level => "oneLevel",
-            .one_level_plus_nested_empty_folders => "oneLevelPlusNestedEmptyFolders",
-            .full => "full",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "oneLevel")) return .one_level;
-        if (std.mem.eql(u8, s, "oneLevelPlusNestedEmptyFolders")) return .one_level_plus_nested_empty_folders;
-        if (std.mem.eql(u8, s, "full")) return .full;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .one_level = "oneLevel",
+        .one_level_plus_nested_empty_folders = "oneLevelPlusNestedEmptyFolders",
+        .full = "full",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitItemDescriptorVersionOptions = enum {
+pub const GitItemDescriptorVersionOptions = union(enum) {
     none,
     previous_change,
     first_parent,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .previous_change => "previousChange",
-            .first_parent => "firstParent",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "previousChange")) return .previous_change;
-        if (std.mem.eql(u8, s, "firstParent")) return .first_parent;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .previous_change = "previousChange",
+        .first_parent = "firstParent",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitItemDescriptorVersionType = enum {
+pub const GitItemDescriptorVersionType = union(enum) {
     branch,
     tag,
     commit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .branch => "branch",
-            .tag => "tag",
-            .commit => "commit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "branch")) return .branch;
-        if (std.mem.eql(u8, s, "tag")) return .tag;
-        if (std.mem.eql(u8, s, "commit")) return .commit;
-        return null;
-    }
+    const wire_names = .{
+        .branch = "branch",
+        .tag = "tag",
+        .commit = "commit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestQueryInputInclude = enum {
+pub const GitPullRequestQueryInputInclude = union(enum) {
     not_set,
     labels,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .labels => "labels",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "labels")) return .labels;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .labels = "labels",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestQueryInputType = enum {
+pub const GitPullRequestQueryInputType = union(enum) {
     not_set,
     last_merge_commit,
     commit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .last_merge_commit => "lastMergeCommit",
-            .commit => "commit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "lastMergeCommit")) return .last_merge_commit;
-        if (std.mem.eql(u8, s, "commit")) return .commit;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .last_merge_commit = "lastMergeCommit",
+        .commit = "commit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestIterationReason = enum {
+pub const GitPullRequestIterationReason = union(enum) {
     push,
     force_push,
     create,
@@ -1351,80 +1303,75 @@ pub const GitPullRequestIterationReason = enum {
     unknown,
     retarget,
     resolve_conflicts,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .push => "push",
-            .force_push => "forcePush",
-            .create => "create",
-            .rebase => "rebase",
-            .unknown => "unknown",
-            .retarget => "retarget",
-            .resolve_conflicts => "resolveConflicts",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "push")) return .push;
-        if (std.mem.eql(u8, s, "forcePush")) return .force_push;
-        if (std.mem.eql(u8, s, "create")) return .create;
-        if (std.mem.eql(u8, s, "rebase")) return .rebase;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "retarget")) return .retarget;
-        if (std.mem.eql(u8, s, "resolveConflicts")) return .resolve_conflicts;
-        return null;
-    }
+    const wire_names = .{
+        .push = "push",
+        .force_push = "forcePush",
+        .create = "create",
+        .rebase = "rebase",
+        .unknown = "unknown",
+        .retarget = "retarget",
+        .resolve_conflicts = "resolveConflicts",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CommentCommentType = enum {
+pub const CommentCommentType = union(enum) {
     unknown,
     text,
     code_change,
     system,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .text => "text",
-            .code_change => "codeChange",
-            .system => "system",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "text")) return .text;
-        if (std.mem.eql(u8, s, "codeChange")) return .code_change;
-        if (std.mem.eql(u8, s, "system")) return .system;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .text = "text",
+        .code_change = "codeChange",
+        .system = "system",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitPullRequestCommentThreadStatus = enum {
+pub const GitPullRequestCommentThreadStatus = union(enum) {
     unknown,
     active,
     fixed,
@@ -1432,44 +1379,40 @@ pub const GitPullRequestCommentThreadStatus = enum {
     closed,
     by_design,
     pending,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .active => "active",
-            .fixed => "fixed",
-            .wont_fix => "wontFix",
-            .closed => "closed",
-            .by_design => "byDesign",
-            .pending => "pending",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "fixed")) return .fixed;
-        if (std.mem.eql(u8, s, "wontFix")) return .wont_fix;
-        if (std.mem.eql(u8, s, "closed")) return .closed;
-        if (std.mem.eql(u8, s, "byDesign")) return .by_design;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .active = "active",
+        .fixed = "fixed",
+        .wont_fix = "wontFix",
+        .closed = "closed",
+        .by_design = "byDesign",
+        .pending = "pending",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitRefUpdateResultUpdateStatus = enum {
+pub const GitRefUpdateResultUpdateStatus = union(enum) {
     succeeded,
     force_push_required,
     stale_old_object_id,
@@ -1486,58 +1429,45 @@ pub const GitRefUpdateResultUpdateStatus = enum {
     rejected_by_policy,
     succeeded_non_existent_ref,
     succeeded_corrupt_ref,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .succeeded => "succeeded",
-            .force_push_required => "forcePushRequired",
-            .stale_old_object_id => "staleOldObjectId",
-            .invalid_ref_name => "invalidRefName",
-            .unprocessed => "unprocessed",
-            .unresolvable_to_commit => "unresolvableToCommit",
-            .write_permission_required => "writePermissionRequired",
-            .manage_note_permission_required => "manageNotePermissionRequired",
-            .create_branch_permission_required => "createBranchPermissionRequired",
-            .create_tag_permission_required => "createTagPermissionRequired",
-            .rejected_by_plugin => "rejectedByPlugin",
-            .locked => "locked",
-            .ref_name_conflict => "refNameConflict",
-            .rejected_by_policy => "rejectedByPolicy",
-            .succeeded_non_existent_ref => "succeededNonExistentRef",
-            .succeeded_corrupt_ref => "succeededCorruptRef",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "forcePushRequired")) return .force_push_required;
-        if (std.mem.eql(u8, s, "staleOldObjectId")) return .stale_old_object_id;
-        if (std.mem.eql(u8, s, "invalidRefName")) return .invalid_ref_name;
-        if (std.mem.eql(u8, s, "unprocessed")) return .unprocessed;
-        if (std.mem.eql(u8, s, "unresolvableToCommit")) return .unresolvable_to_commit;
-        if (std.mem.eql(u8, s, "writePermissionRequired")) return .write_permission_required;
-        if (std.mem.eql(u8, s, "manageNotePermissionRequired")) return .manage_note_permission_required;
-        if (std.mem.eql(u8, s, "createBranchPermissionRequired")) return .create_branch_permission_required;
-        if (std.mem.eql(u8, s, "createTagPermissionRequired")) return .create_tag_permission_required;
-        if (std.mem.eql(u8, s, "rejectedByPlugin")) return .rejected_by_plugin;
-        if (std.mem.eql(u8, s, "locked")) return .locked;
-        if (std.mem.eql(u8, s, "refNameConflict")) return .ref_name_conflict;
-        if (std.mem.eql(u8, s, "rejectedByPolicy")) return .rejected_by_policy;
-        if (std.mem.eql(u8, s, "succeededNonExistentRef")) return .succeeded_non_existent_ref;
-        if (std.mem.eql(u8, s, "succeededCorruptRef")) return .succeeded_corrupt_ref;
-        return null;
-    }
+    const wire_names = .{
+        .succeeded = "succeeded",
+        .force_push_required = "forcePushRequired",
+        .stale_old_object_id = "staleOldObjectId",
+        .invalid_ref_name = "invalidRefName",
+        .unprocessed = "unprocessed",
+        .unresolvable_to_commit = "unresolvableToCommit",
+        .write_permission_required = "writePermissionRequired",
+        .manage_note_permission_required = "manageNotePermissionRequired",
+        .create_branch_permission_required = "createBranchPermissionRequired",
+        .create_tag_permission_required = "createTagPermissionRequired",
+        .rejected_by_plugin = "rejectedByPlugin",
+        .locked = "locked",
+        .ref_name_conflict = "refNameConflict",
+        .rejected_by_policy = "rejectedByPolicy",
+        .succeeded_non_existent_ref = "succeededNonExistentRef",
+        .succeeded_corrupt_ref = "succeededCorruptRef",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1607,7 +1537,7 @@ pub const ListRequestBaseVersionDescriptorVersionType = enum {
     }
 };
 
-pub const GitTreeEntryRefGitObjectType = enum {
+pub const GitTreeEntryRefGitObjectType = union(enum) {
     bad,
     commit,
     tree,
@@ -1616,120 +1546,111 @@ pub const GitTreeEntryRefGitObjectType = enum {
     ext2,
     ofs_delta,
     ref_delta,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .bad => "bad",
-            .commit => "commit",
-            .tree => "tree",
-            .blob => "blob",
-            .tag => "tag",
-            .ext2 => "ext2",
-            .ofs_delta => "ofsDelta",
-            .ref_delta => "refDelta",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "bad")) return .bad;
-        if (std.mem.eql(u8, s, "commit")) return .commit;
-        if (std.mem.eql(u8, s, "tree")) return .tree;
-        if (std.mem.eql(u8, s, "blob")) return .blob;
-        if (std.mem.eql(u8, s, "tag")) return .tag;
-        if (std.mem.eql(u8, s, "ext2")) return .ext2;
-        if (std.mem.eql(u8, s, "ofsDelta")) return .ofs_delta;
-        if (std.mem.eql(u8, s, "refDelta")) return .ref_delta;
-        return null;
-    }
+    const wire_names = .{
+        .bad = "bad",
+        .commit = "commit",
+        .tree = "tree",
+        .blob = "blob",
+        .tag = "tag",
+        .ext2 = "ext2",
+        .ofs_delta = "ofsDelta",
+        .ref_delta = "refDelta",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitForkSyncRequestStatus = enum {
+pub const GitForkSyncRequestStatus = union(enum) {
     queued,
     in_progress,
     completed,
     failed,
     abandoned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .completed => "completed",
-            .failed => "failed",
-            .abandoned => "abandoned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        return null;
-    }
+    const wire_names = .{
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .completed = "completed",
+        .failed = "failed",
+        .abandoned = "abandoned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitMergeStatus = enum {
+pub const GitMergeStatus = union(enum) {
     queued,
     in_progress,
     completed,
     failed,
     abandoned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .completed => "completed",
-            .failed => "failed",
-            .abandoned => "abandoned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        return null;
-    }
+    const wire_names = .{
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .completed = "completed",
+        .failed = "failed",
+        .abandoned = "abandoned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/graph/enums.zig
+++ b/src/graph/enums.zig
@@ -74,36 +74,36 @@ pub const GetRequestSize = enum {
     }
 };
 
-pub const AvatarSize = enum {
+pub const AvatarSize = union(enum) {
     small,
     medium,
     large,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .small => "small",
-            .medium => "medium",
-            .large => "large",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "small")) return .small;
-        if (std.mem.eql(u8, s, "medium")) return .medium;
-        if (std.mem.eql(u8, s, "large")) return .large;
-        return null;
-    }
+    const wire_names = .{
+        .small = "small",
+        .medium = "medium",
+        .large = "large",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/hooks/enums.zig
+++ b/src/hooks/enums.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const InputDescriptorInputMode = enum {
+pub const InputDescriptorInputMode = union(enum) {
     none,
     text_box,
     password_box,
@@ -16,340 +16,324 @@ pub const InputDescriptorInputMode = enum {
     radio_buttons,
     check_box,
     text_area,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .text_box => "textBox",
-            .password_box => "passwordBox",
-            .combo => "combo",
-            .radio_buttons => "radioButtons",
-            .check_box => "checkBox",
-            .text_area => "textArea",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "textBox")) return .text_box;
-        if (std.mem.eql(u8, s, "passwordBox")) return .password_box;
-        if (std.mem.eql(u8, s, "combo")) return .combo;
-        if (std.mem.eql(u8, s, "radioButtons")) return .radio_buttons;
-        if (std.mem.eql(u8, s, "checkBox")) return .check_box;
-        if (std.mem.eql(u8, s, "textArea")) return .text_area;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .text_box = "textBox",
+        .password_box = "passwordBox",
+        .combo = "combo",
+        .radio_buttons = "radioButtons",
+        .check_box = "checkBox",
+        .text_area = "textArea",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const InputValidationDataType = enum {
+pub const InputValidationDataType = union(enum) {
     none,
     string,
     number,
     boolean,
     guid,
     uri,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .string => "string",
-            .number => "number",
-            .boolean => "boolean",
-            .guid => "guid",
-            .uri => "uri",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "number")) return .number;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        if (std.mem.eql(u8, s, "uri")) return .uri;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .string = "string",
+        .number = "number",
+        .boolean = "boolean",
+        .guid = "guid",
+        .uri = "uri",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ConsumerAuthenticationType = enum {
+pub const ConsumerAuthenticationType = union(enum) {
     none,
     o_auth,
     external,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .o_auth => "oAuth",
-            .external => "external",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "oAuth")) return .o_auth;
-        if (std.mem.eql(u8, s, "external")) return .external;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .o_auth = "oAuth",
+        .external = "external",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const SubscriptionStatus = enum {
+pub const SubscriptionStatus = union(enum) {
     enabled,
     on_probation,
     disabled_by_user,
     disabled_by_system,
     disabled_by_inactive_identity,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .enabled => "enabled",
-            .on_probation => "onProbation",
-            .disabled_by_user => "disabledByUser",
-            .disabled_by_system => "disabledBySystem",
-            .disabled_by_inactive_identity => "disabledByInactiveIdentity",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        if (std.mem.eql(u8, s, "onProbation")) return .on_probation;
-        if (std.mem.eql(u8, s, "disabledByUser")) return .disabled_by_user;
-        if (std.mem.eql(u8, s, "disabledBySystem")) return .disabled_by_system;
-        if (std.mem.eql(u8, s, "disabledByInactiveIdentity")) return .disabled_by_inactive_identity;
-        return null;
-    }
+    const wire_names = .{
+        .enabled = "enabled",
+        .on_probation = "onProbation",
+        .disabled_by_user = "disabledByUser",
+        .disabled_by_system = "disabledBySystem",
+        .disabled_by_inactive_identity = "disabledByInactiveIdentity",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationResult = enum {
+pub const NotificationResult = union(enum) {
     pending,
     succeeded,
     failed,
     filtered,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .pending => "pending",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .filtered => "filtered",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "filtered")) return .filtered;
-        return null;
-    }
+    const wire_names = .{
+        .pending = "pending",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .filtered = "filtered",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationStatus = enum {
+pub const NotificationStatus = union(enum) {
     queued,
     processing,
     request_in_progress,
     queued_for_retry,
     completed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .queued => "queued",
-            .processing => "processing",
-            .request_in_progress => "requestInProgress",
-            .queued_for_retry => "queuedForRetry",
-            .completed => "completed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "processing")) return .processing;
-        if (std.mem.eql(u8, s, "requestInProgress")) return .request_in_progress;
-        if (std.mem.eql(u8, s, "queuedForRetry")) return .queued_for_retry;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        return null;
-    }
+    const wire_names = .{
+        .queued = "queued",
+        .processing = "processing",
+        .request_in_progress = "requestInProgress",
+        .queued_for_retry = "queuedForRetry",
+        .completed = "completed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationsQueryResultType = enum {
+pub const NotificationsQueryResultType = union(enum) {
     pending,
     succeeded,
     failed,
     filtered,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .pending => "pending",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .filtered => "filtered",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "filtered")) return .filtered;
-        return null;
-    }
+    const wire_names = .{
+        .pending = "pending",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .filtered = "filtered",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationsQueryStatus = enum {
+pub const NotificationsQueryStatus = union(enum) {
     queued,
     processing,
     request_in_progress,
     queued_for_retry,
     completed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .queued => "queued",
-            .processing => "processing",
-            .request_in_progress => "requestInProgress",
-            .queued_for_retry => "queuedForRetry",
-            .completed => "completed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "processing")) return .processing;
-        if (std.mem.eql(u8, s, "requestInProgress")) return .request_in_progress;
-        if (std.mem.eql(u8, s, "queuedForRetry")) return .queued_for_retry;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        return null;
-    }
+    const wire_names = .{
+        .queued = "queued",
+        .processing = "processing",
+        .request_in_progress = "requestInProgress",
+        .queued_for_retry = "queuedForRetry",
+        .completed = "completed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationResultsSummaryDetailResult = enum {
+pub const NotificationResultsSummaryDetailResult = union(enum) {
     pending,
     succeeded,
     failed,
     filtered,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .pending => "pending",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .filtered => "filtered",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "filtered")) return .filtered;
-        return null;
-    }
+    const wire_names = .{
+        .pending = "pending",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .filtered = "filtered",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -428,33 +412,34 @@ pub const ListRequestResult = enum {
     }
 };
 
-pub const InputFilterConditionOperator = enum {
+pub const InputFilterConditionOperator = union(enum) {
     equals,
     not_equals,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .equals => "equals",
-            .not_equals => "notEquals",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "equals")) return .equals;
-        if (std.mem.eql(u8, s, "notEquals")) return .not_equals;
-        return null;
-    }
+    const wire_names = .{
+        .equals = "equals",
+        .not_equals = "notEquals",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/member_entitlement_management/enums.zig
+++ b/src/member_entitlement_management/enums.zig
@@ -8,112 +8,110 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const AccessLevelAccountLicenseType = enum {
+pub const AccessLevelAccountLicenseType = union(enum) {
     none,
     early_adopter,
     express,
     professional,
     advanced,
     stakeholder,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .early_adopter => "earlyAdopter",
-            .express => "express",
-            .professional => "professional",
-            .advanced => "advanced",
-            .stakeholder => "stakeholder",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "earlyAdopter")) return .early_adopter;
-        if (std.mem.eql(u8, s, "express")) return .express;
-        if (std.mem.eql(u8, s, "professional")) return .professional;
-        if (std.mem.eql(u8, s, "advanced")) return .advanced;
-        if (std.mem.eql(u8, s, "stakeholder")) return .stakeholder;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .early_adopter = "earlyAdopter",
+        .express = "express",
+        .professional = "professional",
+        .advanced = "advanced",
+        .stakeholder = "stakeholder",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AccessLevelAssignmentSource = enum {
+pub const AccessLevelAssignmentSource = union(enum) {
     none,
     unknown,
     group_rule,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .unknown => "unknown",
-            .group_rule => "groupRule",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "groupRule")) return .group_rule;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .unknown = "unknown",
+        .group_rule = "groupRule",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AccessLevelGitHubLicenseType = enum {
+pub const AccessLevelGitHubLicenseType = union(enum) {
     none,
     enterprise,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .enterprise => "enterprise",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "enterprise")) return .enterprise;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .enterprise = "enterprise",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AccessLevelLicensingSource = enum {
+pub const AccessLevelLicensingSource = union(enum) {
     none,
     account,
     msdn,
@@ -121,44 +119,40 @@ pub const AccessLevelLicensingSource = enum {
     auto,
     trial,
     git_hub,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .account => "account",
-            .msdn => "msdn",
-            .profile => "profile",
-            .auto => "auto",
-            .trial => "trial",
-            .git_hub => "gitHub",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "account")) return .account;
-        if (std.mem.eql(u8, s, "msdn")) return .msdn;
-        if (std.mem.eql(u8, s, "profile")) return .profile;
-        if (std.mem.eql(u8, s, "auto")) return .auto;
-        if (std.mem.eql(u8, s, "trial")) return .trial;
-        if (std.mem.eql(u8, s, "gitHub")) return .git_hub;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .account = "account",
+        .msdn = "msdn",
+        .profile = "profile",
+        .auto = "auto",
+        .trial = "trial",
+        .git_hub = "gitHub",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AccessLevelMsdnLicenseType = enum {
+pub const AccessLevelMsdnLicenseType = union(enum) {
     none,
     eligible,
     professional,
@@ -167,46 +161,41 @@ pub const AccessLevelMsdnLicenseType = enum {
     premium,
     ultimate,
     enterprise,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .eligible => "eligible",
-            .professional => "professional",
-            .platforms => "platforms",
-            .test_professional => "testProfessional",
-            .premium => "premium",
-            .ultimate => "ultimate",
-            .enterprise => "enterprise",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "eligible")) return .eligible;
-        if (std.mem.eql(u8, s, "professional")) return .professional;
-        if (std.mem.eql(u8, s, "platforms")) return .platforms;
-        if (std.mem.eql(u8, s, "testProfessional")) return .test_professional;
-        if (std.mem.eql(u8, s, "premium")) return .premium;
-        if (std.mem.eql(u8, s, "ultimate")) return .ultimate;
-        if (std.mem.eql(u8, s, "enterprise")) return .enterprise;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .eligible = "eligible",
+        .professional = "professional",
+        .platforms = "platforms",
+        .test_professional = "testProfessional",
+        .premium = "premium",
+        .ultimate = "ultimate",
+        .enterprise = "enterprise",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AccessLevelStatus = enum {
+pub const AccessLevelStatus = union(enum) {
     none,
     active,
     disabled,
@@ -214,181 +203,174 @@ pub const AccessLevelStatus = enum {
     pending,
     expired,
     pending_disabled,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .active => "active",
-            .disabled => "disabled",
-            .deleted => "deleted",
-            .pending => "pending",
-            .expired => "expired",
-            .pending_disabled => "pendingDisabled",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "expired")) return .expired;
-        if (std.mem.eql(u8, s, "pendingDisabled")) return .pending_disabled;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .active = "active",
+        .disabled = "disabled",
+        .deleted = "deleted",
+        .pending = "pending",
+        .expired = "expired",
+        .pending_disabled = "pendingDisabled",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ProjectEntitlementAssignmentSource = enum {
+pub const ProjectEntitlementAssignmentSource = union(enum) {
     none,
     unknown,
     group_rule,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .unknown => "unknown",
-            .group_rule => "groupRule",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "groupRule")) return .group_rule;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .unknown = "unknown",
+        .group_rule = "groupRule",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GroupGroupType = enum {
+pub const GroupGroupType = union(enum) {
     project_stakeholder,
     project_reader,
     project_contributor,
     project_administrator,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .project_stakeholder => "projectStakeholder",
-            .project_reader => "projectReader",
-            .project_contributor => "projectContributor",
-            .project_administrator => "projectAdministrator",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "projectStakeholder")) return .project_stakeholder;
-        if (std.mem.eql(u8, s, "projectReader")) return .project_reader;
-        if (std.mem.eql(u8, s, "projectContributor")) return .project_contributor;
-        if (std.mem.eql(u8, s, "projectAdministrator")) return .project_administrator;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .project_stakeholder = "projectStakeholder",
+        .project_reader = "projectReader",
+        .project_contributor = "projectContributor",
+        .project_administrator = "projectAdministrator",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ProjectEntitlementProjectPermissionInherited = enum {
+pub const ProjectEntitlementProjectPermissionInherited = union(enum) {
     not_set,
     not_inherited,
     inherited,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .not_inherited => "notInherited",
-            .inherited => "inherited",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "notInherited")) return .not_inherited;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .not_inherited = "notInherited",
+        .inherited = "inherited",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GroupEntitlementStatus = enum {
+pub const GroupEntitlementStatus = union(enum) {
     apply_pending,
     applied,
     incompatible,
     unable_to_apply,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .apply_pending => "applyPending",
-            .applied => "applied",
-            .incompatible => "incompatible",
-            .unable_to_apply => "unableToApply",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "applyPending")) return .apply_pending;
-        if (std.mem.eql(u8, s, "applied")) return .applied;
-        if (std.mem.eql(u8, s, "incompatible")) return .incompatible;
-        if (std.mem.eql(u8, s, "unableToApply")) return .unable_to_apply;
-        return null;
-    }
+    const wire_names = .{
+        .apply_pending = "applyPending",
+        .applied = "applied",
+        .incompatible = "incompatible",
+        .unable_to_apply = "unableToApply",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -422,45 +404,42 @@ pub const AddRequestRuleOption = enum {
     }
 };
 
-pub const GroupEntitlementOperationReferenceStatus = enum {
+pub const GroupEntitlementOperationReferenceStatus = union(enum) {
     not_set,
     queued,
     in_progress,
     cancelled,
     succeeded,
     failed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .cancelled => "cancelled",
-            .succeeded => "succeeded",
-            .failed => "failed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "cancelled")) return .cancelled;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .cancelled = "cancelled",
+        .succeeded = "succeeded",
+        .failed = "failed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -602,79 +581,77 @@ pub const SearchUserEntitlementsRequestSelect = enum {
     }
 };
 
-pub const LicenseSummaryDataAccountLicenseType = enum {
+pub const LicenseSummaryDataAccountLicenseType = union(enum) {
     none,
     early_adopter,
     express,
     professional,
     advanced,
     stakeholder,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .early_adopter => "earlyAdopter",
-            .express => "express",
-            .professional => "professional",
-            .advanced => "advanced",
-            .stakeholder => "stakeholder",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "earlyAdopter")) return .early_adopter;
-        if (std.mem.eql(u8, s, "express")) return .express;
-        if (std.mem.eql(u8, s, "professional")) return .professional;
-        if (std.mem.eql(u8, s, "advanced")) return .advanced;
-        if (std.mem.eql(u8, s, "stakeholder")) return .stakeholder;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .early_adopter = "earlyAdopter",
+        .express = "express",
+        .professional = "professional",
+        .advanced = "advanced",
+        .stakeholder = "stakeholder",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const LicenseSummaryDataGitHubLicenseType = enum {
+pub const LicenseSummaryDataGitHubLicenseType = union(enum) {
     none,
     enterprise,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .enterprise => "enterprise",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "enterprise")) return .enterprise;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .enterprise = "enterprise",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const LicenseSummaryDataMsdnLicenseType = enum {
+pub const LicenseSummaryDataMsdnLicenseType = union(enum) {
     none,
     eligible,
     professional,
@@ -683,46 +660,41 @@ pub const LicenseSummaryDataMsdnLicenseType = enum {
     premium,
     ultimate,
     enterprise,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .eligible => "eligible",
-            .professional => "professional",
-            .platforms => "platforms",
-            .test_professional => "testProfessional",
-            .premium => "premium",
-            .ultimate => "ultimate",
-            .enterprise => "enterprise",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "eligible")) return .eligible;
-        if (std.mem.eql(u8, s, "professional")) return .professional;
-        if (std.mem.eql(u8, s, "platforms")) return .platforms;
-        if (std.mem.eql(u8, s, "testProfessional")) return .test_professional;
-        if (std.mem.eql(u8, s, "premium")) return .premium;
-        if (std.mem.eql(u8, s, "ultimate")) return .ultimate;
-        if (std.mem.eql(u8, s, "enterprise")) return .enterprise;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .eligible = "eligible",
+        .professional = "professional",
+        .platforms = "platforms",
+        .test_professional = "testProfessional",
+        .premium = "premium",
+        .ultimate = "ultimate",
+        .enterprise = "enterprise",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const LicenseSummaryDataSource = enum {
+pub const LicenseSummaryDataSource = union(enum) {
     none,
     account,
     msdn,
@@ -730,40 +702,36 @@ pub const LicenseSummaryDataSource = enum {
     auto,
     trial,
     git_hub,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .account => "account",
-            .msdn => "msdn",
-            .profile => "profile",
-            .auto => "auto",
-            .trial => "trial",
-            .git_hub => "gitHub",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "account")) return .account;
-        if (std.mem.eql(u8, s, "msdn")) return .msdn;
-        if (std.mem.eql(u8, s, "profile")) return .profile;
-        if (std.mem.eql(u8, s, "auto")) return .auto;
-        if (std.mem.eql(u8, s, "trial")) return .trial;
-        if (std.mem.eql(u8, s, "gitHub")) return .git_hub;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .account = "account",
+        .msdn = "msdn",
+        .profile = "profile",
+        .auto = "auto",
+        .trial = "trial",
+        .git_hub = "gitHub",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/notification/enums.zig
+++ b/src/notification/enums.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const NotificationEventFieldTypeSubscriptionFieldType = enum {
+pub const NotificationEventFieldTypeSubscriptionFieldType = union(enum) {
     string,
     integer,
     date_time,
@@ -24,156 +24,145 @@ pub const NotificationEventFieldTypeSubscriptionFieldType = enum {
     picklist_string,
     picklist_double,
     team_project,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .string => "string",
-            .integer => "integer",
-            .date_time => "dateTime",
-            .plain_text => "plainText",
-            .html => "html",
-            .tree_path => "treePath",
-            .history => "history",
-            .double => "double",
-            .guid => "guid",
-            .boolean => "boolean",
-            .identity => "identity",
-            .picklist_integer => "picklistInteger",
-            .picklist_string => "picklistString",
-            .picklist_double => "picklistDouble",
-            .team_project => "teamProject",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "integer")) return .integer;
-        if (std.mem.eql(u8, s, "dateTime")) return .date_time;
-        if (std.mem.eql(u8, s, "plainText")) return .plain_text;
-        if (std.mem.eql(u8, s, "html")) return .html;
-        if (std.mem.eql(u8, s, "treePath")) return .tree_path;
-        if (std.mem.eql(u8, s, "history")) return .history;
-        if (std.mem.eql(u8, s, "double")) return .double;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "identity")) return .identity;
-        if (std.mem.eql(u8, s, "picklistInteger")) return .picklist_integer;
-        if (std.mem.eql(u8, s, "picklistString")) return .picklist_string;
-        if (std.mem.eql(u8, s, "picklistDouble")) return .picklist_double;
-        if (std.mem.eql(u8, s, "teamProject")) return .team_project;
-        return null;
-    }
+    const wire_names = .{
+        .string = "string",
+        .integer = "integer",
+        .date_time = "dateTime",
+        .plain_text = "plainText",
+        .html = "html",
+        .tree_path = "treePath",
+        .history = "history",
+        .double = "double",
+        .guid = "guid",
+        .boolean = "boolean",
+        .identity = "identity",
+        .picklist_integer = "picklistInteger",
+        .picklist_string = "picklistString",
+        .picklist_double = "picklistDouble",
+        .team_project = "teamProject",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationAdminSettingsDefaultGroupDeliveryPreference = enum {
+pub const NotificationAdminSettingsDefaultGroupDeliveryPreference = union(enum) {
     no_delivery,
     each_member,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .no_delivery => "noDelivery",
-            .each_member => "eachMember",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "noDelivery")) return .no_delivery;
-        if (std.mem.eql(u8, s, "eachMember")) return .each_member;
-        return null;
-    }
+    const wire_names = .{
+        .no_delivery = "noDelivery",
+        .each_member = "eachMember",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationAdminSettingsUpdateParametersDefaultGroupDeliveryPreference = enum {
+pub const NotificationAdminSettingsUpdateParametersDefaultGroupDeliveryPreference = union(enum) {
     no_delivery,
     each_member,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .no_delivery => "noDelivery",
-            .each_member => "eachMember",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "noDelivery")) return .no_delivery;
-        if (std.mem.eql(u8, s, "eachMember")) return .each_member;
-        return null;
-    }
+    const wire_names = .{
+        .no_delivery = "noDelivery",
+        .each_member = "eachMember",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationSubscriberDeliveryPreference = enum {
+pub const NotificationSubscriberDeliveryPreference = union(enum) {
     no_delivery,
     preferred_email_address,
     each_member,
     use_default,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .no_delivery => "noDelivery",
-            .preferred_email_address => "preferredEmailAddress",
-            .each_member => "eachMember",
-            .use_default => "useDefault",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "noDelivery")) return .no_delivery;
-        if (std.mem.eql(u8, s, "preferredEmailAddress")) return .preferred_email_address;
-        if (std.mem.eql(u8, s, "eachMember")) return .each_member;
-        if (std.mem.eql(u8, s, "useDefault")) return .use_default;
-        return null;
-    }
+    const wire_names = .{
+        .no_delivery = "noDelivery",
+        .preferred_email_address = "preferredEmailAddress",
+        .each_member = "eachMember",
+        .use_default = "useDefault",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationSubscriberFlags = enum {
+pub const NotificationSubscriberFlags = union(enum) {
     none,
     delivery_preferences_editable,
     supports_preferred_email_address_delivery,
@@ -182,244 +171,228 @@ pub const NotificationSubscriberFlags = enum {
     is_user,
     is_group,
     is_team,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .delivery_preferences_editable => "deliveryPreferencesEditable",
-            .supports_preferred_email_address_delivery => "supportsPreferredEmailAddressDelivery",
-            .supports_each_member_delivery => "supportsEachMemberDelivery",
-            .supports_no_delivery => "supportsNoDelivery",
-            .is_user => "isUser",
-            .is_group => "isGroup",
-            .is_team => "isTeam",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "deliveryPreferencesEditable")) return .delivery_preferences_editable;
-        if (std.mem.eql(u8, s, "supportsPreferredEmailAddressDelivery")) return .supports_preferred_email_address_delivery;
-        if (std.mem.eql(u8, s, "supportsEachMemberDelivery")) return .supports_each_member_delivery;
-        if (std.mem.eql(u8, s, "supportsNoDelivery")) return .supports_no_delivery;
-        if (std.mem.eql(u8, s, "isUser")) return .is_user;
-        if (std.mem.eql(u8, s, "isGroup")) return .is_group;
-        if (std.mem.eql(u8, s, "isTeam")) return .is_team;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .delivery_preferences_editable = "deliveryPreferencesEditable",
+        .supports_preferred_email_address_delivery = "supportsPreferredEmailAddressDelivery",
+        .supports_each_member_delivery = "supportsEachMemberDelivery",
+        .supports_no_delivery = "supportsNoDelivery",
+        .is_user = "isUser",
+        .is_group = "isGroup",
+        .is_team = "isTeam",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationSubscriberUpdateParametersDeliveryPreference = enum {
+pub const NotificationSubscriberUpdateParametersDeliveryPreference = union(enum) {
     no_delivery,
     preferred_email_address,
     each_member,
     use_default,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .no_delivery => "noDelivery",
-            .preferred_email_address => "preferredEmailAddress",
-            .each_member => "eachMember",
-            .use_default => "useDefault",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "noDelivery")) return .no_delivery;
-        if (std.mem.eql(u8, s, "preferredEmailAddress")) return .preferred_email_address;
-        if (std.mem.eql(u8, s, "eachMember")) return .each_member;
-        if (std.mem.eql(u8, s, "useDefault")) return .use_default;
-        return null;
-    }
+    const wire_names = .{
+        .no_delivery = "noDelivery",
+        .preferred_email_address = "preferredEmailAddress",
+        .each_member = "eachMember",
+        .use_default = "useDefault",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const SubscriptionQueryConditionFlags = enum {
+pub const SubscriptionQueryConditionFlags = union(enum) {
     none,
     group_subscription,
     contributed_subscription,
     can_opt_out,
     team_subscription,
     one_actor_matches,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .group_subscription => "groupSubscription",
-            .contributed_subscription => "contributedSubscription",
-            .can_opt_out => "canOptOut",
-            .team_subscription => "teamSubscription",
-            .one_actor_matches => "oneActorMatches",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "groupSubscription")) return .group_subscription;
-        if (std.mem.eql(u8, s, "contributedSubscription")) return .contributed_subscription;
-        if (std.mem.eql(u8, s, "canOptOut")) return .can_opt_out;
-        if (std.mem.eql(u8, s, "teamSubscription")) return .team_subscription;
-        if (std.mem.eql(u8, s, "oneActorMatches")) return .one_actor_matches;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .group_subscription = "groupSubscription",
+        .contributed_subscription = "contributedSubscription",
+        .can_opt_out = "canOptOut",
+        .team_subscription = "teamSubscription",
+        .one_actor_matches = "oneActorMatches",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const SubscriptionQueryQueryFlags = enum {
+pub const SubscriptionQueryQueryFlags = union(enum) {
     none,
     include_invalid_subscriptions,
     include_deleted_subscriptions,
     include_filter_details,
     always_return_basic_information,
     include_system_subscriptions,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .include_invalid_subscriptions => "includeInvalidSubscriptions",
-            .include_deleted_subscriptions => "includeDeletedSubscriptions",
-            .include_filter_details => "includeFilterDetails",
-            .always_return_basic_information => "alwaysReturnBasicInformation",
-            .include_system_subscriptions => "includeSystemSubscriptions",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "includeInvalidSubscriptions")) return .include_invalid_subscriptions;
-        if (std.mem.eql(u8, s, "includeDeletedSubscriptions")) return .include_deleted_subscriptions;
-        if (std.mem.eql(u8, s, "includeFilterDetails")) return .include_filter_details;
-        if (std.mem.eql(u8, s, "alwaysReturnBasicInformation")) return .always_return_basic_information;
-        if (std.mem.eql(u8, s, "includeSystemSubscriptions")) return .include_system_subscriptions;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .include_invalid_subscriptions = "includeInvalidSubscriptions",
+        .include_deleted_subscriptions = "includeDeletedSubscriptions",
+        .include_filter_details = "includeFilterDetails",
+        .always_return_basic_information = "alwaysReturnBasicInformation",
+        .include_system_subscriptions = "includeSystemSubscriptions",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationSubscriptionFlags = enum {
+pub const NotificationSubscriptionFlags = union(enum) {
     none,
     group_subscription,
     contributed_subscription,
     can_opt_out,
     team_subscription,
     one_actor_matches,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .group_subscription => "groupSubscription",
-            .contributed_subscription => "contributedSubscription",
-            .can_opt_out => "canOptOut",
-            .team_subscription => "teamSubscription",
-            .one_actor_matches => "oneActorMatches",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "groupSubscription")) return .group_subscription;
-        if (std.mem.eql(u8, s, "contributedSubscription")) return .contributed_subscription;
-        if (std.mem.eql(u8, s, "canOptOut")) return .can_opt_out;
-        if (std.mem.eql(u8, s, "teamSubscription")) return .team_subscription;
-        if (std.mem.eql(u8, s, "oneActorMatches")) return .one_actor_matches;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .group_subscription = "groupSubscription",
+        .contributed_subscription = "contributedSubscription",
+        .can_opt_out = "canOptOut",
+        .team_subscription = "teamSubscription",
+        .one_actor_matches = "oneActorMatches",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationSubscriptionPermissions = enum {
+pub const NotificationSubscriptionPermissions = union(enum) {
     none,
     view,
     edit,
     delete,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .view => "view",
-            .edit => "edit",
-            .delete => "delete",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "view")) return .view;
-        if (std.mem.eql(u8, s, "edit")) return .edit;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .view = "view",
+        .edit = "edit",
+        .delete = "delete",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationSubscriptionStatus = enum {
+pub const NotificationSubscriptionStatus = union(enum) {
     jailed_by_notifications_volume,
     pending_deletion,
     disabled_argument_exception,
@@ -436,58 +409,45 @@ pub const NotificationSubscriptionStatus = enum {
     disabled,
     enabled,
     enabled_on_probation,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .jailed_by_notifications_volume => "jailedByNotificationsVolume",
-            .pending_deletion => "pendingDeletion",
-            .disabled_argument_exception => "disabledArgumentException",
-            .disabled_project_invalid => "disabledProjectInvalid",
-            .disabled_missing_permissions => "disabledMissingPermissions",
-            .disabled_from_probation => "disabledFromProbation",
-            .disabled_inactive_identity => "disabledInactiveIdentity",
-            .disabled_message_queue_not_supported => "disabledMessageQueueNotSupported",
-            .disabled_missing_identity => "disabledMissingIdentity",
-            .disabled_invalid_role_expression => "disabledInvalidRoleExpression",
-            .disabled_invalid_path_clause => "disabledInvalidPathClause",
-            .disabled_as_duplicate_of_default => "disabledAsDuplicateOfDefault",
-            .disabled_by_admin => "disabledByAdmin",
-            .disabled => "disabled",
-            .enabled => "enabled",
-            .enabled_on_probation => "enabledOnProbation",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "jailedByNotificationsVolume")) return .jailed_by_notifications_volume;
-        if (std.mem.eql(u8, s, "pendingDeletion")) return .pending_deletion;
-        if (std.mem.eql(u8, s, "disabledArgumentException")) return .disabled_argument_exception;
-        if (std.mem.eql(u8, s, "disabledProjectInvalid")) return .disabled_project_invalid;
-        if (std.mem.eql(u8, s, "disabledMissingPermissions")) return .disabled_missing_permissions;
-        if (std.mem.eql(u8, s, "disabledFromProbation")) return .disabled_from_probation;
-        if (std.mem.eql(u8, s, "disabledInactiveIdentity")) return .disabled_inactive_identity;
-        if (std.mem.eql(u8, s, "disabledMessageQueueNotSupported")) return .disabled_message_queue_not_supported;
-        if (std.mem.eql(u8, s, "disabledMissingIdentity")) return .disabled_missing_identity;
-        if (std.mem.eql(u8, s, "disabledInvalidRoleExpression")) return .disabled_invalid_role_expression;
-        if (std.mem.eql(u8, s, "disabledInvalidPathClause")) return .disabled_invalid_path_clause;
-        if (std.mem.eql(u8, s, "disabledAsDuplicateOfDefault")) return .disabled_as_duplicate_of_default;
-        if (std.mem.eql(u8, s, "disabledByAdmin")) return .disabled_by_admin;
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        if (std.mem.eql(u8, s, "enabledOnProbation")) return .enabled_on_probation;
-        return null;
-    }
+    const wire_names = .{
+        .jailed_by_notifications_volume = "jailedByNotificationsVolume",
+        .pending_deletion = "pendingDeletion",
+        .disabled_argument_exception = "disabledArgumentException",
+        .disabled_project_invalid = "disabledProjectInvalid",
+        .disabled_missing_permissions = "disabledMissingPermissions",
+        .disabled_from_probation = "disabledFromProbation",
+        .disabled_inactive_identity = "disabledInactiveIdentity",
+        .disabled_message_queue_not_supported = "disabledMessageQueueNotSupported",
+        .disabled_missing_identity = "disabledMissingIdentity",
+        .disabled_invalid_role_expression = "disabledInvalidRoleExpression",
+        .disabled_invalid_path_clause = "disabledInvalidPathClause",
+        .disabled_as_duplicate_of_default = "disabledAsDuplicateOfDefault",
+        .disabled_by_admin = "disabledByAdmin",
+        .disabled = "disabled",
+        .enabled = "enabled",
+        .enabled_on_probation = "enabledOnProbation",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -575,7 +535,7 @@ pub const GetRequestQueryFlags = enum {
     }
 };
 
-pub const NotificationSubscriptionUpdateParametersStatus = enum {
+pub const NotificationSubscriptionUpdateParametersStatus = union(enum) {
     jailed_by_notifications_volume,
     pending_deletion,
     disabled_argument_exception,
@@ -592,94 +552,80 @@ pub const NotificationSubscriptionUpdateParametersStatus = enum {
     disabled,
     enabled,
     enabled_on_probation,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .jailed_by_notifications_volume => "jailedByNotificationsVolume",
-            .pending_deletion => "pendingDeletion",
-            .disabled_argument_exception => "disabledArgumentException",
-            .disabled_project_invalid => "disabledProjectInvalid",
-            .disabled_missing_permissions => "disabledMissingPermissions",
-            .disabled_from_probation => "disabledFromProbation",
-            .disabled_inactive_identity => "disabledInactiveIdentity",
-            .disabled_message_queue_not_supported => "disabledMessageQueueNotSupported",
-            .disabled_missing_identity => "disabledMissingIdentity",
-            .disabled_invalid_role_expression => "disabledInvalidRoleExpression",
-            .disabled_invalid_path_clause => "disabledInvalidPathClause",
-            .disabled_as_duplicate_of_default => "disabledAsDuplicateOfDefault",
-            .disabled_by_admin => "disabledByAdmin",
-            .disabled => "disabled",
-            .enabled => "enabled",
-            .enabled_on_probation => "enabledOnProbation",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "jailedByNotificationsVolume")) return .jailed_by_notifications_volume;
-        if (std.mem.eql(u8, s, "pendingDeletion")) return .pending_deletion;
-        if (std.mem.eql(u8, s, "disabledArgumentException")) return .disabled_argument_exception;
-        if (std.mem.eql(u8, s, "disabledProjectInvalid")) return .disabled_project_invalid;
-        if (std.mem.eql(u8, s, "disabledMissingPermissions")) return .disabled_missing_permissions;
-        if (std.mem.eql(u8, s, "disabledFromProbation")) return .disabled_from_probation;
-        if (std.mem.eql(u8, s, "disabledInactiveIdentity")) return .disabled_inactive_identity;
-        if (std.mem.eql(u8, s, "disabledMessageQueueNotSupported")) return .disabled_message_queue_not_supported;
-        if (std.mem.eql(u8, s, "disabledMissingIdentity")) return .disabled_missing_identity;
-        if (std.mem.eql(u8, s, "disabledInvalidRoleExpression")) return .disabled_invalid_role_expression;
-        if (std.mem.eql(u8, s, "disabledInvalidPathClause")) return .disabled_invalid_path_clause;
-        if (std.mem.eql(u8, s, "disabledAsDuplicateOfDefault")) return .disabled_as_duplicate_of_default;
-        if (std.mem.eql(u8, s, "disabledByAdmin")) return .disabled_by_admin;
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        if (std.mem.eql(u8, s, "enabledOnProbation")) return .enabled_on_probation;
-        return null;
-    }
+    const wire_names = .{
+        .jailed_by_notifications_volume = "jailedByNotificationsVolume",
+        .pending_deletion = "pendingDeletion",
+        .disabled_argument_exception = "disabledArgumentException",
+        .disabled_project_invalid = "disabledProjectInvalid",
+        .disabled_missing_permissions = "disabledMissingPermissions",
+        .disabled_from_probation = "disabledFromProbation",
+        .disabled_inactive_identity = "disabledInactiveIdentity",
+        .disabled_message_queue_not_supported = "disabledMessageQueueNotSupported",
+        .disabled_missing_identity = "disabledMissingIdentity",
+        .disabled_invalid_role_expression = "disabledInvalidRoleExpression",
+        .disabled_invalid_path_clause = "disabledInvalidPathClause",
+        .disabled_as_duplicate_of_default = "disabledAsDuplicateOfDefault",
+        .disabled_by_admin = "disabledByAdmin",
+        .disabled = "disabled",
+        .enabled = "enabled",
+        .enabled_on_probation = "enabledOnProbation",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const NotificationSubscriptionTemplateType = enum {
+pub const NotificationSubscriptionTemplateType = union(enum) {
     user,
     team,
     both,
     none,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .user => "user",
-            .team => "team",
-            .both => "both",
-            .none => "none",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "user")) return .user;
-        if (std.mem.eql(u8, s, "team")) return .team;
-        if (std.mem.eql(u8, s, "both")) return .both;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        return null;
-    }
+    const wire_names = .{
+        .user = "user",
+        .team = "team",
+        .both = "both",
+        .none = "none",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/operations/enums.zig
+++ b/src/operations/enums.zig
@@ -8,45 +8,42 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const OperationStatus = enum {
+pub const OperationStatus = union(enum) {
     not_set,
     queued,
     in_progress,
     cancelled,
     succeeded,
     failed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .not_set => "notSet",
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .cancelled => "cancelled",
-            .succeeded => "succeeded",
-            .failed => "failed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "notSet")) return .not_set;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "cancelled")) return .cancelled;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        return null;
-    }
+    const wire_names = .{
+        .not_set = "notSet",
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .cancelled = "cancelled",
+        .succeeded = "succeeded",
+        .failed = "failed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/permissions_report/enums.zig
+++ b/src/permissions_report/enums.zig
@@ -8,81 +8,77 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const PermissionsReportReportStatus = enum {
+pub const PermissionsReportReportStatus = union(enum) {
     created,
     in_progress,
     completed_with_errors,
     completed_successfully,
     deleted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .created => "created",
-            .in_progress => "inProgress",
-            .completed_with_errors => "completedWithErrors",
-            .completed_successfully => "completedSuccessfully",
-            .deleted => "deleted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "created")) return .created;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completedWithErrors")) return .completed_with_errors;
-        if (std.mem.eql(u8, s, "completedSuccessfully")) return .completed_successfully;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        return null;
-    }
+    const wire_names = .{
+        .created = "created",
+        .in_progress = "inProgress",
+        .completed_with_errors = "completedWithErrors",
+        .completed_successfully = "completedSuccessfully",
+        .deleted = "deleted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const PermissionsReportResourceResourceType = enum {
+pub const PermissionsReportResourceResourceType = union(enum) {
     repo,
     ref,
     project_git,
     release,
     tfvc,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .repo => "repo",
-            .ref => "ref",
-            .project_git => "projectGit",
-            .release => "release",
-            .tfvc => "tfvc",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "repo")) return .repo;
-        if (std.mem.eql(u8, s, "ref")) return .ref;
-        if (std.mem.eql(u8, s, "projectGit")) return .project_git;
-        if (std.mem.eql(u8, s, "release")) return .release;
-        if (std.mem.eql(u8, s, "tfvc")) return .tfvc;
-        return null;
-    }
+    const wire_names = .{
+        .repo = "repo",
+        .ref = "ref",
+        .project_git = "projectGit",
+        .release = "release",
+        .tfvc = "tfvc",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/pipelines/enums.zig
+++ b/src/pipelines/enums.zig
@@ -8,195 +8,186 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const PipelineConfigurationType = enum {
+pub const PipelineConfigurationType = union(enum) {
     unknown,
     yaml,
     designer_json,
     just_in_time,
     designer_hyphen_json,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .yaml => "yaml",
-            .designer_json => "designerJson",
-            .just_in_time => "justInTime",
-            .designer_hyphen_json => "designerHyphenJson",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "yaml")) return .yaml;
-        if (std.mem.eql(u8, s, "designerJson")) return .designer_json;
-        if (std.mem.eql(u8, s, "justInTime")) return .just_in_time;
-        if (std.mem.eql(u8, s, "designerHyphenJson")) return .designer_hyphen_json;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .yaml = "yaml",
+        .designer_json = "designerJson",
+        .just_in_time = "justInTime",
+        .designer_hyphen_json = "designerHyphenJson",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CreatePipelineConfigurationParametersType = enum {
+pub const CreatePipelineConfigurationParametersType = union(enum) {
     unknown,
     yaml,
     designer_json,
     just_in_time,
     designer_hyphen_json,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .yaml => "yaml",
-            .designer_json => "designerJson",
-            .just_in_time => "justInTime",
-            .designer_hyphen_json => "designerHyphenJson",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "yaml")) return .yaml;
-        if (std.mem.eql(u8, s, "designerJson")) return .designer_json;
-        if (std.mem.eql(u8, s, "justInTime")) return .just_in_time;
-        if (std.mem.eql(u8, s, "designerHyphenJson")) return .designer_hyphen_json;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .yaml = "yaml",
+        .designer_json = "designerJson",
+        .just_in_time = "justInTime",
+        .designer_hyphen_json = "designerHyphenJson",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RepositoryType = enum {
+pub const RepositoryType = union(enum) {
     unknown,
     git_hub,
     azure_repos_git,
     git_hub_enterprise,
     bit_bucket,
     azure_repos_git_hyphenated,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .git_hub => "gitHub",
-            .azure_repos_git => "azureReposGit",
-            .git_hub_enterprise => "gitHubEnterprise",
-            .bit_bucket => "bitBucket",
-            .azure_repos_git_hyphenated => "azureReposGitHyphenated",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "gitHub")) return .git_hub;
-        if (std.mem.eql(u8, s, "azureReposGit")) return .azure_repos_git;
-        if (std.mem.eql(u8, s, "gitHubEnterprise")) return .git_hub_enterprise;
-        if (std.mem.eql(u8, s, "bitBucket")) return .bit_bucket;
-        if (std.mem.eql(u8, s, "azureReposGitHyphenated")) return .azure_repos_git_hyphenated;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .git_hub = "gitHub",
+        .azure_repos_git = "azureReposGit",
+        .git_hub_enterprise = "gitHubEnterprise",
+        .bit_bucket = "bitBucket",
+        .azure_repos_git_hyphenated = "azureReposGitHyphenated",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunResult = enum {
+pub const RunResult = union(enum) {
     unknown,
     succeeded,
     failed,
     canceled,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .canceled => "canceled",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .canceled = "canceled",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunState = enum {
+pub const RunState = union(enum) {
     unknown,
     in_progress,
     canceling,
     completed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .in_progress => "inProgress",
-            .canceling => "canceling",
-            .completed => "completed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "canceling")) return .canceling;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .in_progress = "inProgress",
+        .canceling = "canceling",
+        .completed = "completed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/policy/enums.zig
+++ b/src/policy/enums.zig
@@ -8,45 +8,42 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const PolicyEvaluationRecordStatus = enum {
+pub const PolicyEvaluationRecordStatus = union(enum) {
     queued,
     running,
     approved,
     rejected,
     not_applicable,
     broken,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .queued => "queued",
-            .running => "running",
-            .approved => "approved",
-            .rejected => "rejected",
-            .not_applicable => "notApplicable",
-            .broken => "broken",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "running")) return .running;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "broken")) return .broken;
-        return null;
-    }
+    const wire_names = .{
+        .queued = "queued",
+        .running = "running",
+        .approved = "approved",
+        .rejected = "rejected",
+        .not_applicable = "notApplicable",
+        .broken = "broken",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/processadmin/enums.zig
+++ b/src/processadmin/enums.zig
@@ -8,33 +8,34 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const ValidationIssueIssueType = enum {
+pub const ValidationIssueIssueType = union(enum) {
     warning,
     @"error",
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .warning => "warning",
-            .@"error" => "error",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        return null;
-    }
+    const wire_names = .{
+        .warning = "warning",
+        .@"error" = "error",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/processes/enums.zig
+++ b/src/processes/enums.zig
@@ -38,36 +38,36 @@ pub const ListRequestExpand = enum {
     }
 };
 
-pub const ProcessInfoCustomizationType = enum {
+pub const ProcessInfoCustomizationType = union(enum) {
     system,
     inherited,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .inherited => "inherited",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .inherited = "inherited",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -134,36 +134,36 @@ pub const ListRequestExpand1 = enum {
     }
 };
 
-pub const ProcessBehaviorCustomization = enum {
+pub const ProcessBehaviorCustomization = union(enum) {
     system,
     inherited,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .inherited => "inherited",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .inherited = "inherited",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -236,105 +236,104 @@ pub const ListRequestExpand2 = enum {
     }
 };
 
-pub const ProcessWorkItemTypeCustomization = enum {
+pub const ProcessWorkItemTypeCustomization = union(enum) {
     system,
     inherited,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .inherited => "inherited",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .inherited = "inherited",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const PagePageType = enum {
+pub const PagePageType = union(enum) {
     custom,
     history,
     links,
     attachments,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .custom => "custom",
-            .history => "history",
-            .links => "links",
-            .attachments => "attachments",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        if (std.mem.eql(u8, s, "history")) return .history;
-        if (std.mem.eql(u8, s, "links")) return .links;
-        if (std.mem.eql(u8, s, "attachments")) return .attachments;
-        return null;
-    }
+    const wire_names = .{
+        .custom = "custom",
+        .history = "history",
+        .links = "links",
+        .attachments = "attachments",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemStateResultModelCustomizationType = enum {
+pub const WorkItemStateResultModelCustomizationType = union(enum) {
     system,
     inherited,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .inherited => "inherited",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .inherited = "inherited",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -374,40 +373,40 @@ pub const GetRequestExpand2 = enum {
     }
 };
 
-pub const ProcessWorkItemTypeFieldCustomization = enum {
+pub const ProcessWorkItemTypeFieldCustomization = union(enum) {
     system,
     inherited,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .inherited => "inherited",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .inherited = "inherited",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ProcessWorkItemTypeFieldType = enum {
+pub const ProcessWorkItemTypeFieldType = union(enum) {
     string,
     integer,
     date_time,
@@ -422,54 +421,43 @@ pub const ProcessWorkItemTypeFieldType = enum {
     picklist_integer,
     picklist_string,
     picklist_double,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .string => "string",
-            .integer => "integer",
-            .date_time => "dateTime",
-            .plain_text => "plainText",
-            .html => "html",
-            .tree_path => "treePath",
-            .history => "history",
-            .double => "double",
-            .guid => "guid",
-            .boolean => "boolean",
-            .identity => "identity",
-            .picklist_integer => "picklistInteger",
-            .picklist_string => "picklistString",
-            .picklist_double => "picklistDouble",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "integer")) return .integer;
-        if (std.mem.eql(u8, s, "dateTime")) return .date_time;
-        if (std.mem.eql(u8, s, "plainText")) return .plain_text;
-        if (std.mem.eql(u8, s, "html")) return .html;
-        if (std.mem.eql(u8, s, "treePath")) return .tree_path;
-        if (std.mem.eql(u8, s, "history")) return .history;
-        if (std.mem.eql(u8, s, "double")) return .double;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "identity")) return .identity;
-        if (std.mem.eql(u8, s, "picklistInteger")) return .picklist_integer;
-        if (std.mem.eql(u8, s, "picklistString")) return .picklist_string;
-        if (std.mem.eql(u8, s, "picklistDouble")) return .picklist_double;
-        return null;
-    }
+    const wire_names = .{
+        .string = "string",
+        .integer = "integer",
+        .date_time = "dateTime",
+        .plain_text = "plainText",
+        .html = "html",
+        .tree_path = "treePath",
+        .history = "history",
+        .double = "double",
+        .guid = "guid",
+        .boolean = "boolean",
+        .identity = "identity",
+        .picklist_integer = "picklistInteger",
+        .picklist_string = "picklistString",
+        .picklist_double = "picklistDouble",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -506,7 +494,7 @@ pub const GetRequestExpand3 = enum {
     }
 };
 
-pub const RuleActionActionType = enum {
+pub const RuleActionActionType = union(enum) {
     make_required,
     make_read_only,
     set_default_value,
@@ -522,60 +510,48 @@ pub const RuleActionActionType = enum {
     copy_from_server_current_user,
     hide_target_field,
     disallow_value,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .make_required => "makeRequired",
-            .make_read_only => "makeReadOnly",
-            .set_default_value => "setDefaultValue",
-            .set_default_from_clock => "setDefaultFromClock",
-            .set_default_from_current_user => "setDefaultFromCurrentUser",
-            .set_default_from_field => "setDefaultFromField",
-            .copy_value => "copyValue",
-            .copy_from_clock => "copyFromClock",
-            .copy_from_current_user => "copyFromCurrentUser",
-            .copy_from_field => "copyFromField",
-            .set_value_to_empty => "setValueToEmpty",
-            .copy_from_server_clock => "copyFromServerClock",
-            .copy_from_server_current_user => "copyFromServerCurrentUser",
-            .hide_target_field => "hideTargetField",
-            .disallow_value => "disallowValue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "makeRequired")) return .make_required;
-        if (std.mem.eql(u8, s, "makeReadOnly")) return .make_read_only;
-        if (std.mem.eql(u8, s, "setDefaultValue")) return .set_default_value;
-        if (std.mem.eql(u8, s, "setDefaultFromClock")) return .set_default_from_clock;
-        if (std.mem.eql(u8, s, "setDefaultFromCurrentUser")) return .set_default_from_current_user;
-        if (std.mem.eql(u8, s, "setDefaultFromField")) return .set_default_from_field;
-        if (std.mem.eql(u8, s, "copyValue")) return .copy_value;
-        if (std.mem.eql(u8, s, "copyFromClock")) return .copy_from_clock;
-        if (std.mem.eql(u8, s, "copyFromCurrentUser")) return .copy_from_current_user;
-        if (std.mem.eql(u8, s, "copyFromField")) return .copy_from_field;
-        if (std.mem.eql(u8, s, "setValueToEmpty")) return .set_value_to_empty;
-        if (std.mem.eql(u8, s, "copyFromServerClock")) return .copy_from_server_clock;
-        if (std.mem.eql(u8, s, "copyFromServerCurrentUser")) return .copy_from_server_current_user;
-        if (std.mem.eql(u8, s, "hideTargetField")) return .hide_target_field;
-        if (std.mem.eql(u8, s, "disallowValue")) return .disallow_value;
-        return null;
-    }
+    const wire_names = .{
+        .make_required = "makeRequired",
+        .make_read_only = "makeReadOnly",
+        .set_default_value = "setDefaultValue",
+        .set_default_from_clock = "setDefaultFromClock",
+        .set_default_from_current_user = "setDefaultFromCurrentUser",
+        .set_default_from_field = "setDefaultFromField",
+        .copy_value = "copyValue",
+        .copy_from_clock = "copyFromClock",
+        .copy_from_current_user = "copyFromCurrentUser",
+        .copy_from_field = "copyFromField",
+        .set_value_to_empty = "setValueToEmpty",
+        .copy_from_server_clock = "copyFromServerClock",
+        .copy_from_server_current_user = "copyFromServerCurrentUser",
+        .hide_target_field = "hideTargetField",
+        .disallow_value = "disallowValue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RuleConditionConditionType = enum {
+pub const RuleConditionConditionType = union(enum) {
     when,
     when_not,
     when_changed,
@@ -588,83 +564,74 @@ pub const RuleConditionConditionType = enum {
     when_value_is_not_defined,
     when_current_user_is_member_of_group,
     when_current_user_is_not_member_of_group,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .when => "when",
-            .when_not => "whenNot",
-            .when_changed => "whenChanged",
-            .when_not_changed => "whenNotChanged",
-            .when_was => "whenWas",
-            .when_state_changed_to => "whenStateChangedTo",
-            .when_state_changed_from_and_to => "whenStateChangedFromAndTo",
-            .when_work_item_is_created => "whenWorkItemIsCreated",
-            .when_value_is_defined => "whenValueIsDefined",
-            .when_value_is_not_defined => "whenValueIsNotDefined",
-            .when_current_user_is_member_of_group => "whenCurrentUserIsMemberOfGroup",
-            .when_current_user_is_not_member_of_group => "whenCurrentUserIsNotMemberOfGroup",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "when")) return .when;
-        if (std.mem.eql(u8, s, "whenNot")) return .when_not;
-        if (std.mem.eql(u8, s, "whenChanged")) return .when_changed;
-        if (std.mem.eql(u8, s, "whenNotChanged")) return .when_not_changed;
-        if (std.mem.eql(u8, s, "whenWas")) return .when_was;
-        if (std.mem.eql(u8, s, "whenStateChangedTo")) return .when_state_changed_to;
-        if (std.mem.eql(u8, s, "whenStateChangedFromAndTo")) return .when_state_changed_from_and_to;
-        if (std.mem.eql(u8, s, "whenWorkItemIsCreated")) return .when_work_item_is_created;
-        if (std.mem.eql(u8, s, "whenValueIsDefined")) return .when_value_is_defined;
-        if (std.mem.eql(u8, s, "whenValueIsNotDefined")) return .when_value_is_not_defined;
-        if (std.mem.eql(u8, s, "whenCurrentUserIsMemberOfGroup")) return .when_current_user_is_member_of_group;
-        if (std.mem.eql(u8, s, "whenCurrentUserIsNotMemberOfGroup")) return .when_current_user_is_not_member_of_group;
-        return null;
-    }
+    const wire_names = .{
+        .when = "when",
+        .when_not = "whenNot",
+        .when_changed = "whenChanged",
+        .when_not_changed = "whenNotChanged",
+        .when_was = "whenWas",
+        .when_state_changed_to = "whenStateChangedTo",
+        .when_state_changed_from_and_to = "whenStateChangedFromAndTo",
+        .when_work_item_is_created = "whenWorkItemIsCreated",
+        .when_value_is_defined = "whenValueIsDefined",
+        .when_value_is_not_defined = "whenValueIsNotDefined",
+        .when_current_user_is_member_of_group = "whenCurrentUserIsMemberOfGroup",
+        .when_current_user_is_not_member_of_group = "whenCurrentUserIsNotMemberOfGroup",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ProcessRuleCustomizationType = enum {
+pub const ProcessRuleCustomizationType = union(enum) {
     system,
     inherited,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .system => "system",
-            .inherited => "inherited",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .system = "system",
+        .inherited = "inherited",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/profile/enums.zig
+++ b/src/profile/enums.zig
@@ -8,36 +8,36 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const ProfileProfileState = enum {
+pub const ProfileProfileState = union(enum) {
     custom,
     custom_read_only,
     read_only,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .custom => "custom",
-            .custom_read_only => "customReadOnly",
-            .read_only => "readOnly",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        if (std.mem.eql(u8, s, "customReadOnly")) return .custom_read_only;
-        if (std.mem.eql(u8, s, "readOnly")) return .read_only;
-        return null;
-    }
+    const wire_names = .{
+        .custom = "custom",
+        .custom_read_only = "customReadOnly",
+        .read_only = "readOnly",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/release/enums.zig
+++ b/src/release/enums.zig
@@ -119,43 +119,42 @@ pub const ListRequestQueryOrder = enum {
     }
 };
 
-pub const ReleaseApprovalApprovalType = enum {
+pub const ReleaseApprovalApprovalType = union(enum) {
     undefined,
     pre_deploy,
     post_deploy,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .pre_deploy => "preDeploy",
-            .post_deploy => "postDeploy",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "preDeploy")) return .pre_deploy;
-        if (std.mem.eql(u8, s, "postDeploy")) return .post_deploy;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .pre_deploy = "preDeploy",
+        .post_deploy = "postDeploy",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseApprovalStatus = enum {
+pub const ReleaseApprovalStatus = union(enum) {
     undefined,
     pending,
     approved,
@@ -163,40 +162,36 @@ pub const ReleaseApprovalStatus = enum {
     reassigned,
     canceled,
     skipped,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .pending => "pending",
-            .approved => "approved",
-            .rejected => "rejected",
-            .reassigned => "reassigned",
-            .canceled => "canceled",
-            .skipped => "skipped",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "reassigned")) return .reassigned;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .pending = "pending",
+        .approved = "approved",
+        .rejected = "rejected",
+        .reassigned = "reassigned",
+        .canceled = "canceled",
+        .skipped = "skipped",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -281,148 +276,145 @@ pub const ListRequestQueryOrder1 = enum {
     }
 };
 
-pub const ConditionConditionType = enum {
+pub const ConditionConditionType = union(enum) {
     undefined,
     event,
     environment_state,
     artifact,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .event => "event",
-            .environment_state => "environmentState",
-            .artifact => "artifact",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "event")) return .event;
-        if (std.mem.eql(u8, s, "environmentState")) return .environment_state;
-        if (std.mem.eql(u8, s, "artifact")) return .artifact;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .event = "event",
+        .environment_state = "environmentState",
+        .artifact = "artifact",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DeployPhasePhaseType = enum {
+pub const DeployPhasePhaseType = union(enum) {
     undefined,
     agent_based_deployment,
     run_on_server,
     machine_group_based_deployment,
     deployment_gates,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .agent_based_deployment => "agentBasedDeployment",
-            .run_on_server => "runOnServer",
-            .machine_group_based_deployment => "machineGroupBasedDeployment",
-            .deployment_gates => "deploymentGates",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "agentBasedDeployment")) return .agent_based_deployment;
-        if (std.mem.eql(u8, s, "runOnServer")) return .run_on_server;
-        if (std.mem.eql(u8, s, "machineGroupBasedDeployment")) return .machine_group_based_deployment;
-        if (std.mem.eql(u8, s, "deploymentGates")) return .deployment_gates;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .agent_based_deployment = "agentBasedDeployment",
+        .run_on_server = "runOnServer",
+        .machine_group_based_deployment = "machineGroupBasedDeployment",
+        .deployment_gates = "deploymentGates",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const EnvironmentTriggerTriggerType = enum {
+pub const EnvironmentTriggerTriggerType = union(enum) {
     undefined,
     deployment_group_redeploy,
     rollback_redeploy,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .deployment_group_redeploy => "deploymentGroupRedeploy",
-            .rollback_redeploy => "rollbackRedeploy",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "deploymentGroupRedeploy")) return .deployment_group_redeploy;
-        if (std.mem.eql(u8, s, "rollbackRedeploy")) return .rollback_redeploy;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .deployment_group_redeploy = "deploymentGroupRedeploy",
+        .rollback_redeploy = "rollbackRedeploy",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ApprovalOptionsExecutionOrder = enum {
+pub const ApprovalOptionsExecutionOrder = union(enum) {
     before_gates,
     after_successful_gates,
     after_gates_always,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .before_gates => "beforeGates",
-            .after_successful_gates => "afterSuccessfulGates",
-            .after_gates_always => "afterGatesAlways",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "beforeGates")) return .before_gates;
-        if (std.mem.eql(u8, s, "afterSuccessfulGates")) return .after_successful_gates;
-        if (std.mem.eql(u8, s, "afterGatesAlways")) return .after_gates_always;
-        return null;
-    }
+    const wire_names = .{
+        .before_gates = "beforeGates",
+        .after_successful_gates = "afterSuccessfulGates",
+        .after_gates_always = "afterGatesAlways",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseScheduleDaysToRelease = enum {
+pub const ReleaseScheduleDaysToRelease = union(enum) {
     none,
     monday,
     tuesday,
@@ -432,126 +424,116 @@ pub const ReleaseScheduleDaysToRelease = enum {
     saturday,
     sunday,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .monday => "monday",
-            .tuesday => "tuesday",
-            .wednesday => "wednesday",
-            .thursday => "thursday",
-            .friday => "friday",
-            .saturday => "saturday",
-            .sunday => "sunday",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "monday")) return .monday;
-        if (std.mem.eql(u8, s, "tuesday")) return .tuesday;
-        if (std.mem.eql(u8, s, "wednesday")) return .wednesday;
-        if (std.mem.eql(u8, s, "thursday")) return .thursday;
-        if (std.mem.eql(u8, s, "friday")) return .friday;
-        if (std.mem.eql(u8, s, "saturday")) return .saturday;
-        if (std.mem.eql(u8, s, "sunday")) return .sunday;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .monday = "monday",
+        .tuesday = "tuesday",
+        .wednesday = "wednesday",
+        .thursday = "thursday",
+        .friday = "friday",
+        .saturday = "saturday",
+        .sunday = "sunday",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseReferenceReason = enum {
+pub const ReleaseReferenceReason = union(enum) {
     none,
     manual,
     continuous_integration,
     schedule,
     pull_request,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .manual => "manual",
-            .continuous_integration => "continuousIntegration",
-            .schedule => "schedule",
-            .pull_request => "pullRequest",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "continuousIntegration")) return .continuous_integration;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .manual = "manual",
+        .continuous_integration = "continuousIntegration",
+        .schedule = "schedule",
+        .pull_request = "pullRequest",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseDefinitionSource = enum {
+pub const ReleaseDefinitionSource = union(enum) {
     undefined,
     rest_api,
     user_interface,
     ibiza,
     portal_extension_api,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .rest_api => "restApi",
-            .user_interface => "userInterface",
-            .ibiza => "ibiza",
-            .portal_extension_api => "portalExtensionApi",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "restApi")) return .rest_api;
-        if (std.mem.eql(u8, s, "userInterface")) return .user_interface;
-        if (std.mem.eql(u8, s, "ibiza")) return .ibiza;
-        if (std.mem.eql(u8, s, "portalExtensionApi")) return .portal_extension_api;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .rest_api = "restApi",
+        .user_interface = "userInterface",
+        .ibiza = "ibiza",
+        .portal_extension_api = "portalExtensionApi",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseTriggerBaseTriggerType = enum {
+pub const ReleaseTriggerBaseTriggerType = union(enum) {
     undefined,
     artifact_source,
     schedule,
@@ -559,76 +541,71 @@ pub const ReleaseTriggerBaseTriggerType = enum {
     container_image,
     package,
     pull_request,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .artifact_source => "artifactSource",
-            .schedule => "schedule",
-            .source_repo => "sourceRepo",
-            .container_image => "containerImage",
-            .package => "package",
-            .pull_request => "pullRequest",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "artifactSource")) return .artifact_source;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "sourceRepo")) return .source_repo;
-        if (std.mem.eql(u8, s, "containerImage")) return .container_image;
-        if (std.mem.eql(u8, s, "package")) return .package;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .artifact_source = "artifactSource",
+        .schedule = "schedule",
+        .source_repo = "sourceRepo",
+        .container_image = "containerImage",
+        .package = "package",
+        .pull_request = "pullRequest",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseDefinitionRevisionChangeType = enum {
+pub const ReleaseDefinitionRevisionChangeType = union(enum) {
     add,
     update,
     delete,
     undelete,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .add => "add",
-            .update => "update",
-            .delete => "delete",
-            .undelete => "undelete",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "add")) return .add;
-        if (std.mem.eql(u8, s, "update")) return .update;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "undelete")) return .undelete;
-        return null;
-    }
+    const wire_names = .{
+        .add = "add",
+        .update = "update",
+        .delete = "delete",
+        .undelete = "undelete",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -791,7 +768,7 @@ pub const ListRequestQueryOrder2 = enum {
     }
 };
 
-pub const DeploymentDeploymentStatus = enum {
+pub const DeploymentDeploymentStatus = union(enum) {
     undefined,
     not_deployed,
     in_progress,
@@ -799,44 +776,40 @@ pub const DeploymentDeploymentStatus = enum {
     partially_succeeded,
     failed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .not_deployed => "notDeployed",
-            .in_progress => "inProgress",
-            .succeeded => "succeeded",
-            .partially_succeeded => "partiallySucceeded",
-            .failed => "failed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "notDeployed")) return .not_deployed;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .not_deployed = "notDeployed",
+        .in_progress = "inProgress",
+        .succeeded = "succeeded",
+        .partially_succeeded = "partiallySucceeded",
+        .failed = "failed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DeploymentOperationStatus = enum {
+pub const DeploymentOperationStatus = union(enum) {
     undefined,
     queued,
     scheduled,
@@ -857,105 +830,86 @@ pub const DeploymentOperationStatus = enum {
     evaluating_gates,
     gate_failed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .queued => "queued",
-            .scheduled => "scheduled",
-            .pending => "pending",
-            .approved => "approved",
-            .rejected => "rejected",
-            .deferred => "deferred",
-            .queued_for_agent => "queuedForAgent",
-            .phase_in_progress => "phaseInProgress",
-            .phase_succeeded => "phaseSucceeded",
-            .phase_partially_succeeded => "phasePartiallySucceeded",
-            .phase_failed => "phaseFailed",
-            .canceled => "canceled",
-            .phase_canceled => "phaseCanceled",
-            .manual_intervention_pending => "manualInterventionPending",
-            .queued_for_pipeline => "queuedForPipeline",
-            .cancelling => "cancelling",
-            .evaluating_gates => "evaluatingGates",
-            .gate_failed => "gateFailed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "scheduled")) return .scheduled;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "queuedForAgent")) return .queued_for_agent;
-        if (std.mem.eql(u8, s, "phaseInProgress")) return .phase_in_progress;
-        if (std.mem.eql(u8, s, "phaseSucceeded")) return .phase_succeeded;
-        if (std.mem.eql(u8, s, "phasePartiallySucceeded")) return .phase_partially_succeeded;
-        if (std.mem.eql(u8, s, "phaseFailed")) return .phase_failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "phaseCanceled")) return .phase_canceled;
-        if (std.mem.eql(u8, s, "manualInterventionPending")) return .manual_intervention_pending;
-        if (std.mem.eql(u8, s, "queuedForPipeline")) return .queued_for_pipeline;
-        if (std.mem.eql(u8, s, "cancelling")) return .cancelling;
-        if (std.mem.eql(u8, s, "evaluatingGates")) return .evaluating_gates;
-        if (std.mem.eql(u8, s, "gateFailed")) return .gate_failed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .queued = "queued",
+        .scheduled = "scheduled",
+        .pending = "pending",
+        .approved = "approved",
+        .rejected = "rejected",
+        .deferred = "deferred",
+        .queued_for_agent = "queuedForAgent",
+        .phase_in_progress = "phaseInProgress",
+        .phase_succeeded = "phaseSucceeded",
+        .phase_partially_succeeded = "phasePartiallySucceeded",
+        .phase_failed = "phaseFailed",
+        .canceled = "canceled",
+        .phase_canceled = "phaseCanceled",
+        .manual_intervention_pending = "manualInterventionPending",
+        .queued_for_pipeline = "queuedForPipeline",
+        .cancelling = "cancelling",
+        .evaluating_gates = "evaluatingGates",
+        .gate_failed = "gateFailed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DeploymentReason = enum {
+pub const DeploymentReason = union(enum) {
     none,
     manual,
     automated,
     scheduled,
     redeploy_trigger,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .manual => "manual",
-            .automated => "automated",
-            .scheduled => "scheduled",
-            .redeploy_trigger => "redeployTrigger",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "automated")) return .automated;
-        if (std.mem.eql(u8, s, "scheduled")) return .scheduled;
-        if (std.mem.eql(u8, s, "redeployTrigger")) return .redeploy_trigger;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .manual = "manual",
+        .automated = "automated",
+        .scheduled = "scheduled",
+        .redeploy_trigger = "redeployTrigger",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -992,7 +946,7 @@ pub const ListRequestQueryOrder3 = enum {
     }
 };
 
-pub const ReleaseTaskStatus = enum {
+pub const ReleaseTaskStatus = union(enum) {
     unknown,
     pending,
     in_progress,
@@ -1003,88 +957,78 @@ pub const ReleaseTaskStatus = enum {
     succeeded,
     failed,
     partially_succeeded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .pending => "pending",
-            .in_progress => "inProgress",
-            .success => "success",
-            .failure => "failure",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .partially_succeeded => "partiallySucceeded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "success")) return .success;
-        if (std.mem.eql(u8, s, "failure")) return .failure;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .pending = "pending",
+        .in_progress = "inProgress",
+        .success = "success",
+        .failure = "failure",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .partially_succeeded = "partiallySucceeded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseGatesStatus = enum {
+pub const ReleaseGatesStatus = union(enum) {
     none,
     pending,
     in_progress,
     succeeded,
     failed,
     canceled,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .pending => "pending",
-            .in_progress => "inProgress",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .canceled => "canceled",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .pending = "pending",
+        .in_progress = "inProgress",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .canceled = "canceled",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1199,7 +1143,7 @@ pub const ListRequestExpand1 = enum {
     }
 };
 
-pub const DeploymentAttemptOperationStatus = enum {
+pub const DeploymentAttemptOperationStatus = union(enum) {
     undefined,
     queued,
     scheduled,
@@ -1220,220 +1164,197 @@ pub const DeploymentAttemptOperationStatus = enum {
     evaluating_gates,
     gate_failed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .queued => "queued",
-            .scheduled => "scheduled",
-            .pending => "pending",
-            .approved => "approved",
-            .rejected => "rejected",
-            .deferred => "deferred",
-            .queued_for_agent => "queuedForAgent",
-            .phase_in_progress => "phaseInProgress",
-            .phase_succeeded => "phaseSucceeded",
-            .phase_partially_succeeded => "phasePartiallySucceeded",
-            .phase_failed => "phaseFailed",
-            .canceled => "canceled",
-            .phase_canceled => "phaseCanceled",
-            .manual_intervention_pending => "manualInterventionPending",
-            .queued_for_pipeline => "queuedForPipeline",
-            .cancelling => "cancelling",
-            .evaluating_gates => "evaluatingGates",
-            .gate_failed => "gateFailed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "scheduled")) return .scheduled;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "deferred")) return .deferred;
-        if (std.mem.eql(u8, s, "queuedForAgent")) return .queued_for_agent;
-        if (std.mem.eql(u8, s, "phaseInProgress")) return .phase_in_progress;
-        if (std.mem.eql(u8, s, "phaseSucceeded")) return .phase_succeeded;
-        if (std.mem.eql(u8, s, "phasePartiallySucceeded")) return .phase_partially_succeeded;
-        if (std.mem.eql(u8, s, "phaseFailed")) return .phase_failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "phaseCanceled")) return .phase_canceled;
-        if (std.mem.eql(u8, s, "manualInterventionPending")) return .manual_intervention_pending;
-        if (std.mem.eql(u8, s, "queuedForPipeline")) return .queued_for_pipeline;
-        if (std.mem.eql(u8, s, "cancelling")) return .cancelling;
-        if (std.mem.eql(u8, s, "evaluatingGates")) return .evaluating_gates;
-        if (std.mem.eql(u8, s, "gateFailed")) return .gate_failed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .queued = "queued",
+        .scheduled = "scheduled",
+        .pending = "pending",
+        .approved = "approved",
+        .rejected = "rejected",
+        .deferred = "deferred",
+        .queued_for_agent = "queuedForAgent",
+        .phase_in_progress = "phaseInProgress",
+        .phase_succeeded = "phaseSucceeded",
+        .phase_partially_succeeded = "phasePartiallySucceeded",
+        .phase_failed = "phaseFailed",
+        .canceled = "canceled",
+        .phase_canceled = "phaseCanceled",
+        .manual_intervention_pending = "manualInterventionPending",
+        .queued_for_pipeline = "queuedForPipeline",
+        .cancelling = "cancelling",
+        .evaluating_gates = "evaluatingGates",
+        .gate_failed = "gateFailed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DeploymentAttemptReason = enum {
+pub const DeploymentAttemptReason = union(enum) {
     none,
     manual,
     automated,
     scheduled,
     redeploy_trigger,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .manual => "manual",
-            .automated => "automated",
-            .scheduled => "scheduled",
-            .redeploy_trigger => "redeployTrigger",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "automated")) return .automated;
-        if (std.mem.eql(u8, s, "scheduled")) return .scheduled;
-        if (std.mem.eql(u8, s, "redeployTrigger")) return .redeploy_trigger;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .manual = "manual",
+        .automated = "automated",
+        .scheduled = "scheduled",
+        .redeploy_trigger = "redeployTrigger",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ManualInterventionStatus = enum {
+pub const ManualInterventionStatus = union(enum) {
     unknown,
     pending,
     rejected,
     approved,
     canceled,
     bypassed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .pending => "pending",
-            .rejected => "rejected",
-            .approved => "approved",
-            .canceled => "canceled",
-            .bypassed => "bypassed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "bypassed")) return .bypassed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .pending = "pending",
+        .rejected = "rejected",
+        .approved = "approved",
+        .canceled = "canceled",
+        .bypassed = "bypassed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ManualInterventionType = enum {
+pub const ManualInterventionType = union(enum) {
     task,
     proof_of_presence,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .task => "task",
-            .proof_of_presence => "proofOfPresence",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "task")) return .task;
-        if (std.mem.eql(u8, s, "proofOfPresence")) return .proof_of_presence;
-        return null;
-    }
+    const wire_names = .{
+        .task = "task",
+        .proof_of_presence = "proofOfPresence",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseDeployPhasePhaseType = enum {
+pub const ReleaseDeployPhasePhaseType = union(enum) {
     undefined,
     agent_based_deployment,
     run_on_server,
     machine_group_based_deployment,
     deployment_gates,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .agent_based_deployment => "agentBasedDeployment",
-            .run_on_server => "runOnServer",
-            .machine_group_based_deployment => "machineGroupBasedDeployment",
-            .deployment_gates => "deploymentGates",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "agentBasedDeployment")) return .agent_based_deployment;
-        if (std.mem.eql(u8, s, "runOnServer")) return .run_on_server;
-        if (std.mem.eql(u8, s, "machineGroupBasedDeployment")) return .machine_group_based_deployment;
-        if (std.mem.eql(u8, s, "deploymentGates")) return .deployment_gates;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .agent_based_deployment = "agentBasedDeployment",
+        .run_on_server = "runOnServer",
+        .machine_group_based_deployment = "machineGroupBasedDeployment",
+        .deployment_gates = "deploymentGates",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseDeployPhaseStatus = enum {
+pub const ReleaseDeployPhaseStatus = union(enum) {
     undefined,
     not_started,
     in_progress,
@@ -1443,48 +1364,42 @@ pub const ReleaseDeployPhaseStatus = enum {
     canceled,
     skipped,
     cancelling,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .not_started => "notStarted",
-            .in_progress => "inProgress",
-            .partially_succeeded => "partiallySucceeded",
-            .succeeded => "succeeded",
-            .failed => "failed",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .cancelling => "cancelling",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "notStarted")) return .not_started;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "cancelling")) return .cancelling;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .not_started = "notStarted",
+        .in_progress = "inProgress",
+        .partially_succeeded = "partiallySucceeded",
+        .succeeded = "succeeded",
+        .failed = "failed",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .cancelling = "cancelling",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DeploymentAttemptStatus = enum {
+pub const DeploymentAttemptStatus = union(enum) {
     undefined,
     not_deployed,
     in_progress,
@@ -1492,44 +1407,40 @@ pub const DeploymentAttemptStatus = enum {
     partially_succeeded,
     failed,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .not_deployed => "notDeployed",
-            .in_progress => "inProgress",
-            .succeeded => "succeeded",
-            .partially_succeeded => "partiallySucceeded",
-            .failed => "failed",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "notDeployed")) return .not_deployed;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .not_deployed = "notDeployed",
+        .in_progress = "inProgress",
+        .succeeded = "succeeded",
+        .partially_succeeded = "partiallySucceeded",
+        .failed = "failed",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseEnvironmentStatus = enum {
+pub const ReleaseEnvironmentStatus = union(enum) {
     undefined,
     not_started,
     in_progress,
@@ -1539,194 +1450,182 @@ pub const ReleaseEnvironmentStatus = enum {
     queued,
     scheduled,
     partially_succeeded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .not_started => "notStarted",
-            .in_progress => "inProgress",
-            .succeeded => "succeeded",
-            .canceled => "canceled",
-            .rejected => "rejected",
-            .queued => "queued",
-            .scheduled => "scheduled",
-            .partially_succeeded => "partiallySucceeded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "notStarted")) return .not_started;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "scheduled")) return .scheduled;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .not_started = "notStarted",
+        .in_progress = "inProgress",
+        .succeeded = "succeeded",
+        .canceled = "canceled",
+        .rejected = "rejected",
+        .queued = "queued",
+        .scheduled = "scheduled",
+        .partially_succeeded = "partiallySucceeded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseReason = enum {
+pub const ReleaseReason = union(enum) {
     none,
     manual,
     continuous_integration,
     schedule,
     pull_request,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .manual => "manual",
-            .continuous_integration => "continuousIntegration",
-            .schedule => "schedule",
-            .pull_request => "pullRequest",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "continuousIntegration")) return .continuous_integration;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .manual = "manual",
+        .continuous_integration = "continuousIntegration",
+        .schedule = "schedule",
+        .pull_request = "pullRequest",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseStatus = enum {
+pub const ReleaseStatus = union(enum) {
     undefined,
     draft,
     active,
     abandoned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .draft => "draft",
-            .active => "active",
-            .abandoned => "abandoned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "draft")) return .draft;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .draft = "draft",
+        .active = "active",
+        .abandoned = "abandoned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseStartMetadataReason = enum {
+pub const ReleaseStartMetadataReason = union(enum) {
     none,
     manual,
     continuous_integration,
     schedule,
     pull_request,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .manual => "manual",
-            .continuous_integration => "continuousIntegration",
-            .schedule => "schedule",
-            .pull_request => "pullRequest",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "manual")) return .manual;
-        if (std.mem.eql(u8, s, "continuousIntegration")) return .continuous_integration;
-        if (std.mem.eql(u8, s, "schedule")) return .schedule;
-        if (std.mem.eql(u8, s, "pullRequest")) return .pull_request;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .manual = "manual",
+        .continuous_integration = "continuousIntegration",
+        .schedule = "schedule",
+        .pull_request = "pullRequest",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ReleaseUpdateMetadataStatus = enum {
+pub const ReleaseUpdateMetadataStatus = union(enum) {
     undefined,
     draft,
     active,
     abandoned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .draft => "draft",
-            .active => "active",
-            .abandoned => "abandoned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "draft")) return .draft;
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .draft = "draft",
+        .active = "active",
+        .abandoned = "abandoned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1760,7 +1659,7 @@ pub const GetReleaseEnvironmentRequestExpand = enum {
     }
 };
 
-pub const ReleaseEnvironmentUpdateMetadataStatus = enum {
+pub const ReleaseEnvironmentUpdateMetadataStatus = union(enum) {
     undefined,
     not_started,
     in_progress,
@@ -1770,86 +1669,77 @@ pub const ReleaseEnvironmentUpdateMetadataStatus = enum {
     queued,
     scheduled,
     partially_succeeded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .undefined => "undefined",
-            .not_started => "notStarted",
-            .in_progress => "inProgress",
-            .succeeded => "succeeded",
-            .canceled => "canceled",
-            .rejected => "rejected",
-            .queued => "queued",
-            .scheduled => "scheduled",
-            .partially_succeeded => "partiallySucceeded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "undefined")) return .undefined;
-        if (std.mem.eql(u8, s, "notStarted")) return .not_started;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "scheduled")) return .scheduled;
-        if (std.mem.eql(u8, s, "partiallySucceeded")) return .partially_succeeded;
-        return null;
-    }
+    const wire_names = .{
+        .undefined = "undefined",
+        .not_started = "notStarted",
+        .in_progress = "inProgress",
+        .succeeded = "succeeded",
+        .canceled = "canceled",
+        .rejected = "rejected",
+        .queued = "queued",
+        .scheduled = "scheduled",
+        .partially_succeeded = "partiallySucceeded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ManualInterventionUpdateMetadataStatus = enum {
+pub const ManualInterventionUpdateMetadataStatus = union(enum) {
     unknown,
     pending,
     rejected,
     approved,
     canceled,
     bypassed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .pending => "pending",
-            .rejected => "rejected",
-            .approved => "approved",
-            .canceled => "canceled",
-            .bypassed => "bypassed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "rejected")) return .rejected;
-        if (std.mem.eql(u8, s, "approved")) return .approved;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "bypassed")) return .bypassed;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .pending = "pending",
+        .rejected = "rejected",
+        .approved = "approved",
+        .canceled = "canceled",
+        .bypassed = "bypassed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/search/enums.zig
+++ b/src/search/enums.zig
@@ -8,36 +8,36 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const RepositoryType = enum {
+pub const RepositoryType = union(enum) {
     git,
     tfvc,
     custom,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .git => "git",
-            .tfvc => "tfvc",
-            .custom => "custom",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "git")) return .git;
-        if (std.mem.eql(u8, s, "tfvc")) return .tfvc;
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        return null;
-    }
+    const wire_names = .{
+        .git = "git",
+        .tfvc = "tfvc",
+        .custom = "custom",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/security_roles/enums.zig
+++ b/src/security_roles/enums.zig
@@ -8,33 +8,34 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const RoleAssignmentAccess = enum {
+pub const RoleAssignmentAccess = union(enum) {
     assigned,
     inherited,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .assigned => "assigned",
-            .inherited => "inherited",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "assigned")) return .assigned;
-        if (std.mem.eql(u8, s, "inherited")) return .inherited;
-        return null;
-    }
+    const wire_names = .{
+        .assigned = "assigned",
+        .inherited = "inherited",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/service_endpoint/enums.zig
+++ b/src/service_endpoint/enums.zig
@@ -44,7 +44,7 @@ pub const GetRequestActionFilter = enum {
     }
 };
 
-pub const InputDescriptorInputMode = enum {
+pub const InputDescriptorInputMode = union(enum) {
     none,
     text_box,
     password_box,
@@ -52,124 +52,114 @@ pub const InputDescriptorInputMode = enum {
     radio_buttons,
     check_box,
     text_area,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .text_box => "textBox",
-            .password_box => "passwordBox",
-            .combo => "combo",
-            .radio_buttons => "radioButtons",
-            .check_box => "checkBox",
-            .text_area => "textArea",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "textBox")) return .text_box;
-        if (std.mem.eql(u8, s, "passwordBox")) return .password_box;
-        if (std.mem.eql(u8, s, "combo")) return .combo;
-        if (std.mem.eql(u8, s, "radioButtons")) return .radio_buttons;
-        if (std.mem.eql(u8, s, "checkBox")) return .check_box;
-        if (std.mem.eql(u8, s, "textArea")) return .text_area;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .text_box = "textBox",
+        .password_box = "passwordBox",
+        .combo = "combo",
+        .radio_buttons = "radioButtons",
+        .check_box = "checkBox",
+        .text_area = "textArea",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const InputValidationDataType = enum {
+pub const InputValidationDataType = union(enum) {
     none,
     string,
     number,
     boolean,
     guid,
     uri,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .string => "string",
-            .number => "number",
-            .boolean => "boolean",
-            .guid => "guid",
-            .uri => "uri",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "number")) return .number;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        if (std.mem.eql(u8, s, "uri")) return .uri;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .string = "string",
+        .number = "number",
+        .boolean = "boolean",
+        .guid = "guid",
+        .uri = "uri",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ServiceEndpointExecutionDataResult = enum {
+pub const ServiceEndpointExecutionDataResult = union(enum) {
     succeeded,
     succeeded_with_issues,
     failed,
     canceled,
     skipped,
     abandoned,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .succeeded => "succeeded",
-            .succeeded_with_issues => "succeededWithIssues",
-            .failed => "failed",
-            .canceled => "canceled",
-            .skipped => "skipped",
-            .abandoned => "abandoned",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        if (std.mem.eql(u8, s, "succeededWithIssues")) return .succeeded_with_issues;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "canceled")) return .canceled;
-        if (std.mem.eql(u8, s, "skipped")) return .skipped;
-        if (std.mem.eql(u8, s, "abandoned")) return .abandoned;
-        return null;
-    }
+    const wire_names = .{
+        .succeeded = "succeeded",
+        .succeeded_with_issues = "succeededWithIssues",
+        .failed = "failed",
+        .canceled = "canceled",
+        .skipped = "skipped",
+        .abandoned = "abandoned",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/status/enums.zig
+++ b/src/status/enums.zig
@@ -8,81 +8,77 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const StatusSummaryHealth = enum {
+pub const StatusSummaryHealth = union(enum) {
     unknown,
     unhealthy,
     degraded,
     advisory,
     healthy,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .unhealthy => "unhealthy",
-            .degraded => "degraded",
-            .advisory => "advisory",
-            .healthy => "healthy",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "unhealthy")) return .unhealthy;
-        if (std.mem.eql(u8, s, "degraded")) return .degraded;
-        if (std.mem.eql(u8, s, "advisory")) return .advisory;
-        if (std.mem.eql(u8, s, "healthy")) return .healthy;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .unhealthy = "unhealthy",
+        .degraded = "degraded",
+        .advisory = "advisory",
+        .healthy = "healthy",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GeographyWithHealthHealth = enum {
+pub const GeographyWithHealthHealth = union(enum) {
     unknown,
     unhealthy,
     degraded,
     advisory,
     healthy,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .unhealthy => "unhealthy",
-            .degraded => "degraded",
-            .advisory => "advisory",
-            .healthy => "healthy",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "unhealthy")) return .unhealthy;
-        if (std.mem.eql(u8, s, "degraded")) return .degraded;
-        if (std.mem.eql(u8, s, "advisory")) return .advisory;
-        if (std.mem.eql(u8, s, "healthy")) return .healthy;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .unhealthy = "unhealthy",
+        .degraded = "degraded",
+        .advisory = "advisory",
+        .healthy = "healthy",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/symbol/enums.zig
+++ b/src/symbol/enums.zig
@@ -8,76 +8,75 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const RequestStatus = enum {
+pub const RequestStatus = union(enum) {
     none,
     created,
     sealed,
     unavailable,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .created => "created",
-            .sealed => "sealed",
-            .unavailable => "unavailable",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "created")) return .created;
-        if (std.mem.eql(u8, s, "sealed")) return .sealed;
-        if (std.mem.eql(u8, s, "unavailable")) return .unavailable;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .created = "created",
+        .sealed = "sealed",
+        .unavailable = "unavailable",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DebugEntryCreateBatchCreateBehavior = enum {
+pub const DebugEntryCreateBatchCreateBehavior = union(enum) {
     throw_if_exists,
     skip_if_exists,
     overwrite_if_exists,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .throw_if_exists => "throwIfExists",
-            .skip_if_exists => "skipIfExists",
-            .overwrite_if_exists => "overwriteIfExists",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "throwIfExists")) return .throw_if_exists;
-        if (std.mem.eql(u8, s, "skipIfExists")) return .skip_if_exists;
-        if (std.mem.eql(u8, s, "overwriteIfExists")) return .overwrite_if_exists;
-        return null;
-    }
+    const wire_names = .{
+        .throw_if_exists = "throwIfExists",
+        .skip_if_exists = "skipIfExists",
+        .overwrite_if_exists = "overwriteIfExists",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DebugEntryInformationLevel = enum {
+pub const DebugEntryInformationLevel = union(enum) {
     none,
     binary,
     publics,
@@ -87,77 +86,71 @@ pub const DebugEntryInformationLevel = enum {
     global_symbols,
     private,
     source_indexed,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .binary => "binary",
-            .publics => "publics",
-            .trace_format_present => "traceFormatPresent",
-            .type_info => "typeInfo",
-            .line_numbers => "lineNumbers",
-            .global_symbols => "globalSymbols",
-            .private => "private",
-            .source_indexed => "sourceIndexed",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "binary")) return .binary;
-        if (std.mem.eql(u8, s, "publics")) return .publics;
-        if (std.mem.eql(u8, s, "traceFormatPresent")) return .trace_format_present;
-        if (std.mem.eql(u8, s, "typeInfo")) return .type_info;
-        if (std.mem.eql(u8, s, "lineNumbers")) return .line_numbers;
-        if (std.mem.eql(u8, s, "globalSymbols")) return .global_symbols;
-        if (std.mem.eql(u8, s, "private")) return .private;
-        if (std.mem.eql(u8, s, "sourceIndexed")) return .source_indexed;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .binary = "binary",
+        .publics = "publics",
+        .trace_format_present = "traceFormatPresent",
+        .type_info = "typeInfo",
+        .line_numbers = "lineNumbers",
+        .global_symbols = "globalSymbols",
+        .private = "private",
+        .source_indexed = "sourceIndexed",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const DebugEntryStatus = enum {
+pub const DebugEntryStatus = union(enum) {
     none,
     created,
     blob_missing,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .created => "created",
-            .blob_missing => "blobMissing",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "created")) return .created;
-        if (std.mem.eql(u8, s, "blobMissing")) return .blob_missing;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .created = "created",
+        .blob_missing = "blobMissing",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/test/enums.zig
+++ b/src/test/enums.zig
@@ -8,145 +8,143 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const TestHistoryQueryGroupBy = enum {
+pub const TestHistoryQueryGroupBy = union(enum) {
     branch,
     environment,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .branch => "branch",
-            .environment => "environment",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "branch")) return .branch;
-        if (std.mem.eql(u8, s, "environment")) return .environment;
-        return null;
-    }
+    const wire_names = .{
+        .branch = "branch",
+        .environment = "environment",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestCaseResultResultGroupType = enum {
+pub const TestCaseResultResultGroupType = union(enum) {
     none,
     rerun,
     data_driven,
     ordered_test,
     generic,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .rerun => "rerun",
-            .data_driven => "dataDriven",
-            .ordered_test => "orderedTest",
-            .generic => "generic",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "rerun")) return .rerun;
-        if (std.mem.eql(u8, s, "dataDriven")) return .data_driven;
-        if (std.mem.eql(u8, s, "orderedTest")) return .ordered_test;
-        if (std.mem.eql(u8, s, "generic")) return .generic;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .rerun = "rerun",
+        .data_driven = "dataDriven",
+        .ordered_test = "orderedTest",
+        .generic = "generic",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestSubResultResultGroupType = enum {
+pub const TestSubResultResultGroupType = union(enum) {
     none,
     rerun,
     data_driven,
     ordered_test,
     generic,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .rerun => "rerun",
-            .data_driven => "dataDriven",
-            .ordered_test => "orderedTest",
-            .generic => "generic",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "rerun")) return .rerun;
-        if (std.mem.eql(u8, s, "dataDriven")) return .data_driven;
-        if (std.mem.eql(u8, s, "orderedTest")) return .ordered_test;
-        if (std.mem.eql(u8, s, "generic")) return .generic;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .rerun = "rerun",
+        .data_driven = "dataDriven",
+        .ordered_test = "orderedTest",
+        .generic = "generic",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunStatisticResultMetadata = enum {
+pub const RunStatisticResultMetadata = union(enum) {
     rerun,
     flaky,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .rerun => "rerun",
-            .flaky => "flaky",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "rerun")) return .rerun;
-        if (std.mem.eql(u8, s, "flaky")) return .flaky;
-        return null;
-    }
+    const wire_names = .{
+        .rerun = "rerun",
+        .flaky = "flaky",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestRunSubstate = enum {
+pub const TestRunSubstate = union(enum) {
     none,
     creating_environment,
     running_tests,
@@ -156,48 +154,42 @@ pub const TestRunSubstate = enum {
     pending_analysis,
     analyzed,
     cancellation_in_progress,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .creating_environment => "creatingEnvironment",
-            .running_tests => "runningTests",
-            .canceled_by_user => "canceledByUser",
-            .aborted_by_system => "abortedBySystem",
-            .timed_out => "timedOut",
-            .pending_analysis => "pendingAnalysis",
-            .analyzed => "analyzed",
-            .cancellation_in_progress => "cancellationInProgress",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "creatingEnvironment")) return .creating_environment;
-        if (std.mem.eql(u8, s, "runningTests")) return .running_tests;
-        if (std.mem.eql(u8, s, "canceledByUser")) return .canceled_by_user;
-        if (std.mem.eql(u8, s, "abortedBySystem")) return .aborted_by_system;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "pendingAnalysis")) return .pending_analysis;
-        if (std.mem.eql(u8, s, "analyzed")) return .analyzed;
-        if (std.mem.eql(u8, s, "cancellationInProgress")) return .cancellation_in_progress;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .creating_environment = "creatingEnvironment",
+        .running_tests = "runningTests",
+        .canceled_by_user = "canceledByUser",
+        .aborted_by_system = "abortedBySystem",
+        .timed_out = "timedOut",
+        .pending_analysis = "pendingAnalysis",
+        .analyzed = "analyzed",
+        .cancellation_in_progress = "cancellationInProgress",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunSummaryModelTestOutcome = enum {
+pub const RunSummaryModelTestOutcome = union(enum) {
     unspecified,
     none,
     passed,
@@ -213,60 +205,48 @@ pub const RunSummaryModelTestOutcome = enum {
     paused,
     in_progress,
     not_impacted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .none => "none",
-            .passed => "passed",
-            .failed => "failed",
-            .inconclusive => "inconclusive",
-            .timeout => "timeout",
-            .aborted => "aborted",
-            .blocked => "blocked",
-            .not_executed => "notExecuted",
-            .warning => "warning",
-            .@"error" => "error",
-            .not_applicable => "notApplicable",
-            .paused => "paused",
-            .in_progress => "inProgress",
-            .not_impacted => "notImpacted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "passed")) return .passed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "inconclusive")) return .inconclusive;
-        if (std.mem.eql(u8, s, "timeout")) return .timeout;
-        if (std.mem.eql(u8, s, "aborted")) return .aborted;
-        if (std.mem.eql(u8, s, "blocked")) return .blocked;
-        if (std.mem.eql(u8, s, "notExecuted")) return .not_executed;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "notImpacted")) return .not_impacted;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .none = "none",
+        .passed = "passed",
+        .failed = "failed",
+        .inconclusive = "inconclusive",
+        .timeout = "timeout",
+        .aborted = "aborted",
+        .blocked = "blocked",
+        .not_executed = "notExecuted",
+        .warning = "warning",
+        .@"error" = "error",
+        .not_applicable = "notApplicable",
+        .paused = "paused",
+        .in_progress = "inProgress",
+        .not_impacted = "notImpacted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunUpdateModelSubstate = enum {
+pub const RunUpdateModelSubstate = union(enum) {
     none,
     creating_environment,
     running_tests,
@@ -276,77 +256,71 @@ pub const RunUpdateModelSubstate = enum {
     pending_analysis,
     analyzed,
     cancellation_in_progress,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .creating_environment => "creatingEnvironment",
-            .running_tests => "runningTests",
-            .canceled_by_user => "canceledByUser",
-            .aborted_by_system => "abortedBySystem",
-            .timed_out => "timedOut",
-            .pending_analysis => "pendingAnalysis",
-            .analyzed => "analyzed",
-            .cancellation_in_progress => "cancellationInProgress",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "creatingEnvironment")) return .creating_environment;
-        if (std.mem.eql(u8, s, "runningTests")) return .running_tests;
-        if (std.mem.eql(u8, s, "canceledByUser")) return .canceled_by_user;
-        if (std.mem.eql(u8, s, "abortedBySystem")) return .aborted_by_system;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "pendingAnalysis")) return .pending_analysis;
-        if (std.mem.eql(u8, s, "analyzed")) return .analyzed;
-        if (std.mem.eql(u8, s, "cancellationInProgress")) return .cancellation_in_progress;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .creating_environment = "creatingEnvironment",
+        .running_tests = "runningTests",
+        .canceled_by_user = "canceledByUser",
+        .aborted_by_system = "abortedBySystem",
+        .timed_out = "timedOut",
+        .pending_analysis = "pendingAnalysis",
+        .analyzed = "analyzed",
+        .cancellation_in_progress = "cancellationInProgress",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestAttachmentAttachmentType = enum {
+pub const TestAttachmentAttachmentType = union(enum) {
     general_attachment,
     code_coverage,
     console_log,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .general_attachment => "generalAttachment",
-            .code_coverage => "codeCoverage",
-            .console_log => "consoleLog",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "generalAttachment")) return .general_attachment;
-        if (std.mem.eql(u8, s, "codeCoverage")) return .code_coverage;
-        if (std.mem.eql(u8, s, "consoleLog")) return .console_log;
-        return null;
-    }
+    const wire_names = .{
+        .general_attachment = "generalAttachment",
+        .code_coverage = "codeCoverage",
+        .console_log = "consoleLog",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -473,7 +447,7 @@ pub const ListRequestSource = enum {
     }
 };
 
-pub const TestSessionSource = enum {
+pub const TestSessionSource = union(enum) {
     unknown,
     xt_desktop,
     feedback_desktop,
@@ -481,82 +455,75 @@ pub const TestSessionSource = enum {
     feedback_web,
     xt_desktop2,
     session_insights_for_all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unknown => "unknown",
-            .xt_desktop => "xtDesktop",
-            .feedback_desktop => "feedbackDesktop",
-            .xt_web => "xtWeb",
-            .feedback_web => "feedbackWeb",
-            .xt_desktop2 => "xtDesktop2",
-            .session_insights_for_all => "sessionInsightsForAll",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "xtDesktop")) return .xt_desktop;
-        if (std.mem.eql(u8, s, "feedbackDesktop")) return .feedback_desktop;
-        if (std.mem.eql(u8, s, "xtWeb")) return .xt_web;
-        if (std.mem.eql(u8, s, "feedbackWeb")) return .feedback_web;
-        if (std.mem.eql(u8, s, "xtDesktop2")) return .xt_desktop2;
-        if (std.mem.eql(u8, s, "sessionInsightsForAll")) return .session_insights_for_all;
-        return null;
-    }
+    const wire_names = .{
+        .unknown = "unknown",
+        .xt_desktop = "xtDesktop",
+        .feedback_desktop = "feedbackDesktop",
+        .xt_web = "xtWeb",
+        .feedback_web = "feedbackWeb",
+        .xt_desktop2 = "xtDesktop2",
+        .session_insights_for_all = "sessionInsightsForAll",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestSessionState = enum {
+pub const TestSessionState = union(enum) {
     unspecified,
     not_started,
     in_progress,
     paused,
     completed,
     declined,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .not_started => "notStarted",
-            .in_progress => "inProgress",
-            .paused => "paused",
-            .completed => "completed",
-            .declined => "declined",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "notStarted")) return .not_started;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "declined")) return .declined;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .not_started = "notStarted",
+        .in_progress = "inProgress",
+        .paused = "paused",
+        .completed = "completed",
+        .declined = "declined",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/test_plan/enums.zig
+++ b/src/test_plan/enums.zig
@@ -8,43 +8,42 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const TestSuiteSuiteType = enum {
+pub const TestSuiteSuiteType = union(enum) {
     none,
     dynamic_test_suite,
     static_test_suite,
     requirement_test_suite,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .dynamic_test_suite => "dynamicTestSuite",
-            .static_test_suite => "staticTestSuite",
-            .requirement_test_suite => "requirementTestSuite",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "dynamicTestSuite")) return .dynamic_test_suite;
-        if (std.mem.eql(u8, s, "staticTestSuite")) return .static_test_suite;
-        if (std.mem.eql(u8, s, "requirementTestSuite")) return .requirement_test_suite;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .dynamic_test_suite = "dynamicTestSuite",
+        .static_test_suite = "staticTestSuite",
+        .requirement_test_suite = "requirementTestSuite",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamProjectReferenceState = enum {
+pub const TeamProjectReferenceState = union(enum) {
     deleting,
     new,
     well_formed,
@@ -52,70 +51,67 @@ pub const TeamProjectReferenceState = enum {
     all,
     unchanged,
     deleted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .deleting => "deleting",
-            .new => "new",
-            .well_formed => "wellFormed",
-            .create_pending => "createPending",
-            .all => "all",
-            .unchanged => "unchanged",
-            .deleted => "deleted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "deleting")) return .deleting;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "wellFormed")) return .well_formed;
-        if (std.mem.eql(u8, s, "createPending")) return .create_pending;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        if (std.mem.eql(u8, s, "unchanged")) return .unchanged;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        return null;
-    }
+    const wire_names = .{
+        .deleting = "deleting",
+        .new = "new",
+        .well_formed = "wellFormed",
+        .create_pending = "createPending",
+        .all = "all",
+        .unchanged = "unchanged",
+        .deleted = "deleted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamProjectReferenceVisibility = enum {
+pub const TeamProjectReferenceVisibility = union(enum) {
     private,
     public,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .private => "private",
-            .public => "public",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "private")) return .private;
-        if (std.mem.eql(u8, s, "public")) return .public;
-        return null;
-    }
+    const wire_names = .{
+        .private = "private",
+        .public = "public",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -185,33 +181,34 @@ pub const GetRequestExpand = enum {
     }
 };
 
-pub const TestConfigurationState = enum {
+pub const TestConfigurationState = union(enum) {
     active,
     inactive,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .active => "active",
-            .inactive => "inactive",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "active")) return .active;
-        if (std.mem.eql(u8, s, "inactive")) return .inactive;
-        return null;
-    }
+    const wire_names = .{
+        .active = "active",
+        .inactive = "inactive",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -248,7 +245,7 @@ pub const GetTestCaseListRequestExcludeFlags = enum {
     }
 };
 
-pub const TestPointResultsFailureType = enum {
+pub const TestPointResultsFailureType = union(enum) {
     none,
     regression,
     new_issue,
@@ -256,44 +253,40 @@ pub const TestPointResultsFailureType = enum {
     unknown,
     null_value,
     max_value,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .regression => "regression",
-            .new_issue => "new_Issue",
-            .known_issue => "known_Issue",
-            .unknown => "unknown",
-            .null_value => "null_Value",
-            .max_value => "maxValue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "regression")) return .regression;
-        if (std.mem.eql(u8, s, "new_Issue")) return .new_issue;
-        if (std.mem.eql(u8, s, "known_Issue")) return .known_issue;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        if (std.mem.eql(u8, s, "null_Value")) return .null_value;
-        if (std.mem.eql(u8, s, "maxValue")) return .max_value;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .regression = "regression",
+        .new_issue = "new_Issue",
+        .known_issue = "known_Issue",
+        .unknown = "unknown",
+        .null_value = "null_Value",
+        .max_value = "maxValue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestPointResultsLastResolutionState = enum {
+pub const TestPointResultsLastResolutionState = union(enum) {
     none,
     needs_investigation,
     test_issue,
@@ -301,44 +294,40 @@ pub const TestPointResultsLastResolutionState = enum {
     configuration_issue,
     null_value,
     max_value,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .needs_investigation => "needsInvestigation",
-            .test_issue => "testIssue",
-            .product_issue => "productIssue",
-            .configuration_issue => "configurationIssue",
-            .null_value => "nullValue",
-            .max_value => "maxValue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "needsInvestigation")) return .needs_investigation;
-        if (std.mem.eql(u8, s, "testIssue")) return .test_issue;
-        if (std.mem.eql(u8, s, "productIssue")) return .product_issue;
-        if (std.mem.eql(u8, s, "configurationIssue")) return .configuration_issue;
-        if (std.mem.eql(u8, s, "nullValue")) return .null_value;
-        if (std.mem.eql(u8, s, "maxValue")) return .max_value;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .needs_investigation = "needsInvestigation",
+        .test_issue = "testIssue",
+        .product_issue = "productIssue",
+        .configuration_issue = "configurationIssue",
+        .null_value = "nullValue",
+        .max_value = "maxValue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestPointResultsLastResultState = enum {
+pub const TestPointResultsLastResultState = union(enum) {
     unspecified,
     pending,
     queued,
@@ -346,44 +335,40 @@ pub const TestPointResultsLastResultState = enum {
     paused,
     completed,
     max_value,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .pending => "pending",
-            .queued => "queued",
-            .in_progress => "inProgress",
-            .paused => "paused",
-            .completed => "completed",
-            .max_value => "maxValue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "maxValue")) return .max_value;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .pending = "pending",
+        .queued = "queued",
+        .in_progress = "inProgress",
+        .paused = "paused",
+        .completed = "completed",
+        .max_value = "maxValue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestPointResultsOutcome = enum {
+pub const TestPointResultsOutcome = union(enum) {
     unspecified,
     none,
     passed,
@@ -400,104 +385,88 @@ pub const TestPointResultsOutcome = enum {
     in_progress,
     not_impacted,
     max_value,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .none => "none",
-            .passed => "passed",
-            .failed => "failed",
-            .inconclusive => "inconclusive",
-            .timeout => "timeout",
-            .aborted => "aborted",
-            .blocked => "blocked",
-            .not_executed => "notExecuted",
-            .warning => "warning",
-            .@"error" => "error",
-            .not_applicable => "notApplicable",
-            .paused => "paused",
-            .in_progress => "inProgress",
-            .not_impacted => "notImpacted",
-            .max_value => "maxValue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "passed")) return .passed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "inconclusive")) return .inconclusive;
-        if (std.mem.eql(u8, s, "timeout")) return .timeout;
-        if (std.mem.eql(u8, s, "aborted")) return .aborted;
-        if (std.mem.eql(u8, s, "blocked")) return .blocked;
-        if (std.mem.eql(u8, s, "notExecuted")) return .not_executed;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "notImpacted")) return .not_impacted;
-        if (std.mem.eql(u8, s, "maxValue")) return .max_value;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .none = "none",
+        .passed = "passed",
+        .failed = "failed",
+        .inconclusive = "inconclusive",
+        .timeout = "timeout",
+        .aborted = "aborted",
+        .blocked = "blocked",
+        .not_executed = "notExecuted",
+        .warning = "warning",
+        .@"error" = "error",
+        .not_applicable = "notApplicable",
+        .paused = "paused",
+        .in_progress = "inProgress",
+        .not_impacted = "notImpacted",
+        .max_value = "maxValue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestPointResultsState = enum {
+pub const TestPointResultsState = union(enum) {
     none,
     ready,
     completed,
     not_ready,
     in_progress,
     max_value,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .ready => "ready",
-            .completed => "completed",
-            .not_ready => "notReady",
-            .in_progress => "inProgress",
-            .max_value => "maxValue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "ready")) return .ready;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "notReady")) return .not_ready;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "maxValue")) return .max_value;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .ready = "ready",
+        .completed = "completed",
+        .not_ready = "notReady",
+        .in_progress = "inProgress",
+        .max_value = "maxValue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ResultsOutcome = enum {
+pub const ResultsOutcome = union(enum) {
     unspecified,
     none,
     passed,
@@ -514,94 +483,80 @@ pub const ResultsOutcome = enum {
     in_progress,
     not_impacted,
     max_value,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .none => "none",
-            .passed => "passed",
-            .failed => "failed",
-            .inconclusive => "inconclusive",
-            .timeout => "timeout",
-            .aborted => "aborted",
-            .blocked => "blocked",
-            .not_executed => "notExecuted",
-            .warning => "warning",
-            .@"error" => "error",
-            .not_applicable => "notApplicable",
-            .paused => "paused",
-            .in_progress => "inProgress",
-            .not_impacted => "notImpacted",
-            .max_value => "maxValue",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "passed")) return .passed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "inconclusive")) return .inconclusive;
-        if (std.mem.eql(u8, s, "timeout")) return .timeout;
-        if (std.mem.eql(u8, s, "aborted")) return .aborted;
-        if (std.mem.eql(u8, s, "blocked")) return .blocked;
-        if (std.mem.eql(u8, s, "notExecuted")) return .not_executed;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "notImpacted")) return .not_impacted;
-        if (std.mem.eql(u8, s, "maxValue")) return .max_value;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .none = "none",
+        .passed = "passed",
+        .failed = "failed",
+        .inconclusive = "inconclusive",
+        .timeout = "timeout",
+        .aborted = "aborted",
+        .blocked = "blocked",
+        .not_executed = "notExecuted",
+        .warning = "warning",
+        .@"error" = "error",
+        .not_applicable = "notApplicable",
+        .paused = "paused",
+        .in_progress = "inProgress",
+        .not_impacted = "notImpacted",
+        .max_value = "maxValue",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CloneOperationCommonResponseState = enum {
+pub const CloneOperationCommonResponseState = union(enum) {
     failed,
     in_progress,
     queued,
     succeeded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .failed => "failed",
-            .in_progress => "inProgress",
-            .queued => "queued",
-            .succeeded => "succeeded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "queued")) return .queued;
-        if (std.mem.eql(u8, s, "succeeded")) return .succeeded;
-        return null;
-    }
+    const wire_names = .{
+        .failed = "failed",
+        .in_progress = "inProgress",
+        .queued = "queued",
+        .succeeded = "succeeded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -701,33 +656,34 @@ pub const ListRequestSuiteEntryType = enum {
     }
 };
 
-pub const SuiteEntrySuiteEntryType = enum {
+pub const SuiteEntrySuiteEntryType = union(enum) {
     test_case,
     suite,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .test_case => "testCase",
-            .suite => "suite",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "testCase")) return .test_case;
-        if (std.mem.eql(u8, s, "suite")) return .suite;
-        return null;
-    }
+    const wire_names = .{
+        .test_case = "testCase",
+        .suite = "suite",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/test_results/enums.zig
+++ b/src/test_results/enums.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const CodeCoverageSummaryCoverageDetailedSummaryStatus = enum {
+pub const CodeCoverageSummaryCoverageDetailedSummaryStatus = union(enum) {
     none,
     in_progress,
     finalized,
@@ -32,114 +32,91 @@ pub const CodeCoverageSummaryCoverageDetailedSummaryStatus = enum {
     module_merge_invoker_job_timeout,
     monitor_job_timeout,
     invalid_coverage_input,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .in_progress => "inProgress",
-            .finalized => "finalized",
-            .pending => "pending",
-            .update_request_queued => "updateRequestQueued",
-            .no_modules_found => "noModulesFound",
-            .number_of_files_exceeded => "numberOfFilesExceeded",
-            .no_input_files => "noInputFiles",
-            .build_cancelled => "buildCancelled",
-            .failed_jobs => "failedJobs",
-            .module_merge_job_timeout => "moduleMergeJobTimeout",
-            .code_coverage_success => "codeCoverageSuccess",
-            .invalid_build_configuration => "invalidBuildConfiguration",
-            .coverage_analyzer_build_not_found => "coverageAnalyzerBuildNotFound",
-            .failed_to_requeue => "failedToRequeue",
-            .build_bailed_out => "buildBailedOut",
-            .no_code_coverage_task => "noCodeCoverageTask",
-            .merge_job_failed => "mergeJobFailed",
-            .merge_invoker_job_failed => "mergeInvokerJobFailed",
-            .monitor_job_failed => "monitorJobFailed",
-            .module_merge_invoker_job_timeout => "moduleMergeInvokerJobTimeout",
-            .monitor_job_timeout => "monitorJobTimeout",
-            .invalid_coverage_input => "invalidCoverageInput",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "finalized")) return .finalized;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "updateRequestQueued")) return .update_request_queued;
-        if (std.mem.eql(u8, s, "noModulesFound")) return .no_modules_found;
-        if (std.mem.eql(u8, s, "numberOfFilesExceeded")) return .number_of_files_exceeded;
-        if (std.mem.eql(u8, s, "noInputFiles")) return .no_input_files;
-        if (std.mem.eql(u8, s, "buildCancelled")) return .build_cancelled;
-        if (std.mem.eql(u8, s, "failedJobs")) return .failed_jobs;
-        if (std.mem.eql(u8, s, "moduleMergeJobTimeout")) return .module_merge_job_timeout;
-        if (std.mem.eql(u8, s, "codeCoverageSuccess")) return .code_coverage_success;
-        if (std.mem.eql(u8, s, "invalidBuildConfiguration")) return .invalid_build_configuration;
-        if (std.mem.eql(u8, s, "coverageAnalyzerBuildNotFound")) return .coverage_analyzer_build_not_found;
-        if (std.mem.eql(u8, s, "failedToRequeue")) return .failed_to_requeue;
-        if (std.mem.eql(u8, s, "buildBailedOut")) return .build_bailed_out;
-        if (std.mem.eql(u8, s, "noCodeCoverageTask")) return .no_code_coverage_task;
-        if (std.mem.eql(u8, s, "mergeJobFailed")) return .merge_job_failed;
-        if (std.mem.eql(u8, s, "mergeInvokerJobFailed")) return .merge_invoker_job_failed;
-        if (std.mem.eql(u8, s, "monitorJobFailed")) return .monitor_job_failed;
-        if (std.mem.eql(u8, s, "moduleMergeInvokerJobTimeout")) return .module_merge_invoker_job_timeout;
-        if (std.mem.eql(u8, s, "monitorJobTimeout")) return .monitor_job_timeout;
-        if (std.mem.eql(u8, s, "invalidCoverageInput")) return .invalid_coverage_input;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .in_progress = "inProgress",
+        .finalized = "finalized",
+        .pending = "pending",
+        .update_request_queued = "updateRequestQueued",
+        .no_modules_found = "noModulesFound",
+        .number_of_files_exceeded = "numberOfFilesExceeded",
+        .no_input_files = "noInputFiles",
+        .build_cancelled = "buildCancelled",
+        .failed_jobs = "failedJobs",
+        .module_merge_job_timeout = "moduleMergeJobTimeout",
+        .code_coverage_success = "codeCoverageSuccess",
+        .invalid_build_configuration = "invalidBuildConfiguration",
+        .coverage_analyzer_build_not_found = "coverageAnalyzerBuildNotFound",
+        .failed_to_requeue = "failedToRequeue",
+        .build_bailed_out = "buildBailedOut",
+        .no_code_coverage_task = "noCodeCoverageTask",
+        .merge_job_failed = "mergeJobFailed",
+        .merge_invoker_job_failed = "mergeInvokerJobFailed",
+        .monitor_job_failed = "monitorJobFailed",
+        .module_merge_invoker_job_timeout = "moduleMergeInvokerJobTimeout",
+        .monitor_job_timeout = "monitorJobTimeout",
+        .invalid_coverage_input = "invalidCoverageInput",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CodeCoverageSummaryStatus = enum {
+pub const CodeCoverageSummaryStatus = union(enum) {
     none,
     in_progress,
     completed,
     finalized,
     pending,
     update_request_queued,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .in_progress => "inProgress",
-            .completed => "completed",
-            .finalized => "finalized",
-            .pending => "pending",
-            .update_request_queued => "updateRequestQueued",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "finalized")) return .finalized;
-        if (std.mem.eql(u8, s, "pending")) return .pending;
-        if (std.mem.eql(u8, s, "updateRequestQueued")) return .update_request_queued;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .in_progress = "inProgress",
+        .completed = "completed",
+        .finalized = "finalized",
+        .pending = "pending",
+        .update_request_queued = "updateRequestQueued",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -185,91 +162,85 @@ pub const QueryRequestScopeFilter = enum {
     }
 };
 
-pub const CustomTestFieldDefinitionFieldType = enum {
+pub const CustomTestFieldDefinitionFieldType = union(enum) {
     bit,
     date_time,
     int,
     float,
     string,
     guid,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .bit => "bit",
-            .date_time => "dateTime",
-            .int => "int",
-            .float => "float",
-            .string => "string",
-            .guid => "guid",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "bit")) return .bit;
-        if (std.mem.eql(u8, s, "dateTime")) return .date_time;
-        if (std.mem.eql(u8, s, "int")) return .int;
-        if (std.mem.eql(u8, s, "float")) return .float;
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        return null;
-    }
+    const wire_names = .{
+        .bit = "bit",
+        .date_time = "dateTime",
+        .int = "int",
+        .float = "float",
+        .string = "string",
+        .guid = "guid",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CustomTestFieldDefinitionScope = enum {
+pub const CustomTestFieldDefinitionScope = union(enum) {
     none,
     test_run,
     test_result,
     test_run_and_test_result,
     system,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .test_run => "testRun",
-            .test_result => "testResult",
-            .test_run_and_test_result => "testRunAndTestResult",
-            .system => "system",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "testRun")) return .test_run;
-        if (std.mem.eql(u8, s, "testResult")) return .test_result;
-        if (std.mem.eql(u8, s, "testRunAndTestResult")) return .test_run_and_test_result;
-        if (std.mem.eql(u8, s, "system")) return .system;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .test_run = "testRun",
+        .test_result = "testResult",
+        .test_run_and_test_result = "testRunAndTestResult",
+        .system = "system",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AggregatedResultDetailsByOutcomeOutcome = enum {
+pub const AggregatedResultDetailsByOutcomeOutcome = union(enum) {
     unspecified,
     none,
     passed,
@@ -285,138 +256,122 @@ pub const AggregatedResultDetailsByOutcomeOutcome = enum {
     paused,
     in_progress,
     not_impacted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .none => "none",
-            .passed => "passed",
-            .failed => "failed",
-            .inconclusive => "inconclusive",
-            .timeout => "timeout",
-            .aborted => "aborted",
-            .blocked => "blocked",
-            .not_executed => "notExecuted",
-            .warning => "warning",
-            .@"error" => "error",
-            .not_applicable => "notApplicable",
-            .paused => "paused",
-            .in_progress => "inProgress",
-            .not_impacted => "notImpacted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "passed")) return .passed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "inconclusive")) return .inconclusive;
-        if (std.mem.eql(u8, s, "timeout")) return .timeout;
-        if (std.mem.eql(u8, s, "aborted")) return .aborted;
-        if (std.mem.eql(u8, s, "blocked")) return .blocked;
-        if (std.mem.eql(u8, s, "notExecuted")) return .not_executed;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "notImpacted")) return .not_impacted;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .none = "none",
+        .passed = "passed",
+        .failed = "failed",
+        .inconclusive = "inconclusive",
+        .timeout = "timeout",
+        .aborted = "aborted",
+        .blocked = "blocked",
+        .not_executed = "notExecuted",
+        .warning = "warning",
+        .@"error" = "error",
+        .not_applicable = "notApplicable",
+        .paused = "paused",
+        .in_progress = "inProgress",
+        .not_impacted = "notImpacted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestCaseResultResultGroupType = enum {
+pub const TestCaseResultResultGroupType = union(enum) {
     none,
     rerun,
     data_driven,
     ordered_test,
     generic,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .rerun => "rerun",
-            .data_driven => "dataDriven",
-            .ordered_test => "orderedTest",
-            .generic => "generic",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "rerun")) return .rerun;
-        if (std.mem.eql(u8, s, "dataDriven")) return .data_driven;
-        if (std.mem.eql(u8, s, "orderedTest")) return .ordered_test;
-        if (std.mem.eql(u8, s, "generic")) return .generic;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .rerun = "rerun",
+        .data_driven = "dataDriven",
+        .ordered_test = "orderedTest",
+        .generic = "generic",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestSubResultResultGroupType = enum {
+pub const TestSubResultResultGroupType = union(enum) {
     none,
     rerun,
     data_driven,
     ordered_test,
     generic,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .rerun => "rerun",
-            .data_driven => "dataDriven",
-            .ordered_test => "orderedTest",
-            .generic => "generic",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "rerun")) return .rerun;
-        if (std.mem.eql(u8, s, "dataDriven")) return .data_driven;
-        if (std.mem.eql(u8, s, "orderedTest")) return .ordered_test;
-        if (std.mem.eql(u8, s, "generic")) return .generic;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .rerun = "rerun",
+        .data_driven = "dataDriven",
+        .ordered_test = "orderedTest",
+        .generic = "generic",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AggregatedResultsByOutcomeOutcome = enum {
+pub const AggregatedResultsByOutcomeOutcome = union(enum) {
     unspecified,
     none,
     passed,
@@ -432,122 +387,110 @@ pub const AggregatedResultsByOutcomeOutcome = enum {
     paused,
     in_progress,
     not_impacted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .none => "none",
-            .passed => "passed",
-            .failed => "failed",
-            .inconclusive => "inconclusive",
-            .timeout => "timeout",
-            .aborted => "aborted",
-            .blocked => "blocked",
-            .not_executed => "notExecuted",
-            .warning => "warning",
-            .@"error" => "error",
-            .not_applicable => "notApplicable",
-            .paused => "paused",
-            .in_progress => "inProgress",
-            .not_impacted => "notImpacted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "passed")) return .passed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "inconclusive")) return .inconclusive;
-        if (std.mem.eql(u8, s, "timeout")) return .timeout;
-        if (std.mem.eql(u8, s, "aborted")) return .aborted;
-        if (std.mem.eql(u8, s, "blocked")) return .blocked;
-        if (std.mem.eql(u8, s, "notExecuted")) return .not_executed;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "notImpacted")) return .not_impacted;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .none = "none",
+        .passed = "passed",
+        .failed = "failed",
+        .inconclusive = "inconclusive",
+        .timeout = "timeout",
+        .aborted = "aborted",
+        .blocked = "blocked",
+        .not_executed = "notExecuted",
+        .warning = "warning",
+        .@"error" = "error",
+        .not_applicable = "notApplicable",
+        .paused = "paused",
+        .in_progress = "inProgress",
+        .not_impacted = "notImpacted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ResultsFilterExecutedIn = enum {
+pub const ResultsFilterExecutedIn = union(enum) {
     any,
     tcm,
     tfs,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .any => "any",
-            .tcm => "tcm",
-            .tfs => "tfs",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "any")) return .any;
-        if (std.mem.eql(u8, s, "tcm")) return .tcm;
-        if (std.mem.eql(u8, s, "tfs")) return .tfs;
-        return null;
-    }
+    const wire_names = .{
+        .any = "any",
+        .tcm = "tcm",
+        .tfs = "tfs",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestResultsContextContextType = enum {
+pub const TestResultsContextContextType = union(enum) {
     build,
     release,
     pipeline,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .build => "build",
-            .release => "release",
-            .pipeline => "pipeline",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "build")) return .build;
-        if (std.mem.eql(u8, s, "release")) return .release;
-        if (std.mem.eql(u8, s, "pipeline")) return .pipeline;
-        return null;
-    }
+    const wire_names = .{
+        .build = "build",
+        .release = "release",
+        .pipeline = "pipeline",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -659,106 +602,106 @@ pub const QueryRequestDetailsToInclude = enum {
     }
 };
 
-pub const TestHistoryQueryGroupBy = enum {
+pub const TestHistoryQueryGroupBy = union(enum) {
     branch,
     environment,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .branch => "branch",
-            .environment => "environment",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "branch")) return .branch;
-        if (std.mem.eql(u8, s, "environment")) return .environment;
-        return null;
-    }
+    const wire_names = .{
+        .branch = "branch",
+        .environment = "environment",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemToTestLinksExecutedIn = enum {
+pub const WorkItemToTestLinksExecutedIn = union(enum) {
     any,
     tcm,
     tfs,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .any => "any",
-            .tcm => "tcm",
-            .tfs => "tfs",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "any")) return .any;
-        if (std.mem.eql(u8, s, "tcm")) return .tcm;
-        if (std.mem.eql(u8, s, "tfs")) return .tfs;
-        return null;
-    }
+    const wire_names = .{
+        .any = "any",
+        .tcm = "tcm",
+        .tfs = "tfs",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AggregatedRunsByOutcomeOutcome = enum {
+pub const AggregatedRunsByOutcomeOutcome = union(enum) {
     passed,
     failed,
     not_impacted,
     others,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .passed => "passed",
-            .failed => "failed",
-            .not_impacted => "notImpacted",
-            .others => "others",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "passed")) return .passed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "notImpacted")) return .not_impacted;
-        if (std.mem.eql(u8, s, "others")) return .others;
-        return null;
-    }
+    const wire_names = .{
+        .passed = "passed",
+        .failed = "failed",
+        .not_impacted = "notImpacted",
+        .others = "others",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AggregatedRunsByStateState = enum {
+pub const AggregatedRunsByStateState = union(enum) {
     unspecified,
     not_started,
     in_progress,
@@ -766,44 +709,40 @@ pub const AggregatedRunsByStateState = enum {
     aborted,
     waiting,
     needs_investigation,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .not_started => "notStarted",
-            .in_progress => "inProgress",
-            .completed => "completed",
-            .aborted => "aborted",
-            .waiting => "waiting",
-            .needs_investigation => "needsInvestigation",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "notStarted")) return .not_started;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "completed")) return .completed;
-        if (std.mem.eql(u8, s, "aborted")) return .aborted;
-        if (std.mem.eql(u8, s, "waiting")) return .waiting;
-        if (std.mem.eql(u8, s, "needsInvestigation")) return .needs_investigation;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .not_started = "notStarted",
+        .in_progress = "inProgress",
+        .completed = "completed",
+        .aborted = "aborted",
+        .waiting = "waiting",
+        .needs_investigation = "needsInvestigation",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamProjectReferenceState = enum {
+pub const TeamProjectReferenceState = union(enum) {
     deleting,
     new,
     well_formed,
@@ -811,104 +750,102 @@ pub const TeamProjectReferenceState = enum {
     all,
     unchanged,
     deleted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .deleting => "deleting",
-            .new => "new",
-            .well_formed => "wellFormed",
-            .create_pending => "createPending",
-            .all => "all",
-            .unchanged => "unchanged",
-            .deleted => "deleted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "deleting")) return .deleting;
-        if (std.mem.eql(u8, s, "new")) return .new;
-        if (std.mem.eql(u8, s, "wellFormed")) return .well_formed;
-        if (std.mem.eql(u8, s, "createPending")) return .create_pending;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        if (std.mem.eql(u8, s, "unchanged")) return .unchanged;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        return null;
-    }
+    const wire_names = .{
+        .deleting = "deleting",
+        .new = "new",
+        .well_formed = "wellFormed",
+        .create_pending = "createPending",
+        .all = "all",
+        .unchanged = "unchanged",
+        .deleted = "deleted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamProjectReferenceVisibility = enum {
+pub const TeamProjectReferenceVisibility = union(enum) {
     private,
     public,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .private => "private",
-            .public => "public",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "private")) return .private;
-        if (std.mem.eql(u8, s, "public")) return .public;
-        return null;
-    }
+    const wire_names = .{
+        .private = "private",
+        .public = "public",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunStatisticResultMetadata = enum {
+pub const RunStatisticResultMetadata = union(enum) {
     rerun,
     flaky,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .rerun => "rerun",
-            .flaky => "flaky",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "rerun")) return .rerun;
-        if (std.mem.eql(u8, s, "flaky")) return .flaky;
-        return null;
-    }
+    const wire_names = .{
+        .rerun = "rerun",
+        .flaky = "flaky",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestRunSubstate = enum {
+pub const TestRunSubstate = union(enum) {
     none,
     creating_environment,
     running_tests,
@@ -918,48 +855,42 @@ pub const TestRunSubstate = enum {
     pending_analysis,
     analyzed,
     cancellation_in_progress,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .creating_environment => "creatingEnvironment",
-            .running_tests => "runningTests",
-            .canceled_by_user => "canceledByUser",
-            .aborted_by_system => "abortedBySystem",
-            .timed_out => "timedOut",
-            .pending_analysis => "pendingAnalysis",
-            .analyzed => "analyzed",
-            .cancellation_in_progress => "cancellationInProgress",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "creatingEnvironment")) return .creating_environment;
-        if (std.mem.eql(u8, s, "runningTests")) return .running_tests;
-        if (std.mem.eql(u8, s, "canceledByUser")) return .canceled_by_user;
-        if (std.mem.eql(u8, s, "abortedBySystem")) return .aborted_by_system;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "pendingAnalysis")) return .pending_analysis;
-        if (std.mem.eql(u8, s, "analyzed")) return .analyzed;
-        if (std.mem.eql(u8, s, "cancellationInProgress")) return .cancellation_in_progress;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .creating_environment = "creatingEnvironment",
+        .running_tests = "runningTests",
+        .canceled_by_user = "canceledByUser",
+        .aborted_by_system = "abortedBySystem",
+        .timed_out = "timedOut",
+        .pending_analysis = "pendingAnalysis",
+        .analyzed = "analyzed",
+        .cancellation_in_progress = "cancellationInProgress",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunSummaryModelTestOutcome = enum {
+pub const RunSummaryModelTestOutcome = union(enum) {
     unspecified,
     none,
     passed,
@@ -975,60 +906,48 @@ pub const RunSummaryModelTestOutcome = enum {
     paused,
     in_progress,
     not_impacted,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .unspecified => "unspecified",
-            .none => "none",
-            .passed => "passed",
-            .failed => "failed",
-            .inconclusive => "inconclusive",
-            .timeout => "timeout",
-            .aborted => "aborted",
-            .blocked => "blocked",
-            .not_executed => "notExecuted",
-            .warning => "warning",
-            .@"error" => "error",
-            .not_applicable => "notApplicable",
-            .paused => "paused",
-            .in_progress => "inProgress",
-            .not_impacted => "notImpacted",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "unspecified")) return .unspecified;
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "passed")) return .passed;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "inconclusive")) return .inconclusive;
-        if (std.mem.eql(u8, s, "timeout")) return .timeout;
-        if (std.mem.eql(u8, s, "aborted")) return .aborted;
-        if (std.mem.eql(u8, s, "blocked")) return .blocked;
-        if (std.mem.eql(u8, s, "notExecuted")) return .not_executed;
-        if (std.mem.eql(u8, s, "warning")) return .warning;
-        if (std.mem.eql(u8, s, "error")) return .@"error";
-        if (std.mem.eql(u8, s, "notApplicable")) return .not_applicable;
-        if (std.mem.eql(u8, s, "paused")) return .paused;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "notImpacted")) return .not_impacted;
-        return null;
-    }
+    const wire_names = .{
+        .unspecified = "unspecified",
+        .none = "none",
+        .passed = "passed",
+        .failed = "failed",
+        .inconclusive = "inconclusive",
+        .timeout = "timeout",
+        .aborted = "aborted",
+        .blocked = "blocked",
+        .not_executed = "notExecuted",
+        .warning = "warning",
+        .@"error" = "error",
+        .not_applicable = "notApplicable",
+        .paused = "paused",
+        .in_progress = "inProgress",
+        .not_impacted = "notImpacted",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const RunUpdateModelSubstate = enum {
+pub const RunUpdateModelSubstate = union(enum) {
     none,
     creating_environment,
     running_tests,
@@ -1038,111 +957,164 @@ pub const RunUpdateModelSubstate = enum {
     pending_analysis,
     analyzed,
     cancellation_in_progress,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .creating_environment => "creatingEnvironment",
-            .running_tests => "runningTests",
-            .canceled_by_user => "canceledByUser",
-            .aborted_by_system => "abortedBySystem",
-            .timed_out => "timedOut",
-            .pending_analysis => "pendingAnalysis",
-            .analyzed => "analyzed",
-            .cancellation_in_progress => "cancellationInProgress",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "creatingEnvironment")) return .creating_environment;
-        if (std.mem.eql(u8, s, "runningTests")) return .running_tests;
-        if (std.mem.eql(u8, s, "canceledByUser")) return .canceled_by_user;
-        if (std.mem.eql(u8, s, "abortedBySystem")) return .aborted_by_system;
-        if (std.mem.eql(u8, s, "timedOut")) return .timed_out;
-        if (std.mem.eql(u8, s, "pendingAnalysis")) return .pending_analysis;
-        if (std.mem.eql(u8, s, "analyzed")) return .analyzed;
-        if (std.mem.eql(u8, s, "cancellationInProgress")) return .cancellation_in_progress;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .creating_environment = "creatingEnvironment",
+        .running_tests = "runningTests",
+        .canceled_by_user = "canceledByUser",
+        .aborted_by_system = "abortedBySystem",
+        .timed_out = "timedOut",
+        .pending_analysis = "pendingAnalysis",
+        .analyzed = "analyzed",
+        .cancellation_in_progress = "cancellationInProgress",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestAttachmentAttachmentType = enum {
+pub const TestAttachmentAttachmentType = union(enum) {
     general_attachment,
     code_coverage,
     console_log,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .general_attachment => "generalAttachment",
-            .code_coverage => "codeCoverage",
-            .console_log => "consoleLog",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "generalAttachment")) return .general_attachment;
-        if (std.mem.eql(u8, s, "codeCoverage")) return .code_coverage;
-        if (std.mem.eql(u8, s, "consoleLog")) return .console_log;
-        return null;
-    }
+    const wire_names = .{
+        .general_attachment = "generalAttachment",
+        .code_coverage = "codeCoverage",
+        .console_log = "consoleLog",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestLogStoreEndpointDetailsEndpointType = enum {
+pub const TestLogReferenceScope = union(enum) {
+    run,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .run = "run",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+pub const TestLogReferenceType = union(enum) {
+    general_attachment,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .general_attachment = "generalAttachment",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+pub const TestLogStoreEndpointDetailsEndpointType = union(enum) {
     root,
     file,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .root => "root",
-            .file => "file",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "root")) return .root;
-        if (std.mem.eql(u8, s, "file")) return .file;
-        return null;
-    }
+    const wire_names = .{
+        .root = "root",
+        .file = "file",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestLogStoreEndpointDetailsStatus = enum {
+pub const TestLogStoreEndpointDetailsStatus = union(enum) {
     success,
     failed,
     file_already_exists,
@@ -1160,93 +1132,79 @@ pub const TestLogStoreEndpointDetailsStatus = enum {
     file_not_found,
     directory_not_found,
     storage_capacity_exceeded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .success => "success",
-            .failed => "failed",
-            .file_already_exists => "fileAlreadyExists",
-            .invalid_input => "invalidInput",
-            .invalid_file_name => "invalidFileName",
-            .invalid_container => "invalidContainer",
-            .transfer_failed => "transferFailed",
-            .feature_disabled => "featureDisabled",
-            .build_does_not_exist => "buildDoesNotExist",
-            .run_does_not_exist => "runDoesNotExist",
-            .container_not_created => "containerNotCreated",
-            .api_not_supported => "apiNotSupported",
-            .file_size_exceeds => "fileSizeExceeds",
-            .container_not_found => "containerNotFound",
-            .file_not_found => "fileNotFound",
-            .directory_not_found => "directoryNotFound",
-            .storage_capacity_exceeded => "storageCapacityExceeded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "success")) return .success;
-        if (std.mem.eql(u8, s, "failed")) return .failed;
-        if (std.mem.eql(u8, s, "fileAlreadyExists")) return .file_already_exists;
-        if (std.mem.eql(u8, s, "invalidInput")) return .invalid_input;
-        if (std.mem.eql(u8, s, "invalidFileName")) return .invalid_file_name;
-        if (std.mem.eql(u8, s, "invalidContainer")) return .invalid_container;
-        if (std.mem.eql(u8, s, "transferFailed")) return .transfer_failed;
-        if (std.mem.eql(u8, s, "featureDisabled")) return .feature_disabled;
-        if (std.mem.eql(u8, s, "buildDoesNotExist")) return .build_does_not_exist;
-        if (std.mem.eql(u8, s, "runDoesNotExist")) return .run_does_not_exist;
-        if (std.mem.eql(u8, s, "containerNotCreated")) return .container_not_created;
-        if (std.mem.eql(u8, s, "apiNotSupported")) return .api_not_supported;
-        if (std.mem.eql(u8, s, "fileSizeExceeds")) return .file_size_exceeds;
-        if (std.mem.eql(u8, s, "containerNotFound")) return .container_not_found;
-        if (std.mem.eql(u8, s, "fileNotFound")) return .file_not_found;
-        if (std.mem.eql(u8, s, "directoryNotFound")) return .directory_not_found;
-        if (std.mem.eql(u8, s, "storageCapacityExceeded")) return .storage_capacity_exceeded;
-        return null;
-    }
+    const wire_names = .{
+        .success = "success",
+        .failed = "failed",
+        .file_already_exists = "fileAlreadyExists",
+        .invalid_input = "invalidInput",
+        .invalid_file_name = "invalidFileName",
+        .invalid_container = "invalidContainer",
+        .transfer_failed = "transferFailed",
+        .feature_disabled = "featureDisabled",
+        .build_does_not_exist = "buildDoesNotExist",
+        .run_does_not_exist = "runDoesNotExist",
+        .container_not_created = "containerNotCreated",
+        .api_not_supported = "apiNotSupported",
+        .file_size_exceeds = "fileSizeExceeds",
+        .container_not_found = "containerNotFound",
+        .file_not_found = "fileNotFound",
+        .directory_not_found = "directoryNotFound",
+        .storage_capacity_exceeded = "storageCapacityExceeded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TestLogStoreAttachmentAttachmentType = enum {
+pub const TestLogStoreAttachmentAttachmentType = union(enum) {
     general_attachment,
     code_coverage,
     console_log,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .general_attachment => "generalAttachment",
-            .code_coverage => "codeCoverage",
-            .console_log => "consoleLog",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "generalAttachment")) return .general_attachment;
-        if (std.mem.eql(u8, s, "codeCoverage")) return .code_coverage;
-        if (std.mem.eql(u8, s, "consoleLog")) return .console_log;
-        return null;
-    }
+    const wire_names = .{
+        .general_attachment = "generalAttachment",
+        .code_coverage = "codeCoverage",
+        .console_log = "consoleLog",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1286,138 +1244,137 @@ pub const GetRequestSettingsType = enum {
     }
 };
 
-pub const FlakyTestBugConfigBugMetadatum = enum {
+pub const FlakyTestBugConfigBugMetadatum = union(enum) {
     error_message,
     stack_trace,
     test_name,
     machine,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .error_message => "errorMessage",
-            .stack_trace => "stackTrace",
-            .test_name => "testName",
-            .machine => "machine",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "errorMessage")) return .error_message;
-        if (std.mem.eql(u8, s, "stackTrace")) return .stack_trace;
-        if (std.mem.eql(u8, s, "testName")) return .test_name;
-        if (std.mem.eql(u8, s, "machine")) return .machine;
-        return null;
-    }
+    const wire_names = .{
+        .error_message = "errorMessage",
+        .stack_trace = "stackTrace",
+        .test_name = "testName",
+        .machine = "machine",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const AdvancedFlakyDetectionParameterParameterType = enum {
+pub const AdvancedFlakyDetectionParameterParameterType = union(enum) {
     failure_rate,
     pass_rate,
     timing_variability,
     rerun_count,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .failure_rate => "failureRate",
-            .pass_rate => "passRate",
-            .timing_variability => "timingVariability",
-            .rerun_count => "rerunCount",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "failureRate")) return .failure_rate;
-        if (std.mem.eql(u8, s, "passRate")) return .pass_rate;
-        if (std.mem.eql(u8, s, "timingVariability")) return .timing_variability;
-        if (std.mem.eql(u8, s, "rerunCount")) return .rerun_count;
-        return null;
-    }
+    const wire_names = .{
+        .failure_rate = "failureRate",
+        .pass_rate = "passRate",
+        .timing_variability = "timingVariability",
+        .rerun_count = "rerunCount",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const FlakySettingsAdvancedSystemDetectionMode = enum {
+pub const FlakySettingsAdvancedSystemDetectionMode = union(enum) {
     disabled,
     preview,
     enabled,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .disabled => "disabled",
-            .preview => "preview",
-            .enabled => "enabled",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "disabled")) return .disabled;
-        if (std.mem.eql(u8, s, "preview")) return .preview;
-        if (std.mem.eql(u8, s, "enabled")) return .enabled;
-        return null;
-    }
+    const wire_names = .{
+        .disabled = "disabled",
+        .preview = "preview",
+        .enabled = "enabled",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const FlakyDetectionFlakyDetectionType = enum {
+pub const FlakyDetectionFlakyDetectionType = union(enum) {
     custom,
     system,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .custom => "custom",
-            .system => "system",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "custom")) return .custom;
-        if (std.mem.eql(u8, s, "system")) return .system;
-        return null;
-    }
+    const wire_names = .{
+        .custom = "custom",
+        .system = "system",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/test_results/models.zig
+++ b/src/test_results/models.zig
@@ -1729,11 +1729,11 @@ pub const TestLogReference = struct {
     /// runid for test log, if context is run
     run_id: ?i32 = null,
     /// Test Log Scope
-    scope: ?[]const u8 = null,
+    scope: ?enums.TestLogReferenceScope = null,
     /// SubResultid for test log, if context is run and log is related to subresult
     sub_result_id: ?i32 = null,
     /// Log Type
-    type: ?[]const u8 = null,
+    type: ?enums.TestLogReferenceType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/tfvc/enums.zig
+++ b/src/tfvc/enums.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const TfvcChangeChangeType = enum {
+pub const TfvcChangeChangeType = union(enum) {
     none,
     add,
     edit,
@@ -24,159 +24,147 @@ pub const TfvcChangeChangeType = enum {
     target_rename,
     property,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .add => "add",
-            .edit => "edit",
-            .encoding => "encoding",
-            .rename => "rename",
-            .delete => "delete",
-            .undelete => "undelete",
-            .branch => "branch",
-            .merge => "merge",
-            .lock => "lock",
-            .rollback => "rollback",
-            .source_rename => "sourceRename",
-            .target_rename => "targetRename",
-            .property => "property",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "add")) return .add;
-        if (std.mem.eql(u8, s, "edit")) return .edit;
-        if (std.mem.eql(u8, s, "encoding")) return .encoding;
-        if (std.mem.eql(u8, s, "rename")) return .rename;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "undelete")) return .undelete;
-        if (std.mem.eql(u8, s, "branch")) return .branch;
-        if (std.mem.eql(u8, s, "merge")) return .merge;
-        if (std.mem.eql(u8, s, "lock")) return .lock;
-        if (std.mem.eql(u8, s, "rollback")) return .rollback;
-        if (std.mem.eql(u8, s, "sourceRename")) return .source_rename;
-        if (std.mem.eql(u8, s, "targetRename")) return .target_rename;
-        if (std.mem.eql(u8, s, "property")) return .property;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .add = "add",
+        .edit = "edit",
+        .encoding = "encoding",
+        .rename = "rename",
+        .delete = "delete",
+        .undelete = "undelete",
+        .branch = "branch",
+        .merge = "merge",
+        .lock = "lock",
+        .rollback = "rollback",
+        .source_rename = "sourceRename",
+        .target_rename = "targetRename",
+        .property = "property",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const ItemContentContentType = enum {
+pub const ItemContentContentType = union(enum) {
     raw_text,
     base64encoded,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .raw_text => "rawText",
-            .base64encoded => "base64Encoded",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "rawText")) return .raw_text;
-        if (std.mem.eql(u8, s, "base64Encoded")) return .base64encoded;
-        return null;
-    }
+    const wire_names = .{
+        .raw_text = "rawText",
+        .base64encoded = "base64Encoded",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TfvcItemDescriptorRecursionLevel = enum {
+pub const TfvcItemDescriptorRecursionLevel = union(enum) {
     none,
     one_level,
     one_level_plus_nested_empty_folders,
     full,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .one_level => "oneLevel",
-            .one_level_plus_nested_empty_folders => "oneLevelPlusNestedEmptyFolders",
-            .full => "full",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "oneLevel")) return .one_level;
-        if (std.mem.eql(u8, s, "oneLevelPlusNestedEmptyFolders")) return .one_level_plus_nested_empty_folders;
-        if (std.mem.eql(u8, s, "full")) return .full;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .one_level = "oneLevel",
+        .one_level_plus_nested_empty_folders = "oneLevelPlusNestedEmptyFolders",
+        .full = "full",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TfvcItemDescriptorVersionOption = enum {
+pub const TfvcItemDescriptorVersionOption = union(enum) {
     none,
     previous,
     use_rename,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .previous => "previous",
-            .use_rename => "useRename",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "previous")) return .previous;
-        if (std.mem.eql(u8, s, "useRename")) return .use_rename;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .previous = "previous",
+        .use_rename = "useRename",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TfvcItemDescriptorVersionType = enum {
+pub const TfvcItemDescriptorVersionType = union(enum) {
     none,
     changeset,
     shelveset,
@@ -185,42 +173,37 @@ pub const TfvcItemDescriptorVersionType = enum {
     latest,
     tip,
     merge_source,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .changeset => "changeset",
-            .shelveset => "shelveset",
-            .change => "change",
-            .date => "date",
-            .latest => "latest",
-            .tip => "tip",
-            .merge_source => "mergeSource",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "changeset")) return .changeset;
-        if (std.mem.eql(u8, s, "shelveset")) return .shelveset;
-        if (std.mem.eql(u8, s, "change")) return .change;
-        if (std.mem.eql(u8, s, "date")) return .date;
-        if (std.mem.eql(u8, s, "latest")) return .latest;
-        if (std.mem.eql(u8, s, "tip")) return .tip;
-        if (std.mem.eql(u8, s, "mergeSource")) return .merge_source;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .changeset = "changeset",
+        .shelveset = "shelveset",
+        .change = "change",
+        .date = "date",
+        .latest = "latest",
+        .tip = "tip",
+        .merge_source = "mergeSource",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/tokens/enums.zig
+++ b/src/tokens/enums.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const PatTokenResultPatTokenError = enum {
+pub const PatTokenResultPatTokenError = union(enum) {
     none,
     display_name_required,
     invalid_display_name,
@@ -46,100 +46,66 @@ pub const PatTokenResultPatTokenError = enum {
     failed_to_read_org_policy,
     global_pat_creation_blocked,
     expired_pat_cannot_be_extended,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .display_name_required => "displayNameRequired",
-            .invalid_display_name => "invalidDisplayName",
-            .invalid_valid_to => "invalidValidTo",
-            .invalid_scope => "invalidScope",
-            .user_id_required => "userIdRequired",
-            .invalid_user_id => "invalidUserId",
-            .invalid_user_type => "invalidUserType",
-            .access_denied => "accessDenied",
-            .failed_to_issue_access_token => "failedToIssueAccessToken",
-            .invalid_client => "invalidClient",
-            .invalid_client_type => "invalidClientType",
-            .invalid_client_id => "invalidClientId",
-            .invalid_target_accounts => "invalidTargetAccounts",
-            .host_authorization_not_found => "hostAuthorizationNotFound",
-            .authorization_not_found => "authorizationNotFound",
-            .failed_to_update_access_token => "failedToUpdateAccessToken",
-            .source_not_supported => "sourceNotSupported",
-            .invalid_source_ip => "invalidSourceIP",
-            .invalid_source => "invalidSource",
-            .duplicate_hash => "duplicateHash",
-            .ssh_policy_disabled => "sshPolicyDisabled",
-            .invalid_token => "invalidToken",
-            .token_not_found => "tokenNotFound",
-            .invalid_authorization_id => "invalidAuthorizationId",
-            .failed_to_read_tenant_policy => "failedToReadTenantPolicy",
-            .global_pat_policy_violation => "globalPatPolicyViolation",
-            .full_scope_pat_policy_violation => "fullScopePatPolicyViolation",
-            .pat_lifespan_policy_violation => "patLifespanPolicyViolation",
-            .invalid_token_type => "invalidTokenType",
-            .invalid_audience => "invalidAudience",
-            .invalid_subject => "invalidSubject",
-            .deployment_host_not_supported => "deploymentHostNotSupported",
-            .disable_pat_creation_policy_violation => "disablePatCreationPolicyViolation",
-            .failed_to_read_org_policy => "failedToReadOrgPolicy",
-            .global_pat_creation_blocked => "globalPATCreationBlocked",
-            .expired_pat_cannot_be_extended => "expiredPatCannotBeExtended",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "displayNameRequired")) return .display_name_required;
-        if (std.mem.eql(u8, s, "invalidDisplayName")) return .invalid_display_name;
-        if (std.mem.eql(u8, s, "invalidValidTo")) return .invalid_valid_to;
-        if (std.mem.eql(u8, s, "invalidScope")) return .invalid_scope;
-        if (std.mem.eql(u8, s, "userIdRequired")) return .user_id_required;
-        if (std.mem.eql(u8, s, "invalidUserId")) return .invalid_user_id;
-        if (std.mem.eql(u8, s, "invalidUserType")) return .invalid_user_type;
-        if (std.mem.eql(u8, s, "accessDenied")) return .access_denied;
-        if (std.mem.eql(u8, s, "failedToIssueAccessToken")) return .failed_to_issue_access_token;
-        if (std.mem.eql(u8, s, "invalidClient")) return .invalid_client;
-        if (std.mem.eql(u8, s, "invalidClientType")) return .invalid_client_type;
-        if (std.mem.eql(u8, s, "invalidClientId")) return .invalid_client_id;
-        if (std.mem.eql(u8, s, "invalidTargetAccounts")) return .invalid_target_accounts;
-        if (std.mem.eql(u8, s, "hostAuthorizationNotFound")) return .host_authorization_not_found;
-        if (std.mem.eql(u8, s, "authorizationNotFound")) return .authorization_not_found;
-        if (std.mem.eql(u8, s, "failedToUpdateAccessToken")) return .failed_to_update_access_token;
-        if (std.mem.eql(u8, s, "sourceNotSupported")) return .source_not_supported;
-        if (std.mem.eql(u8, s, "invalidSourceIP")) return .invalid_source_ip;
-        if (std.mem.eql(u8, s, "invalidSource")) return .invalid_source;
-        if (std.mem.eql(u8, s, "duplicateHash")) return .duplicate_hash;
-        if (std.mem.eql(u8, s, "sshPolicyDisabled")) return .ssh_policy_disabled;
-        if (std.mem.eql(u8, s, "invalidToken")) return .invalid_token;
-        if (std.mem.eql(u8, s, "tokenNotFound")) return .token_not_found;
-        if (std.mem.eql(u8, s, "invalidAuthorizationId")) return .invalid_authorization_id;
-        if (std.mem.eql(u8, s, "failedToReadTenantPolicy")) return .failed_to_read_tenant_policy;
-        if (std.mem.eql(u8, s, "globalPatPolicyViolation")) return .global_pat_policy_violation;
-        if (std.mem.eql(u8, s, "fullScopePatPolicyViolation")) return .full_scope_pat_policy_violation;
-        if (std.mem.eql(u8, s, "patLifespanPolicyViolation")) return .pat_lifespan_policy_violation;
-        if (std.mem.eql(u8, s, "invalidTokenType")) return .invalid_token_type;
-        if (std.mem.eql(u8, s, "invalidAudience")) return .invalid_audience;
-        if (std.mem.eql(u8, s, "invalidSubject")) return .invalid_subject;
-        if (std.mem.eql(u8, s, "deploymentHostNotSupported")) return .deployment_host_not_supported;
-        if (std.mem.eql(u8, s, "disablePatCreationPolicyViolation")) return .disable_pat_creation_policy_violation;
-        if (std.mem.eql(u8, s, "failedToReadOrgPolicy")) return .failed_to_read_org_policy;
-        if (std.mem.eql(u8, s, "globalPATCreationBlocked")) return .global_pat_creation_blocked;
-        if (std.mem.eql(u8, s, "expiredPatCannotBeExtended")) return .expired_pat_cannot_be_extended;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .display_name_required = "displayNameRequired",
+        .invalid_display_name = "invalidDisplayName",
+        .invalid_valid_to = "invalidValidTo",
+        .invalid_scope = "invalidScope",
+        .user_id_required = "userIdRequired",
+        .invalid_user_id = "invalidUserId",
+        .invalid_user_type = "invalidUserType",
+        .access_denied = "accessDenied",
+        .failed_to_issue_access_token = "failedToIssueAccessToken",
+        .invalid_client = "invalidClient",
+        .invalid_client_type = "invalidClientType",
+        .invalid_client_id = "invalidClientId",
+        .invalid_target_accounts = "invalidTargetAccounts",
+        .host_authorization_not_found = "hostAuthorizationNotFound",
+        .authorization_not_found = "authorizationNotFound",
+        .failed_to_update_access_token = "failedToUpdateAccessToken",
+        .source_not_supported = "sourceNotSupported",
+        .invalid_source_ip = "invalidSourceIP",
+        .invalid_source = "invalidSource",
+        .duplicate_hash = "duplicateHash",
+        .ssh_policy_disabled = "sshPolicyDisabled",
+        .invalid_token = "invalidToken",
+        .token_not_found = "tokenNotFound",
+        .invalid_authorization_id = "invalidAuthorizationId",
+        .failed_to_read_tenant_policy = "failedToReadTenantPolicy",
+        .global_pat_policy_violation = "globalPatPolicyViolation",
+        .full_scope_pat_policy_violation = "fullScopePatPolicyViolation",
+        .pat_lifespan_policy_violation = "patLifespanPolicyViolation",
+        .invalid_token_type = "invalidTokenType",
+        .invalid_audience = "invalidAudience",
+        .invalid_subject = "invalidSubject",
+        .deployment_host_not_supported = "deploymentHostNotSupported",
+        .disable_pat_creation_policy_violation = "disablePatCreationPolicyViolation",
+        .failed_to_read_org_policy = "failedToReadOrgPolicy",
+        .global_pat_creation_blocked = "globalPATCreationBlocked",
+        .expired_pat_cannot_be_extended = "expiredPatCannotBeExtended",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/wiki/enums.zig
+++ b/src/wiki/enums.zig
@@ -8,99 +8,100 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const WikiV2Type = enum {
+pub const WikiV2Type = union(enum) {
     project_wiki,
     code_wiki,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .project_wiki => "projectWiki",
-            .code_wiki => "codeWiki",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "projectWiki")) return .project_wiki;
-        if (std.mem.eql(u8, s, "codeWiki")) return .code_wiki;
-        return null;
-    }
+    const wire_names = .{
+        .project_wiki = "projectWiki",
+        .code_wiki = "codeWiki",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitVersionDescriptorVersionOptions = enum {
+pub const GitVersionDescriptorVersionOptions = union(enum) {
     none,
     previous_change,
     first_parent,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .previous_change => "previousChange",
-            .first_parent => "firstParent",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "previousChange")) return .previous_change;
-        if (std.mem.eql(u8, s, "firstParent")) return .first_parent;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .previous_change = "previousChange",
+        .first_parent = "firstParent",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const GitVersionDescriptorVersionType = enum {
+pub const GitVersionDescriptorVersionType = union(enum) {
     branch,
     tag,
     commit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .branch => "branch",
-            .tag => "tag",
-            .commit => "commit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "branch")) return .branch;
-        if (std.mem.eql(u8, s, "tag")) return .tag;
-        if (std.mem.eql(u8, s, "commit")) return .commit;
-        return null;
-    }
+    const wire_names = .{
+        .branch = "branch",
+        .tag = "tag",
+        .commit = "commit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/wit/enums.zig
+++ b/src/wit/enums.zig
@@ -8,69 +8,69 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const AccountRecentActivityWorkItemModel2ActivityType = enum {
+pub const AccountRecentActivityWorkItemModel2ActivityType = union(enum) {
     visited,
     edited,
     deleted,
     restored,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .visited => "visited",
-            .edited => "edited",
-            .deleted => "deleted",
-            .restored => "restored",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "visited")) return .visited;
-        if (std.mem.eql(u8, s, "edited")) return .edited;
-        if (std.mem.eql(u8, s, "deleted")) return .deleted;
-        if (std.mem.eql(u8, s, "restored")) return .restored;
-        return null;
-    }
+    const wire_names = .{
+        .visited = "visited",
+        .edited = "edited",
+        .deleted = "deleted",
+        .restored = "restored",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemClassificationNodeStructureType = enum {
+pub const WorkItemClassificationNodeStructureType = union(enum) {
     area,
     iteration,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .area => "area",
-            .iteration => "iteration",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "area")) return .area;
-        if (std.mem.eql(u8, s, "iteration")) return .iteration;
-        return null;
-    }
+    const wire_names = .{
+        .area = "area",
+        .iteration = "iteration",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -227,7 +227,7 @@ pub const ListRequestExpand = enum {
     }
 };
 
-pub const WorkItemField2Type = enum {
+pub const WorkItemField2Type = union(enum) {
     string,
     integer,
     date_time,
@@ -242,93 +242,80 @@ pub const WorkItemField2Type = enum {
     picklist_string,
     picklist_integer,
     picklist_double,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .string => "string",
-            .integer => "integer",
-            .date_time => "dateTime",
-            .plain_text => "plainText",
-            .html => "html",
-            .tree_path => "treePath",
-            .history => "history",
-            .double => "double",
-            .guid => "guid",
-            .boolean => "boolean",
-            .identity => "identity",
-            .picklist_string => "picklistString",
-            .picklist_integer => "picklistInteger",
-            .picklist_double => "picklistDouble",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "string")) return .string;
-        if (std.mem.eql(u8, s, "integer")) return .integer;
-        if (std.mem.eql(u8, s, "dateTime")) return .date_time;
-        if (std.mem.eql(u8, s, "plainText")) return .plain_text;
-        if (std.mem.eql(u8, s, "html")) return .html;
-        if (std.mem.eql(u8, s, "treePath")) return .tree_path;
-        if (std.mem.eql(u8, s, "history")) return .history;
-        if (std.mem.eql(u8, s, "double")) return .double;
-        if (std.mem.eql(u8, s, "guid")) return .guid;
-        if (std.mem.eql(u8, s, "boolean")) return .boolean;
-        if (std.mem.eql(u8, s, "identity")) return .identity;
-        if (std.mem.eql(u8, s, "picklistString")) return .picklist_string;
-        if (std.mem.eql(u8, s, "picklistInteger")) return .picklist_integer;
-        if (std.mem.eql(u8, s, "picklistDouble")) return .picklist_double;
-        return null;
-    }
+    const wire_names = .{
+        .string = "string",
+        .integer = "integer",
+        .date_time = "dateTime",
+        .plain_text = "plainText",
+        .html = "html",
+        .tree_path = "treePath",
+        .history = "history",
+        .double = "double",
+        .guid = "guid",
+        .boolean = "boolean",
+        .identity = "identity",
+        .picklist_string = "picklistString",
+        .picklist_integer = "picklistInteger",
+        .picklist_double = "picklistDouble",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemField2Usage = enum {
+pub const WorkItemField2Usage = union(enum) {
     none,
     work_item,
     work_item_link,
     tree,
     work_item_type_extension,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .work_item => "workItem",
-            .work_item_link => "workItemLink",
-            .tree => "tree",
-            .work_item_type_extension => "workItemTypeExtension",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "workItem")) return .work_item;
-        if (std.mem.eql(u8, s, "workItemLink")) return .work_item_link;
-        if (std.mem.eql(u8, s, "tree")) return .tree;
-        if (std.mem.eql(u8, s, "workItemTypeExtension")) return .work_item_type_extension;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .work_item = "workItem",
+        .work_item_link = "workItemLink",
+        .tree = "tree",
+        .work_item_type_extension = "workItemTypeExtension",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -371,40 +358,40 @@ pub const ListRequestExpand1 = enum {
     }
 };
 
-pub const WorkItemQueryClauseLogicalOperator = enum {
+pub const WorkItemQueryClauseLogicalOperator = union(enum) {
     none,
     @"and",
     @"or",
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .@"and" => "and",
-            .@"or" => "or",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "and")) return .@"and";
-        if (std.mem.eql(u8, s, "or")) return .@"or";
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .@"and" = "and",
+        .@"or" = "or",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const QueryHierarchyItemFilterOptions = enum {
+pub const QueryHierarchyItemFilterOptions = union(enum) {
     work_items,
     links_one_hop_must_contain,
     links_one_hop_may_contain,
@@ -412,103 +399,100 @@ pub const QueryHierarchyItemFilterOptions = enum {
     links_recursive_must_contain,
     links_recursive_may_contain,
     links_recursive_does_not_contain,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .work_items => "workItems",
-            .links_one_hop_must_contain => "linksOneHopMustContain",
-            .links_one_hop_may_contain => "linksOneHopMayContain",
-            .links_one_hop_does_not_contain => "linksOneHopDoesNotContain",
-            .links_recursive_must_contain => "linksRecursiveMustContain",
-            .links_recursive_may_contain => "linksRecursiveMayContain",
-            .links_recursive_does_not_contain => "linksRecursiveDoesNotContain",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "workItems")) return .work_items;
-        if (std.mem.eql(u8, s, "linksOneHopMustContain")) return .links_one_hop_must_contain;
-        if (std.mem.eql(u8, s, "linksOneHopMayContain")) return .links_one_hop_may_contain;
-        if (std.mem.eql(u8, s, "linksOneHopDoesNotContain")) return .links_one_hop_does_not_contain;
-        if (std.mem.eql(u8, s, "linksRecursiveMustContain")) return .links_recursive_must_contain;
-        if (std.mem.eql(u8, s, "linksRecursiveMayContain")) return .links_recursive_may_contain;
-        if (std.mem.eql(u8, s, "linksRecursiveDoesNotContain")) return .links_recursive_does_not_contain;
-        return null;
-    }
+    const wire_names = .{
+        .work_items = "workItems",
+        .links_one_hop_must_contain = "linksOneHopMustContain",
+        .links_one_hop_may_contain = "linksOneHopMayContain",
+        .links_one_hop_does_not_contain = "linksOneHopDoesNotContain",
+        .links_recursive_must_contain = "linksRecursiveMustContain",
+        .links_recursive_may_contain = "linksRecursiveMayContain",
+        .links_recursive_does_not_contain = "linksRecursiveDoesNotContain",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const QueryHierarchyItemQueryRecursionOption = enum {
+pub const QueryHierarchyItemQueryRecursionOption = union(enum) {
     parent_first,
     child_first,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .parent_first => "parentFirst",
-            .child_first => "childFirst",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "parentFirst")) return .parent_first;
-        if (std.mem.eql(u8, s, "childFirst")) return .child_first;
-        return null;
-    }
+    const wire_names = .{
+        .parent_first = "parentFirst",
+        .child_first = "childFirst",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const QueryHierarchyItemQueryType = enum {
+pub const QueryHierarchyItemQueryType = union(enum) {
     flat,
     tree,
     one_hop,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .flat => "flat",
-            .tree => "tree",
-            .one_hop => "oneHop",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "flat")) return .flat;
-        if (std.mem.eql(u8, s, "tree")) return .tree;
-        if (std.mem.eql(u8, s, "oneHop")) return .one_hop;
-        return null;
-    }
+    const wire_names = .{
+        .flat = "flat",
+        .tree = "tree",
+        .one_hop = "oneHop",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -551,102 +535,102 @@ pub const GetRequestExpand = enum {
     }
 };
 
-pub const QueryBatchGetRequestExpand = enum {
+pub const QueryBatchGetRequestExpand = union(enum) {
     none,
     wiql,
     clauses,
     all,
     minimal,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .wiql => "wiql",
-            .clauses => "clauses",
-            .all => "all",
-            .minimal => "minimal",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "wiql")) return .wiql;
-        if (std.mem.eql(u8, s, "clauses")) return .clauses;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        if (std.mem.eql(u8, s, "minimal")) return .minimal;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .wiql = "wiql",
+        .clauses = "clauses",
+        .all = "all",
+        .minimal = "minimal",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const QueryBatchGetRequestErrorPolicy = enum {
+pub const QueryBatchGetRequestErrorPolicy = union(enum) {
     fail,
     omit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .fail => "fail",
-            .omit => "omit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "fail")) return .fail;
-        if (std.mem.eql(u8, s, "omit")) return .omit;
-        return null;
-    }
+    const wire_names = .{
+        .fail = "fail",
+        .omit = "omit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemMultilineFieldsFormat = enum {
+pub const WorkItemMultilineFieldsFormat = union(enum) {
     markdown,
     html,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .markdown => "markdown",
-            .html => "html",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "markdown")) return .markdown;
-        if (std.mem.eql(u8, s, "html")) return .html;
-        return null;
-    }
+    const wire_names = .{
+        .markdown = "markdown",
+        .html = "html",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -935,72 +919,71 @@ pub const UpdateRequestExpand = enum {
     }
 };
 
-pub const WorkItemBatchGetRequestExpand = enum {
+pub const WorkItemBatchGetRequestExpand = union(enum) {
     none,
     relations,
     fields,
     links,
     all,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .relations => "relations",
-            .fields => "fields",
-            .links => "links",
-            .all => "all",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "relations")) return .relations;
-        if (std.mem.eql(u8, s, "fields")) return .fields;
-        if (std.mem.eql(u8, s, "links")) return .links;
-        if (std.mem.eql(u8, s, "all")) return .all;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .relations = "relations",
+        .fields = "fields",
+        .links = "links",
+        .all = "all",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemBatchGetRequestErrorPolicy = enum {
+pub const WorkItemBatchGetRequestErrorPolicy = union(enum) {
     fail,
     omit,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .fail => "fail",
-            .omit => "omit",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "fail")) return .fail;
-        if (std.mem.eql(u8, s, "omit")) return .omit;
-        return null;
-    }
+    const wire_names = .{
+        .fail = "fail",
+        .omit = "omit",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1121,75 +1104,73 @@ pub const GetCommentsBatchRequestExpand = enum {
     }
 };
 
-pub const CommentFormat = enum {
+pub const CommentFormat = union(enum) {
     markdown,
     html,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .markdown => "markdown",
-            .html => "html",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "markdown")) return .markdown;
-        if (std.mem.eql(u8, s, "html")) return .html;
-        return null;
-    }
+    const wire_names = .{
+        .markdown = "markdown",
+        .html = "html",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const CommentReactionType = enum {
+pub const CommentReactionType = union(enum) {
     like,
     dislike,
     heart,
     hooray,
     smile,
     confused,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .like => "like",
-            .dislike => "dislike",
-            .heart => "heart",
-            .hooray => "hooray",
-            .smile => "smile",
-            .confused => "confused",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "like")) return .like;
-        if (std.mem.eql(u8, s, "dislike")) return .dislike;
-        if (std.mem.eql(u8, s, "heart")) return .heart;
-        if (std.mem.eql(u8, s, "hooray")) return .hooray;
-        if (std.mem.eql(u8, s, "smile")) return .smile;
-        if (std.mem.eql(u8, s, "confused")) return .confused;
-        return null;
-    }
+    const wire_names = .{
+        .like = "like",
+        .dislike = "dislike",
+        .heart = "heart",
+        .hooray = "hooray",
+        .smile = "smile",
+        .confused = "confused",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -1430,66 +1411,67 @@ pub const GetRequestExpand2 = enum {
     }
 };
 
-pub const WorkItemQueryResultQueryResultType = enum {
+pub const WorkItemQueryResultQueryResultType = union(enum) {
     work_item,
     work_item_link,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .work_item => "workItem",
-            .work_item_link => "workItemLink",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "workItem")) return .work_item;
-        if (std.mem.eql(u8, s, "workItemLink")) return .work_item_link;
-        return null;
-    }
+    const wire_names = .{
+        .work_item = "workItem",
+        .work_item_link = "workItemLink",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemQueryResultQueryType = enum {
+pub const WorkItemQueryResultQueryType = union(enum) {
     flat,
     tree,
     one_hop,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .flat => "flat",
-            .tree => "tree",
-            .one_hop => "oneHop",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "flat")) return .flat;
-        if (std.mem.eql(u8, s, "tree")) return .tree;
-        if (std.mem.eql(u8, s, "oneHop")) return .one_hop;
-        return null;
-    }
+    const wire_names = .{
+        .flat = "flat",
+        .tree = "tree",
+        .one_hop = "oneHop",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/work/enums.zig
+++ b/src/work/enums.zig
@@ -8,112 +8,197 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-pub const PlanUserPermissions = enum {
+pub const PlanType = union(enum) {
+    delivery_timeline_view,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .delivery_timeline_view = "deliveryTimelineView",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+pub const PlanUserPermissions = union(enum) {
     none,
     view,
     edit,
     delete,
     manage,
     all_permissions,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .none => "none",
-            .view => "view",
-            .edit => "edit",
-            .delete => "delete",
-            .manage => "manage",
-            .all_permissions => "allPermissions",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "none")) return .none;
-        if (std.mem.eql(u8, s, "view")) return .view;
-        if (std.mem.eql(u8, s, "edit")) return .edit;
-        if (std.mem.eql(u8, s, "delete")) return .delete;
-        if (std.mem.eql(u8, s, "manage")) return .manage;
-        if (std.mem.eql(u8, s, "allPermissions")) return .all_permissions;
-        return null;
-    }
+    const wire_names = .{
+        .none = "none",
+        .view = "view",
+        .edit = "edit",
+        .delete = "delete",
+        .manage = "manage",
+        .all_permissions = "allPermissions",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TimelineCriteriaStatusType = enum {
+pub const CreatePlanType = union(enum) {
+    delivery_timeline_view,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .delivery_timeline_view = "deliveryTimelineView",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+pub const UpdatePlanType = union(enum) {
+    delivery_timeline_view,
+    unrecognized: []const u8,
+
+    const wire_names = .{
+        .delivery_timeline_view = "deliveryTimelineView",
+    };
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
+};
+
+pub const TimelineCriteriaStatusType = union(enum) {
     ok,
     invalid_filter_clause,
     unknown,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .ok => "ok",
-            .invalid_filter_clause => "invalidFilterClause",
-            .unknown => "unknown",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "ok")) return .ok;
-        if (std.mem.eql(u8, s, "invalidFilterClause")) return .invalid_filter_clause;
-        if (std.mem.eql(u8, s, "unknown")) return .unknown;
-        return null;
-    }
+    const wire_names = .{
+        .ok = "ok",
+        .invalid_filter_clause = "invalidFilterClause",
+        .unknown = "unknown",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TimelineIterationStatusType = enum {
+pub const TimelineIterationStatusType = union(enum) {
     ok,
     is_overlapping,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .ok => "ok",
-            .is_overlapping => "isOverlapping",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "ok")) return .ok;
-        if (std.mem.eql(u8, s, "isOverlapping")) return .is_overlapping;
-        return null;
-    }
+    const wire_names = .{
+        .ok = "ok",
+        .is_overlapping = "isOverlapping",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TimelineTeamStatusType = enum {
+pub const TimelineTeamStatusType = union(enum) {
     ok,
     doesnt_exist_or_access_denied,
     max_teams_exceeded,
@@ -121,239 +206,236 @@ pub const TimelineTeamStatusType = enum {
     backlog_in_error,
     missing_team_field_value,
     no_iterations_exist,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .ok => "ok",
-            .doesnt_exist_or_access_denied => "doesntExistOrAccessDenied",
-            .max_teams_exceeded => "maxTeamsExceeded",
-            .max_team_fields_exceeded => "maxTeamFieldsExceeded",
-            .backlog_in_error => "backlogInError",
-            .missing_team_field_value => "missingTeamFieldValue",
-            .no_iterations_exist => "noIterationsExist",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "ok")) return .ok;
-        if (std.mem.eql(u8, s, "doesntExistOrAccessDenied")) return .doesnt_exist_or_access_denied;
-        if (std.mem.eql(u8, s, "maxTeamsExceeded")) return .max_teams_exceeded;
-        if (std.mem.eql(u8, s, "maxTeamFieldsExceeded")) return .max_team_fields_exceeded;
-        if (std.mem.eql(u8, s, "backlogInError")) return .backlog_in_error;
-        if (std.mem.eql(u8, s, "missingTeamFieldValue")) return .missing_team_field_value;
-        if (std.mem.eql(u8, s, "noIterationsExist")) return .no_iterations_exist;
-        return null;
-    }
+    const wire_names = .{
+        .ok = "ok",
+        .doesnt_exist_or_access_denied = "doesntExistOrAccessDenied",
+        .max_teams_exceeded = "maxTeamsExceeded",
+        .max_team_fields_exceeded = "maxTeamFieldsExceeded",
+        .backlog_in_error = "backlogInError",
+        .missing_team_field_value = "missingTeamFieldValue",
+        .no_iterations_exist = "noIterationsExist",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const WorkItemMultilineFieldsFormat = enum {
+pub const WorkItemMultilineFieldsFormat = union(enum) {
     markdown,
     html,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .markdown => "markdown",
-            .html => "html",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "markdown")) return .markdown;
-        if (std.mem.eql(u8, s, "html")) return .html;
-        return null;
-    }
+    const wire_names = .{
+        .markdown = "markdown",
+        .html = "html",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BacklogConfigurationBugsBehavior = enum {
+pub const BacklogConfigurationBugsBehavior = union(enum) {
     off,
     as_requirements,
     as_tasks,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .off => "off",
-            .as_requirements => "asRequirements",
-            .as_tasks => "asTasks",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "off")) return .off;
-        if (std.mem.eql(u8, s, "asRequirements")) return .as_requirements;
-        if (std.mem.eql(u8, s, "asTasks")) return .as_tasks;
-        return null;
-    }
+    const wire_names = .{
+        .off = "off",
+        .as_requirements = "asRequirements",
+        .as_tasks = "asTasks",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BacklogLevelConfigurationType = enum {
+pub const BacklogLevelConfigurationType = union(enum) {
     portfolio,
     requirement,
     task,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .portfolio => "portfolio",
-            .requirement => "requirement",
-            .task => "task",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "portfolio")) return .portfolio;
-        if (std.mem.eql(u8, s, "requirement")) return .requirement;
-        if (std.mem.eql(u8, s, "task")) return .task;
-        return null;
-    }
+    const wire_names = .{
+        .portfolio = "portfolio",
+        .requirement = "requirement",
+        .task = "task",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const BoardColumnColumnType = enum {
+pub const BoardColumnColumnType = union(enum) {
     incoming,
     in_progress,
     outgoing,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .incoming => "incoming",
-            .in_progress => "inProgress",
-            .outgoing => "outgoing",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "incoming")) return .incoming;
-        if (std.mem.eql(u8, s, "inProgress")) return .in_progress;
-        if (std.mem.eql(u8, s, "outgoing")) return .outgoing;
-        return null;
-    }
+    const wire_names = .{
+        .incoming = "incoming",
+        .in_progress = "inProgress",
+        .outgoing = "outgoing",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamIterationAttributesTimeFrame = enum {
+pub const TeamIterationAttributesTimeFrame = union(enum) {
     past,
     current,
     future,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .past => "past",
-            .current => "current",
-            .future => "future",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "past")) return .past;
-        if (std.mem.eql(u8, s, "current")) return .current;
-        if (std.mem.eql(u8, s, "future")) return .future;
-        return null;
-    }
+    const wire_names = .{
+        .past = "past",
+        .current = "current",
+        .future = "future",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamSettingBugsBehavior = enum {
+pub const TeamSettingBugsBehavior = union(enum) {
     off,
     as_requirements,
     as_tasks,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .off => "off",
-            .as_requirements => "asRequirements",
-            .as_tasks => "asTasks",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "off")) return .off;
-        if (std.mem.eql(u8, s, "asRequirements")) return .as_requirements;
-        if (std.mem.eql(u8, s, "asTasks")) return .as_tasks;
-        return null;
-    }
+    const wire_names = .{
+        .off = "off",
+        .as_requirements = "asRequirements",
+        .as_tasks = "asTasks",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamSettingWorkingDay = enum {
+pub const TeamSettingWorkingDay = union(enum) {
     sunday,
     monday,
     tuesday,
@@ -361,77 +443,73 @@ pub const TeamSettingWorkingDay = enum {
     thursday,
     friday,
     saturday,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .sunday => "sunday",
-            .monday => "monday",
-            .tuesday => "tuesday",
-            .wednesday => "wednesday",
-            .thursday => "thursday",
-            .friday => "friday",
-            .saturday => "saturday",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "sunday")) return .sunday;
-        if (std.mem.eql(u8, s, "monday")) return .monday;
-        if (std.mem.eql(u8, s, "tuesday")) return .tuesday;
-        if (std.mem.eql(u8, s, "wednesday")) return .wednesday;
-        if (std.mem.eql(u8, s, "thursday")) return .thursday;
-        if (std.mem.eql(u8, s, "friday")) return .friday;
-        if (std.mem.eql(u8, s, "saturday")) return .saturday;
-        return null;
-    }
+    const wire_names = .{
+        .sunday = "sunday",
+        .monday = "monday",
+        .tuesday = "tuesday",
+        .wednesday = "wednesday",
+        .thursday = "thursday",
+        .friday = "friday",
+        .saturday = "saturday",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamSettingsPatchBugsBehavior = enum {
+pub const TeamSettingsPatchBugsBehavior = union(enum) {
     off,
     as_requirements,
     as_tasks,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .off => "off",
-            .as_requirements => "asRequirements",
-            .as_tasks => "asTasks",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "off")) return .off;
-        if (std.mem.eql(u8, s, "asRequirements")) return .as_requirements;
-        if (std.mem.eql(u8, s, "asTasks")) return .as_tasks;
-        return null;
-    }
+    const wire_names = .{
+        .off = "off",
+        .as_requirements = "asRequirements",
+        .as_tasks = "asTasks",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
-pub const TeamSettingsPatchWorkingDay = enum {
+pub const TeamSettingsPatchWorkingDay = union(enum) {
     sunday,
     monday,
     tuesday,
@@ -439,40 +517,36 @@ pub const TeamSettingsPatchWorkingDay = enum {
     thursday,
     friday,
     saturday,
+    unrecognized: []const u8,
 
-    pub fn toWire(self: @This()) []const u8 {
-        return switch (self) {
-            .sunday => "sunday",
-            .monday => "monday",
-            .tuesday => "tuesday",
-            .wednesday => "wednesday",
-            .thursday => "thursday",
-            .friday => "friday",
-            .saturday => "saturday",
-        };
-    }
-
-    pub fn fromWire(s: []const u8) ?@This() {
-        if (std.mem.eql(u8, s, "sunday")) return .sunday;
-        if (std.mem.eql(u8, s, "monday")) return .monday;
-        if (std.mem.eql(u8, s, "tuesday")) return .tuesday;
-        if (std.mem.eql(u8, s, "wednesday")) return .wednesday;
-        if (std.mem.eql(u8, s, "thursday")) return .thursday;
-        if (std.mem.eql(u8, s, "friday")) return .friday;
-        if (std.mem.eql(u8, s, "saturday")) return .saturday;
-        return null;
-    }
+    const wire_names = .{
+        .sunday = "sunday",
+        .monday = "monday",
+        .tuesday = "tuesday",
+        .wednesday = "wednesday",
+        .thursday = "thursday",
+        .friday = "friday",
+        .saturday = "saturday",
+    };
 
     pub fn zerdeDeserialize(
         comptime T: type,
         allocator: std.mem.Allocator,
         deserializer: anytype,
     ) @TypeOf(deserializer.*).Error!T {
-        return core.fixed_enum.deserialize(T, allocator, deserializer);
+        return core.open_enum.deserialize(T, wire_names, allocator, deserializer);
     }
 
     pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
-        return core.fixed_enum.serialize(self, serializer);
+        return core.open_enum.serialize(self, wire_names, serializer);
+    }
+
+    pub fn toWire(self: @This()) []const u8 {
+        return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 

--- a/src/work/models.zig
+++ b/src/work/models.zig
@@ -74,7 +74,7 @@ pub const Plan = struct {
     /// Revision of the plan. Used to safeguard users from overwriting each other's changes.
     revision: ?i32 = null,
     /// Type of the plan
-    type: ?[]const u8 = null,
+    type: ?enums.PlanType = null,
     /// The resource url to locate the plan via rest api
     url: ?[]const u8 = null,
     /// Bit flag indicating set of permissions a user has to the plan.
@@ -148,7 +148,7 @@ pub const CreatePlan = struct {
     /// Plan properties.
     properties: ?CreatePlanProperties = null,
     /// Type of plan to create.
-    type: ?[]const u8 = null,
+    type: ?enums.CreatePlanType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -171,7 +171,7 @@ pub const UpdatePlan = struct {
     /// Revision of the plan that was updated - the value used here should match the one the server gave the client in the Plan.
     revision: ?i32 = null,
     /// Type of the plan
-    type: ?[]const u8 = null,
+    type: ?enums.UpdatePlanType = null,
 
     pub const serde = .{
         .rename_all = .camel_case,


### PR DESCRIPTION
Azure DevOps returns enum values its own specification does not declare, and adds new ones without republishing. Listing an organization's projects failed outright against the live service because `visibility` came back as `organization` where the spec declares only `private` and `public`.

`azure-devops-rust-api` patches that single enum by hand. The upstream fix (cataggar/vsts-rest-api-specs@30b2105a) widens every string enum in the model schemas instead, which is how Azure data-plane enums are normally modelled anyway.

Generated enums are now a tagged union carrying an `unrecognized: []const u8` arm, so an unknown value round-trips instead of failing deserialization. Known values keep their tag names, so a `switch` needs one extra arm rather than rewriting. Request parameters keep their closed enums — those come from the caller, not the service.