### PR TITLE
Pick up the core fixes for duplicate headers and large responses

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,16 +5,16 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1d73a90eefef7caa705509a3c40cfaceb09513c0",
-            .hash = "azure_sdk_core-0.2.0-eFY0EkI6BgAXeSYiGU0DIKpU112vANE7f5Qln9zfErfT",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
+            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
         },
         .azure_sdk_messaging_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#381b11a05c271b66d6496f9fc3aa9c1633a3c5aa",
-            .hash = "azure_sdk_messaging_common-0.2.0-YklmSkWIAADy4QHeNJAVUdRq-xKFeRx75G1TjE5lMeHR",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#2dd41660a706db7bbaa2ef2fe76b67e92568a8e6",
+            .hash = "azure_sdk_messaging_common-0.2.0-YklmSkWIAACgiNHymgq5TSnhW6t9nULx2U8H4kxUgGWN",
         },
         .azure_sdk_storage_blobs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3beb8819585cb1663975446d1fc6b68ca56e16ef",
-            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgD0bdgR13OktiQ1moQ9O1QDCcPsgVdlb8lf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#4a21c5e1d85e9da22fa9481b7ffde8920bf53fae",
+            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgAxYhvh6lYm59jMOZ_-NaWDqKDvXheMlGoU",
         },
         .azure_sdk_amqp = .{
             .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bd5330d983ca75a56771a085659ec1136c9a81f6",


### PR DESCRIPTION
Core sent the `User-Agent` header twice and capped a buffered response body at 16 MB. Both defects were found running the Azure DevOps SDK against a live organization: the duplicate header draws a flat `400 Invalid Header` from services strict enough to check, and one organization's repository listing is a single 17 MB response.

Both are fixed in core `3acfe9d57` (#379, #384). This moves `sdk/eventhubs` onto it, and onto the sibling packages that have already been moved, so every pin stays at its branch head.

The move stays within core `0.2.0`, so it is a patch-level bump and needs no source changes here.