### PR TITLE
Pick up the core fixes for duplicate headers and large responses

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,20 +5,20 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
-            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
+            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
         },
         .azure_sdk_storage_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#755d3fe130a0ce8b1379a23abfd5ea1ef6ac4f9b",
-            .hash = "azure_sdk_storage_common-0.2.0-JzoreP9kAACIJrt3wR1biYx3X0vYljV9IiAfu86cFa7e",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#17d6f1550c53cda7245f07bc487de1dd7a00f265",
+            .hash = "azure_sdk_storage_common-0.2.0-JzoreP9kAAB71S4mgwDVPdCfjSL0auVfrlU8hhaD4O-q",
         },
         .azure_sdk_storage_blobs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3beb8819585cb1663975446d1fc6b68ca56e16ef",
-            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#4a21c5e1d85e9da22fa9481b7ffde8920bf53fae",
+            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgAxYhvh6lYm59jMOZ_-NaWDqKDvXheMlGoU",
         },
         .azure_sdk_storage_queues = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#230c3871c66cf01c56cd0e1074b9671469f26937",
-            .hash = "azure_sdk_storage_queues-0.1.0-LKTiC7hzAAAgGj0CZmqC9bZisbmSLm9hCqk7z0anGmj9",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#e02a5870bc9594fd487060dcdaf7538b79753370",
+            .hash = "azure_sdk_storage_queues-0.1.0-LKTiC7hzAAAsObDHKG7ERKNGJ8TaVHiICq-S0c1wPm0V",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",


### PR DESCRIPTION
Core sent the `User-Agent` header twice and capped a buffered response body at 16 MB. Both defects were found running the Azure DevOps SDK against a live organization: the duplicate header draws a flat `400 Invalid Header` from services strict enough to check, and one organization's repository listing is a single 17 MB response.

Both are fixed in core `3acfe9d57` (#379, #384). This moves `sdk/kusto` onto it, and onto the sibling packages that have already been moved, so every pin stays at its branch head.

The move stays within core `0.2.0`, so it is a patch-level bump and needs no source changes here.