### PR TITLE
Pick up the core fixes for duplicate headers and large responses

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
-            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
+            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",


### PR DESCRIPTION
Core sent the `User-Agent` header twice and capped a buffered response body at 16 MB. Both defects were found running the Azure DevOps SDK against a live organization: the duplicate header draws a flat `400 Invalid Header` from services strict enough to check, and one organization's repository listing is a single 17 MB response.

Both are fixed in core `3acfe9d57` (#379, #384). This moves `sdk/data_appconfiguration` onto it.

The move stays within core `0.2.0`, so it is a patch-level bump and needs no source changes here.