### PR TITLE
Route Core crypto helpers through providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The canonical package/module name is `azure_sdk_core`, released from
 | `crypto.CryptoProvider` | Pluggable random, MD5, SHA-256, and HMAC-SHA256 operations |
 | `crypto.StdCryptoProvider` | Pure-Zig provider backed by `std.Io` and `std.crypto` |
 | `credentials.CachedTokenCredential` | In-memory token cache with expiry |
-| `base64` | Base64, HMAC-SHA256, SHA-256, and MD5 helpers |
+| `base64` | Provider-backed HMAC-SHA256, SHA-256, and integrity-only MD5 helpers |
 | `url` | URL parsing and RFC 3986 percent encoding |
 | `errors` | Azure error-envelope parsing |
 | `lro` | Long-running-operation polling |

--- a/base64.zig
+++ b/base64.zig
@@ -2,6 +2,7 @@
 ///!
 ///! Wraps `std.base64.standard` with allocator-aware helpers.
 const std = @import("std");
+const crypto = @import("crypto.zig");
 
 const encoder = std.base64.standard.Encoder;
 const decoder = std.base64.standard.Decoder;
@@ -44,28 +45,44 @@ pub fn urlDecode(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 {
 
 // ─────────────── Crypto helpers (thin wrappers) ───────────────
 
-const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
-const Sha256 = std.crypto.hash.sha2.Sha256;
-const Md5 = std.crypto.hash.Md5;
+fn wipe(bytes: []u8) void {
+    const volatile_bytes: []volatile u8 = bytes;
+    @memset(volatile_bytes, 0);
+}
 
 /// HMAC-SHA256: sign `message` with `key`, return base64-encoded MAC.
-pub fn hmacSha256Base64(allocator: std.mem.Allocator, key: []const u8, message: []const u8) ![]u8 {
-    var mac: [HmacSha256.mac_length]u8 = undefined;
-    HmacSha256.create(&mac, message, key);
+pub fn hmacSha256Base64(
+    allocator: std.mem.Allocator,
+    provider: crypto.CryptoProvider,
+    key: []const u8,
+    message: []const u8,
+) ![]u8 {
+    var mac = try provider.hmacSha256(key, message);
+    defer wipe(&mac);
     return encode(allocator, &mac);
 }
 
 /// SHA-256 hash of `data`, base64-encoded.
-pub fn sha256Base64(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
-    var hash: [Sha256.digest_length]u8 = undefined;
-    Sha256.hash(data, &hash, .{});
+pub fn sha256Base64(
+    allocator: std.mem.Allocator,
+    provider: crypto.CryptoProvider,
+    data: []const u8,
+) ![]u8 {
+    var hash = try provider.sha256(data);
+    defer wipe(&hash);
     return encode(allocator, &hash);
 }
 
-/// MD5 hash of `data`, base64-encoded (for Content-MD5 header).
-pub fn md5Base64(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
-    var hash: [Md5.digest_length]u8 = undefined;
-    Md5.hash(data, &hash, .{});
+/// MD5 hash of `data`, base64-encoded for integrity and compatibility only.
+///
+/// MD5 must not be used as a security primitive.
+pub fn md5Base64(
+    allocator: std.mem.Allocator,
+    provider: crypto.CryptoProvider,
+    data: []const u8,
+) ![]u8 {
+    var hash = try provider.md5(data);
+    defer wipe(&hash);
     return encode(allocator, &hash);
 }
 
@@ -107,28 +124,185 @@ test "invalid base64url does not leak" {
     );
 }
 
-test "hmacSha256Base64 known vector" {
+const TestCryptoProvider = struct {
+    const Operation = enum {
+        none,
+        md5,
+        sha256,
+        hmac_sha256,
+    };
+
+    calls: usize = 0,
+    operation: Operation = .none,
+    data: []const u8 = "",
+    key: []const u8 = "",
+    message: []const u8 = "",
+    fail: bool = false,
+
+    const vtable: crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn provider(self: *@This()) crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn record(self: *@This(), operation: Operation) !void {
+        self.calls += 1;
+        self.operation = operation;
+        if (self.fail) return error.ProviderFailure;
+    }
+
+    fn randomBytes(_: *anyopaque, _: []u8) !void {
+        return error.Unused;
+    }
+
+    fn md5(context: *anyopaque, data: []const u8, out: *crypto.Md5Digest) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.data = data;
+        @memset(out, 0xa5);
+        try self.record(.md5);
+    }
+
+    fn sha256(context: *anyopaque, data: []const u8, out: *crypto.Sha256Digest) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.data = data;
+        @memset(out, 0xa5);
+        try self.record(.sha256);
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        out: *crypto.HmacSha256Digest,
+    ) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.key = key;
+        self.message = message;
+        @memset(out, 0xa5);
+        try self.record(.hmac_sha256);
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !crypto.Sha256Operation {
+        return error.Unused;
+    }
+};
+
+test "provider-backed base64 crypto helpers use standard vectors" {
     const allocator = std.testing.allocator;
-    // HMAC-SHA256("", "key") is a known value.
-    const mac = try hmacSha256Base64(allocator, "key", "");
+    var provider_impl = crypto.StdCryptoProvider.init(std.testing.io);
+    const provider = provider_impl.asProvider();
+
+    const mac = try hmacSha256Base64(allocator, provider, "key", "");
     defer allocator.free(mac);
-    // Just verify it's base64 and 44 chars (32 bytes → 44 base64 chars with padding).
-    try std.testing.expectEqual(@as(usize, 44), mac.len);
-    try std.testing.expectEqual(@as(u8, '='), mac[43]);
+    try std.testing.expectEqualStrings(
+        "XV0TlWPJW1lnub2ajJsjOp3ttFByeUzSMtwbdIMmB9A=",
+        mac,
+    );
+
+    const sha256 = try sha256Base64(allocator, provider, "hello");
+    defer allocator.free(sha256);
+    try std.testing.expectEqualStrings(
+        "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=",
+        sha256,
+    );
+
+    const md5 = try md5Base64(allocator, provider, "hello");
+    defer allocator.free(md5);
+    try std.testing.expectEqualStrings("XUFAKrxLKna5cZ2REBfFkg==", md5);
 }
 
-test "sha256Base64" {
+test "provider-backed base64 crypto helpers handle empty input" {
     const allocator = std.testing.allocator;
-    const hash = try sha256Base64(allocator, "hello");
-    defer allocator.free(hash);
-    // SHA-256("hello") = LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ= (known)
-    try std.testing.expectEqualStrings("LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=", hash);
+    var provider_impl = crypto.StdCryptoProvider.init(std.testing.io);
+    const provider = provider_impl.asProvider();
+
+    const sha256 = try sha256Base64(allocator, provider, "");
+    defer allocator.free(sha256);
+    try std.testing.expectEqualStrings(
+        "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+        sha256,
+    );
+
+    const md5 = try md5Base64(allocator, provider, "");
+    defer allocator.free(md5);
+    try std.testing.expectEqualStrings("1B2M2Y8AsgTpgAmY7PhCfg==", md5);
 }
 
-test "md5Base64" {
+test "base64 crypto helpers dispatch to the selected provider" {
     const allocator = std.testing.allocator;
-    const hash = try md5Base64(allocator, "hello");
-    defer allocator.free(hash);
-    // MD5("hello") = XUFAKrxLKna5cZ2REBfFkg== (known)
-    try std.testing.expectEqualStrings("XUFAKrxLKna5cZ2REBfFkg==", hash);
+    var spy = TestCryptoProvider{};
+    const provider = spy.provider();
+
+    const md5 = try md5Base64(allocator, provider, "md5-data");
+    defer allocator.free(md5);
+    try std.testing.expectEqual(.md5, spy.operation);
+    try std.testing.expectEqualStrings("md5-data", spy.data);
+    try std.testing.expectEqualStrings("paWlpaWlpaWlpaWlpaWlpQ==", md5);
+
+    const sha256 = try sha256Base64(allocator, provider, "sha-data");
+    defer allocator.free(sha256);
+    try std.testing.expectEqual(.sha256, spy.operation);
+    try std.testing.expectEqualStrings("sha-data", spy.data);
+    try std.testing.expectEqualStrings(
+        "paWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaU=",
+        sha256,
+    );
+
+    const mac = try hmacSha256Base64(allocator, provider, "secret", "message");
+    defer allocator.free(mac);
+    try std.testing.expectEqual(.hmac_sha256, spy.operation);
+    try std.testing.expectEqualStrings("secret", spy.key);
+    try std.testing.expectEqualStrings("message", spy.message);
+    try std.testing.expectEqualStrings(
+        "paWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaU=",
+        mac,
+    );
+    try std.testing.expectEqual(@as(usize, 3), spy.calls);
+}
+
+test "provider failures propagate before base64 output allocation" {
+    var fault = TestCryptoProvider{ .fail = true };
+    const provider = fault.provider();
+
+    try std.testing.expectError(
+        error.ProviderFailure,
+        md5Base64(std.testing.failing_allocator, provider, "data"),
+    );
+    try std.testing.expectError(
+        error.ProviderFailure,
+        sha256Base64(std.testing.failing_allocator, provider, "data"),
+    );
+    try std.testing.expectError(
+        error.ProviderFailure,
+        hmacSha256Base64(std.testing.failing_allocator, provider, "key", "message"),
+    );
+    try std.testing.expectEqual(@as(usize, 3), fault.calls);
+}
+
+test "base64 crypto helpers return allocation failures without output" {
+    var spy = TestCryptoProvider{};
+    const provider = spy.provider();
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        md5Base64(std.testing.failing_allocator, provider, "data"),
+    );
+    try std.testing.expectError(
+        error.OutOfMemory,
+        sha256Base64(std.testing.failing_allocator, provider, "data"),
+    );
+    try std.testing.expectError(
+        error.OutOfMemory,
+        hmacSha256Base64(std.testing.failing_allocator, provider, "key", "message"),
+    );
+    try std.testing.expectEqual(@as(usize, 3), spy.calls);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,6 +14,8 @@
         "build.zig",
         "build.zig.zon",
         "root.zig",
+        "crypto.zig",
+        "http.zig",
         "arm",
         "credentials",
         "http",

--- a/crypto.zig
+++ b/crypto.zig
@@ -1,8 +1,13 @@
 const std = @import("std");
 
-pub const Md5Digest = [std.crypto.hash.Md5.digest_length]u8;
-pub const Sha256Digest = [std.crypto.hash.sha2.Sha256.digest_length]u8;
-pub const HmacSha256Digest = [std.crypto.auth.hmac.sha2.HmacSha256.mac_length]u8;
+pub const Md5Digest = [16]u8;
+pub const Sha256Digest = [32]u8;
+pub const HmacSha256Digest = [32]u8;
+
+fn wipe(bytes: []u8) void {
+    const volatile_bytes: []volatile u8 = bytes;
+    @memset(volatile_bytes, 0);
+}
 
 /// A single-owner incremental SHA-256 operation.
 ///
@@ -27,6 +32,7 @@ pub const Sha256Operation = struct {
 
     pub fn final(self: *Sha256Operation) !Sha256Digest {
         var out: Sha256Digest = undefined;
+        errdefer wipe(&out);
         try self.vtable.final(self.context, &out);
         return out;
     }
@@ -74,12 +80,14 @@ pub const CryptoProvider = struct {
 
     pub fn md5(self: CryptoProvider, data: []const u8) !Md5Digest {
         var out: Md5Digest = undefined;
+        errdefer wipe(&out);
         try self.vtable.md5(self.context, data, &out);
         return out;
     }
 
     pub fn sha256(self: CryptoProvider, data: []const u8) !Sha256Digest {
         var out: Sha256Digest = undefined;
+        errdefer wipe(&out);
         try self.vtable.sha256(self.context, data, &out);
         return out;
     }
@@ -90,6 +98,7 @@ pub const CryptoProvider = struct {
         message: []const u8,
     ) !HmacSha256Digest {
         var out: HmacSha256Digest = undefined;
+        errdefer wipe(&out);
         try self.vtable.hmac_sha256(self.context, key, message, &out);
         return out;
     }
@@ -189,7 +198,7 @@ const StdSha256State = struct {
     fn deinit(context: *anyopaque) void {
         const self: *StdSha256State = @ptrCast(@alignCast(context));
         const allocator = self.allocator;
-        self.* = undefined;
+        wipe(std.mem.asBytes(self));
         allocator.destroy(self);
     }
 };
@@ -232,6 +241,28 @@ test "StdCryptoProvider incremental SHA-256 has stable allocated state" {
         0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
     }, &digest);
     try std.testing.expectError(error.Sha256AlreadyFinalized, operation.update("d"));
+}
+
+test "StdCryptoProvider incremental SHA-256 handles empty input" {
+    var provider_impl = StdCryptoProvider.init(std.testing.io);
+    var operation = try provider_impl.asProvider().sha256Init(std.testing.allocator);
+    defer operation.deinit();
+
+    const digest = try operation.final();
+    try std.testing.expectEqualSlices(u8, &.{
+        0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+        0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+        0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+        0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+    }, &digest);
+}
+
+test "StdCryptoProvider incremental SHA-256 propagates allocation failure" {
+    var provider_impl = StdCryptoProvider.init(std.testing.io);
+    try std.testing.expectError(
+        error.OutOfMemory,
+        provider_impl.asProvider().sha256Init(std.testing.failing_allocator),
+    );
 }
 
 test "CryptoProvider descriptors copy and dispatch through borrowed context" {

--- a/identity/client_certificate.zig
+++ b/identity/client_certificate.zig
@@ -16,7 +16,7 @@ const Context = core.context.Context;
 /// Note: This implementation sends the raw PEM content as the assertion.
 /// A production implementation would sign a JWT with the private key
 /// and use the certificate thumbprint in the JWT header. This requires
-/// RSA/EC signing which could be added via `std.crypto`.
+/// RSA/EC signing which could be added through `CryptoProvider`.
 pub const ClientCertificateCredential = struct {
     tenant_id: []const u8,
     client_id: []const u8,

--- a/root.zig
+++ b/root.zig
@@ -8,7 +8,7 @@
 ///!   TLS    → std.crypto.tls
 ///!   JSON   → serde.json (typed schemas)
 ///!   XML    → serde.xml (typed schemas)
-///!   Crypto → std.crypto (HMAC-SHA256, SHA-256, MD5)
+///!   Crypto → configured CryptoProvider (HMAC-SHA256, SHA-256, MD5)
 ///!   Base64 → std.base64
 
 // Re-export sub-modules for `@import("azure_sdk_core").http`, etc.


### PR DESCRIPTION
Part of #414

## Summary
- make `base64.hmacSha256Base64`, `base64.sha256Base64`, and `base64.md5Base64` take the configured `CryptoProvider` after the allocator
- remove direct MD5, SHA-256, and HMAC-SHA256 calls from Core helper code; only `StdCryptoProvider` invokes the standard cryptographic implementations
- preserve provider errors unchanged and invoke providers before allocating or encoding returned output, with no standard-provider fallback
- wipe temporary digest/MAC buffers on success, provider failure, and allocation failure, and wipe incremental SHA-256 provider state during deinitialization
- document MD5 as integrity/compatibility-only

## API and downstream implications
The canonical helper signatures are now allocator, provider, then operation inputs. Storage, Tables, Messaging, and Container Registry package branches must pass the provider from their `HttpRuntime`; callers that decode account/signing keys remain responsible for securely wiping those caller-owned decoded buffers. No std-only compatibility overloads are retained.

Incremental SHA-256 remains available through `CryptoProvider.sha256Init`; coverage now includes chunked input, empty input, and allocation failure for downstream Container Registry streaming digest work.

## Tests
- standard MD5, SHA-256, and HMAC-SHA256 vectors, including empty input
- spy provider dispatch and argument forwarding
- fault provider propagation before output allocation
- allocation failure with no returned output
- incremental SHA-256 chunked, empty, and allocation-failure paths

## Validation
- `zig fmt base64.zig crypto.zig identity/client_certificate.zig root.zig`
- `zig build`
- `zig build test --summary all` (190/190 tests passed)
