### PR TITLE
Repin azure_sdk_core for the configurable response body ceiling

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -5,4 +5,4 @@ source_branch=typespec
 source_path=typespec/specs
 selected_api_version=7.2
 api_areas=44
-command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=5acfa4e5a9c5c7047f74eff472d8f3e1ebc1fe7b -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EglTBgB_64f-rD5Fd-CYsYveOH0iWOEG_eaomVNX generate-devops-package)
+command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=3acfe9d5779b98d2ffcbddbf4112348e11de7122 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY generate-devops-package)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5acfa4e5a9c5c7047f74eff472d8f3e1ebc1fe7b",
-            .hash = "azure_sdk_core-0.2.0-eFY0EglTBgB_64f-rD5Fd-CYsYveOH0iWOEG_eaomVNX",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
+            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",


### PR DESCRIPTION
Core capped a buffered response at a hard-coded 16 MB. Listing the Git repositories of a real Azure DevOps organization returns 17 MB in one response, so that operation failed with `StreamTooLong` and no caller could raise the bound.

Picks up #384, which exposes the bound as `StdHttpTransport.max_response_body` and raises the default to 64 MB.

No generated code changes; only the dependency pin and the recorded generator command move.