### PR TITLE
Migrate generated Container Registry client to HTTP runtime

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,0 +1,3 @@
+generator_commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4
+fixture=codegen/fixtures/container_registry.json
+command=(cd codegen/cli && zig build -Dcontainer-registry-output=<package-output> -Dazure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf generate-container-registry-package)

--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,3 +1,3 @@
 generator_commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4
 fixture=codegen/fixtures/container_registry.json
-command=(cd codegen/cli && zig build -Dcontainer-registry-output=<package-output> -Dazure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf generate-container-registry-package)
+command=(cd codegen/cli && zig build -Dcontainer-registry-output=<package-output> -Dazure-sdk-core-commit=bc77bcacbb64af935ca53d60bf8a351c9592bc41 -Dazure-sdk-core-hash=azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV generate-container-registry-package)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ unions. It does not add challenge authentication, safe continuation
 validation, digest verification, transfer replay, or domain ownership
 helpers. Use `azure_sdk_container_registry` for those behaviors.
 
-The generated `initWithPipeline` constructor is the protocol escape
-hatch for callers that need custom policies or operations not surfaced
-by the hand-written package. The supplied pipeline and transport are
-borrowed and must outlive every generated client and active operation.
+The generated `init` constructor accepts the caller's
+`core.http.HttpPipeline`. Construct that pipeline from a
+`core.http.HttpRuntime` and the policy chain required by the application.
+The runtime descriptors and their backend contexts are borrowed and must
+outlive every generated client and active operation.
 Generated result fields follow their declared allocator ownership; free
 or deinitialize every owned body/header/model value shown by the type.
 
@@ -39,12 +40,13 @@ responses.
 
 ```bash
 zig build test --summary all
-(cd ../../codegen/cli && zig build generate-container-registry-package)
-../../scripts/verify-container-registry-regeneration.sh
+gh workflow run generated-package-pr.yml \
+  -f target_branch=rest/container_registry \
+  -f generator_commit=<main-commit>
 ```
 
-Local development depends directly on the repository's
-`azure_sdk_core` package. Release staging replaces that local path with
-an immutable commit/hash pin. See the
-[package branch model](../../doc/package-branch-model.md) and
-[Container Registry release staging](../../eng/container_registry_release/README.md).
+The package manifest pins `azure_sdk_core` by immutable commit and Zig
+package hash. See the
+[package branch model](https://github.com/cataggar/azure-sdk-for-zig/blob/main/doc/package-branch-model.md)
+and
+[Container Registry release staging](https://github.com/cataggar/azure-sdk-for-zig/blob/main/eng/container_registry_release/README.md).

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,12 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#763ff49c6e424750508c06886ecb7ef61f3e7000",
+            .hash = "azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf",
         },
         .serde = .{
-            .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
-            .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
+            .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",
+            .hash = "serde-1.0.1-1DszT1XhDACnteUU3yWahMMjLjkJqB34hwROPIfhZc7l",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#763ff49c6e424750508c06886ecb7ef61f3e7000",
-            .hash = "azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_rest_container_registry,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0x5dd0e10aa1e38a93,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/src/clients.zig
+++ b/src/clients.zig
@@ -20,75 +20,27 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
     return false;
 }
 const default_api_version = "2021-07-01";
-const auth_scopes: []const []const u8 = &.{"https://containerregistry.azure.net/.default"};
 
 /// Metadata API definition for the Azure Container Registry runtime
 pub const ContainerRegistryClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ContainerRegistryClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ContainerRegistryClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn containerRegistry(self: *@This()) ContainerRegistry {
@@ -119,7 +71,7 @@ pub const ContainerRegistryClient = struct {
 pub const ContainerRegistry = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateManifestResult = union(enum) {
         status_201: struct {
@@ -203,6 +155,7 @@ pub const ContainerRegistry = struct {
     };
     /// Tells whether this Docker Registry instance supports Docker Registry HTTP API v2
     pub fn checkDockerV2Support(self: *@This(), alloc: std.mem.Allocator) !void {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/", .{self.endpoint});
         defer alloc.free(base_url);
         var url_buf: std.ArrayList(u8) = .empty;
@@ -230,6 +183,7 @@ pub const ContainerRegistry = struct {
     /// Get the manifest identified by `name` and `reference` where `reference` can be
     /// a tag or digest.
     pub fn getManifest(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8, accept: ?[]const u8) !models.ManifestWrapper {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
@@ -262,6 +216,7 @@ pub const ContainerRegistry = struct {
     /// Put the manifest identified by `name` and `reference` where `reference` can be
     /// a tag or digest.
     pub fn createManifest(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8, payload: models.Manifest) !CreateManifestResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
@@ -324,6 +279,7 @@ pub const ContainerRegistry = struct {
     /// Delete the manifest identified by `name` and `reference`. Note that a manifest
     /// can _only_ be deleted by `digest`.
     pub fn deleteManifest(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8) !DeleteManifestResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
@@ -369,6 +325,7 @@ pub const ContainerRegistry = struct {
     }
     /// List repositories
     pub fn getRepositories(self: *@This(), alloc: std.mem.Allocator, last: ?[]const u8, n: ?i32) !GetRepositoriesResult {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/_catalog", .{self.endpoint});
         defer alloc.free(base_url);
         var url_buf: std.ArrayList(u8) = .empty;
@@ -379,16 +336,16 @@ pub const ContainerRegistry = struct {
         defer alloc.free(encoded_query_0);
         try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
         has_query = true;
-        if (last) |v| {
+        if (last) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            const enc = try core.url.percentEncode(alloc, v);
+            const enc = try core.url.percentEncode(alloc, query_value);
             defer alloc.free(enc);
             try url_buf.print(alloc, "{s}last={s}", .{ sep, enc });
             has_query = true;
         }
-        if (n) |v| {
+        if (n) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            try url_buf.print(alloc, "{s}n={d}", .{ sep, v });
+            try url_buf.print(alloc, "{s}n={d}", .{ sep, query_value });
             has_query = true;
         }
         const url = try url_buf.toOwnedSlice(alloc);
@@ -424,6 +381,7 @@ pub const ContainerRegistry = struct {
     }
     /// Get repository attributes
     pub fn getProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8) !models.ContainerRepositoryProperties {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}", .{ self.endpoint, encoded_path_0 });
@@ -453,6 +411,7 @@ pub const ContainerRegistry = struct {
     }
     /// Delete the repository identified by `name`
     pub fn deleteRepository(self: *@This(), alloc: std.mem.Allocator, name: []const u8) !DeleteRepositoryResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}", .{ self.endpoint, encoded_path_0 });
@@ -497,6 +456,7 @@ pub const ContainerRegistry = struct {
     /// Update the attribute identified by `name` where `reference` is the name of the
     /// repository.
     pub fn updateProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, value: ?models.RepositoryChangeableAttributes) !models.ContainerRepositoryProperties {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}", .{ self.endpoint, encoded_path_0 });
@@ -534,6 +494,7 @@ pub const ContainerRegistry = struct {
     }
     /// List tags of a repository
     pub fn getTags(self: *@This(), alloc: std.mem.Allocator, name: []const u8, last: ?[]const u8, n: ?i32, orderby: ?enums.ArtifactTagOrder, digest: ?[]const u8) !GetTagsResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_tags", .{ self.endpoint, encoded_path_0 });
@@ -546,28 +507,28 @@ pub const ContainerRegistry = struct {
         defer alloc.free(encoded_query_0);
         try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
         has_query = true;
-        if (last) |v| {
+        if (last) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            const enc = try core.url.percentEncode(alloc, v);
+            const enc = try core.url.percentEncode(alloc, query_value);
             defer alloc.free(enc);
             try url_buf.print(alloc, "{s}last={s}", .{ sep, enc });
             has_query = true;
         }
-        if (n) |v| {
+        if (n) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            try url_buf.print(alloc, "{s}n={d}", .{ sep, v });
+            try url_buf.print(alloc, "{s}n={d}", .{ sep, query_value });
             has_query = true;
         }
-        if (orderby) |v| {
+        if (orderby) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            const enc = try core.url.percentEncode(alloc, v.toWire());
+            const enc = try core.url.percentEncode(alloc, query_value.toWire());
             defer alloc.free(enc);
             try url_buf.print(alloc, "{s}orderby={s}", .{ sep, enc });
             has_query = true;
         }
-        if (digest) |v| {
+        if (digest) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            const enc = try core.url.percentEncode(alloc, v);
+            const enc = try core.url.percentEncode(alloc, query_value);
             defer alloc.free(enc);
             try url_buf.print(alloc, "{s}digest={s}", .{ sep, enc });
             has_query = true;
@@ -605,6 +566,7 @@ pub const ContainerRegistry = struct {
     }
     /// Get tag attributes by tag
     pub fn getTagProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8) !models.ArtifactTagProperties {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
@@ -636,6 +598,7 @@ pub const ContainerRegistry = struct {
     }
     /// Update tag attributes
     pub fn updateTagAttributes(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8, value: ?models.TagChangeableAttributes) !models.ArtifactTagProperties {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
@@ -675,6 +638,7 @@ pub const ContainerRegistry = struct {
     }
     /// Delete tag
     pub fn deleteTag(self: *@This(), alloc: std.mem.Allocator, name: []const u8, reference: []const u8) !DeleteTagResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, reference);
@@ -720,6 +684,7 @@ pub const ContainerRegistry = struct {
     }
     /// List manifests of a repository
     pub fn getManifests(self: *@This(), alloc: std.mem.Allocator, name: []const u8, last: ?[]const u8, n: ?i32, orderby: ?enums.ArtifactManifestOrder) !GetManifestsResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/acr/v1/{s}/_manifests", .{ self.endpoint, encoded_path_0 });
@@ -732,21 +697,21 @@ pub const ContainerRegistry = struct {
         defer alloc.free(encoded_query_0);
         try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
         has_query = true;
-        if (last) |v| {
+        if (last) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            const enc = try core.url.percentEncode(alloc, v);
+            const enc = try core.url.percentEncode(alloc, query_value);
             defer alloc.free(enc);
             try url_buf.print(alloc, "{s}last={s}", .{ sep, enc });
             has_query = true;
         }
-        if (n) |v| {
+        if (n) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            try url_buf.print(alloc, "{s}n={d}", .{ sep, v });
+            try url_buf.print(alloc, "{s}n={d}", .{ sep, query_value });
             has_query = true;
         }
-        if (orderby) |v| {
+        if (orderby) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            const enc = try core.url.percentEncode(alloc, v.toWire());
+            const enc = try core.url.percentEncode(alloc, query_value.toWire());
             defer alloc.free(enc);
             try url_buf.print(alloc, "{s}orderby={s}", .{ sep, enc });
             has_query = true;
@@ -784,6 +749,7 @@ pub const ContainerRegistry = struct {
     }
     /// Get manifest attributes
     pub fn getManifestProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !models.ArtifactManifestProperties {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
@@ -815,6 +781,7 @@ pub const ContainerRegistry = struct {
     }
     /// Update properties of a manifest
     pub fn updateManifestProperties(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8, value: ?models.ManifestChangeableAttributes) !models.ArtifactManifestProperties {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
@@ -857,7 +824,7 @@ pub const ContainerRegistry = struct {
 pub const ContainerRegistryBlob = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetBlobResult = union(enum) {
         status_200: struct {
@@ -987,6 +954,7 @@ pub const ContainerRegistryBlob = struct {
     };
     /// Retrieve the blob from the registry identified by digest.
     pub fn getBlob(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !GetBlobResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
@@ -1056,6 +1024,7 @@ pub const ContainerRegistryBlob = struct {
     }
     /// Same as GET, except only the headers are returned.
     pub fn checkBlobExists(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !CheckBlobExistsResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
@@ -1122,6 +1091,7 @@ pub const ContainerRegistryBlob = struct {
     }
     /// Removes an already uploaded blob.
     pub fn deleteBlob(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8) !DeleteBlobResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
@@ -1167,6 +1137,7 @@ pub const ContainerRegistryBlob = struct {
     }
     /// Mount a blob identified by the `mount` parameter from another repository.
     pub fn mountBlob(self: *@This(), alloc: std.mem.Allocator, name: []const u8, from: []const u8, mount: []const u8) !MountBlobResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/uploads/", .{ self.endpoint, encoded_path_0 });
@@ -1231,6 +1202,7 @@ pub const ContainerRegistryBlob = struct {
     /// Retrieve status of upload identified by uuid. The primary purpose of this
     /// endpoint is to resolve the current status of a resumable upload.
     pub fn getUploadStatus(self: *@This(), alloc: std.mem.Allocator, next_blob_uuid_link: []const u8) !GetUploadStatusResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
         defer alloc.free(encoded_path_0);
         const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
@@ -1288,6 +1260,7 @@ pub const ContainerRegistryBlob = struct {
     }
     /// Upload a stream of data without completing the upload.
     pub fn uploadChunk(self: *@This(), alloc: std.mem.Allocator, next_blob_uuid_link: []const u8, value: []const u8) !UploadChunkResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
         defer alloc.free(encoded_path_0);
         const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
@@ -1355,6 +1328,7 @@ pub const ContainerRegistryBlob = struct {
     /// request without a body will just complete the upload with previously uploaded
     /// content.
     pub fn completeUpload(self: *@This(), alloc: std.mem.Allocator, digest: []const u8, next_blob_uuid_link: []const u8, value: ?[]const u8) !CompleteUploadResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
         defer alloc.free(encoded_path_0);
         const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
@@ -1425,6 +1399,7 @@ pub const ContainerRegistryBlob = struct {
     /// Cancel outstanding upload processes, releasing associated resources. If this is
     /// not called, the unfinished uploads will eventually timeout.
     pub fn cancelUpload(self: *@This(), alloc: std.mem.Allocator, next_blob_uuid_link: []const u8) !void {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.expandGreedyPathValue(alloc, next_blob_uuid_link);
         defer alloc.free(encoded_path_0);
         const endpoint_uri = std.Uri.parse(self.endpoint) catch return error.InvalidUrl;
@@ -1461,6 +1436,7 @@ pub const ContainerRegistryBlob = struct {
     }
     /// Initiate a resumable blob upload with an empty request body.
     pub fn startUpload(self: *@This(), alloc: std.mem.Allocator, name: []const u8) !StartUploadResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/v2/{s}/blobs/uploads/", .{ self.endpoint, encoded_path_0 });
@@ -1519,6 +1495,7 @@ pub const ContainerRegistryBlob = struct {
     /// issuing a HEAD request. If the header `Accept-Range: bytes` is returned, range
     /// requests can be used to fetch partial content.
     pub fn getChunk(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8, range: []const u8) !GetChunkResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
@@ -1574,6 +1551,7 @@ pub const ContainerRegistryBlob = struct {
     }
     /// Same as GET, except only the headers are returned.
     pub fn checkChunkExists(self: *@This(), alloc: std.mem.Allocator, name: []const u8, digest: []const u8, range: []const u8) !CheckChunkExistsResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodeRepositoryName(alloc, name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, digest);
@@ -1629,9 +1607,10 @@ pub const ContainerRegistryBlob = struct {
 pub const Authentication = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Exchange AAD tokens for an ACR refresh Token
     pub fn exchangeAadAccessTokenForAcrRefreshToken(self: *@This(), alloc: std.mem.Allocator, body: models.MultipartBodyParameter) !models.AcrRefreshToken {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/oauth2/exchange", .{self.endpoint});
         defer alloc.free(base_url);
         const url = base_url;
@@ -1689,6 +1668,7 @@ pub const Authentication = struct {
     }
     /// Exchange ACR Refresh token for an ACR Access Token
     pub fn exchangeAcrRefreshTokenForAcrAccessToken(self: *@This(), alloc: std.mem.Allocator, body: models.MultipartBodyParameter) !models.AcrAccessToken {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/oauth2/token", .{self.endpoint});
         defer alloc.free(base_url);
         const url = base_url;
@@ -1746,6 +1726,7 @@ pub const Authentication = struct {
     }
     /// Exchange Username, Password and Scope for an ACR Access Token
     pub fn getAcrAccessTokenFromLogin(self: *@This(), alloc: std.mem.Allocator, service: []const u8, scope: []const u8) !models.AcrAccessToken {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/oauth2/token", .{self.endpoint});
         defer alloc.free(base_url);
         var url_buf: std.ArrayList(u8) = .empty;

--- a/src/clients_test.zig
+++ b/src/clients_test.zig
@@ -56,17 +56,21 @@ fn expectPublicMethods(comptime Client: type, comptime methods: []const []const 
 const Mock = struct {
     allocator: std.mem.Allocator,
     mode: enum { blob, redirect, multipart, cancel },
-    transport: core.http.HttpTransport = undefined,
     calls: usize = 0,
 
     fn init(allocator: std.mem.Allocator, mode: @FieldType(@This(), "mode")) @This() {
-        var result = @This(){ .allocator = allocator, .mode = mode };
-        result.transport = .{ .sendFn = send };
-        return result;
+        return .{ .allocator = allocator, .mode = mode };
     }
 
-    fn send(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *@This() = @alignCast(@fieldParentPtr("transport", transport));
+    fn asTransport(self: *@This()) core.http.HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = send },
+        };
+    }
+
+    fn send(context: *anyopaque, request: *core.http.Request) !core.http.Response {
+        const self: *@This() = @ptrCast(@alignCast(context));
         self.calls += 1;
         const headers = std.StringHashMap([]const u8).init(self.allocator);
         var response_headers = core.http.ResponseHeaders.init(self.allocator);
@@ -153,15 +157,16 @@ const Mock = struct {
 
 test "generated ACR raw, multipart, statuses, and validated continuations" {
     const allocator = std.testing.allocator;
-    var empty = [_]*core.pipeline.HttpPolicy{};
+    var empty = [_]*core.http.HttpPolicy{};
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
 
     var blob_mock = Mock.init(allocator, .blob);
-    const blob_pipeline = core.pipeline.HttpPipeline{
-        .policies = &empty,
-        .transport_impl = &blob_mock.transport,
-    };
-    var root = clients.ContainerRegistryClient.initWithPipeline(
-        allocator,
+    const blob_runtime = core.http.HttpRuntime.init(
+        blob_mock.asTransport(),
+        crypto.asProvider(),
+    );
+    const blob_pipeline = core.http.HttpPipeline.init(blob_runtime, &empty);
+    var root = clients.ContainerRegistryClient.init(
         blob_pipeline,
         .{ .endpoint = "https://registry.example" },
     );
@@ -186,12 +191,12 @@ test "generated ACR raw, multipart, statuses, and validated continuations" {
     try std.testing.expectEqual(@as(usize, 1), blob_mock.calls);
 
     var redirect_mock = Mock.init(allocator, .redirect);
-    const redirect_pipeline = core.pipeline.HttpPipeline{
-        .policies = &empty,
-        .transport_impl = &redirect_mock.transport,
-    };
-    root = clients.ContainerRegistryClient.initWithPipeline(
-        allocator,
+    const redirect_runtime = core.http.HttpRuntime.init(
+        redirect_mock.asTransport(),
+        crypto.asProvider(),
+    );
+    const redirect_pipeline = core.http.HttpPipeline.init(redirect_runtime, &empty);
+    root = clients.ContainerRegistryClient.init(
         redirect_pipeline,
         .{ .endpoint = "https://registry.example" },
     );
@@ -229,12 +234,12 @@ test "generated ACR raw, multipart, statuses, and validated continuations" {
     try std.testing.expectEqual(@as(usize, 2), redirect_mock.calls);
 
     var multipart_mock = Mock.init(allocator, .multipart);
-    const multipart_pipeline = core.pipeline.HttpPipeline{
-        .policies = &empty,
-        .transport_impl = &multipart_mock.transport,
-    };
-    root = clients.ContainerRegistryClient.initWithPipeline(
-        allocator,
+    const multipart_runtime = core.http.HttpRuntime.init(
+        multipart_mock.asTransport(),
+        crypto.asProvider(),
+    );
+    const multipart_pipeline = core.http.HttpPipeline.init(multipart_runtime, &empty);
+    root = clients.ContainerRegistryClient.init(
         multipart_pipeline,
         .{ .endpoint = "https://registry.example" },
     );
@@ -251,12 +256,12 @@ test "generated ACR raw, multipart, statuses, and validated continuations" {
     try std.testing.expectEqualStrings("token", token.refresh_token.?);
 
     var cancel_mock = Mock.init(allocator, .cancel);
-    const cancel_pipeline = core.pipeline.HttpPipeline{
-        .policies = &empty,
-        .transport_impl = &cancel_mock.transport,
-    };
-    root = clients.ContainerRegistryClient.initWithPipeline(
-        allocator,
+    const cancel_runtime = core.http.HttpRuntime.init(
+        cancel_mock.asTransport(),
+        crypto.asProvider(),
+    );
+    const cancel_pipeline = core.http.HttpPipeline.init(cancel_runtime, &empty);
+    root = clients.ContainerRegistryClient.init(
         cancel_pipeline,
         .{ .endpoint = "https://registry.example" },
     );

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -36,6 +36,10 @@ pub const ArtifactTagOrder = union(enum) {
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
     }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
 };
 
 /// Sort options for ordering manifests in a collection.
@@ -65,6 +69,10 @@ pub const ArtifactManifestOrder = union(enum) {
 
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -115,6 +123,10 @@ pub const ArtifactArchitecture = union(enum) {
 
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };
 
@@ -168,6 +180,10 @@ pub const ArtifactOperatingSystem = union(enum) {
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
     }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
 };
 
 /// Can take a value of access_token_refresh_token, or access_token, or
@@ -199,11 +215,38 @@ pub const PostContentSchemaGrantType = union(enum) {
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
     }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
 };
 
 /// The available API versions.
 pub const Versions = enum {
     v2021_07_01,
+
+    pub fn toWire(self: @This()) []const u8 {
+        return switch (self) {
+            .v2021_07_01 => "2021-07-01",
+        };
+    }
+
+    pub fn fromWire(s: []const u8) ?@This() {
+        if (std.mem.eql(u8, s, "2021-07-01")) return .v2021_07_01;
+        return null;
+    }
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.fixed_enum.deserialize(T, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.fixed_enum.serialize(self, serializer);
+    }
 };
 
 /// Grant type is expected to be refresh_token
@@ -231,5 +274,9 @@ pub const TokenGrantType = union(enum) {
 
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
+    }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
     }
 };

--- a/src/models.zig
+++ b/src/models.zig
@@ -451,19 +451,19 @@ pub const Repositories = struct {
 pub const ContainerRepositoryProperties = struct {
     /// Registry login server name. This is likely to be similar to
     /// {registry-name}.azurecr.io.
-    registry_login_server: []const u8,
+    registry_login_server: ?[]const u8 = null,
     /// Image name
-    name: []const u8,
+    name: ?[]const u8 = null,
     /// Image created time
-    created_on: []const u8,
+    created_on: ?[]const u8 = null,
     /// Image last update time
-    last_updated_on: []const u8,
+    last_updated_on: ?[]const u8 = null,
     /// Number of the manifests
-    manifest_count: i32,
+    manifest_count: ?i32 = null,
     /// Number of the tags
-    tag_count: i32,
+    tag_count: ?i32 = null,
     /// Writeable properties of the resource
-    changeable_attributes: RepositoryChangeableAttributes,
+    changeable_attributes: ?RepositoryChangeableAttributes = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -502,11 +502,11 @@ pub const RepositoryChangeableAttributes = struct {
 pub const TagList = struct {
     /// Registry login server name. This is likely to be similar to
     /// {registry-name}.azurecr.io.
-    registry_login_server: []const u8,
+    registry_login_server: ?[]const u8 = null,
     /// Image name
-    repository: []const u8,
+    repository: ?[]const u8 = null,
     /// List of tag attribute details
-    tag_attribute_bases: []const TagAttributesBase,
+    tag_attribute_bases: ?[]const TagAttributesBase = null,
     /// Link to the next page of results
     link: ?[]const u8 = null,
 
@@ -523,17 +523,17 @@ pub const TagList = struct {
 /// Tag attribute details
 pub const TagAttributesBase = struct {
     /// Tag name
-    name: []const u8,
+    name: ?[]const u8 = null,
     /// Tag digest
-    digest: []const u8,
+    digest: ?[]const u8 = null,
     /// Tag created time
-    created_on: []const u8,
+    created_on: ?[]const u8 = null,
     /// Tag last update time
-    last_updated_on: []const u8,
+    last_updated_on: ?[]const u8 = null,
     /// Is signed
     signed: ?bool = null,
     /// Writeable properties of the resource
-    changeable_attributes: TagChangeableAttributes,
+    changeable_attributes: ?TagChangeableAttributes = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -570,11 +570,11 @@ pub const TagChangeableAttributes = struct {
 pub const ArtifactTagProperties = struct {
     /// Registry login server name. This is likely to be similar to
     /// {registry-name}.azurecr.io.
-    registry_login_server: []const u8,
+    registry_login_server: ?[]const u8 = null,
     /// Image name
-    repository_name: []const u8,
+    repository_name: ?[]const u8 = null,
     /// List of tag attribute details
-    tag: TagAttributesBase,
+    tag: ?TagAttributesBase = null,
 
     pub const serde = .{
         .rename_all = .camel_case,
@@ -609,13 +609,13 @@ pub const AcrManifests = struct {
 /// Manifest details
 pub const ManifestAttributesBase = struct {
     /// Manifest
-    digest: []const u8,
+    digest: ?[]const u8 = null,
     /// Image size
     size: ?i64 = null,
     /// Created time
-    created_on: []const u8,
+    created_on: ?[]const u8 = null,
     /// Last update time
-    last_updated_on: []const u8,
+    last_updated_on: ?[]const u8 = null,
     /// CPU architecture
     architecture: ?enums.ArtifactArchitecture = null,
     /// Operating system
@@ -646,7 +646,7 @@ pub const ManifestAttributesBase = struct {
 /// The artifact's platform, consisting of operating system and architecture.
 pub const ArtifactManifestPlatform = struct {
     /// Manifest digest
-    digest: []const u8,
+    digest: ?[]const u8 = null,
     /// CPU architecture
     architecture: ?enums.ArtifactArchitecture = null,
     /// Operating system
@@ -690,7 +690,7 @@ pub const ArtifactManifestProperties = struct {
     /// Repository name
     repository_name: ?[]const u8 = null,
     /// Manifest attributes
-    manifest: ManifestAttributesBase,
+    manifest: ?ManifestAttributesBase = null,
 
     pub const serde = .{
         .rename_all = .camel_case,

--- a/src/root.zig
+++ b/src/root.zig
@@ -6,6 +6,9 @@ const clients = @import("clients.zig");
 pub const models = @import("models.zig");
 pub const enums = @import("enums.zig");
 pub const ContainerRegistryClient = clients.ContainerRegistryClient;
+pub const ContainerRegistry = clients.ContainerRegistry;
+pub const ContainerRegistryBlob = clients.ContainerRegistryBlob;
+pub const Authentication = clients.Authentication;
 
 test {
     _ = @import("clients_test.zig");


### PR DESCRIPTION
Part of #412

## Summary
- regenerate the entirely generator-owned Container Registry REST package with the tooling merged in #419
- record exact generated provenance in `.azure-sdk-generator` for generator commit `c83a1cbef5f728d7530fdec4a724cc453233cfa4`, fixture path, and canonical command
- replace generated `core.pipeline.HttpPipeline` usage and the credential/transport-owning constructor with the canonical caller-supplied `core.http.HttpPipeline` construction path
- remove generated `initWithPipeline`, `PipelineOptions`, `deinit`, and generated policy ownership
- update generated fixture tests to construct `core.http.HttpRuntime` from copyable transport and crypto provider descriptors
- bump the package from released `0.1.0` to breaking version `0.2.0`

## Core dependency
- released tag: `azure_sdk_core/v0.3.0`
- commit: `bc77bcacbb64af935ca53d60bf8a351c9592bc41`
- package hash: `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- full immutable git URL is recorded in `build.zig.zon`; no local path is used
- `.azure-sdk-generator` records the same released Core commit and hash in its replay command

## Validation
- verified `azure_rest_container_registry/v0.2.0` does not exist and `check-version` accepts `0.2.0` after `0.1.0`
- verified `azure_sdk_core/v0.3.0` resolves to `bc77bcacbb64af935ca53d60bf8a351c9592bc41`
- `zig fetch` returned the recorded Core package hash
- `zig fmt --check .`
- `zig build test --summary all` (4/4 package tests passed)
- generator tests against Core v0.3.0 (27/27 passed)
- replayed exact generation and compared trees: generated service output is unchanged; only the intentional manifest version differs
- `zig run eng/package_branch_tool.zig -- validate-tree azure_rest_container_registry <package-worktree>`
- manifest paths and immutable dependency pins remain exact
- examples/live targets are not exposed by this package; package CI explicitly reports none configured