### PR TITLE
Make the SDK work against a real Azure DevOps organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pub fn main(init: std.process.Init) !void {
 
     var git = client.git();
     var repositories = git.repositories();
-    const list = try repositories.list(
+    const result = try repositories.list(
         init.gpa,
         "contoso",
         "my-project",
@@ -37,9 +37,10 @@ pub fn main(init: std.process.Init) !void {
         null,
         null,
     );
-    defer init.gpa.free(list);
 
-    for (list) |repository| {
+    // Azure DevOps wraps every collection in a `{count, value}` envelope,
+    // so list operations return that rather than a bare slice.
+    for (result.value orelse &.{}) |repository| {
         std.debug.print("{s}\n", .{repository.name orelse "<unnamed>"});
     }
 }
@@ -49,6 +50,12 @@ pub fn main(init: std.process.Init) !void {
 The generated operations take it as a path parameter, so the field exists
 so callers can write `client.organization` instead of threading the name
 through every call site.
+
+Azure DevOps never returns a bare JSON array: every collection comes back
+wrapped in an object carrying a `value` array and, on most endpoints, a
+`count`. List operations therefore return a generated `<Item>List`
+envelope, and callers read `.value`. `count` is optional because some
+endpoints omit it.
 
 ## The 44 areas
 
@@ -130,8 +137,9 @@ pub fn fetch(self: *Fetcher, allocator: std.mem.Allocator, token: ?[]const u8) !
 Some Azure DevOps operations report the next token in the response body
 and some in the `x-ms-continuationtoken` response header. Both are
 reachable: header-paged operations return a result union whose
-`status_200.headers` carries `x_ms_continuationtoken`, and an absent
-header is the end-of-collection signal. See
+`status_200.headers` carries `x_ms_continuationtoken` and whose
+`status_200.body` is the collection envelope, so the fetcher reads
+`body.value`. An absent header is the end-of-collection signal. See
 `examples/list_builds.zig` for a header-token pager and
 `examples/page_audit_log.zig` for a body-token one.
 

--- a/build.zig
+++ b/build.zig
@@ -91,7 +91,7 @@ pub fn build(b: *std.Build) void {
                 },
             }),
         });
-        examples_step.dependOn(&executable.step);
+        examples_step.dependOn(&b.addInstallArtifact(executable, .{}).step);
         test_step.dependOn(&executable.step);
     }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,12 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#da55987aa3c90393a726fc1fa5e86ccd69d72271",
-            .hash = "azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
+            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
         },
         .azure_rest_devops = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bff2a105d6293237cd34915d842814cb84fe052e",
-            .hash = "azure_rest_devops-0.1.0-anpXMvm8QwAzYDuUfhq19MTgnhwP3hqX-le-ttVFkdCc",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bb73526b43837f609df2b63fb8b08caa659f1c57",
+            .hash = "azure_rest_devops-0.1.0-anpXMs5vQwC3S97m6Uv4b8l38Vp3fZ16GnuOLE0268sA",
         },
     },
     .paths = .{

--- a/examples/list_builds.zig
+++ b/examples/list_builds.zig
@@ -5,6 +5,10 @@
 //! The generated operation surfaces it on `status_200.headers`, so the
 //! pager can drive the listing to exhaustion.
 //!
+//! A busy project holds tens of thousands of builds, so this stops after
+//! `max_pages` rather than reading them all: `next` may be abandoned at
+//! any point. Drop the check to walk the whole listing.
+//!
 //! See `page_audit_log.zig` for the other flavour, where the token
 //! arrives on the response *body* instead.
 //!
@@ -24,6 +28,7 @@ const models = devops.protocol.build.models;
 const Build = models.Build;
 
 const page_size: i32 = 25;
+const max_pages: usize = 4;
 
 /// Captures the sub-client and the operation's fixed parameters so the
 /// pager only has to supply the continuation token.
@@ -31,8 +36,12 @@ const BuildFetcher = struct {
     builds: devops.protocol.build.Builds,
     organization: []const u8,
     project: []const u8,
-    /// The header value is owned by the response, which is freed once
-    /// the page is handed back, so it is copied here to outlive it.
+    /// One page's worth of parsed response. Reset before each fetch, so
+    /// memory stays bounded no matter how long the listing runs. Safe
+    /// because the caller is done with a page before asking for the next.
+    page_arena: std.heap.ArenaAllocator,
+    /// The header value is owned by the response, which is discarded with
+    /// the arena, so it is copied here to outlive it.
     token_buffer: ?[]u8 = null,
     allocator: std.mem.Allocator,
 
@@ -41,8 +50,9 @@ const BuildFetcher = struct {
         allocator: std.mem.Allocator,
         token: ?[]const u8,
     ) !devops.Page(Build) {
+        _ = self.page_arena.reset(.retain_capacity);
         const result = try self.builds.list(
-            allocator,
+            self.page_arena.allocator(),
             self.organization,
             self.project,
             null,
@@ -60,7 +70,10 @@ const BuildFetcher = struct {
             token,
             null,
             null,
-            null,
+            // Azure DevOps only issues a continuation token for this
+            // operation when an explicit order is requested; with the
+            // default order it returns the first page and nothing else.
+            .queue_time_descending,
             null,
             null,
             null,
@@ -69,8 +82,7 @@ const BuildFetcher = struct {
 
         switch (result) {
             .status_200 => |ok| {
-                defer allocator.free(ok.body);
-                const items = try allocator.dupe(Build, ok.body);
+                const items = try allocator.dupe(Build, ok.body.value orelse &.{});
                 errdefer allocator.free(items);
 
                 if (self.token_buffer) |buffer| self.allocator.free(buffer);
@@ -88,6 +100,7 @@ const BuildFetcher = struct {
     fn deinit(self: *BuildFetcher) void {
         if (self.token_buffer) |buffer| self.allocator.free(buffer);
         self.token_buffer = null;
+        self.page_arena.deinit();
     }
 };
 
@@ -108,6 +121,7 @@ pub fn main(init: std.process.Init) !void {
         .builds = build_client.builds(),
         .organization = settings.organization,
         .project = project,
+        .page_arena = .init(allocator),
         .allocator = allocator,
     };
     defer fetcher.deinit();
@@ -115,18 +129,26 @@ pub fn main(init: std.process.Init) !void {
     var pages = devops.ContinuationPager(Build, BuildFetcher).init(&fetcher);
 
     var total: usize = 0;
+    var page_count: usize = 0;
     while (try pages.next(allocator)) |page| {
         defer allocator.free(page);
+        page_count += 1;
         for (page) |build| {
             total += 1;
             std.debug.print(
                 "  #{s}  {s}\n",
                 .{
                     build.build_number orelse "<none>",
-                    if (build.status) |status| @tagName(status) else "unknown",
+                    // `toWire` gives the service's spelling, including
+                    // for values this build of the SDK doesn't know.
+                    if (build.status) |status| status.toWire() else "unknown",
                 },
             );
         }
+        if (page_count == max_pages) break;
     }
-    std.debug.print("{d} builds in {s}\n", .{ total, project });
+    std.debug.print(
+        "{d} builds across {d} pages in {s}\n",
+        .{ total, page_count, project },
+    );
 }

--- a/examples/list_projects.zig
+++ b/examples/list_projects.zig
@@ -11,7 +11,11 @@ const core = @import("azure_sdk_core");
 const support = @import("devops_example_support");
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
+    // The parsed response owns a string per field; an arena frees the
+    // whole graph at once rather than walking it.
+    var arena = std.heap.ArenaAllocator.init(init.gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
@@ -25,7 +29,7 @@ pub fn main(init: std.process.Init) !void {
     // Core package, so the accessor is `core_area`.
     var core_area = client.core_area();
     var projects = core_area.projects();
-    const list = try projects.list(
+    const result = try projects.list(
         allocator,
         settings.organization,
         null,
@@ -34,7 +38,7 @@ pub fn main(init: std.process.Init) !void {
         null,
         null,
     );
-    defer allocator.free(list);
+    const list = result.value orelse &.{};
 
     std.debug.print("{d} projects in {s}\n", .{ list.len, settings.organization });
     for (list) |project| {

--- a/examples/list_repositories.zig
+++ b/examples/list_repositories.zig
@@ -12,7 +12,11 @@ const core = @import("azure_sdk_core");
 const support = @import("devops_example_support");
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
+    // The parsed response owns a string per field; an arena frees the
+    // whole graph at once rather than walking it.
+    var arena = std.heap.ArenaAllocator.init(init.gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
@@ -25,7 +29,7 @@ pub fn main(init: std.process.Init) !void {
 
     var git = client.git();
     var repositories = git.repositories();
-    const list = try repositories.list(
+    const result = try repositories.list(
         allocator,
         settings.organization,
         project,
@@ -33,7 +37,7 @@ pub fn main(init: std.process.Init) !void {
         null,
         null,
     );
-    defer allocator.free(list);
+    const list = result.value orelse &.{};
 
     std.debug.print("{d} repositories in {s}\n", .{ list.len, project });
     for (list) |repository| {

--- a/examples/page_audit_log.zig
+++ b/examples/page_audit_log.zig
@@ -28,8 +28,12 @@ const batch_size: i32 = 100;
 const AuditFetcher = struct {
     audit_log: devops.protocol.audit.AuditLog,
     organization: []const u8,
-    /// The service's token is owned by the parsed body, which is freed
-    /// once the page is handed back, so it is copied here to outlive it.
+    /// One page's worth of parsed response. Reset before each fetch, so
+    /// memory stays bounded no matter how long the listing runs. Safe
+    /// because the caller is done with a page before asking for the next.
+    page_arena: std.heap.ArenaAllocator,
+    /// The service's token is owned by the parsed body, which is
+    /// discarded with the arena, so it is copied here to outlive it.
     token_buffer: ?[]u8 = null,
     allocator: std.mem.Allocator,
 
@@ -38,8 +42,9 @@ const AuditFetcher = struct {
         allocator: std.mem.Allocator,
         token: ?[]const u8,
     ) !devops.Page(Entry) {
+        _ = self.page_arena.reset(.retain_capacity);
         const result = try self.audit_log.query(
-            allocator,
+            self.page_arena.allocator(),
             self.organization,
             null,
             null,
@@ -68,6 +73,7 @@ const AuditFetcher = struct {
     fn deinit(self: *AuditFetcher) void {
         if (self.token_buffer) |buffer| self.allocator.free(buffer);
         self.token_buffer = null;
+        self.page_arena.deinit();
     }
 };
 
@@ -86,6 +92,7 @@ pub fn main(init: std.process.Init) !void {
     var fetcher: AuditFetcher = .{
         .audit_log = audit.auditLog(),
         .organization = settings.organization,
+        .page_arena = .init(allocator),
         .allocator = allocator,
     };
     defer fetcher.deinit();

--- a/examples/query_work_items.zig
+++ b/examples/query_work_items.zig
@@ -20,7 +20,11 @@ const wiql_query =
 ;
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
+    // The parsed response owns a string per field; an arena frees the
+    // whole graph at once rather than walking it.
+    var arena = std.heap.ArenaAllocator.init(init.gpa);
+    defer arena.deinit();
+    const allocator = arena.allocator();
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();

--- a/live_tests/main.zig
+++ b/live_tests/main.zig
@@ -33,7 +33,9 @@ fn load(env: *const std.process.Environ.Map) !Settings {
 }
 
 test "live: the organization's projects can be listed with a PAT" {
-    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
     var env = try std.process.Environ.createMap(std.testing.environ, allocator);
     defer env.deinit();
     const settings = try load(&env);
@@ -50,7 +52,7 @@ test "live: the organization's projects can be listed with a PAT" {
 
     var core_area = client.core_area();
     var projects = core_area.projects();
-    const list = try projects.list(
+    const result = try projects.list(
         allocator,
         settings.organization,
         null,
@@ -59,12 +61,15 @@ test "live: the organization's projects can be listed with a PAT" {
         null,
         null,
     );
-    defer allocator.free(list);
+    // Azure DevOps wraps every collection in a `{count, value}` envelope.
+    const list = result.value orelse return error.MissingCollectionEnvelope;
     try std.testing.expect(list.len > 0);
 }
 
 test "live: a project's Git repositories can be listed" {
-    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
     var env = try std.process.Environ.createMap(std.testing.environ, allocator);
     defer env.deinit();
     const settings = try load(&env);
@@ -82,7 +87,7 @@ test "live: a project's Git repositories can be listed" {
 
     var git = client.git();
     var repositories = git.repositories();
-    const list = try repositories.list(
+    const result = try repositories.list(
         allocator,
         settings.organization,
         project,
@@ -90,14 +95,16 @@ test "live: a project's Git repositories can be listed" {
         null,
         null,
     );
-    defer allocator.free(list);
+    const list = result.value orelse return error.MissingCollectionEnvelope;
     for (list) |repository| {
         try std.testing.expect(repository.id != null);
     }
 }
 
 test "live: an invalid PAT is rejected rather than silently succeeding" {
-    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
     var env = try std.process.Environ.createMap(std.testing.environ, allocator);
     defer env.deinit();
     const settings = try load(&env);


### PR DESCRIPTION
The SDK had never been run against a live Azure DevOps organization. Doing so surfaced four blocking defects, each fixed and merged upstream first; this PR repins onto those fixes and updates the call sites they change.

| Defect | Fix |
| --- | --- |
| Duplicate `User-Agent` header, rejected with `400 Invalid Header` | `sdk/core` #379 |
| 16 MB response body ceiling (one org's repositories are 17 MB) | `sdk/core` #384 |
| Collections arrive wrapped in a `{count, value}` envelope | `rest/devops` #381 |
| Service returns enum values the spec omits | `rest/devops` #383 |

## What changed here

- Repinned `azure_sdk_core` to `3acfe9d57` and `azure_rest_devops` to `bb73526b4`.
- List results are read as `result.value`; the README explains the envelope.
- `@tagName` on a generated enum gives way to `toWire()`.
- `zig build examples` now installs to `./zig-out/bin` as the README always claimed.
- Examples no longer leak: single-shot ones take an arena, the two pagers reset a per-page arena so memory stays bounded however long the listing runs.
- `Builds.list` only issues a continuation token when an explicit query order is requested, so the pager example asks for one and now genuinely pages; it stops after four pages rather than walking 28,000 builds.

## Verification

Against a real organization: 110 projects, 18,119 repositories, 17 work items, 100 builds across 4 pages, zero leaks. `zig build test` 14/14, `zig build live-test` 3/3, `zig fmt --check` clean.