### PR TITLE
Pick up the core fixes for duplicate headers and large responses

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,12 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#b7b47b2b172fa069fdb3979e8dea395f97c008a8",
-            .hash = "azure_sdk_core-0.1.3-eFY0Eu3NBQCWhAf8JkUhPNkV_vNq_w68JXIUYNFAEamz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
+            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
         },
         .azure_rest_arm_avs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#20a2807f813864dabc0673ad72d400ee7d104945",
-            .hash = "azure_rest_arm_avs-0.1.0-JCvS8N8JBwCoC36NQdwOM4AN5LGy434N2sZP9ENPSINW",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#7dc2477fa347a43f0a326a947cb544e9632e2bd8",
+            .hash = "azure_rest_arm_avs-0.1.0-JCvS8N8JBwDuvCz25jAfiFXn00A-Cn2ONqCnnHj9nxJy",
         },
     },
     .paths = .{


### PR DESCRIPTION
Core sent the `User-Agent` header twice and capped a buffered response body at 16 MB. Both defects were found running the Azure DevOps SDK against a live organization: the duplicate header draws a flat `400 Invalid Header` from services strict enough to check, and one organization's repository listing is a single 17 MB response.

Both are fixed in core `3acfe9d57` (#379, #384). This moves `example/arm_avs_wasi` onto it, and onto the sibling packages that have already been moved, so every pin stays at its branch head.

The move stays within core `0.2.0`, so it is a patch-level bump and needs no source changes here.