### PR TITLE
Introduce HTTP runtime and crypto provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ The canonical package/module name is `azure_sdk_core`, released from
 | `http.StdHttpTransport` | Streaming HTTP via `std.http.Client` with gzip, deflate, and zstd response decoding |
 | `http.MockTransport` | Canned buffered and streaming responses for tests |
 | `http.SequenceMockTransport` | Ordered responses for retry tests |
-| `pipeline.HttpPipeline` | Policies followed by one transport |
-| `pipeline.TelemetryPolicy` | Adds `User-Agent` |
-| `pipeline.LoggingPolicy` | Logs requests through `std.log` |
-| `pipeline.RetryPolicy` | Bounded exponential backoff, jitter, and `Retry-After` |
-| `pipeline.BearerTokenAuthPolicy` | Bearer authentication with token caching |
-| `pipeline.RequestIdPolicy` | Adds an `x-ms-client-request-id` UUID |
+| `http.HttpRuntime` | Selected HTTP transport and SDK crypto provider |
+| `http.HttpPipeline` | Policies followed by one runtime |
+| `http.TelemetryPolicy` | Adds `User-Agent` |
+| `http.LoggingPolicy` | Logs requests through `std.log` |
+| `http.RetryPolicy` | Bounded exponential backoff, jitter, and `Retry-After` |
+| `http.BearerTokenAuthPolicy` | Bearer authentication with token caching |
+| `http.RequestIdPolicy` | Adds an `x-ms-client-request-id` UUID |
+| `crypto.CryptoProvider` | Pluggable random, MD5, SHA-256, and HMAC-SHA256 operations |
+| `crypto.StdCryptoProvider` | Pure-Zig provider backed by `std.Io` and `std.crypto` |
 | `credentials.CachedTokenCredential` | In-memory token cache with expiry |
 | `base64` | Base64, HMAC-SHA256, SHA-256, and MD5 helpers |
 | `url` | URL parsing and RFC 3986 percent encoding |
@@ -33,6 +36,26 @@ single-owner `HttpOperation`. Consume its reader and call `finish` to drain for
 connection reuse, or `abort`/`cancel` to close early. Always call `deinit`;
 it aborts an active operation. Streaming request preparation runs once and
 does not replay a consumed reader.
+
+HTTP construction has one explicit dependency path:
+
+```zig
+var transport = core.http.StdHttpTransport.init(allocator, io);
+defer transport.deinit();
+var crypto = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    transport.asTransport(),
+    crypto.asProvider(),
+);
+var pipeline = core.http.HttpPipeline.init(runtime, policies);
+```
+
+Transport and crypto descriptors, and therefore `HttpRuntime`, copy by value
+while borrowing their backend contexts. Keep `transport` and `crypto` alive
+for every pipeline, credential call, client, and open operation that uses
+them. `StdHttpTransport` remains caller-serialized. Custom crypto provider
+contexts must be concurrent-safe or caller-serialized. Incremental SHA-256
+operations own stable allocator-backed state and must be deinitialized once.
 
 ## Identity
 

--- a/credentials/env_token.zig
+++ b/credentials/env_token.zig
@@ -40,6 +40,7 @@ pub const EnvTokenCredential = struct {
         cred: *token.TokenCredential,
         _: token.TokenRequestContext,
         _: context_mod.Context,
+        _: @import("../http/runtime.zig").HttpRuntime,
     ) anyerror!token.AccessToken {
         const self: *EnvTokenCredential = @alignCast(@fieldParentPtr("credential", cred));
         // Return an explicitly owned copy; AccessToken carries its allocator.

--- a/credentials/token.zig
+++ b/credentials/token.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 const context_mod = @import("../context.zig");
+const crypto_mod = @import("../crypto.zig");
+const transport = @import("../http/transport.zig");
+const HttpRuntime = @import("../http/runtime.zig").HttpRuntime;
 
 /// An OAuth2 access token with expiry.
 pub const AccessToken = struct {
@@ -21,19 +24,24 @@ pub const TokenRequestContext = struct {
 };
 
 /// Abstract credential — any type that can produce an access token.
+///
+/// The runtime is supplied for each acquisition. Network credentials use its
+/// transport instead of retaining an independent transport descriptor.
 pub const TokenCredential = struct {
     getTokenFn: *const fn (
         self: *TokenCredential,
         request_context: TokenRequestContext,
         ctx: context_mod.Context,
+        runtime: HttpRuntime,
     ) anyerror!AccessToken,
 
     pub fn getToken(
         self: *TokenCredential,
         request_context: TokenRequestContext,
         ctx: context_mod.Context,
+        runtime: HttpRuntime,
     ) !AccessToken {
-        return self.getTokenFn(self, request_context, ctx);
+        return self.getTokenFn(self, request_context, ctx, runtime);
     }
 };
 
@@ -77,6 +85,7 @@ pub const CachedTokenCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         ctx: context_mod.Context,
+        runtime: HttpRuntime,
     ) anyerror!AccessToken {
         const self: *CachedTokenCredential = @alignCast(@fieldParentPtr("credential", cred));
         const now = currentTimestamp();
@@ -89,7 +98,7 @@ pub const CachedTokenCredential = struct {
         }
 
         // Fetch fresh token.
-        var fresh = try self.inner.getToken(request_context, ctx);
+        var fresh = try self.inner.getToken(request_context, ctx, runtime);
         defer fresh.deinit();
 
         const replacement = try self.allocator.dupe(u8, fresh.token);
@@ -121,6 +130,7 @@ test "CachedTokenCredential caches token" {
             _: *TokenCredential,
             _: TokenRequestContext,
             _: context_mod.Context,
+            _: HttpRuntime,
         ) anyerror!AccessToken {
             call_count += 1;
             const token = try allocator.dupe(u8, "test-token");
@@ -140,14 +150,18 @@ test "CachedTokenCredential caches token" {
 
     const ctx = context_mod.Context.none;
     const req = TokenRequestContext{ .scopes = &.{"https://vault.azure.net/.default"} };
+    var mock = transport.MockTransport.init(allocator, 200, "unused");
+    defer mock.deinit();
+    var crypto = crypto_mod.StdCryptoProvider.init(std.testing.io);
+    const runtime = HttpRuntime.init(mock.asTransport(), crypto.asProvider());
 
     // First call fetches.
-    const t1 = try cached.asCredential().getToken(req, ctx);
+    const t1 = try cached.asCredential().getToken(req, ctx, runtime);
     try std.testing.expectEqualStrings("test-token", t1.token);
     try std.testing.expectEqual(@as(u32, 1), Counter.call_count);
 
     // Second call returns cached — no new fetch.
-    const t2 = try cached.asCredential().getToken(req, ctx);
+    const t2 = try cached.asCredential().getToken(req, ctx, runtime);
     try std.testing.expectEqualStrings("test-token", t2.token);
     try std.testing.expectEqual(@as(u32, 1), Counter.call_count);
 }

--- a/crypto.zig
+++ b/crypto.zig
@@ -1,0 +1,297 @@
+const std = @import("std");
+
+pub const Md5Digest = [std.crypto.hash.Md5.digest_length]u8;
+pub const Sha256Digest = [std.crypto.hash.sha2.Sha256.digest_length]u8;
+pub const HmacSha256Digest = [std.crypto.auth.hmac.sha2.HmacSha256.mac_length]u8;
+
+/// A single-owner incremental SHA-256 operation.
+///
+/// The provider allocates stable operation state with the allocator passed to
+/// `CryptoProvider.sha256Init`. The caller must call `deinit` exactly once and
+/// must not copy this value after beginning to use it. Unless an
+/// implementation documents otherwise, its provider context must remain alive
+/// until the operation is deinitialized.
+pub const Sha256Operation = struct {
+    context: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        update: *const fn (context: *anyopaque, data: []const u8) anyerror!void,
+        final: *const fn (context: *anyopaque, out: *Sha256Digest) anyerror!void,
+        deinit: *const fn (context: *anyopaque) void,
+    };
+
+    pub fn update(self: *Sha256Operation, data: []const u8) !void {
+        return self.vtable.update(self.context, data);
+    }
+
+    pub fn final(self: *Sha256Operation) !Sha256Digest {
+        var out: Sha256Digest = undefined;
+        try self.vtable.final(self.context, &out);
+        return out;
+    }
+
+    pub fn deinit(self: *Sha256Operation) void {
+        self.vtable.deinit(self.context);
+        self.* = undefined;
+    }
+};
+
+/// Copyable descriptor for SDK cryptographic operations.
+///
+/// The descriptor borrows `context`; copies remain valid only while that
+/// context is alive. Provider implementations must either make their context
+/// concurrent-safe or require callers to serialize every descriptor copy.
+/// Failures are returned directly and are never replaced with a fallback
+/// provider.
+pub const CryptoProvider = struct {
+    context: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        random_bytes: *const fn (context: *anyopaque, out: []u8) anyerror!void,
+        md5: *const fn (context: *anyopaque, data: []const u8, out: *Md5Digest) anyerror!void,
+        sha256: *const fn (
+            context: *anyopaque,
+            data: []const u8,
+            out: *Sha256Digest,
+        ) anyerror!void,
+        hmac_sha256: *const fn (
+            context: *anyopaque,
+            key: []const u8,
+            message: []const u8,
+            out: *HmacSha256Digest,
+        ) anyerror!void,
+        sha256_init: *const fn (
+            context: *anyopaque,
+            allocator: std.mem.Allocator,
+        ) anyerror!Sha256Operation,
+    };
+
+    pub fn randomBytes(self: CryptoProvider, out: []u8) !void {
+        return self.vtable.random_bytes(self.context, out);
+    }
+
+    pub fn md5(self: CryptoProvider, data: []const u8) !Md5Digest {
+        var out: Md5Digest = undefined;
+        try self.vtable.md5(self.context, data, &out);
+        return out;
+    }
+
+    pub fn sha256(self: CryptoProvider, data: []const u8) !Sha256Digest {
+        var out: Sha256Digest = undefined;
+        try self.vtable.sha256(self.context, data, &out);
+        return out;
+    }
+
+    pub fn hmacSha256(
+        self: CryptoProvider,
+        key: []const u8,
+        message: []const u8,
+    ) !HmacSha256Digest {
+        var out: HmacSha256Digest = undefined;
+        try self.vtable.hmac_sha256(self.context, key, message, &out);
+        return out;
+    }
+
+    pub fn sha256Init(
+        self: CryptoProvider,
+        allocator: std.mem.Allocator,
+    ) !Sha256Operation {
+        return self.vtable.sha256_init(self.context, allocator);
+    }
+};
+
+/// Pure-Zig provider backed by `std.Io.randomSecure` and `std.crypto`.
+///
+/// `std.Io.randomSecure` is fallible and is used directly, without falling
+/// back to process-local pseudorandomness. The provider context is
+/// concurrent-safe when its `std.Io` implementation honors the standard
+/// library's thread-safety contract.
+pub const StdCryptoProvider = struct {
+    io: std.Io,
+
+    const vtable: CryptoProvider.VTable = .{
+        .random_bytes = &randomBytesImpl,
+        .md5 = &md5Impl,
+        .sha256 = &sha256Impl,
+        .hmac_sha256 = &hmacSha256Impl,
+        .sha256_init = &sha256InitImpl,
+    };
+
+    pub fn init(io: std.Io) StdCryptoProvider {
+        return .{ .io = io };
+    }
+
+    pub fn asProvider(self: *StdCryptoProvider) CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytesImpl(context: *anyopaque, out: []u8) !void {
+        const self: *StdCryptoProvider = @ptrCast(@alignCast(context));
+        return self.io.randomSecure(out);
+    }
+
+    fn md5Impl(_: *anyopaque, data: []const u8, out: *Md5Digest) !void {
+        std.crypto.hash.Md5.hash(data, out, .{});
+    }
+
+    fn sha256Impl(_: *anyopaque, data: []const u8, out: *Sha256Digest) !void {
+        std.crypto.hash.sha2.Sha256.hash(data, out, .{});
+    }
+
+    fn hmacSha256Impl(
+        _: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        out: *HmacSha256Digest,
+    ) !void {
+        std.crypto.auth.hmac.sha2.HmacSha256.create(out, message, key);
+    }
+
+    fn sha256InitImpl(
+        _: *anyopaque,
+        allocator: std.mem.Allocator,
+    ) !Sha256Operation {
+        const state = try allocator.create(StdSha256State);
+        state.* = .{
+            .allocator = allocator,
+            .hasher = std.crypto.hash.sha2.Sha256.init(.{}),
+        };
+        return .{ .context = state, .vtable = &StdSha256State.vtable };
+    }
+};
+
+const StdSha256State = struct {
+    allocator: std.mem.Allocator,
+    hasher: std.crypto.hash.sha2.Sha256,
+    finalized: bool = false,
+
+    const vtable: Sha256Operation.VTable = .{
+        .update = &update,
+        .final = &final,
+        .deinit = &deinit,
+    };
+
+    fn update(context: *anyopaque, data: []const u8) !void {
+        const self: *StdSha256State = @ptrCast(@alignCast(context));
+        if (self.finalized) return error.Sha256AlreadyFinalized;
+        self.hasher.update(data);
+    }
+
+    fn final(context: *anyopaque, out: *Sha256Digest) !void {
+        const self: *StdSha256State = @ptrCast(@alignCast(context));
+        if (self.finalized) return error.Sha256AlreadyFinalized;
+        self.hasher.final(out);
+        self.finalized = true;
+    }
+
+    fn deinit(context: *anyopaque) void {
+        const self: *StdSha256State = @ptrCast(@alignCast(context));
+        const allocator = self.allocator;
+        self.* = undefined;
+        allocator.destroy(self);
+    }
+};
+
+test "StdCryptoProvider standard vectors" {
+    var provider_impl = StdCryptoProvider.init(std.testing.io);
+    const provider = provider_impl.asProvider();
+
+    try std.testing.expectEqualSlices(u8, &.{
+        0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+        0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72,
+    }, &(try provider.md5("abc")));
+    try std.testing.expectEqualSlices(u8, &.{
+        0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+        0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+        0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+        0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
+    }, &(try provider.sha256("abc")));
+    try std.testing.expectEqualSlices(u8, &.{
+        0xf7, 0xbc, 0x83, 0xf4, 0x30, 0x53, 0x84, 0x24,
+        0xb1, 0x32, 0x98, 0xe6, 0xaa, 0x6f, 0xb1, 0x43,
+        0xef, 0x4d, 0x59, 0xa1, 0x49, 0x46, 0x17, 0x59,
+        0x97, 0x47, 0x9d, 0xbc, 0x2d, 0x1a, 0x3c, 0xd8,
+    }, &(try provider.hmacSha256("key", "The quick brown fox jumps over the lazy dog")));
+}
+
+test "StdCryptoProvider incremental SHA-256 has stable allocated state" {
+    var provider_impl = StdCryptoProvider.init(std.testing.io);
+    var operation = try provider_impl.asProvider().sha256Init(std.testing.allocator);
+    defer operation.deinit();
+
+    try operation.update("a");
+    try operation.update("b");
+    try operation.update("c");
+    const digest = try operation.final();
+    try std.testing.expectEqualSlices(u8, &.{
+        0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+        0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+        0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+        0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
+    }, &digest);
+    try std.testing.expectError(error.Sha256AlreadyFinalized, operation.update("d"));
+}
+
+test "CryptoProvider descriptors copy and dispatch through borrowed context" {
+    const Spy = struct {
+        calls: usize = 0,
+
+        const vtable: CryptoProvider.VTable = .{
+            .random_bytes = &randomBytes,
+            .md5 = &md5,
+            .sha256 = &sha256,
+            .hmac_sha256 = &hmacSha256,
+            .sha256_init = &sha256Init,
+        };
+
+        fn provider(self: *@This()) CryptoProvider {
+            return .{ .context = self, .vtable = &vtable };
+        }
+
+        fn randomBytes(context: *anyopaque, out: []u8) !void {
+            const self: *@This() = @ptrCast(@alignCast(context));
+            self.calls += 1;
+            @memset(out, 0xa5);
+        }
+
+        fn md5(_: *anyopaque, _: []const u8, _: *Md5Digest) !void {
+            return error.Unused;
+        }
+
+        fn sha256(_: *anyopaque, _: []const u8, _: *Sha256Digest) !void {
+            return error.Unused;
+        }
+
+        fn hmacSha256(
+            _: *anyopaque,
+            _: []const u8,
+            _: []const u8,
+            _: *HmacSha256Digest,
+        ) !void {
+            return error.Unused;
+        }
+
+        fn sha256Init(_: *anyopaque, _: std.mem.Allocator) !Sha256Operation {
+            return error.Unused;
+        }
+    };
+
+    var spy = Spy{};
+    const first = spy.provider();
+    const copied = first;
+    var bytes: [4]u8 = undefined;
+    try copied.randomBytes(&bytes);
+    try std.testing.expectEqualSlices(u8, &.{ 0xa5, 0xa5, 0xa5, 0xa5 }, &bytes);
+    try std.testing.expectEqual(@as(usize, 1), spy.calls);
+}
+
+test "StdCryptoProvider does not fall back after secure randomness failure" {
+    var provider_impl = StdCryptoProvider.init(std.Io.failing);
+    var bytes: [16]u8 = undefined;
+    try std.testing.expectError(
+        error.EntropyUnavailable,
+        provider_impl.asProvider().randomBytes(&bytes),
+    );
+}

--- a/http.zig
+++ b/http.zig
@@ -1,0 +1,46 @@
+//! Canonical HTTP facade for Azure SDK Core.
+
+const transport = @import("http/transport.zig");
+const pipeline = @import("http/pipeline.zig");
+const runtime = @import("http/runtime.zig");
+const decompression = @import("http/decompression.zig");
+
+pub const Method = transport.Method;
+pub const RedirectPolicy = transport.RedirectPolicy;
+pub const Request = transport.Request;
+pub const ResponseHeader = transport.ResponseHeader;
+pub const ResponseHeaders = transport.ResponseHeaders;
+pub const Response = transport.Response;
+pub const CancellationToken = transport.CancellationToken;
+pub const StreamingRequestBody = transport.StreamingRequestBody;
+pub const ReplayableBytes = transport.ReplayableBytes;
+pub const OpenOptions = transport.OpenOptions;
+pub const OperationState = transport.OperationState;
+pub const HttpOperation = transport.HttpOperation;
+pub const HttpTransport = transport.HttpTransport;
+pub const StdHttpTransport = transport.StdHttpTransport;
+pub const MockTransport = transport.MockTransport;
+pub const SequenceMockTransport = transport.SequenceMockTransport;
+
+pub const HttpRuntime = runtime.HttpRuntime;
+pub const HttpPolicy = pipeline.HttpPolicy;
+pub const HttpPipeline = pipeline.HttpPipeline;
+pub const TelemetryPolicy = pipeline.TelemetryPolicy;
+pub const LoggingPolicy = pipeline.LoggingPolicy;
+pub const RetryPolicy = pipeline.RetryPolicy;
+pub const BearerTokenAuthPolicy = pipeline.BearerTokenAuthPolicy;
+pub const RequestIdPolicy = pipeline.RequestIdPolicy;
+pub const TracingPolicy = pipeline.TracingPolicy;
+pub const ensureRequestId = pipeline.ensureRequestId;
+pub const DecompressionPolicy = decompression.DecompressionPolicy;
+
+/// WASI HTTP transport, available only on `wasm32-wasi`.
+pub const wasi = if (@import("builtin").target.cpu.arch == .wasm32 and
+    @import("builtin").target.os.tag == .wasi)
+    @import("http/wasi_http.zig")
+else
+    struct {};
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/http/decompression.zig
+++ b/http/decompression.zig
@@ -8,13 +8,21 @@
 ///! may compress responses. The actual decompression is handled by the
 ///! `StdHttpTransport` (std.http.Client).
 const std = @import("std");
+const crypto_mod = @import("../crypto.zig");
 const transport = @import("transport.zig");
 const pipeline_mod = @import("pipeline.zig");
+const HttpRuntime = @import("runtime.zig").HttpRuntime;
 
 const Request = transport.Request;
 const Response = transport.Response;
 const HttpTransport = transport.HttpTransport;
 const HttpPolicy = pipeline_mod.HttpPolicy;
+
+var testing_crypto_provider = crypto_mod.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: HttpTransport) HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 
 /// Pipeline policy that requests compressed responses.
 ///
@@ -36,22 +44,22 @@ pub const DecompressionPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        try prepareImpl(policy, request);
-        return callNext(request, next, final_transport);
+        try prepareImpl(policy, request, runtime);
+        return callNext(request, next, runtime);
     }
 
-    fn prepareImpl(_: *HttpPolicy, request: *Request) !void {
+    fn prepareImpl(_: *HttpPolicy, request: *Request, _: HttpRuntime) !void {
         try request.setHeader("Accept-Encoding", "gzip, deflate");
     }
 };
 
-fn callNext(request: *Request, next: []*HttpPolicy, final_transport: *HttpTransport) !Response {
+fn callNext(request: *Request, next: []*HttpPolicy, runtime: HttpRuntime) !Response {
     if (next.len == 0) {
-        return final_transport.send(request);
+        return runtime.transport.send(request);
     }
-    return next[0].process(request, next[1..], final_transport);
+    return next[0].process(request, next[1..], runtime);
 }
 
 test "DecompressionPolicy sets Accept-Encoding" {
@@ -60,10 +68,7 @@ test "DecompressionPolicy sets Accept-Encoding" {
     defer mock.deinit();
     var decomp = DecompressionPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{decomp.asPolicy()};
-    var pip = pipeline_mod.HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pip = pipeline_mod.HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pip.send(&req);
@@ -77,10 +82,7 @@ test "DecompressionPolicy prepares streaming request" {
     defer mock.deinit();
     var decomp = DecompressionPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{decomp.asPolicy()};
-    var pip = pipeline_mod.HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pip = pipeline_mod.HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var operation = try pip.open(&req, .{});

--- a/http/pipeline.zig
+++ b/http/pipeline.zig
@@ -1,11 +1,19 @@
 const std = @import("std");
+const crypto_mod = @import("../crypto.zig");
 const transport = @import("transport.zig");
+const HttpRuntime = @import("runtime.zig").HttpRuntime;
 
 const Request = transport.Request;
 const Response = transport.Response;
 const HttpTransport = transport.HttpTransport;
 const HttpOperation = transport.HttpOperation;
 const OpenOptions = transport.OpenOptions;
+
+var testing_crypto_provider = crypto_mod.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: HttpTransport) HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 
 fn nanoTimestamp() i128 {
     var threaded: std.Io.Threaded = .init_single_threaded;
@@ -36,32 +44,33 @@ pub const HttpPolicy = struct {
         self: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response,
     prepareFn: ?*const fn (
         self: *HttpPolicy,
         request: *Request,
+        runtime: HttpRuntime,
     ) anyerror!void = null,
     openFn: ?*const fn (
         self: *HttpPolicy,
         request: *Request,
         options: OpenOptions,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!*HttpOperation = null,
 
     pub fn process(
         self: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        return self.processFn(self, request, next, final_transport);
+        return self.processFn(self, request, next, runtime);
     }
 
-    pub fn prepare(self: *HttpPolicy, request: *Request) !void {
+    pub fn prepare(self: *HttpPolicy, request: *Request, runtime: HttpRuntime) !void {
         const prepareFn = self.prepareFn orelse return error.StreamingPolicyUnsupported;
-        return prepareFn(self, request);
+        return prepareFn(self, request, runtime);
     }
 
     pub fn open(
@@ -69,22 +78,29 @@ pub const HttpPolicy = struct {
         request: *Request,
         options: OpenOptions,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !*HttpOperation {
-        if (self.openFn) |openFn| return openFn(self, request, options, next, final_transport);
-        try self.prepare(request);
-        return callNextOpen(request, options, next, final_transport);
+        if (self.openFn) |openFn| return openFn(self, request, options, next, runtime);
+        try self.prepare(request, runtime);
+        return callNextOpen(request, options, next, runtime);
     }
 };
 
-/// Ordered chain of policy pointers that terminates at an `HttpTransport`.
+/// Ordered policy chain with an explicit runtime copied by value.
 pub const HttpPipeline = struct {
     policies: []*HttpPolicy,
-    transport_impl: *HttpTransport,
+    runtime: HttpRuntime,
+
+    pub fn init(runtime: HttpRuntime, policies: []*HttpPolicy) HttpPipeline {
+        return .{
+            .policies = policies,
+            .runtime = runtime,
+        };
+    }
 
     pub fn send(self: *HttpPipeline, request: *Request) !Response {
         request.transport_started = false;
-        return callNext(request, self.policies, self.transport_impl);
+        return callNext(request, self.policies, self.runtime);
     }
 
     /// Opens a streaming operation through the same ordered policy chain used
@@ -96,7 +112,7 @@ pub const HttpPipeline = struct {
     ) !*HttpOperation {
         request.transport_started = false;
         try checkOpenCancelled(options);
-        return callNextOpen(request, options, self.policies, self.transport_impl);
+        return callNextOpen(request, options, self.policies, self.runtime);
     }
 };
 
@@ -107,22 +123,22 @@ fn checkOpenCancelled(options: OpenOptions) !void {
 }
 
 /// Advance through the remaining policies, calling the transport at the end.
-fn callNext(request: *Request, next: []*HttpPolicy, final_transport: *HttpTransport) !Response {
+fn callNext(request: *Request, next: []*HttpPolicy, runtime: HttpRuntime) !Response {
     if (next.len == 0) {
-        return final_transport.send(request);
+        return runtime.transport.send(request);
     }
-    return next[0].process(request, next[1..], final_transport);
+    return next[0].process(request, next[1..], runtime);
 }
 
 fn callNextOpen(
     request: *Request,
     options: OpenOptions,
     next: []*HttpPolicy,
-    final_transport: *HttpTransport,
+    runtime: HttpRuntime,
 ) !*HttpOperation {
     try checkOpenCancelled(options);
-    if (next.len == 0) return final_transport.open(request, options);
-    return next[0].open(request, options, next[1..], final_transport);
+    if (next.len == 0) return runtime.transport.open(request, options);
+    return next[0].open(request, options, next[1..], runtime);
 }
 
 // ───────────────────────────── Policies ─────────────────────────────
@@ -147,13 +163,13 @@ pub const TelemetryPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        try prepareImpl(policy, request);
-        return callNext(request, next, final_transport);
+        try prepareImpl(policy, request, runtime);
+        return callNext(request, next, runtime);
     }
 
-    fn prepareImpl(policy: *HttpPolicy, request: *Request) !void {
+    fn prepareImpl(policy: *HttpPolicy, request: *Request, _: HttpRuntime) !void {
         const self: *TelemetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
         try request.setHeader("User-Agent", self.user_agent);
     }
@@ -175,15 +191,15 @@ pub const LoggingPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        try prepareImpl(policy, request);
-        const response = try callNext(request, next, final_transport);
+        try prepareImpl(policy, request, runtime);
+        const response = try callNext(request, next, runtime);
         std.log.info("azure-sdk: {d} {s}", .{ response.status_code, request.url });
         return response;
     }
 
-    fn prepareImpl(_: *HttpPolicy, request: *Request) !void {
+    fn prepareImpl(_: *HttpPolicy, request: *Request, _: HttpRuntime) !void {
         std.log.info("azure-sdk: {s} {s}", .{ @tagName(request.method), request.url });
     }
 };
@@ -221,15 +237,15 @@ pub const RetryPolicy = struct {
             status == 502 or status == 503 or status == 504;
     }
 
-    fn prepareImpl(_: *HttpPolicy, _: *Request) !void {}
+    fn prepareImpl(_: *HttpPolicy, _: *Request, _: HttpRuntime) !void {}
 
     fn processImpl(
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        if (!request.retryable) return callNext(request, next, final_transport);
+        if (!request.retryable) return callNext(request, next, runtime);
         const self: *RetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
         const deadline_ns: ?i128 = if (request.operation_timeout_ms) |timeout_ms|
             std.math.add(
@@ -244,7 +260,7 @@ pub const RetryPolicy = struct {
         while (true) {
             if (deadlineExpired(deadline_ns)) return error.OperationTimedOut;
 
-            const result = callNext(request, next, final_transport);
+            const result = callNext(request, next, runtime);
             if (result) |resp| {
                 if (!isRetryable(resp.status_code) or attempt >= self.max_retries) return resp;
 
@@ -289,10 +305,10 @@ pub const RetryPolicy = struct {
         request: *Request,
         options: OpenOptions,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !*HttpOperation {
         if (!request.retryable or !options.isReplayable())
-            return callNextOpen(request, options, next, final_transport);
+            return callNextOpen(request, options, next, runtime);
 
         const self: *RetryPolicy = @alignCast(@fieldParentPtr("policy", policy));
         const deadline_ns: ?i128 = if (request.operation_timeout_ms) |timeout_ms|
@@ -315,7 +331,7 @@ pub const RetryPolicy = struct {
                 if (current_options.body) |*body| try body.rewind();
             }
 
-            const result = callNextOpen(request, current_options, next, final_transport);
+            const result = callNextOpen(request, current_options, next, runtime);
             if (result) |operation| {
                 if (!isRetryable(operation.status_code) or attempt >= self.max_retries)
                     return operation;
@@ -445,13 +461,13 @@ pub const BearerTokenAuthPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        try prepareImpl(policy, request);
-        return callNext(request, next, final_transport);
+        try prepareImpl(policy, request, runtime);
+        return callNext(request, next, runtime);
     }
 
-    fn prepareImpl(policy: *HttpPolicy, request: *Request) !void {
+    fn prepareImpl(policy: *HttpPolicy, request: *Request, runtime: HttpRuntime) !void {
         const self: *BearerTokenAuthPolicy = @alignCast(@fieldParentPtr("policy", policy));
         const now = unixTimestampSeconds();
         const refresh_buffer: i64 = 300; // 5 minutes before expiry
@@ -463,6 +479,7 @@ pub const BearerTokenAuthPolicy = struct {
             var fresh = try self.credential.getToken(
                 .{ .scopes = self.scopes },
                 ctx,
+                runtime,
             );
             defer fresh.deinit();
             const replacement = try self.allocator.dupe(u8, fresh.token);
@@ -489,12 +506,10 @@ pub const BearerTokenAuthPolicy = struct {
 };
 
 /// Ensures a request has a caller-preserving unique client request ID.
-pub fn ensureRequestId(request: *Request) !void {
+pub fn ensureRequestId(request: *Request, runtime: HttpRuntime) !void {
     if (request.getHeader("x-ms-client-request-id") != null) return;
     const uuid_mod = @import("../uuid.zig");
-    const seed: u64 = @truncate(@as(u128, @bitCast(nanoTimestamp())));
-    var prng = std.Random.DefaultPrng.init(seed);
-    const id = uuid_mod.Uuid.init(prng.random());
+    const id = try uuid_mod.Uuid.init(runtime.crypto);
     const id_str = id.toString();
     try request.setHeader("x-ms-client-request-id", &id_str);
 }
@@ -515,14 +530,14 @@ pub const RequestIdPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        try prepareImpl(policy, request);
-        return callNext(request, next, final_transport);
+        try prepareImpl(policy, request, runtime);
+        return callNext(request, next, runtime);
     }
 
-    fn prepareImpl(_: *HttpPolicy, request: *Request) !void {
-        try ensureRequestId(request);
+    fn prepareImpl(_: *HttpPolicy, request: *Request, runtime: HttpRuntime) !void {
+        try ensureRequestId(request, runtime);
     }
 };
 
@@ -555,12 +570,12 @@ pub const TracingPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
         const self: *TracingPolicy = @alignCast(@fieldParentPtr("policy", policy));
 
         const span = self.tracer.startSpan("HTTP", .client) catch {
-            return callNext(request, next, final_transport);
+            return callNext(request, next, runtime);
         };
 
         // Set standard Azure SDK span attributes.
@@ -573,7 +588,7 @@ pub const TracingPolicy = struct {
         }
 
         // Execute the rest of the pipeline.
-        const response = callNext(request, next, final_transport) catch |err| {
+        const response = callNext(request, next, runtime) catch |err| {
             span.setStatus(.@"error");
             span.end();
             return err;
@@ -595,15 +610,15 @@ pub const TracingPolicy = struct {
         request: *Request,
         options: OpenOptions,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !*HttpOperation {
         const self: *TracingPolicy = @alignCast(@fieldParentPtr("policy", policy));
         const span = self.tracer.startSpan("HTTP", .client) catch
-            return callNextOpen(request, options, next, final_transport);
+            return callNextOpen(request, options, next, runtime);
         span.setAttribute("http.method", @tagName(request.method)) catch {};
         span.setAttribute("url.full", request.url) catch {};
         span.setAttribute("az.namespace", self.az_namespace) catch {};
-        const operation = callNextOpen(request, options, next, final_transport) catch |err| {
+        const operation = callNextOpen(request, options, next, runtime) catch |err| {
             span.setStatus(.@"error");
             span.end();
             return err;
@@ -620,10 +635,7 @@ test "pipeline with telemetry and mock transport" {
     defer mock.deinit();
     var telemetry = TelemetryPolicy.init("azsdk-zig-test/0.1.0");
     var policy_ptrs = [_]*HttpPolicy{telemetry.asPolicy()};
-    var pipeline_inst = HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pipeline_inst.send(&req);
@@ -644,10 +656,7 @@ test "pipeline prepares streaming policies without retrying" {
         request_id.asPolicy(),
         retry.asPolicy(),
     };
-    var pipeline_inst = HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var request = Request.init(allocator, .GET, "https://example.com");
     defer request.deinit();
     var operation = try pipeline_inst.open(&request, .{});
@@ -679,10 +688,10 @@ test "RetryPolicy replays only explicitly rewindable streaming bodies" {
         .{ .status = 503, .body = "retry" },
         .{ .status = 200, .body = "ok" },
     });
-    var replay_pipeline = HttpPipeline{
-        .policies = &policies,
-        .transport_impl = replay_sequence.asTransport(),
-    };
+    var replay_pipeline = HttpPipeline.init(
+        testingRuntime(replay_sequence.asTransport()),
+        &policies,
+    );
     var replay_request = Request.init(allocator, .POST, "https://example.com/upload");
     defer replay_request.deinit();
     var replay = transport.ReplayableBytes.init("replayable");
@@ -698,10 +707,10 @@ test "RetryPolicy replays only explicitly rewindable streaming bodies" {
         .{ .status = 503, .body = "retry" },
         .{ .status = 200, .body = "unexpected" },
     });
-    var one_shot_pipeline = HttpPipeline{
-        .policies = &policies,
-        .transport_impl = one_shot_sequence.asTransport(),
-    };
+    var one_shot_pipeline = HttpPipeline.init(
+        testingRuntime(one_shot_sequence.asTransport()),
+        &policies,
+    );
     var one_shot_request = Request.init(allocator, .POST, "https://example.com/upload");
     defer one_shot_request.deinit();
     var source = std.Io.Reader.fixed("one-shot");
@@ -733,19 +742,27 @@ test "RetryPolicy propagates streaming cancellation without retry or rewind" {
     };
 
     const CancellingTransport = struct {
-        transport: HttpTransport = .{ .sendFn = &send, .openFn = &open },
         call_count: usize = 0,
 
-        fn send(_: *HttpTransport, _: *Request) anyerror!Response {
+        const vtable: HttpTransport.VTable = .{
+            .send = &send,
+            .open = &open,
+        };
+
+        fn asTransport(self: *@This()) HttpTransport {
+            return .{ .context = self, .vtable = &vtable };
+        }
+
+        fn send(_: *anyopaque, _: *Request) anyerror!Response {
             return error.UnexpectedBufferedSend;
         }
 
         fn open(
-            transport_impl: *HttpTransport,
+            context: *anyopaque,
             _: *Request,
             options: OpenOptions,
         ) anyerror!*HttpOperation {
-            const self: *@This() = @alignCast(@fieldParentPtr("transport", transport_impl));
+            const self: *@This() = @ptrCast(@alignCast(context));
             self.call_count += 1;
             if (options.body) |body| {
                 var byte: [1]u8 = undefined;
@@ -761,10 +778,7 @@ test "RetryPolicy propagates streaming cancellation without retry or rewind" {
     var retry = RetryPolicy.init();
     retry.initial_delay_ms = 0;
     var policies = [_]*HttpPolicy{retry.asPolicy()};
-    var pipeline_inst = HttpPipeline{
-        .policies = &policies,
-        .transport_impl = &cancelling.transport,
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(cancelling.asTransport()), &policies);
     var request = Request.init(allocator, .POST, "https://example.com/upload");
     defer request.deinit();
     var token = transport.CancellationToken{};
@@ -788,7 +802,7 @@ test "pipeline rejects policies without streaming preparation" {
             _: *HttpPolicy,
             _: *Request,
             _: []*HttpPolicy,
-            _: *HttpTransport,
+            _: HttpRuntime,
         ) anyerror!Response {
             return error.UnexpectedPolicyCall;
         }
@@ -799,10 +813,7 @@ test "pipeline rejects policies without streaming preparation" {
     defer mock.deinit();
     var unsupported = HttpPolicy{ .processFn = &UnsupportedPolicy.process };
     var policies = [_]*HttpPolicy{&unsupported};
-    var pipeline_inst = HttpPipeline{
-        .policies = &policies,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policies);
     var request = Request.init(allocator, .GET, "https://example.com");
     defer request.deinit();
     try std.testing.expectError(
@@ -817,10 +828,7 @@ test "pipeline with no policies" {
     var mock = transport.MockTransport.init(allocator, 404, "not found");
     defer mock.deinit();
     var empty = [_]*HttpPolicy{};
-    var pipeline_inst = HttpPipeline{
-        .policies = &empty,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &empty);
     var req = Request.init(allocator, .GET, "https://example.com/missing");
     defer req.deinit();
     var resp = try pipeline_inst.send(&req);
@@ -835,10 +843,7 @@ test "pipeline with multiple policies" {
     var telemetry = TelemetryPolicy.init("azsdk-zig-test/0.1.0");
     var logging = LoggingPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{ telemetry.asPolicy(), logging.asPolicy() };
-    var pipeline_inst = HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pipeline_inst.send(&req);
@@ -852,10 +857,7 @@ test "RequestIdPolicy injects x-ms-client-request-id" {
     defer mock.deinit();
     var rid = RequestIdPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{rid.asPolicy()};
-    var pipeline_inst = HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pipeline_inst.send(&req);
@@ -872,10 +874,7 @@ test "RequestIdPolicy preserves caller-provided request ID" {
     defer mock.deinit();
     var rid = RequestIdPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{rid.asPolicy()};
-    var pipeline_inst = HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     try req.setHeader("X-MS-Client-Request-Id", "caller-request-id");
@@ -887,6 +886,23 @@ test "RequestIdPolicy preserves caller-provided request ID" {
     );
 }
 
+test "RequestIdPolicy provider failure occurs before transport dispatch" {
+    const allocator = std.testing.allocator;
+    var mock = transport.MockTransport.init(allocator, 200, "unexpected");
+    defer mock.deinit();
+    var failing_crypto = crypto_mod.StdCryptoProvider.init(std.Io.failing);
+    const runtime = HttpRuntime.init(mock.asTransport(), failing_crypto.asProvider());
+    var request_id = RequestIdPolicy.init();
+    var policies = [_]*HttpPolicy{request_id.asPolicy()};
+    var pipeline_inst = HttpPipeline.init(runtime, &policies);
+    var request = Request.init(allocator, .GET, "https://example.com");
+    defer request.deinit();
+
+    try std.testing.expectError(error.EntropyUnavailable, pipeline_inst.send(&request));
+    try std.testing.expect(!request.transport_started);
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+}
+
 test "BearerTokenAuthPolicy injects Authorization header" {
     const allocator = std.testing.allocator;
     const creds = @import("../credentials/token.zig");
@@ -896,6 +912,7 @@ test "BearerTokenAuthPolicy injects Authorization header" {
             _: *creds.TokenCredential,
             _: creds.TokenRequestContext,
             _: @import("../context.zig").Context,
+            _: HttpRuntime,
         ) anyerror!creds.AccessToken {
             const token = try allocator.dupe(u8, "stub-token");
             return .{
@@ -916,10 +933,7 @@ test "BearerTokenAuthPolicy injects Authorization header" {
     );
     defer auth.deinit();
     var policy_ptrs = [_]*HttpPolicy{auth.asPolicy()};
-    var pipeline_inst = HttpPipeline{
-        .policies = &policy_ptrs,
-        .transport_impl = mock.asTransport(),
-    };
+    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pipeline_inst.send(&req);
@@ -933,7 +947,7 @@ test "RetryPolicy passes through 200 without retry" {
     defer mock.deinit();
     var retry = RetryPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = mock.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pip.send(&req);
@@ -971,7 +985,7 @@ test "RetryPolicy passes through 404 without retry" {
     defer mock.deinit();
     var retry = RetryPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = mock.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pip.send(&req);
@@ -989,7 +1003,7 @@ test "RetryPolicy retries 500 then succeeds" {
     var retry = RetryPolicy.init();
     retry.initial_delay_ms = 0;
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(seq.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pip.send(&req);
@@ -1007,7 +1021,7 @@ test "RetryPolicy retries 429 then succeeds" {
     var retry = RetryPolicy.init();
     retry.initial_delay_ms = 0;
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(seq.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pip.send(&req);
@@ -1025,7 +1039,7 @@ test "RetryPolicy bypasses retries for non-retryable requests" {
     var retry = RetryPolicy.init();
     retry.initial_delay_ms = 0;
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(seq.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .POST, "https://example.com/create");
     defer req.deinit();
     req.retryable = false;
@@ -1043,7 +1057,7 @@ test "RetryPolicy zero timeout prevents a retryable send" {
     });
     var retry = RetryPolicy.init();
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(seq.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     req.operation_timeout_ms = 0;
@@ -1061,7 +1075,7 @@ test "RetryPolicy timeout prevents a second attempt" {
     var retry = RetryPolicy.init();
     retry.initial_delay_ms = 100;
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(seq.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     req.operation_timeout_ms = 1;
@@ -1079,7 +1093,7 @@ test "RetryPolicy gives up after max retries" {
     retry.initial_delay_ms = 0;
     retry.max_retries = 2;
     var policy_ptrs = [_]*HttpPolicy{retry.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = seq.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(seq.asTransport()), &policy_ptrs);
     var req = Request.init(allocator, .GET, "https://example.com");
     defer req.deinit();
     var resp = try pip.send(&req);
@@ -1113,7 +1127,7 @@ test "TracingPolicy creates span with attributes" {
 
     var tracing_policy = TracingPolicy.init(rec_tracer.asTracer(), "KeyVault");
     var policy_ptrs = [_]*HttpPolicy{tracing_policy.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = mock.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
 
     var req = Request.init(allocator, .GET, "https://vault.azure.net/secrets/mysecret");
     defer req.deinit();
@@ -1141,7 +1155,7 @@ test "TracingPolicy sets error status on failure" {
 
     var tracing_policy = TracingPolicy.init(rec_tracer.asTracer(), "Storage");
     var policy_ptrs = [_]*HttpPolicy{tracing_policy.asPolicy()};
-    var pip = HttpPipeline{ .policies = &policy_ptrs, .transport_impl = mock.asTransport() };
+    var pip = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
 
     var req = Request.init(allocator, .GET, "https://storage.blob.core.windows.net");
     defer req.deinit();

--- a/http/runtime.zig
+++ b/http/runtime.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const crypto = @import("../crypto.zig");
+const transport = @import("transport.zig");
+
+/// Explicit HTTP dependencies copied into pipelines and passed to policies
+/// and credentials.
+///
+/// Both descriptors are copied by value and borrow their backend contexts.
+/// Those contexts must outlive every pipeline, client, credential call, and
+/// open operation that uses this runtime. `StdHttpTransport` remains
+/// caller-serialized. Crypto provider contexts must be concurrent-safe or
+/// caller-serialized by the application.
+pub const HttpRuntime = struct {
+    transport: transport.HttpTransport,
+    crypto: crypto.CryptoProvider,
+
+    pub fn init(
+        http_transport: transport.HttpTransport,
+        crypto_provider: crypto.CryptoProvider,
+    ) HttpRuntime {
+        return .{
+            .transport = http_transport,
+            .crypto = crypto_provider,
+        };
+    }
+};
+
+test "HttpRuntime copies borrowed descriptors by value" {
+    var mock = transport.MockTransport.init(std.testing.allocator, 200, "ok");
+    defer mock.deinit();
+    var provider = crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = HttpRuntime.init(mock.asTransport(), provider.asProvider());
+    const copied = runtime;
+
+    try std.testing.expectEqual(runtime.transport.context, copied.transport.context);
+    try std.testing.expectEqual(runtime.transport.vtable, copied.transport.vtable);
+    try std.testing.expectEqual(runtime.crypto.context, copied.crypto.context);
+    try std.testing.expectEqual(runtime.crypto.vtable, copied.crypto.vtable);
+}

--- a/http/transport.zig
+++ b/http/transport.zig
@@ -424,26 +424,33 @@ pub const HttpOperation = struct {
     }
 };
 
-/// Pluggable HTTP transport interface.
+/// Copyable borrowed descriptor for a pluggable HTTP transport.
 ///
-/// Default implementation uses `std.http.Client` (TLS via `std.crypto.tls`).
-/// Users may supply their own for testing or custom networking.
-/// Custom implementations must honor `.not_allowed`; this is a security
-/// contract for bootstrap calls.
+/// The descriptor borrows `context`, which must outlive all descriptor copies
+/// and open operations. Implementations must honor `.not_allowed`; this is a
+/// security contract for bootstrap calls. Redirect handling remains
+/// centralized in this descriptor rather than in concrete transports.
+/// Contexts must be concurrent-safe or caller-serialized;
+/// `StdHttpTransport` is caller-serialized.
 pub const HttpTransport = struct {
-    sendFn: *const fn (self: *HttpTransport, request: *Request) anyerror!Response,
-    openFn: ?*const fn (
-        self: *HttpTransport,
-        request: *Request,
-        options: OpenOptions,
-    ) anyerror!*HttpOperation = null,
+    context: *anyopaque,
+    vtable: *const VTable,
 
-    pub fn send(self: *HttpTransport, request: *Request) !Response {
+    pub const VTable = struct {
+        send: *const fn (context: *anyopaque, request: *Request) anyerror!Response,
+        open: ?*const fn (
+            context: *anyopaque,
+            request: *Request,
+            options: OpenOptions,
+        ) anyerror!*HttpOperation = null,
+    };
+
+    pub fn send(self: HttpTransport, request: *Request) !Response {
         return sendFollowingRedirects(self, request);
     }
 
     pub fn open(
-        self: *HttpTransport,
+        self: HttpTransport,
         request: *Request,
         options: OpenOptions,
     ) !*HttpOperation {
@@ -453,7 +460,7 @@ pub const HttpTransport = struct {
 
 const max_redirects = 10;
 
-fn sendFollowingRedirects(transport: *HttpTransport, request: *Request) !Response {
+fn sendFollowingRedirects(transport: HttpTransport, request: *Request) !Response {
     var current = request;
     var owned: ?*OwnedRedirectRequest = null;
     defer if (owned) |value| value.destroy();
@@ -461,7 +468,7 @@ fn sendFollowingRedirects(transport: *HttpTransport, request: *Request) !Respons
     var redirect_count: usize = 0;
     while (true) {
         current.transport_started = true;
-        var response = try transport.sendFn(transport, current);
+        var response = try transport.vtable.send(transport.context, current);
         const action = redirectAction(
             response.status_code,
             current.method,
@@ -498,7 +505,7 @@ fn sendFollowingRedirects(transport: *HttpTransport, request: *Request) !Respons
 }
 
 fn openFollowingRedirects(
-    transport: *HttpTransport,
+    transport: HttpTransport,
     request: *Request,
     options: OpenOptions,
 ) !*HttpOperation {
@@ -566,14 +573,14 @@ fn openFollowingRedirects(
 }
 
 fn rawOpen(
-    transport: *HttpTransport,
+    transport: HttpTransport,
     request: *Request,
     options: OpenOptions,
 ) !*HttpOperation {
     try checkCancelled(options.cancellation);
-    if (transport.openFn) |openFn| {
+    if (transport.vtable.open) |openFn| {
         request.transport_started = true;
-        return openFn(transport, request, options);
+        return openFn(transport.context, request, options);
     }
     if (options.body != null) return error.StreamingRequestUnsupported;
     request.transport_started = true;
@@ -689,8 +696,8 @@ const BufferedOperation = struct {
     response: Response,
     reader_impl: std.Io.Reader,
 
-    fn openRaw(transport: *HttpTransport, request: *Request) !*HttpOperation {
-        return fromResponse(try transport.sendFn(transport, request));
+    fn openRaw(transport: HttpTransport, request: *Request) !*HttpOperation {
+        return fromResponse(try transport.vtable.send(transport.context, request));
     }
 
     fn fromResponse(response_value: Response) !*HttpOperation {
@@ -752,11 +759,14 @@ pub const StdHttpTransport = struct {
     /// in one response, or set `.unlimited` to remove the ceiling. Only
     /// applies to `send`; a streaming operation reads at the caller's pace.
     max_response_body: std.Io.Limit = .limited(default_max_response_body),
-    transport: HttpTransport,
-
     /// Chosen to hold the largest responses seen in practice while still
     /// failing fast on a stream that never ends.
     pub const default_max_response_body = 64 * 1024 * 1024;
+
+    const vtable: HttpTransport.VTable = .{
+        .send = &sendImpl,
+        .open = &openImpl,
+    };
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io) StdHttpTransport {
         return initWithClient(allocator, .{ .allocator = allocator, .io = io });
@@ -771,12 +781,11 @@ pub const StdHttpTransport = struct {
         return .{
             .allocator = allocator,
             .client = client,
-            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
 
-    pub fn asTransport(self: *StdHttpTransport) *HttpTransport {
-        return &self.transport;
+    pub fn asTransport(self: *StdHttpTransport) HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     pub fn deinit(self: *StdHttpTransport) void {
@@ -799,8 +808,8 @@ pub const StdHttpTransport = struct {
         return shared;
     }
 
-    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(context: *anyopaque, request: *Request) !Response {
+        const self: *StdHttpTransport = @ptrCast(@alignCast(context));
         const allocator = self.allocator;
 
         var operation = try StdStreamingOperation.open(
@@ -837,11 +846,11 @@ pub const StdHttpTransport = struct {
     }
 
     fn openImpl(
-        transport: *HttpTransport,
+        context: *anyopaque,
         request: *Request,
         options: OpenOptions,
     ) !*HttpOperation {
-        const self: *StdHttpTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *StdHttpTransport = @ptrCast(@alignCast(context));
         return StdStreamingOperation.open(try self.sharedClient(), request, options);
     }
 };
@@ -1245,7 +1254,6 @@ pub const MockTransport = struct {
     response_status: u16,
     response_body: []const u8,
     allocator: std.mem.Allocator,
-    transport: HttpTransport,
     last_method: ?Method = null,
     last_url: ?[]u8 = null,
     last_headers: std.StringHashMap([]const u8),
@@ -1264,12 +1272,16 @@ pub const MockTransport = struct {
     stream_cancel_count: usize = 0,
     stream_deinit_count: usize = 0,
 
+    const vtable: HttpTransport.VTable = .{
+        .send = &sendImpl,
+        .open = &openImpl,
+    };
+
     pub fn init(allocator: std.mem.Allocator, status: u16, body: []const u8) MockTransport {
         return .{
             .response_status = status,
             .response_body = body,
             .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
             .last_method = null,
             .last_url = null,
             .last_headers = std.StringHashMap([]const u8).init(allocator),
@@ -1278,8 +1290,8 @@ pub const MockTransport = struct {
         };
     }
 
-    pub fn asTransport(self: *MockTransport) *HttpTransport {
-        return &self.transport;
+    pub fn asTransport(self: *MockTransport) HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     pub fn deinit(self: *MockTransport) void {
@@ -1288,8 +1300,8 @@ pub const MockTransport = struct {
         deinitOwnedHeaders(self.allocator, &self.last_headers);
     }
 
-    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *MockTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(context: *anyopaque, request: *Request) !Response {
+        const self: *MockTransport = @ptrCast(@alignCast(context));
         try self.captureRequest(request, request.body);
 
         const response_body_copy = try self.allocator.dupe(u8, self.response_body);
@@ -1306,11 +1318,11 @@ pub const MockTransport = struct {
     }
 
     fn openImpl(
-        transport: *HttpTransport,
+        context: *anyopaque,
         request: *Request,
         options: OpenOptions,
     ) !*HttpOperation {
-        const self: *MockTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *MockTransport = @ptrCast(@alignCast(context));
         if (options.body != null and request.body != null) return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
         const framing = requestBodyFraming(request, options);
@@ -1611,7 +1623,6 @@ pub const SequenceMockTransport = struct {
     responses: []const CannedResponse,
     call_count: usize = 0,
     allocator: std.mem.Allocator,
-    transport: HttpTransport,
     captured_methods: [16]?Method = .{null} ** 16,
     captured_authorization: [16]bool = .{false} ** 16,
     captured_cookie: [16]bool = .{false} ** 16,
@@ -1627,30 +1638,34 @@ pub const SequenceMockTransport = struct {
     captured_bodies: [16][512]u8 = undefined,
     cancel_after_open: ?*CancellationToken = null,
 
+    const vtable: HttpTransport.VTable = .{
+        .send = &sendImpl,
+        .open = &openImpl,
+    };
+
     pub fn init(allocator: std.mem.Allocator, responses: []const CannedResponse) SequenceMockTransport {
         return .{
             .responses = responses,
             .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
 
-    pub fn asTransport(self: *SequenceMockTransport) *HttpTransport {
-        return &self.transport;
+    pub fn asTransport(self: *SequenceMockTransport) HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
-    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *SequenceMockTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(context: *anyopaque, request: *Request) !Response {
+        const self: *SequenceMockTransport = @ptrCast(@alignCast(context));
         const idx = try self.capture(request, request.body);
         return self.response(idx);
     }
 
     fn openImpl(
-        transport: *HttpTransport,
+        context: *anyopaque,
         request: *Request,
         options: OpenOptions,
     ) !*HttpOperation {
-        const self: *SequenceMockTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *SequenceMockTransport = @ptrCast(@alignCast(context));
         if (options.body != null and request.body != null) return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
         const framing = requestBodyFraming(request, options);
@@ -1785,14 +1800,15 @@ test "streaming preflight failures do not mark transport as started" {
     const allocator = std.testing.allocator;
     var mock = MockTransport.init(allocator, 200, "ok");
     defer mock.deinit();
-    mock.transport.openFn = null;
+    const send_only_vtable: HttpTransport.VTable = .{ .send = &MockTransport.sendImpl };
+    const send_only = HttpTransport{ .context = &mock, .vtable = &send_only_vtable };
 
     var unsupported_request = Request.init(allocator, .POST, "https://example.com/upload");
     defer unsupported_request.deinit();
     var source = std.Io.Reader.fixed("body");
     try std.testing.expectError(
         error.StreamingRequestUnsupported,
-        mock.asTransport().open(&unsupported_request, .{
+        send_only.open(&unsupported_request, .{
             .body = StreamingRequestBody.knownLength(&source, 4),
         }),
     );
@@ -1808,6 +1824,26 @@ test "streaming preflight failures do not mark transport as started" {
     );
     try std.testing.expect(!cancelled_request.transport_started);
     try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+}
+
+test "HttpTransport descriptors copy and retain centralized redirects" {
+    const allocator = std.testing.allocator;
+    var sequence = SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "/next" }},
+        },
+        .{ .status = 200, .body = "ok" },
+    });
+    const first = sequence.asTransport();
+    const copied = first;
+    var request = Request.init(allocator, .GET, "https://example.com/start");
+    defer request.deinit();
+    var response = try copied.send(&request);
+    defer response.deinit();
+    try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
+    try std.testing.expectEqualStrings("https://example.com/next", sequence.capturedUrl(1));
 }
 
 test "response isSuccess" {

--- a/http/wasi_http.zig
+++ b/http/wasi_http.zig
@@ -14,7 +14,7 @@
 //! wired up and returns `error.RequestBodyUnsupported`.
 //!
 //! Compiles only on `wasm32-wasi`. Callers should reach this through the
-//! target-guarded `azure_sdk_core.wasi_http` re-export in `root.zig`.
+//! target-guarded `azure_sdk_core.http.wasi` re-export.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -22,7 +22,7 @@ const transport = @import("transport.zig");
 
 comptime {
     if (!(builtin.target.cpu.arch == .wasm32 and builtin.target.os.tag == .wasi))
-        @compileError("azure_sdk_core.wasi_http is only supported on wasm32-wasi");
+        @compileError("azure_sdk_core.http.wasi is only supported on wasm32-wasi");
 }
 
 // ── Canonical-ABI lowered host imports ─────────────────────────────────
@@ -108,14 +108,15 @@ inline fn retClear() void {
 
 pub const WasiHttpTransport = struct {
     allocator: std.mem.Allocator,
-    transport: transport.HttpTransport,
+
+    const vtable: transport.HttpTransport.VTable = .{ .send = &sendImpl };
 
     pub fn init(allocator: std.mem.Allocator) WasiHttpTransport {
-        return .{ .allocator = allocator, .transport = .{ .sendFn = &sendImpl } };
+        return .{ .allocator = allocator };
     }
 
-    pub fn asTransport(self: *WasiHttpTransport) *transport.HttpTransport {
-        return &self.transport;
+    pub fn asTransport(self: *WasiHttpTransport) transport.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn methodDisc(m: transport.Method) i32 {
@@ -130,8 +131,8 @@ pub const WasiHttpTransport = struct {
         };
     }
 
-    fn sendImpl(t: *transport.HttpTransport, request: *transport.Request) anyerror!transport.Response {
-        const self: *WasiHttpTransport = @fieldParentPtr("transport", t);
+    fn sendImpl(context: *anyopaque, request: *transport.Request) anyerror!transport.Response {
+        const self: *WasiHttpTransport = @ptrCast(@alignCast(context));
         const allocator = self.allocator;
 
         if (request.body != null) return error.RequestBodyUnsupported;

--- a/identity/azure_cli.zig
+++ b/identity/azure_cli.zig
@@ -33,6 +33,7 @@ pub const AzureCliCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         _: Context,
+        _: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *AzureCliCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;

--- a/identity/azure_developer_cli.zig
+++ b/identity/azure_developer_cli.zig
@@ -33,6 +33,7 @@ pub const AzureDeveloperCliCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         _: Context,
+        _: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *AzureDeveloperCliCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;

--- a/identity/azure_pipelines.zig
+++ b/identity/azure_pipelines.zig
@@ -21,14 +21,12 @@ pub const AzurePipelinesCredential = struct {
     client_id: []const u8,
     service_connection_id: []const u8,
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
     credential: TokenCredential,
     oidc_request_uri: ?[]const u8,
     system_access_token: ?[]const u8,
 
     pub fn init(
         allocator: std.mem.Allocator,
-        transport: *core.http.HttpTransport,
         tenant_id: []const u8,
         client_id: []const u8,
         service_connection_id: []const u8,
@@ -38,7 +36,6 @@ pub const AzurePipelinesCredential = struct {
             .client_id = client_id,
             .service_connection_id = service_connection_id,
             .allocator = allocator,
-            .transport = transport,
             .credential = .{ .getTokenFn = &getTokenImpl },
             .oidc_request_uri = std.process.getEnvVarOwned(allocator, "SYSTEM_OIDCREQUESTURI") catch null,
             .system_access_token = std.process.getEnvVarOwned(allocator, "SYSTEM_ACCESSTOKEN") catch null,
@@ -58,6 +55,7 @@ pub const AzurePipelinesCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         ctx: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *AzurePipelinesCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;
@@ -82,7 +80,7 @@ pub const AzurePipelinesCredential = struct {
         try req.setHeader("Authorization", auth_header);
         req.body = "{}";
 
-        var resp = try self.transport.send(&req);
+        var resp = try runtime.transport.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) return error.OidcTokenRequestFailed;
@@ -105,13 +103,12 @@ pub const AzurePipelinesCredential = struct {
 
         var assertion_cred = client_assertion.ClientAssertionCredential.init(
             allocator,
-            self.transport,
             self.tenant_id,
             self.client_id,
             &getAssertion.call,
         );
 
-        return assertion_cred.asCredential().getToken(request_context, ctx);
+        return assertion_cred.asCredential().getToken(request_context, ctx, runtime);
     }
 };
 

--- a/identity/azure_pipelines.zig
+++ b/identity/azure_pipelines.zig
@@ -76,6 +76,7 @@ pub const AzurePipelinesCredential = struct {
 
         var req = core.http.Request.init(allocator, .POST, oidc_url);
         defer req.deinit();
+        req.redirect_policy = .not_allowed;
         try req.setHeader("Content-Type", "application/json");
         try req.setHeader("Authorization", auth_header);
         req.body = "{}";

--- a/identity/client_assertion.zig
+++ b/identity/client_assertion.zig
@@ -7,6 +7,12 @@ const TokenCredential = core.credentials.TokenCredential;
 const TokenRequestContext = core.credentials.TokenRequestContext;
 const Context = core.context.Context;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
+
 /// Callback type that returns a JWT assertion string.
 /// The caller owns the returned memory and must free it.
 pub const AssertionCallback = *const fn (allocator: std.mem.Allocator) anyerror![]u8;
@@ -27,13 +33,11 @@ pub const ClientAssertionCredential = struct {
     client_id: []const u8,
     authority_host: []const u8 = "https://login.microsoftonline.com",
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
     credential: TokenCredential,
     get_assertion: AssertionCallback,
 
     pub fn init(
         allocator: std.mem.Allocator,
-        transport: *core.http.HttpTransport,
         tenant_id: []const u8,
         client_id: []const u8,
         get_assertion: AssertionCallback,
@@ -42,7 +46,6 @@ pub const ClientAssertionCredential = struct {
             .tenant_id = tenant_id,
             .client_id = client_id,
             .allocator = allocator,
-            .transport = transport,
             .credential = .{ .getTokenFn = &getTokenImpl },
             .get_assertion = get_assertion,
         };
@@ -56,6 +59,7 @@ pub const ClientAssertionCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         _: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *ClientAssertionCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;
@@ -97,7 +101,7 @@ pub const ClientAssertionCredential = struct {
         try req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.body = body;
 
-        var resp = try self.transport.send(&req);
+        var resp = try runtime.transport.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) return error.AuthenticationFailed;
@@ -147,7 +151,6 @@ test "ClientAssertionCredential getToken" {
 
     var cred = ClientAssertionCredential.init(
         allocator,
-        mock.asTransport(),
         "tenant-1",
         "client-1",
         &getAssertion,
@@ -156,6 +159,7 @@ test "ClientAssertionCredential getToken" {
     const token = try cred.asCredential().getToken(
         .{ .scopes = &.{"https://vault.azure.net/.default"} },
         core.context.Context.none,
+        testingRuntime(mock.asTransport()),
     );
     defer allocator.free(token.token);
 

--- a/identity/client_assertion.zig
+++ b/identity/client_assertion.zig
@@ -98,6 +98,7 @@ pub const ClientAssertionCredential = struct {
 
         var req = core.http.Request.init(allocator, .POST, url);
         defer req.deinit();
+        req.redirect_policy = .not_allowed;
         try req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.body = body;
 
@@ -167,4 +168,49 @@ test "ClientAssertionCredential getToken" {
     // Verify the request was sent to the correct token endpoint.
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "tenant-1/oauth2/v2.0/token") != null);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
+}
+
+test "ClientAssertionCredential does not replay assertion across 308 redirect" {
+    const allocator = std.testing.allocator;
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 308,
+            .body = "",
+            .headers = &.{.{
+                .name = "Location",
+                .value = "https://attacker.example/token",
+            }},
+        },
+        .{
+            .status = 200,
+            .body = "{\"access_token\":\"stolen\",\"expires_in\":3600}",
+        },
+    });
+    const getAssertion = struct {
+        fn call(alloc: std.mem.Allocator) anyerror![]u8 {
+            return alloc.dupe(u8, "signed-assertion");
+        }
+    }.call;
+    var credential = ClientAssertionCredential.init(
+        allocator,
+        "tenant",
+        "client",
+        &getAssertion,
+    );
+
+    try std.testing.expectError(
+        error.AuthenticationFailed,
+        credential.asCredential().getToken(
+            .{ .scopes = &.{"https://vault.azure.net/.default"} },
+            Context.none,
+            testingRuntime(sequence.asTransport()),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), sequence.call_count);
+    try std.testing.expect(std.mem.find(
+        u8,
+        sequence.capturedBody(0),
+        "client_assertion=signed-assertion",
+    ) != null);
 }

--- a/identity/client_certificate.zig
+++ b/identity/client_certificate.zig
@@ -23,12 +23,10 @@ pub const ClientCertificateCredential = struct {
     certificate_path: []const u8,
     authority_host: []const u8 = "https://login.microsoftonline.com",
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
     credential: TokenCredential,
 
     pub fn init(
         allocator: std.mem.Allocator,
-        transport: *core.http.HttpTransport,
         tenant_id: []const u8,
         client_id: []const u8,
         certificate_path: []const u8,
@@ -38,7 +36,6 @@ pub const ClientCertificateCredential = struct {
             .client_id = client_id,
             .certificate_path = certificate_path,
             .allocator = allocator,
-            .transport = transport,
             .credential = .{ .getTokenFn = &getTokenImpl },
         };
     }
@@ -51,6 +48,7 @@ pub const ClientCertificateCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         ctx: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *ClientCertificateCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;
@@ -90,14 +88,13 @@ pub const ClientCertificateCredential = struct {
 
         var assertion_cred = client_assertion.ClientAssertionCredential.init(
             allocator,
-            self.transport,
             self.tenant_id,
             self.client_id,
             &StaticAssertion.getAssertion,
         );
         assertion_cred.authority_host = self.authority_host;
 
-        return assertion_cred.asCredential().getToken(request_context, ctx);
+        return assertion_cred.asCredential().getToken(request_context, ctx, runtime);
     }
 };
 
@@ -131,12 +128,9 @@ fn buildCertificateAssertion(
 
 test "ClientCertificateCredential fields" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
 
     const cred = ClientCertificateCredential.init(
         allocator,
-        mock.asTransport(),
         "tenant-1",
         "client-1",
         "/path/to/cert.pem",

--- a/identity/client_secret.zig
+++ b/identity/client_secret.zig
@@ -7,6 +7,12 @@ const TokenCredential = core.credentials.TokenCredential;
 const TokenRequestContext = core.credentials.TokenRequestContext;
 const Context = core.context.Context;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
+
 /// Authenticates a service principal with a client secret (OAuth 2.0 client_credentials).
 ///
 /// POST `{authority}/{tenant_id}/oauth2/v2.0/token`
@@ -17,12 +23,10 @@ pub const ClientSecretCredential = struct {
     client_secret: []const u8,
     authority_host: []const u8 = "https://login.microsoftonline.com",
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
     credential: TokenCredential,
 
     pub fn init(
         allocator: std.mem.Allocator,
-        transport: *core.http.HttpTransport,
         tenant_id: []const u8,
         client_id: []const u8,
         client_secret: []const u8,
@@ -32,7 +36,6 @@ pub const ClientSecretCredential = struct {
             .client_id = client_id,
             .client_secret = client_secret,
             .allocator = allocator,
-            .transport = transport,
             .credential = .{ .getTokenFn = &getTokenImpl },
         };
     }
@@ -45,6 +48,7 @@ pub const ClientSecretCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         _: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *ClientSecretCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;
@@ -84,7 +88,7 @@ pub const ClientSecretCredential = struct {
         try req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.body = body;
 
-        var resp = try self.transport.send(&req);
+        var resp = try runtime.transport.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -198,7 +202,6 @@ test "ClientSecretCredential init" {
     defer mock.deinit();
     var cred = ClientSecretCredential.init(
         allocator,
-        mock.asTransport(),
         "tenant-123",
         "client-456",
         "secret-789",
@@ -207,6 +210,7 @@ test "ClientSecretCredential init" {
     const token = try cred.asCredential().getToken(
         .{ .scopes = &.{"https://vault.azure.net/.default"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     const after = currentTimestamp();
     defer allocator.free(token.token);
@@ -224,7 +228,6 @@ test "ClientSecretCredential auth failure" {
     defer mock.deinit();
     var cred = ClientSecretCredential.init(
         allocator,
-        mock.asTransport(),
         "tenant-123",
         "client-456",
         "bad-secret",
@@ -232,6 +235,7 @@ test "ClientSecretCredential auth failure" {
     const result = cred.asCredential().getToken(
         .{ .scopes = &.{"https://vault.azure.net/.default"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     try std.testing.expectError(error.AuthenticationFailed, result);
 }
@@ -244,7 +248,6 @@ test "ClientSecretCredential form-encodes dynamic fields" {
     defer mock.deinit();
     var credential = ClientSecretCredential.init(
         allocator,
-        mock.asTransport(),
         "tenant",
         "client&id",
         "secret+=&%",
@@ -252,6 +255,7 @@ test "ClientSecretCredential form-encodes dynamic fields" {
     var token = try credential.asCredential().getToken(
         .{ .scopes = &.{"scope one"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     defer token.deinit();
     try std.testing.expectEqualStrings(

--- a/identity/client_secret.zig
+++ b/identity/client_secret.zig
@@ -85,6 +85,7 @@ pub const ClientSecretCredential = struct {
 
         var req = core.http.Request.init(allocator, .POST, url);
         defer req.deinit();
+        req.redirect_policy = .not_allowed;
         try req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.body = body;
 
@@ -218,6 +219,7 @@ test "ClientSecretCredential init" {
     try std.testing.expect(token.expires_on >= before + 3600);
     try std.testing.expect(token.expires_on <= after + 3600);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
 }
 
 test "ClientSecretCredential auth failure" {
@@ -262,6 +264,45 @@ test "ClientSecretCredential form-encodes dynamic fields" {
         "grant_type=client_credentials&client_id=client%26id&client_secret=secret%2B%3D%26%25&scope=scope%20one",
         mock.last_body.?,
     );
+}
+
+test "ClientSecretCredential does not replay secret body across 307 redirect" {
+    const allocator = std.testing.allocator;
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{
+                .name = "Location",
+                .value = "https://attacker.example/token",
+            }},
+        },
+        .{
+            .status = 200,
+            .body = "{\"access_token\":\"stolen\",\"expires_in\":3600}",
+        },
+    });
+    var credential = ClientSecretCredential.init(
+        allocator,
+        "tenant",
+        "client",
+        "super-secret",
+    );
+
+    try std.testing.expectError(
+        error.AuthenticationFailed,
+        credential.asCredential().getToken(
+            .{ .scopes = &.{"https://vault.azure.net/.default"} },
+            Context.none,
+            testingRuntime(sequence.asTransport()),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), sequence.call_count);
+    try std.testing.expect(std.mem.find(
+        u8,
+        sequence.capturedBody(0),
+        "client_secret=super-secret",
+    ) != null);
 }
 
 test "parseTokenResponse malformed JSON" {

--- a/identity/default_azure_credential.zig
+++ b/identity/default_azure_credential.zig
@@ -6,6 +6,12 @@ const TokenCredential = core.credentials.TokenCredential;
 const TokenRequestContext = core.credentials.TokenRequestContext;
 const Context = core.context.Context;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
+
 fn envGet(env: anytype, key: []const u8) ?[]const u8 {
     return env.get(key);
 }
@@ -35,11 +41,12 @@ pub const ChainedTokenCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         ctx: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *ChainedTokenCredential = @fieldParentPtr("credential", cred);
         var last_err: anyerror = error.NoCredentialSucceeded;
         for (self.sources) |source| {
-            const result = source.cred.getToken(request_context, ctx);
+            const result = source.cred.getToken(request_context, ctx, runtime);
             if (result) |token| return token else |err| {
                 last_err = err;
                 std.log.debug("azure-identity: {s} failed: {}", .{ source.name, err });
@@ -169,13 +176,11 @@ pub const DefaultAzureCredential = struct {
     pub fn init(
         allocator: std.mem.Allocator,
         io: std.Io,
-        transport: *core.http.HttpTransport,
         env: anytype,
     ) !DefaultAzureCredential {
         return initWithSelection(
             allocator,
             io,
-            transport,
             env,
             try TokenCredentialSelection.fromEnv(env),
         );
@@ -186,7 +191,6 @@ pub const DefaultAzureCredential = struct {
     pub fn initWithSelection(
         allocator: std.mem.Allocator,
         io: std.Io,
-        transport: *core.http.HttpTransport,
         env: anytype,
         requested: TokenCredentialSelection,
     ) !DefaultAzureCredential {
@@ -194,7 +198,7 @@ pub const DefaultAzureCredential = struct {
         state.* = .{
             .chain = undefined,
             .selection = requested,
-            .mi_cred = @import("managed_identity.zig").ManagedIdentityCredential.init(allocator, transport),
+            .mi_cred = @import("managed_identity.zig").ManagedIdentityCredential.init(allocator),
             .cli_cred = @import("azure_cli.zig").AzureCliCredential.init(allocator, io),
             .azd_cred = @import("azure_developer_cli.zig").AzureDeveloperCliCredential.init(allocator, io),
         };
@@ -216,7 +220,6 @@ pub const DefaultAzureCredential = struct {
         if (requested.includes(.environment)) {
             state.env_cred = @import("environment.zig").EnvironmentCredential.init(
                 allocator,
-                transport,
                 env,
             ) catch |err| switch (err) {
                 error.EnvironmentNotConfigured => null,
@@ -232,7 +235,6 @@ pub const DefaultAzureCredential = struct {
             if (wi_tenant != null and wi_client != null and wi_file != null) {
                 state.wi_cred = try @import("workload_identity.zig").WorkloadIdentityCredential.init(
                     allocator,
-                    transport,
                     wi_tenant.?,
                     wi_client.?,
                     wi_file.?,
@@ -333,18 +335,16 @@ fn expectChain(
 
 test "ChainedTokenCredential uses first success" {
     const allocator = std.testing.allocator;
-    var mock_fail = core.http.MockTransport.init(allocator, 401, "fail");
-    defer mock_fail.deinit();
-    var mock_ok = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"chained-ok","expires_in":3600}
-    );
-    defer mock_ok.deinit();
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 401, .body = "fail" },
+        .{ .status = 200, .body = "{\"access_token\":\"chained-ok\",\"expires_in\":3600}" },
+    });
 
     const client_secret = @import("client_secret.zig");
     // First credential will fail (401).
-    var cred1 = client_secret.ClientSecretCredential.init(allocator, mock_fail.asTransport(), "t", "c", "s");
+    var cred1 = client_secret.ClientSecretCredential.init(allocator, "t", "c", "s");
     // Second will succeed.
-    var cred2 = client_secret.ClientSecretCredential.init(allocator, mock_ok.asTransport(), "t", "c", "s");
+    var cred2 = client_secret.ClientSecretCredential.init(allocator, "t", "c", "s");
 
     var sources = [_]ChainedTokenCredential.Source{
         .{ .name = "fail", .cred = cred1.asCredential() },
@@ -354,6 +354,7 @@ test "ChainedTokenCredential uses first success" {
     const token = try chain.asCredential().getToken(
         .{ .scopes = &.{"https://vault.azure.net/.default"} },
         Context.none,
+        testingRuntime(sequence.asTransport()),
     );
     defer allocator.free(token.token);
     try std.testing.expectEqualStrings("chained-ok", token.token);
@@ -371,21 +372,16 @@ test "DefaultAzureCredential remains valid after return and move" {
     try env.put("AZURE_TOKEN_CREDENTIALS", "ManagedIdentityCredential");
 
     const Factory = struct {
-        fn create(
-            alloc: std.mem.Allocator,
-            transport: *core.http.HttpTransport,
-            test_env: TestEnv,
-        ) !DefaultAzureCredential {
+        fn create(alloc: std.mem.Allocator, test_env: TestEnv) !DefaultAzureCredential {
             return DefaultAzureCredential.init(
                 alloc,
                 std.testing.io,
-                transport,
                 test_env,
             );
         }
     };
 
-    var returned = try Factory.create(allocator, mock.asTransport(), env);
+    var returned = try Factory.create(allocator, env);
     var moved = returned;
     returned = undefined;
     defer moved.deinit();
@@ -393,6 +389,7 @@ test "DefaultAzureCredential remains valid after return and move" {
     const token = try moved.asCredential().getToken(
         .{ .scopes = &.{"https://vault.azure.net/.default"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     defer allocator.free(token.token);
     try std.testing.expectEqualStrings("managed-identity-token", token.token);
@@ -418,7 +415,6 @@ test "DefaultAzureCredential owns environment credential values" {
     var credential = try DefaultAzureCredential.init(
         allocator,
         std.testing.io,
-        mock.asTransport(),
         env,
     );
     defer credential.deinit();
@@ -433,6 +429,7 @@ test "DefaultAzureCredential owns environment credential values" {
     const token = try credential.asCredential().getToken(
         .{ .scopes = &.{"https://vault.azure.net/.default"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     defer allocator.free(token.token);
     try std.testing.expectEqualStrings("environment-token", token.token);
@@ -461,8 +458,6 @@ test "TokenCredentialSelection parses AZURE_TOKEN_CREDENTIALS values" {
 
 test "DefaultAzureCredential omits managed identity by default" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
 
     var env = TestEnv.init(allocator);
     defer env.deinit();
@@ -470,7 +465,6 @@ test "DefaultAzureCredential omits managed identity by default" {
     var credential = try DefaultAzureCredential.init(
         allocator,
         std.testing.io,
-        mock.asTransport(),
         env,
     );
     defer credential.deinit();
@@ -482,8 +476,6 @@ test "DefaultAzureCredential omits managed identity by default" {
 
 test "DefaultAzureCredential prod selection enables managed identity" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
 
     var env = TestEnv.init(allocator);
     defer env.deinit();
@@ -496,7 +488,6 @@ test "DefaultAzureCredential prod selection enables managed identity" {
     var credential = try DefaultAzureCredential.init(
         allocator,
         std.testing.io,
-        mock.asTransport(),
         env,
     );
     defer credential.deinit();
@@ -511,8 +502,6 @@ test "DefaultAzureCredential prod selection enables managed identity" {
 
 test "DefaultAzureCredential dev selection uses developer tools only" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
 
     var env = TestEnv.init(allocator);
     defer env.deinit();
@@ -524,7 +513,6 @@ test "DefaultAzureCredential dev selection uses developer tools only" {
     var credential = try DefaultAzureCredential.init(
         allocator,
         std.testing.io,
-        mock.asTransport(),
         env,
     );
     defer credential.deinit();
@@ -534,8 +522,6 @@ test "DefaultAzureCredential dev selection uses developer tools only" {
 
 test "DefaultAzureCredential honors a named credential" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
 
     var env = TestEnv.init(allocator);
     defer env.deinit();
@@ -547,7 +533,6 @@ test "DefaultAzureCredential honors a named credential" {
     var credential = try DefaultAzureCredential.init(
         allocator,
         std.testing.io,
-        mock.asTransport(),
         env,
     );
     defer credential.deinit();
@@ -557,8 +542,6 @@ test "DefaultAzureCredential honors a named credential" {
 
 test "DefaultAzureCredential rejects an unknown selection" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
 
     var env = TestEnv.init(allocator);
     defer env.deinit();
@@ -567,15 +550,12 @@ test "DefaultAzureCredential rejects an unknown selection" {
     try std.testing.expectError(error.UnknownTokenCredentialSelection, DefaultAzureCredential.init(
         allocator,
         std.testing.io,
-        mock.asTransport(),
         env,
     ));
 }
 
 test "DefaultAzureCredential rejects a selection with no configured credential" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
 
     var env = TestEnv.init(allocator);
     defer env.deinit();
@@ -584,7 +564,6 @@ test "DefaultAzureCredential rejects a selection with no configured credential" 
     try std.testing.expectError(error.NoCredentialConfigured, DefaultAzureCredential.init(
         allocator,
         std.testing.io,
-        mock.asTransport(),
         env,
     ));
 }

--- a/identity/environment.zig
+++ b/identity/environment.zig
@@ -6,6 +6,12 @@ const TokenCredential = core.credentials.TokenCredential;
 const TokenRequestContext = core.credentials.TokenRequestContext;
 const Context = core.context.Context;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
+
 /// Authenticates using environment variables.
 ///
 /// Requires `AZURE_TENANT_ID` + `AZURE_CLIENT_ID`, then one of:
@@ -15,7 +21,6 @@ const Context = core.context.Context;
 /// Optional: `AZURE_AUTHORITY_HOST` overrides the AAD endpoint.
 pub const EnvironmentCredential = struct {
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
     credential: TokenCredential,
 
     // Captured from env at init time.
@@ -28,7 +33,6 @@ pub const EnvironmentCredential = struct {
     /// if the required vars are missing.
     pub fn init(
         allocator: std.mem.Allocator,
-        transport: *core.http.HttpTransport,
         env: anytype,
     ) !EnvironmentCredential {
         const tenant_source = envGet(env, "AZURE_TENANT_ID") orelse return error.EnvironmentNotConfigured;
@@ -49,7 +53,6 @@ pub const EnvironmentCredential = struct {
 
         return .{
             .allocator = allocator,
-            .transport = transport,
             .credential = .{ .getTokenFn = &getTokenImpl },
             .tenant_id = tenant_id,
             .client_id = client_id,
@@ -74,19 +77,19 @@ pub const EnvironmentCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         ctx: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *EnvironmentCredential = @fieldParentPtr("credential", cred);
         // Delegate to ClientSecretCredential.
         const client_secret_mod = @import("client_secret.zig");
         var inner = client_secret_mod.ClientSecretCredential.init(
             self.allocator,
-            self.transport,
             self.tenant_id,
             self.client_id,
             self.client_secret,
         );
         inner.authority_host = self.authority_host;
-        return inner.asCredential().getToken(request_context, ctx);
+        return inner.asCredential().getToken(request_context, ctx, runtime);
     }
 };
 
@@ -121,7 +124,7 @@ test "EnvironmentCredential missing vars" {
     var env = TestEnv.init(allocator);
     defer env.deinit();
     // No vars set → should fail.
-    const result = EnvironmentCredential.init(allocator, mock.asTransport(), env);
+    const result = EnvironmentCredential.init(allocator, env);
     try std.testing.expectError(error.EnvironmentNotConfigured, result);
 }
 
@@ -137,11 +140,12 @@ test "EnvironmentCredential with secret" {
     try env.put("AZURE_CLIENT_ID", "c");
     try env.put("AZURE_CLIENT_SECRET", "s");
 
-    var cred = try EnvironmentCredential.init(allocator, mock.asTransport(), env);
+    var cred = try EnvironmentCredential.init(allocator, env);
     defer cred.deinit();
     const token = try cred.asCredential().getToken(
         .{ .scopes = &.{"https://management.azure.com/.default"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     defer allocator.free(token.token);
     try std.testing.expectEqualStrings("env-token", token.token);

--- a/identity/managed_identity.zig
+++ b/identity/managed_identity.zig
@@ -6,6 +6,12 @@ const TokenCredential = core.credentials.TokenCredential;
 const TokenRequestContext = core.credentials.TokenRequestContext;
 const Context = core.context.Context;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
+
 /// Authenticates using the Azure Instance Metadata Service (IMDS).
 ///
 /// GET `http://169.254.169.254/metadata/identity/oauth2/token`
@@ -13,18 +19,13 @@ const Context = core.context.Context;
 ///   Header: `Metadata: true`
 pub const ManagedIdentityCredential = struct {
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
     credential: TokenCredential,
     client_id: ?[]const u8 = null,
     endpoint: []const u8 = "http://169.254.169.254/metadata/identity/oauth2/token",
 
-    pub fn init(
-        allocator: std.mem.Allocator,
-        transport: *core.http.HttpTransport,
-    ) ManagedIdentityCredential {
+    pub fn init(allocator: std.mem.Allocator) ManagedIdentityCredential {
         return .{
             .allocator = allocator,
-            .transport = transport,
             .credential = .{ .getTokenFn = &getTokenImpl },
         };
     }
@@ -41,6 +42,7 @@ pub const ManagedIdentityCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         _: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *ManagedIdentityCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;
@@ -74,7 +76,7 @@ pub const ManagedIdentityCredential = struct {
         defer req.deinit();
         try req.setHeader("Metadata", "true");
 
-        var resp = try self.transport.send(&req);
+        var resp = try runtime.transport.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -121,10 +123,11 @@ test "ManagedIdentityCredential" {
         \\{"access_token":"msi-token","expires_in":"86400","expires_on":"1743523200"}
     );
     defer mock.deinit();
-    var cred = ManagedIdentityCredential.init(allocator, mock.asTransport());
+    var cred = ManagedIdentityCredential.init(allocator);
     var token = try cred.asCredential().getToken(
         .{ .scopes = &.{"https://vault.azure.net/.default"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     defer token.deinit();
     try std.testing.expectEqualStrings("msi-token", token.token);
@@ -140,11 +143,12 @@ test "ManagedIdentityCredential with client_id" {
         \\{"access_token":"msi-ua","expires_on":1743523200}
     );
     defer mock.deinit();
-    var cred = ManagedIdentityCredential.init(allocator, mock.asTransport());
+    var cred = ManagedIdentityCredential.init(allocator);
     cred.withClientId("user-assigned-id");
     var token = try cred.asCredential().getToken(
         .{ .scopes = &.{"https://storage.azure.com/.default"} },
         Context.none,
+        testingRuntime(mock.asTransport()),
     );
     defer token.deinit();
     try std.testing.expectEqualStrings("msi-ua", token.token);

--- a/identity/managed_identity.zig
+++ b/identity/managed_identity.zig
@@ -74,6 +74,7 @@ pub const ManagedIdentityCredential = struct {
 
         var req = core.http.Request.init(allocator, .GET, url_str);
         defer req.deinit();
+        req.redirect_policy = .not_allowed;
         try req.setHeader("Metadata", "true");
 
         var resp = try runtime.transport.send(&req);
@@ -133,6 +134,7 @@ test "ManagedIdentityCredential" {
     try std.testing.expectEqualStrings("msi-token", token.token);
     try std.testing.expectEqual(@as(i64, 1743523200), token.expires_on);
     try std.testing.expectEqual(core.http.Method.GET, mock.last_method.?);
+    try std.testing.expectEqual(core.http.RedirectPolicy.not_allowed, mock.last_redirect_policy.?);
     // Verify URL contains resource without /.default.
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "resource=https://vault.azure.net") != null);
 }

--- a/identity/workload_identity.zig
+++ b/identity/workload_identity.zig
@@ -6,6 +6,12 @@ const TokenCredential = core.credentials.TokenCredential;
 const TokenRequestContext = core.credentials.TokenRequestContext;
 const Context = core.context.Context;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
+
 /// Authenticates using Kubernetes workload identity (OIDC federation).
 ///
 /// Reads the projected service-account token from a file, then exchanges it
@@ -82,6 +88,17 @@ pub const WorkloadIdentityCredential = struct {
         else
             return error.NoScopesProvided;
 
+        return self.exchangeAssertion(assertion, scope, runtime);
+    }
+
+    fn exchangeAssertion(
+        self: *WorkloadIdentityCredential,
+        assertion: []const u8,
+        scope: []const u8,
+        runtime: core.http.HttpRuntime,
+    ) !AccessToken {
+        const allocator = self.allocator;
+
         // POST client_assertion to the token endpoint.
         const url = try std.fmt.allocPrint(allocator, "{s}/{s}/oauth2/v2.0/token", .{
             self.authority_host,
@@ -109,6 +126,7 @@ pub const WorkloadIdentityCredential = struct {
 
         var req = core.http.Request.init(allocator, .POST, url);
         defer req.deinit();
+        req.redirect_policy = .not_allowed;
         try req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.body = body;
 
@@ -155,4 +173,44 @@ test "WorkloadIdentityCredential fields" {
     defer cred.deinit();
     try std.testing.expectEqualStrings("tenant", cred.tenant_id);
     try std.testing.expectEqualStrings("client", cred.client_id);
+}
+
+test "WorkloadIdentityCredential does not replay assertion across 308 redirect" {
+    const allocator = std.testing.allocator;
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 308,
+            .body = "",
+            .headers = &.{.{
+                .name = "Location",
+                .value = "https://attacker.example/token",
+            }},
+        },
+        .{
+            .status = 200,
+            .body = "{\"access_token\":\"stolen\",\"expires_in\":3600}",
+        },
+    });
+    var credential = try WorkloadIdentityCredential.init(
+        allocator,
+        "tenant",
+        "client",
+        "/unused",
+    );
+    defer credential.deinit();
+
+    try std.testing.expectError(
+        error.AuthenticationFailed,
+        credential.exchangeAssertion(
+            "federated-assertion",
+            "https://vault.azure.net/.default",
+            testingRuntime(sequence.asTransport()),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), sequence.call_count);
+    try std.testing.expect(std.mem.find(
+        u8,
+        sequence.capturedBody(0),
+        "client_assertion=federated-assertion",
+    ) != null);
 }

--- a/identity/workload_identity.zig
+++ b/identity/workload_identity.zig
@@ -12,7 +12,6 @@ const Context = core.context.Context;
 /// for an AAD token via the client-assertion flow.
 pub const WorkloadIdentityCredential = struct {
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
     credential: TokenCredential,
 
     tenant_id: []u8,
@@ -22,7 +21,6 @@ pub const WorkloadIdentityCredential = struct {
 
     pub fn init(
         allocator: std.mem.Allocator,
-        transport: *core.http.HttpTransport,
         tenant_id: []const u8,
         client_id: []const u8,
         token_file_path: []const u8,
@@ -37,7 +35,6 @@ pub const WorkloadIdentityCredential = struct {
         errdefer allocator.free(authority_host);
         return .{
             .allocator = allocator,
-            .transport = transport,
             .credential = .{ .getTokenFn = &getTokenImpl },
             .tenant_id = owned_tenant_id,
             .client_id = owned_client_id,
@@ -71,6 +68,7 @@ pub const WorkloadIdentityCredential = struct {
         cred: *TokenCredential,
         request_context: TokenRequestContext,
         _: Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!AccessToken {
         const self: *WorkloadIdentityCredential = @fieldParentPtr("credential", cred);
         const allocator = self.allocator;
@@ -114,7 +112,7 @@ pub const WorkloadIdentityCredential = struct {
         try req.setHeader("Content-Type", "application/x-www-form-urlencoded");
         req.body = body;
 
-        var resp = try self.transport.send(&req);
+        var resp = try runtime.transport.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -148,10 +146,8 @@ fn readTokenFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
 
 test "WorkloadIdentityCredential fields" {
     const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
     var cred = try WorkloadIdentityCredential.init(
         allocator,
-        mock.asTransport(),
         "tenant",
         "client",
         "/var/run/secrets/azure/tokens/azure-identity-token",

--- a/lro.zig
+++ b/lro.zig
@@ -7,6 +7,14 @@ const std = @import("std");
 const serde = @import("serde");
 const http = @import("http/transport.zig");
 const pipeline_mod = @import("http/pipeline.zig");
+const crypto_mod = @import("crypto.zig");
+const HttpRuntime = @import("http/runtime.zig").HttpRuntime;
+
+var testing_crypto_provider = crypto_mod.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: http.HttpTransport) HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 
 fn sleepMs(ms: u64) void {
     var threaded: std.Io.Threaded = .init_single_threaded;
@@ -446,7 +454,7 @@ test "pollUntilDone succeeds after polling" {
         .{ .status = 200, .body = "{\"status\":\"Succeeded\",\"result\":\"done\"}" },
     });
     var empty = [_]*pipeline_mod.HttpPolicy{};
-    var pip = pipeline_mod.HttpPipeline{ .policies = &empty, .transport_impl = seq.asTransport() };
+    var pip = pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &empty);
 
     var result = try pollUntilDone(allocator, &pip, "https://vault.azure.net/operations/op1", 0, 10);
     defer result.deinit();
@@ -461,7 +469,7 @@ test "pollUntilDone times out" {
         .{ .status = 200, .body = "{\"status\":\"InProgress\"}" },
     });
     var empty = [_]*pipeline_mod.HttpPolicy{};
-    var pip = pipeline_mod.HttpPipeline{ .policies = &empty, .transport_impl = seq.asTransport() };
+    var pip = pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &empty);
 
     const result = pollUntilDone(allocator, &pip, "https://vault.azure.net/operations/op1", 0, 2);
     try std.testing.expectError(error.PollTimeout, result);
@@ -495,7 +503,7 @@ test "Poller operation-location strategy" {
 
     var poller = try Poller.init(
         allocator,
-        .{ .policies = &empty, .transport_impl = seq.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &empty),
         initial_resp,
         "https://vault.azure.net/keys/mykey",
         .{ .poll_interval_ms = 0 },
@@ -538,7 +546,7 @@ test "Poller location strategy" {
 
     var poller = try Poller.init(
         allocator,
-        .{ .policies = &empty, .transport_impl = seq.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &empty),
         initial_resp,
         "https://example.com/resources/1",
         .{ .poll_interval_ms = 0 },
@@ -576,7 +584,7 @@ test "Poller provisioning-state strategy" {
 
     var poller = try Poller.init(
         allocator,
-        .{ .policies = &empty, .transport_impl = seq.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &empty),
         initial_resp,
         "https://management.azure.com/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
         .{ .poll_interval_ms = 0, .strategy = .provisioning_state },
@@ -619,7 +627,7 @@ test "Poller azure-async-operation with final GET" {
 
     var poller = try Poller.init(
         allocator,
-        .{ .policies = &empty, .transport_impl = seq.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &empty),
         initial_resp,
         "https://example.com/resources/1",
         .{ .poll_interval_ms = 0 },
@@ -664,7 +672,7 @@ test "Poller single poll" {
 
     var poller = try Poller.init(
         allocator,
-        .{ .policies = &empty, .transport_impl = seq.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &empty),
         initial_resp,
         null,
         .{ .poll_interval_ms = 0 },
@@ -700,7 +708,7 @@ test "Poller auto-detect fails without headers" {
 
     const result = Poller.init(
         allocator,
-        .{ .policies = &empty, .transport_impl = mock.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(mock.asTransport()), &empty),
         initial_resp,
         null,
         .{},

--- a/pager.zig
+++ b/pager.zig
@@ -2,7 +2,15 @@ const std = @import("std");
 const serde = @import("serde");
 const pipeline_mod = @import("http/pipeline.zig");
 const transport = @import("http/transport.zig");
+const crypto_mod = @import("crypto.zig");
+const HttpRuntime = @import("http/runtime.zig").HttpRuntime;
 const url_mod = @import("url.zig");
+
+var testing_crypto_provider = crypto_mod.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: transport.HttpTransport) HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 
 /// Log a non-2xx HTTP response body so the developer sees the ARM/data-plane
 /// error message before the generic `PageFetchFailed` propagates upward.
@@ -370,7 +378,7 @@ test "PipelinePager single page" {
     defer mock.deinit();
 
     var pip = PipelinePager([]const u8).init(
-        .{ .policies = &.{}, .transport_impl = mock.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(mock.asTransport()), &.{}),
         "https://example.com/items",
         allocator,
         &parseTestPage,
@@ -406,7 +414,7 @@ test "PipelinePager multiple pages" {
     var seq = transport.SequenceMockTransport.init(allocator, &responses);
 
     var pip = PipelinePager([]const u8).init(
-        .{ .policies = &.{}, .transport_impl = seq.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &.{}),
         "https://example.com/items",
         allocator,
         &parseTestPage,
@@ -442,7 +450,7 @@ test "PipelinePager error propagation" {
     defer mock.deinit();
 
     var pip = PipelinePager([]const u8).init(
-        .{ .policies = &.{}, .transport_impl = mock.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(mock.asTransport()), &.{}),
         "https://example.com/items",
         allocator,
         &parseTestPage,
@@ -482,7 +490,7 @@ test "XmlPager paginates via NextMarker" {
     var seq = transport.SequenceMockTransport.init(allocator, &responses);
 
     var pager = try XmlPager(Envelope).init(
-        .{ .policies = &.{}, .transport_impl = seq.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(seq.asTransport()), &.{}),
         "https://example.com/?comp=list",
         "2026-06-06",
         null,
@@ -512,7 +520,7 @@ test "Pager interface via asPager" {
     defer mock.deinit();
 
     var pip = PipelinePager([]const u8).init(
-        .{ .policies = &.{}, .transport_impl = mock.asTransport() },
+        pipeline_mod.HttpPipeline.init(testingRuntime(mock.asTransport()), &.{}),
         "https://example.com/items",
         allocator,
         &parseTestPage,

--- a/root.zig
+++ b/root.zig
@@ -12,9 +12,8 @@
 ///!   Base64 → std.base64
 
 // Re-export sub-modules for `@import("azure_sdk_core").http`, etc.
-pub const http = @import("http/transport.zig");
-pub const pipeline = @import("http/pipeline.zig");
-pub const decompression = @import("http/decompression.zig");
+pub const http = @import("http.zig");
+pub const crypto = @import("crypto.zig");
 pub const credentials = @import("credentials/token.zig");
 pub const identity = @import("identity/root.zig");
 pub const context = @import("context.zig");
@@ -36,16 +35,6 @@ pub const arm = @import("arm/resource.zig");
 pub const open_enum = @import("open_enum.zig");
 pub const fixed_enum = @import("fixed_enum.zig");
 pub const env_token = @import("credentials/env_token.zig");
-
-/// WASI HTTP transport for running the SDK inside a `wasi:http`-capable
-/// WebAssembly component (wamr / wasmtime). Only present on `wasm32-wasi`;
-/// resolves to an empty namespace on every other target so consumers can
-/// reference `core.wasi_http` unconditionally.
-pub const wasi_http = if (@import("builtin").target.cpu.arch == .wasm32 and
-    @import("builtin").target.os.tag == .wasi)
-    @import("http/wasi_http.zig")
-else
-    struct {};
 
 pub const version: []const u8 = @import("build_options").version;
 pub const user_agent_prefix: []const u8 = "azsdk-zig-core/" ++ version;

--- a/uuid.zig
+++ b/uuid.zig
@@ -1,15 +1,13 @@
 const std = @import("std");
+const crypto = @import("crypto.zig");
 
 /// UUID v4 (random).
-///
-/// Accepts a `std.Random` so callers can supply their own source
-/// (e.g. `std.Random.DefaultCsprng` seeded from `std.Io.random`).
 pub const Uuid = struct {
     bytes: [16]u8,
 
-    pub fn init(rng: std.Random) Uuid {
+    pub fn init(provider: crypto.CryptoProvider) !Uuid {
         var bytes: [16]u8 = undefined;
-        rng.bytes(&bytes);
+        try provider.randomBytes(&bytes);
         // Set version 4 (bits 48-51).
         bytes[6] = (bytes[6] & 0x0f) | 0x40;
         // Set variant 1 (bits 64-65).
@@ -36,9 +34,50 @@ pub const Uuid = struct {
 };
 
 test "uuid v4 format" {
-    // Use a deterministic PRNG for reproducible tests.
-    var prng = std.Random.DefaultPrng.init(42);
-    const id = Uuid.init(prng.random());
+    const DeterministicProvider = struct {
+        const vtable: crypto.CryptoProvider.VTable = .{
+            .random_bytes = &randomBytes,
+            .md5 = &md5,
+            .sha256 = &sha256,
+            .hmac_sha256 = &hmacSha256,
+            .sha256_init = &sha256Init,
+        };
+
+        fn provider(self: *@This()) crypto.CryptoProvider {
+            return .{ .context = self, .vtable = &vtable };
+        }
+
+        fn randomBytes(_: *anyopaque, out: []u8) !void {
+            for (out, 0..) |*byte, index| byte.* = @truncate(index);
+        }
+
+        fn md5(_: *anyopaque, _: []const u8, _: *crypto.Md5Digest) !void {
+            return error.Unused;
+        }
+
+        fn sha256(_: *anyopaque, _: []const u8, _: *crypto.Sha256Digest) !void {
+            return error.Unused;
+        }
+
+        fn hmacSha256(
+            _: *anyopaque,
+            _: []const u8,
+            _: []const u8,
+            _: *crypto.HmacSha256Digest,
+        ) !void {
+            return error.Unused;
+        }
+
+        fn sha256Init(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+        ) !crypto.Sha256Operation {
+            return error.Unused;
+        }
+    };
+
+    var provider = DeterministicProvider{};
+    const id = try Uuid.init(provider.provider());
     const s = id.toString();
     // Version nibble
     try std.testing.expectEqual(@as(u8, '4'), s[14]);


### PR DESCRIPTION
Part of #412

## Summary
- add the top-level `core.http` facade, `HttpRuntime`, and `core.crypto` provider API
- replace self-referential transports with copyable borrowed context/vtable descriptors while preserving centralized redirect and streaming behavior
- add pure-Zig `StdCryptoProvider` with fallible secure randomness, MD5, SHA-256, HMAC-SHA256, and allocator-backed incremental SHA-256
- store runtime by value in `HttpPipeline`, pass it through policies and token acquisition, and remove independently retained transports from network credentials
- route request-ID generation through the configured crypto provider and fail before transport dispatch
- prohibit redirects for credential bootstrap requests so secrets, assertions, and metadata are never replayed to redirect targets

## Breaking API changes
- `core.pipeline`, `core.decompression`, and `core.wasi_http` are consolidated under `core.http`
- concrete transports return `HttpTransport` descriptors by value
- `HttpPipeline` is constructed with `HttpPipeline.init(runtime, policies)`
- `TokenCredential.getToken` and policy callbacks receive `HttpRuntime`
- network credential initializers no longer accept or retain a transport
- `Uuid.init` now accepts a `CryptoProvider` and is fallible

## Validation
- `zig fmt --check *.zig http/*.zig identity/*.zig credentials/*.zig`
- `zig build`
- `zig build test --summary all` (186 tests passed)
- all package CI checks pass on macOS, Ubuntu, and Windows
- `zig build package-check --summary all` not run because this package branch does not expose a `package-check` step
