### PR TITLE
Add Core conformance suites and prepare 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ Core CI runs the raw transport suite against `StdHttpTransport` and
 `MockTransport`, the pipeline and allocation-failure suites against reusable
 fakes, and the crypto suite against `StdCryptoProvider`. The standard
 transport is caller-serialized; the standard SDK crypto provider supports
-concurrent hash/HMAC calls.
+concurrent hash/HMAC calls. CI also archives exactly the manifest `.paths`,
+fetches that archive into a separate consumer package, and resolves all three
+modules through `b.dependency`; omitted package files therefore fail the
+package test.
 
 The WASI HTTP implementation separates target-neutral request adaptation from
 the `wasi:http@0.2.6` host externs. Native tests use an injectable fake host for
@@ -187,6 +190,8 @@ give each iteration enough work to dominate it.
 
 ```bash
 zig build test --summary all
+zig build package-consumer-check --summary all
+zig build wasi-check --summary all
 ```
 
 The package depends on `serde`. See the

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Core HTTP, authentication, error, paging, long-running-operation, URL, crypto,
 and utility infrastructure for the Azure SDK for Zig.
 
 The canonical package/module name is `azure_sdk_core`, released from
-`sdk/core`. Identity remains part of this package.
+`sdk/core`. Identity remains part of this package. The current breaking
+provider/streaming release line is `0.3.0`.
 
 ## Core surface
 
@@ -56,6 +57,47 @@ for every pipeline, credential call, client, and open operation that uses
 them. `StdHttpTransport` remains caller-serialized. Custom crypto provider
 contexts must be concurrent-safe or caller-serialized. Incremental SHA-256
 operations own stable allocator-backed state and must be deinitialized once.
+
+## Adapter conformance
+
+Core exports two test-only build modules in addition to the production
+`azure_sdk_core` module:
+
+- `azure_sdk_core_http_conformance`
+- `azure_sdk_core_crypto_conformance`
+
+Optional adapter packages import these modules from their pinned Core
+dependency and invoke the public factory-based runners. They are deliberately
+not imported by `root.zig`, and Core has no dependency on optional HTTP or
+crypto adapters.
+
+```zig
+const core_dep = b.dependency("azure_sdk_core", .{
+    .target = target,
+    .optimize = optimize,
+});
+const http_contracts = core_dep.module("azure_sdk_core_http_conformance");
+const crypto_contracts = core_dep.module("azure_sdk_core_crypto_conformance");
+```
+
+HTTP factories publish explicit capabilities for streaming, response-header
+ordering, framing validation, response limits, cancellation grade,
+decompression ownership, lifecycle observation, and bounded-memory
+logical-large uploads. Crypto factories publish incremental-allocation and
+concurrency guarantees. A skipped capability is not evidence of runtime
+support.
+
+Core CI runs the raw transport suite against `StdHttpTransport` and
+`MockTransport`, the pipeline and allocation-failure suites against reusable
+fakes, and the crypto suite against `StdCryptoProvider`. The standard
+transport is caller-serialized; the standard SDK crypto provider supports
+concurrent hash/HMAC calls.
+
+The WASI HTTP implementation separates target-neutral request adaptation from
+the `wasi:http@0.2.6` host externs. Native tests use an injectable fake host for
+the target-neutral seam. `zig build wasi-check` only proves that the
+`wasm32-wasi` guest code builds; it does **not** claim a runtime WASI engine,
+network, TLS, or trust-provider test.
 
 ## Identity
 

--- a/build.zig
+++ b/build.zig
@@ -127,6 +127,50 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    const package_archive = b.addSystemCommand(&.{ "tar", "-czf" });
+    package_archive.has_side_effects = true;
+    const archive = package_archive.addOutputFileArg(
+        "azure_sdk_core-manifest-filtered.tar.gz",
+    );
+    package_archive.addArg("-C");
+    package_archive.addArg(b.pathFromRoot("."));
+    inline for (@import("build.zig.zon").paths) |included_path| {
+        package_archive.addArg(included_path);
+    }
+
+    const package_consumer_files = b.addWriteFiles();
+    _ = package_consumer_files.addCopyFile(
+        b.path("conformance/package_consumer/build.zig"),
+        "build.zig",
+    );
+    _ = package_consumer_files.addCopyFile(
+        b.path("conformance/package_consumer/build.zig.zon"),
+        "build.zig.zon",
+    );
+    _ = package_consumer_files.addCopyFile(
+        b.path("conformance/package_consumer/consumer.zig"),
+        "consumer.zig",
+    );
+    const package_consumer_dir = package_consumer_files.getDirectory();
+
+    const package_fetch = b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "fetch",
+        "--save=core",
+    });
+    package_fetch.setCwd(package_consumer_dir);
+    package_fetch.addFileArg(archive);
+
+    const package_consumer_test = b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "build",
+        "test",
+        "--summary",
+        "all",
+    });
+    package_consumer_test.setCwd(package_consumer_dir);
+    package_consumer_test.step.dependOn(&package_fetch.step);
+
     const wasi_target = b.resolveTargetQuery(.{
         .cpu_arch = .wasm32,
         .os_tag = .wasi,
@@ -162,6 +206,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(crypto_conformance_tests).step);
     test_step.dependOn(&b.addRunArtifact(wasi_adapter_tests).step);
     test_step.dependOn(&consumer_check.step);
+    test_step.dependOn(&package_consumer_test.step);
     test_step.dependOn(&wasi_check.step);
 
     const conformance_consumer_step = b.step(
@@ -169,6 +214,12 @@ pub fn build(b: *std.Build) void {
         "Compile a consumer of the exported conformance modules",
     );
     conformance_consumer_step.dependOn(&consumer_check.step);
+
+    const package_consumer_step = b.step(
+        "package-consumer-check",
+        "Test conformance modules from the manifest-filtered package archive",
+    );
+    package_consumer_step.dependOn(&package_consumer_test.step);
 
     const wasi_step = b.step(
         "wasi-check",

--- a/build.zig
+++ b/build.zig
@@ -17,13 +17,46 @@ pub fn build(b: *std.Build) void {
     options.addOption([]const u8, "version", package_version);
     const options_mod = options.createModule();
 
-    _ = b.addModule("azure_sdk_core", .{
+    const core_mod = b.addModule("azure_sdk_core", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
             .{ .name = "serde", .module = serde_mod },
             .{ .name = "build_options", .module = options_mod },
+        },
+    });
+
+    const conformance_fakes_mod = b.createModule(.{
+        .root_source_file = b.path("conformance/fakes.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "azure_sdk_core", .module = core_mod },
+        },
+    });
+    const http_conformance_mod = b.addModule("azure_sdk_core_http_conformance", .{
+        .root_source_file = b.path("conformance/http_transport.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "azure_sdk_core", .module = core_mod },
+            .{
+                .name = "azure_sdk_core_conformance_fakes",
+                .module = conformance_fakes_mod,
+            },
+        },
+    });
+    const crypto_conformance_mod = b.addModule("azure_sdk_core_crypto_conformance", .{
+        .root_source_file = b.path("conformance/crypto_provider.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "azure_sdk_core", .module = core_mod },
+            .{
+                .name = "azure_sdk_core_conformance_fakes",
+                .module = conformance_fakes_mod,
+            },
         },
     });
 
@@ -38,6 +71,108 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    const http_conformance_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("conformance/http_transport.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = core_mod },
+                .{
+                    .name = "azure_sdk_core_conformance_fakes",
+                    .module = conformance_fakes_mod,
+                },
+            },
+        }),
+    });
+    const crypto_conformance_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("conformance/crypto_provider.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = core_mod },
+                .{
+                    .name = "azure_sdk_core_conformance_fakes",
+                    .module = conformance_fakes_mod,
+                },
+            },
+        }),
+    });
+    const wasi_adapter_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("wasi_adapter_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const consumer_check = b.addObject(.{
+        .name = "core-conformance-consumer-check",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("conformance/consumer.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = core_mod },
+                .{
+                    .name = "azure_sdk_core_http_conformance",
+                    .module = http_conformance_mod,
+                },
+                .{
+                    .name = "azure_sdk_core_crypto_conformance",
+                    .module = crypto_conformance_mod,
+                },
+            },
+        }),
+    });
+
+    const wasi_target = b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .wasi,
+    });
+    const wasi_serde_dep = b.dependency("serde", .{
+        .target = wasi_target,
+        .optimize = optimize,
+    });
+    const wasi_core_mod = b.createModule(.{
+        .root_source_file = b.path("root.zig"),
+        .target = wasi_target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "serde", .module = wasi_serde_dep.module("serde") },
+            .{ .name = "build_options", .module = options_mod },
+        },
+    });
+    const wasi_check = b.addObject(.{
+        .name = "core-wasi-build-check",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("conformance/wasi_build_check.zig"),
+            .target = wasi_target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = wasi_core_mod },
+            },
+        }),
+    });
+
     const test_step = b.step("test", "Run Core tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
+    test_step.dependOn(&b.addRunArtifact(http_conformance_tests).step);
+    test_step.dependOn(&b.addRunArtifact(crypto_conformance_tests).step);
+    test_step.dependOn(&b.addRunArtifact(wasi_adapter_tests).step);
+    test_step.dependOn(&consumer_check.step);
+    test_step.dependOn(&wasi_check.step);
+
+    const conformance_consumer_step = b.step(
+        "conformance-consumer-check",
+        "Compile a consumer of the exported conformance modules",
+    );
+    conformance_consumer_step.dependOn(&consumer_check.step);
+
+    const wasi_step = b.step(
+        "wasi-check",
+        "Build-check the Core WASI HTTP transport (no runtime coverage)",
+    );
+    wasi_step.dependOn(&wasi_check.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 /// Single source of truth for the package version: the manifest.
 const package_version = @import("build.zig.zon").version;
@@ -127,7 +128,11 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
-    const package_archive = b.addSystemCommand(&.{ "tar", "-czf" });
+    const package_archive = b.addSystemCommand(&.{"tar"});
+    if (builtin.target.os.tag == .windows) {
+        package_archive.addArg("--force-local");
+    }
+    package_archive.addArg("-czf");
     package_archive.has_side_effects = true;
     const archive = package_archive.addOutputFileArg(
         "azure_sdk_core-manifest-filtered.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_core,
-    .version = "0.2.0",
+    .version = "0.3.0",
     .fingerprint = 0x0fdf522a12345678,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
@@ -19,6 +19,7 @@
         "arm",
         "credentials",
         "http",
+        "conformance",
         "identity",
         "tracing",
         "perf",
@@ -37,6 +38,7 @@
         "safe_debug.zig",
         "url.zig",
         "uuid.zig",
+        "wasi_adapter_test.zig",
         "README.md",
         "LICENSE.txt",
     },

--- a/conformance/consumer.zig
+++ b/conformance/consumer.zig
@@ -1,0 +1,16 @@
+const core = @import("azure_sdk_core");
+const http_conformance = @import("azure_sdk_core_http_conformance");
+const crypto_conformance = @import("azure_sdk_core_crypto_conformance");
+
+comptime {
+    _ = core.http.HttpTransport;
+    _ = http_conformance.BackendFactory;
+    _ = http_conformance.runRawTransportContracts;
+    _ = http_conformance.runPipelineContracts;
+    _ = http_conformance.runAllocationFailureContracts;
+    _ = crypto_conformance.ProviderFactory;
+    _ = crypto_conformance.runCryptoContracts;
+    _ = crypto_conformance.runProviderBoundaryContracts;
+}
+
+export fn azureSdkCoreConformanceConsumerCheck() void {}

--- a/conformance/crypto_provider.zig
+++ b/conformance/crypto_provider.zig
@@ -1,0 +1,316 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+pub const fakes = @import("azure_sdk_core_conformance_fakes");
+
+pub const Concurrency = enum {
+    caller_serialized,
+    concurrent_safe,
+};
+
+pub const Capabilities = struct {
+    random_bytes: bool = true,
+    incremental_sha256: bool = true,
+    incremental_uses_allocator: bool = true,
+    concurrency: Concurrency = .caller_serialized,
+};
+
+pub const ProviderInstance = struct {
+    provider: core.crypto.CryptoProvider,
+    context: *anyopaque,
+    deinitFn: *const fn (context: *anyopaque) void,
+
+    pub fn deinit(self: *ProviderInstance) void {
+        self.deinitFn(self.context);
+        self.* = undefined;
+    }
+};
+
+pub const ProviderFactory = struct {
+    name: []const u8,
+    capabilities: Capabilities,
+    context: ?*anyopaque = null,
+    createFn: *const fn (
+        context: ?*anyopaque,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+    ) anyerror!ProviderInstance,
+
+    pub fn create(
+        self: ProviderFactory,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+    ) !ProviderInstance {
+        return self.createFn(self.context, allocator, io);
+    }
+};
+
+/// Run the deterministic SDK crypto-provider contract.
+///
+/// Adapter packages should expose their provider through `ProviderFactory`
+/// and invoke this runner from their own tests.
+pub fn runCryptoContracts(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: ProviderFactory,
+) !void {
+    var instance = try factory.create(allocator, io);
+    defer instance.deinit();
+    const provider = instance.provider;
+
+    try expectHex(
+        "d41d8cd98f00b204e9800998ecf8427e",
+        &(try provider.md5("")),
+    );
+    try expectHex(
+        "900150983cd24fb0d6963f7d28e17f72",
+        &(try provider.md5("abc")),
+    );
+    try expectHex(
+        "e3b0c44298fc1c149afbf4c8996fb924" ++ "27ae41e4649b934ca495991b7852b855",
+        &(try provider.sha256("")),
+    );
+    try expectHex(
+        "ba7816bf8f01cfea414140de5dae2223" ++ "b00361a396177a9cb410ff61f20015ad",
+        &(try provider.sha256("abc")),
+    );
+
+    var key_0b: [20]u8 = undefined;
+    @memset(&key_0b, 0x0b);
+    try expectHex(
+        "b0344c61d8db38535ca8afceaf0bf12b" ++ "881dc200c9833da726e9376c2e32cff7",
+        &(try provider.hmacSha256(&key_0b, "Hi There")),
+    );
+    try expectHex(
+        "5bdcc146bf60754e6a042426089575c7" ++ "5a003f089d2739839dec58b964ec3843",
+        &(try provider.hmacSha256("Jefe", "what do ya want for nothing?")),
+    );
+    var key_aa: [20]u8 = undefined;
+    @memset(&key_aa, 0xaa);
+    var data_dd: [50]u8 = undefined;
+    @memset(&data_dd, 0xdd);
+    try expectHex(
+        "773ea91e36800e46854db8ebd09181a7" ++ "2959098b3ef8c122d9635514ced565fe",
+        &(try provider.hmacSha256(&key_aa, &data_dd)),
+    );
+    try expectHex(
+        "b613679a0814d9ec772f95d778c35fc5" ++ "ff1697c493715653c6c712144292c5ad",
+        &(try provider.hmacSha256("", "")),
+    );
+
+    if (factory.capabilities.random_bytes) {
+        var empty: [0]u8 = .{};
+        try provider.randomBytes(&empty);
+        var random: [32]u8 = undefined;
+        try provider.randomBytes(&random);
+    }
+
+    if (factory.capabilities.incremental_sha256) {
+        var operation = try provider.sha256Init(allocator);
+        defer operation.deinit();
+        try operation.update("");
+        try operation.update("a");
+        try operation.update("b");
+        try operation.update("c");
+        try expectHex(
+            "ba7816bf8f01cfea414140de5dae2223" ++ "b00361a396177a9cb410ff61f20015ad",
+            &(try operation.final()),
+        );
+        try std.testing.expectError(
+            error.Sha256AlreadyFinalized,
+            operation.update("after-final"),
+        );
+
+        var empty_operation = try provider.sha256Init(allocator);
+        defer empty_operation.deinit();
+        try expectHex(
+            "e3b0c44298fc1c149afbf4c8996fb924" ++ "27ae41e4649b934ca495991b7852b855",
+            &(try empty_operation.final()),
+        );
+    }
+
+    if (factory.capabilities.incremental_sha256 and
+        factory.capabilities.incremental_uses_allocator)
+    {
+        try std.testing.expectError(
+            error.OutOfMemory,
+            provider.sha256Init(std.testing.failing_allocator),
+        );
+    }
+
+    if (factory.capabilities.concurrency == .concurrent_safe) {
+        try runConcurrencyContract(provider);
+    }
+}
+
+/// Exercise dispatch spies and providers that write output before failing.
+///
+/// A provider failure must remain an error through Core's direct and
+/// base64-allocating helpers; callers must never receive a partial digest as a
+/// successful result or an allocation-produced wrapper value.
+pub fn runProviderBoundaryContracts() !void {
+    var spy = fakes.SpyCryptoProvider{};
+    const copied = spy.asProvider();
+    const provider = copied;
+
+    var random: [4]u8 = undefined;
+    try provider.randomBytes(&random);
+    try std.testing.expectEqualSlices(u8, &.{ 0x5a, 0x5a, 0x5a, 0x5a }, &random);
+    _ = try provider.md5("md5");
+    try std.testing.expectEqual(fakes.SpyCryptoProvider.Operation.md5, spy.operation);
+    try std.testing.expectEqualStrings("md5", spy.data);
+    _ = try provider.sha256("sha");
+    try std.testing.expectEqual(fakes.SpyCryptoProvider.Operation.sha256, spy.operation);
+    try std.testing.expectEqualStrings("sha", spy.data);
+    _ = try provider.hmacSha256("key", "message");
+    try std.testing.expectEqual(
+        fakes.SpyCryptoProvider.Operation.hmac_sha256,
+        spy.operation,
+    );
+    try std.testing.expectEqualStrings("key", spy.key);
+    try std.testing.expectEqualStrings("message", spy.message);
+    try std.testing.expectError(
+        error.SpyIncrementalUnsupported,
+        provider.sha256Init(std.testing.allocator),
+    );
+    try std.testing.expectEqual(
+        fakes.SpyCryptoProvider.Operation.sha256_init,
+        spy.operation,
+    );
+    try std.testing.expectEqual(@as(usize, 5), spy.calls);
+
+    var fault = fakes.FaultCryptoProvider{};
+    const failing = fault.asProvider();
+    var failed_random: [4]u8 = @splat(0);
+    try std.testing.expectError(
+        error.ProviderFailure,
+        failing.randomBytes(&failed_random),
+    );
+    try std.testing.expectEqual(@as(u8, 0xa5), failed_random[0]);
+    try std.testing.expectError(error.ProviderFailure, failing.md5("data"));
+    try std.testing.expectError(error.ProviderFailure, failing.sha256("data"));
+    try std.testing.expectError(
+        error.ProviderFailure,
+        failing.hmacSha256("key", "message"),
+    );
+    try std.testing.expectError(
+        error.ProviderFailure,
+        failing.sha256Init(std.testing.allocator),
+    );
+    try std.testing.expectError(
+        error.ProviderFailure,
+        core.base64.md5Base64(std.testing.failing_allocator, failing, "data"),
+    );
+    try std.testing.expectError(
+        error.ProviderFailure,
+        core.base64.sha256Base64(std.testing.failing_allocator, failing, "data"),
+    );
+    try std.testing.expectError(
+        error.ProviderFailure,
+        core.base64.hmacSha256Base64(
+            std.testing.failing_allocator,
+            failing,
+            "key",
+            "message",
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 8), fault.calls.load(.monotonic));
+}
+
+fn expectHex(expected: []const u8, actual: []const u8) !void {
+    const digits = "0123456789abcdef";
+    try std.testing.expectEqual(actual.len * 2, expected.len);
+    for (actual, 0..) |byte, index| {
+        try std.testing.expectEqual(
+            digits[byte >> 4],
+            expected[index * 2],
+        );
+        try std.testing.expectEqual(
+            digits[byte & 0x0f],
+            expected[index * 2 + 1],
+        );
+    }
+}
+
+fn runConcurrencyContract(provider: core.crypto.CryptoProvider) !void {
+    const Worker = struct {
+        provider: core.crypto.CryptoProvider,
+        failed: *std.atomic.Value(bool),
+
+        fn run(self: @This()) void {
+            for (0..256) |_| {
+                const digest = self.provider.sha256("concurrent") catch {
+                    self.failed.store(true, .release);
+                    return;
+                };
+                var expected: core.crypto.Sha256Digest = undefined;
+                std.crypto.hash.sha2.Sha256.hash("concurrent", &expected, .{});
+                if (!std.mem.eql(u8, &digest, &expected)) {
+                    self.failed.store(true, .release);
+                    return;
+                }
+                _ = self.provider.hmacSha256("key", "message") catch {
+                    self.failed.store(true, .release);
+                    return;
+                };
+            }
+        }
+    };
+
+    var failed = std.atomic.Value(bool).init(false);
+    const worker = Worker{ .provider = provider, .failed = &failed };
+    var threads: [4]std.Thread = undefined;
+    for (&threads) |*thread| {
+        thread.* = try std.Thread.spawn(.{}, Worker.run, .{worker});
+    }
+    for (threads) |thread| thread.join();
+    try std.testing.expect(!failed.load(.acquire));
+}
+
+const StdProviderState = struct {
+    allocator: std.mem.Allocator,
+    provider: core.crypto.StdCryptoProvider,
+
+    fn destroy(context: *anyopaque) void {
+        const self: *StdProviderState = @ptrCast(@alignCast(context));
+        self.allocator.destroy(self);
+    }
+};
+
+fn createStdProvider(
+    _: ?*anyopaque,
+    allocator: std.mem.Allocator,
+    io: std.Io,
+) !ProviderInstance {
+    const state = try allocator.create(StdProviderState);
+    state.* = .{
+        .allocator = allocator,
+        .provider = core.crypto.StdCryptoProvider.init(io),
+    };
+    return .{
+        .provider = state.provider.asProvider(),
+        .context = state,
+        .deinitFn = &StdProviderState.destroy,
+    };
+}
+
+pub fn standardProviderFactory() ProviderFactory {
+    return .{
+        .name = "std.crypto",
+        .capabilities = .{
+            .concurrency = .concurrent_safe,
+        },
+        .createFn = &createStdProvider,
+    };
+}
+
+test "standard crypto provider conforms" {
+    try runCryptoContracts(
+        std.testing.allocator,
+        std.testing.io,
+        standardProviderFactory(),
+    );
+}
+
+test "crypto provider boundaries reject partial success" {
+    try runProviderBoundaryContracts();
+}

--- a/conformance/crypto_provider.zig
+++ b/conformance/crypto_provider.zig
@@ -248,10 +248,20 @@ fn runConcurrencyContract(provider: core.crypto.CryptoProvider) !void {
                     self.failed.store(true, .release);
                     return;
                 }
-                _ = self.provider.hmacSha256("key", "message") catch {
+                const mac = self.provider.hmacSha256("key", "message") catch {
                     self.failed.store(true, .release);
                     return;
                 };
+                var expected_mac: core.crypto.HmacSha256Digest = undefined;
+                std.crypto.auth.hmac.sha2.HmacSha256.create(
+                    &expected_mac,
+                    "message",
+                    "key",
+                );
+                if (!std.mem.eql(u8, &mac, &expected_mac)) {
+                    self.failed.store(true, .release);
+                    return;
+                }
             }
         }
     };

--- a/conformance/fakes.zig
+++ b/conformance/fakes.zig
@@ -1,0 +1,223 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+pub const FaultCryptoProvider = struct {
+    calls: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    pub fn asProvider(self: *FaultCryptoProvider) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn record(self: *FaultCryptoProvider) !void {
+        _ = self.calls.fetchAdd(1, .monotonic);
+        return error.ProviderFailure;
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *FaultCryptoProvider = @ptrCast(@alignCast(context));
+        if (out.len > 0) out[0] = 0xa5;
+        return self.record();
+    }
+
+    fn md5(
+        context: *anyopaque,
+        _: []const u8,
+        out: *core.crypto.Md5Digest,
+    ) !void {
+        const self: *FaultCryptoProvider = @ptrCast(@alignCast(context));
+        @memset(out, 0xa5);
+        return self.record();
+    }
+
+    fn sha256(
+        context: *anyopaque,
+        _: []const u8,
+        out: *core.crypto.Sha256Digest,
+    ) !void {
+        const self: *FaultCryptoProvider = @ptrCast(@alignCast(context));
+        @memset(out, 0xa5);
+        return self.record();
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self: *FaultCryptoProvider = @ptrCast(@alignCast(context));
+        @memset(out, 0xa5);
+        return self.record();
+    }
+
+    fn sha256Init(
+        context: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        const self: *FaultCryptoProvider = @ptrCast(@alignCast(context));
+        try self.record();
+        unreachable;
+    }
+};
+
+pub const SpyCryptoProvider = struct {
+    pub const Operation = enum {
+        none,
+        random_bytes,
+        md5,
+        sha256,
+        hmac_sha256,
+        sha256_init,
+    };
+
+    calls: usize = 0,
+    operation: Operation = .none,
+    data: []const u8 = "",
+    key: []const u8 = "",
+    message: []const u8 = "",
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    pub fn asProvider(self: *SpyCryptoProvider) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn record(self: *SpyCryptoProvider, operation: Operation) void {
+        self.calls += 1;
+        self.operation = operation;
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *SpyCryptoProvider = @ptrCast(@alignCast(context));
+        self.record(.random_bytes);
+        @memset(out, 0x5a);
+    }
+
+    fn md5(
+        context: *anyopaque,
+        data: []const u8,
+        out: *core.crypto.Md5Digest,
+    ) !void {
+        const self: *SpyCryptoProvider = @ptrCast(@alignCast(context));
+        self.record(.md5);
+        self.data = data;
+        @memset(out, 0x5a);
+    }
+
+    fn sha256(
+        context: *anyopaque,
+        data: []const u8,
+        out: *core.crypto.Sha256Digest,
+    ) !void {
+        const self: *SpyCryptoProvider = @ptrCast(@alignCast(context));
+        self.record(.sha256);
+        self.data = data;
+        @memset(out, 0x5a);
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self: *SpyCryptoProvider = @ptrCast(@alignCast(context));
+        self.record(.hmac_sha256);
+        self.key = key;
+        self.message = message;
+        @memset(out, 0x5a);
+    }
+
+    fn sha256Init(
+        context: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        const self: *SpyCryptoProvider = @ptrCast(@alignCast(context));
+        self.record(.sha256_init);
+        return error.SpyIncrementalUnsupported;
+    }
+};
+
+pub const RepeatingReader = struct {
+    interface: std.Io.Reader,
+    byte: u8,
+    remaining: usize,
+
+    pub fn init(byte: u8, length: usize) RepeatingReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .byte = byte,
+            .remaining = length,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *RepeatingReader = @alignCast(
+            @fieldParentPtr("interface", interface),
+        );
+        if (self.remaining == 0) return error.EndOfStream;
+        var bytes: [4096]u8 = undefined;
+        @memset(&bytes, self.byte);
+        const count = @min(self.remaining, limit.minInt(bytes.len));
+        try writer.writeAll(bytes[0..count]);
+        self.remaining -= count;
+        return count;
+    }
+};
+
+pub const CancellingReader = struct {
+    interface: std.Io.Reader,
+    token: *core.http.CancellationToken,
+    emitted: bool = false,
+
+    pub fn init(token: *core.http.CancellationToken) CancellingReader {
+        return .{
+            .interface = .{
+                .vtable = &.{ .stream = &stream },
+                .buffer = &.{},
+                .seek = 0,
+                .end = 0,
+            },
+            .token = token,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *CancellingReader = @alignCast(
+            @fieldParentPtr("interface", interface),
+        );
+        if (self.emitted) return error.EndOfStream;
+        const bytes = limit.sliceConst("part");
+        try writer.writeAll(bytes);
+        self.emitted = true;
+        self.token.cancel();
+        return bytes.len;
+    }
+};

--- a/conformance/http_transport.zig
+++ b/conformance/http_transport.zig
@@ -1,0 +1,964 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+pub const scripted = @import("scripted_http_server.zig");
+pub const fakes = @import("azure_sdk_core_conformance_fakes");
+
+pub const CancellationGrade = enum {
+    none,
+    preflight,
+    cooperative_upload,
+};
+
+pub const Capabilities = struct {
+    streaming: bool = true,
+    ordered_duplicate_response_headers: bool = true,
+    request_framing_validation: bool = true,
+    response_framing_validation: bool = false,
+    response_body_limit: bool = false,
+    decompression: bool = false,
+    cancellation: CancellationGrade = .preflight,
+    lifecycle_observable: bool = false,
+    automatic_request_headers: bool = false,
+    bounded_memory_logical_large_upload: bool = false,
+};
+
+pub const BackendOptions = struct {
+    response: scripted.Response = .{},
+    expect_request: bool = true,
+    allow_peer_failure: bool = false,
+    max_response_body: ?usize = null,
+};
+
+pub const Observation = struct {
+    request_count: usize = 0,
+    body: []const u8 = "",
+    body_length: usize = 0,
+    user_agent_count: usize = 0,
+    accept_encoding_count: usize = 0,
+    host_count: usize = 0,
+    connection_count: usize = 0,
+    accept_count: usize = 0,
+    finish_count: usize = 0,
+    abort_count: usize = 0,
+    cancel_count: usize = 0,
+    deinit_count: usize = 0,
+};
+
+pub const BackendInstance = struct {
+    transport: core.http.HttpTransport,
+    url: []const u8,
+    context: *anyopaque,
+    finishFn: *const fn (context: *anyopaque) anyerror!void,
+    observeFn: *const fn (context: *anyopaque) Observation,
+    deinitFn: *const fn (context: *anyopaque) void,
+
+    pub fn finish(self: *BackendInstance) !void {
+        return self.finishFn(self.context);
+    }
+
+    pub fn observe(self: *const BackendInstance) Observation {
+        return self.observeFn(self.context);
+    }
+
+    pub fn deinit(self: *BackendInstance) void {
+        self.deinitFn(self.context);
+        self.* = undefined;
+    }
+};
+
+pub const BackendFactory = struct {
+    name: []const u8,
+    capabilities: Capabilities,
+    context: ?*anyopaque = null,
+    createFn: *const fn (
+        context: ?*anyopaque,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        options: BackendOptions,
+    ) anyerror!BackendInstance,
+
+    pub fn create(
+        self: BackendFactory,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        options: BackendOptions,
+    ) !BackendInstance {
+        return self.createFn(self.context, allocator, io, options);
+    }
+};
+
+/// Run raw transport contracts against a backend factory.
+///
+/// Capabilities explicitly distinguish unsupported contracts from failures,
+/// including build-only backends whose runtime host is unavailable.
+pub fn runRawTransportContracts(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    try runBufferedContract(allocator, io, factory);
+    if (factory.capabilities.streaming) {
+        try runStreamingContract(allocator, io, factory, true);
+        try runStreamingContract(allocator, io, factory, false);
+        try runLifecycleContract(allocator, io, factory);
+    }
+    if (factory.capabilities.request_framing_validation) {
+        try runRequestFramingContracts(allocator, io, factory);
+    }
+    if (factory.capabilities.cancellation != .none) {
+        try runCancellationContracts(allocator, io, factory);
+    }
+    if (factory.capabilities.response_framing_validation) {
+        try runResponseFramingContract(allocator, io, factory);
+    }
+    if (factory.capabilities.response_body_limit) {
+        try runResponseLimitContract(allocator, io, factory);
+    }
+    if (factory.capabilities.decompression) {
+        try runDecompressionContract(allocator, io, factory, false);
+        try runDecompressionContract(allocator, io, factory, true);
+    }
+    if (factory.capabilities.bounded_memory_logical_large_upload) {
+        try runLogicalLargeUploadContract(allocator, io, factory);
+    }
+}
+
+/// Run Core pipeline ownership, redirect, replay, retry, and decompression
+/// contracts. Adapter packages should invoke this with their backend factory.
+pub fn runPipelineContracts(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    try runPipelineDispatchContract(allocator, io, factory);
+    try runRedirectContracts(allocator);
+    try runRetryContracts(allocator);
+    if (factory.capabilities.decompression) {
+        try runPipelineDecompressionContract(allocator, io, factory);
+    }
+}
+
+/// Exhaustively fail allocator calls in the reusable fake streaming,
+/// redirect, and retry fixtures.
+pub fn runAllocationFailureContracts() !void {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        mockStreamingAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        redirectAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        retryAllocationFixture,
+        .{},
+    );
+}
+
+fn runBufferedContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    const headers = [_]scripted.Header{
+        .{ .name = "X-Duplicate", .value = "first" },
+        .{ .name = "x-duplicate", .value = "second" },
+    };
+    var backend = try factory.create(allocator, io, .{
+        .response = .{
+            .status_code = 201,
+            .reason = "Created",
+            .headers = &headers,
+            .body = "buffered-response",
+        },
+    });
+    defer backend.deinit();
+
+    const copied = backend.transport;
+    var request = core.http.Request.init(allocator, .GET, backend.url);
+    defer request.deinit();
+    try request.setHeader("User-Agent", "azsdk-zig-conformance/0.3.0");
+    try request.setHeader("Accept-Encoding", "identity");
+    try request.setHeader("Accept", "application/json");
+
+    var response = try copied.send(&request);
+    defer response.deinit();
+    try backend.finish();
+    try std.testing.expectEqual(@as(u16, 201), response.status_code);
+    try std.testing.expectEqualStrings("buffered-response", response.body);
+    if (factory.capabilities.ordered_duplicate_response_headers) {
+        const values = try response.getHeaderValues(allocator, "X-DUPLICATE");
+        defer allocator.free(values);
+        try std.testing.expectEqual(@as(usize, 2), values.len);
+        try std.testing.expectEqualStrings("first", values[0]);
+        try std.testing.expectEqualStrings("second", values[1]);
+    }
+
+    const observation = backend.observe();
+    try std.testing.expectEqual(@as(usize, 1), observation.request_count);
+    if (factory.capabilities.automatic_request_headers) {
+        try std.testing.expectEqual(@as(usize, 1), observation.user_agent_count);
+        try std.testing.expectEqual(@as(usize, 1), observation.accept_encoding_count);
+        try std.testing.expectEqual(@as(usize, 1), observation.host_count);
+        try std.testing.expectEqual(@as(usize, 1), observation.connection_count);
+        try std.testing.expectEqual(@as(usize, 1), observation.accept_count);
+    }
+}
+
+fn runStreamingContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+    known_length: bool,
+) !void {
+    var backend = try factory.create(allocator, io, .{
+        .response = .{ .status_code = 202, .reason = "Accepted", .body = "stream-response" },
+    });
+    defer backend.deinit();
+
+    var request = core.http.Request.init(allocator, .POST, backend.url);
+    defer request.deinit();
+    var reader = std.Io.Reader.fixed("stream-upload");
+    const body = if (known_length)
+        core.http.StreamingRequestBody.knownLength(&reader, "stream-upload".len)
+    else
+        core.http.StreamingRequestBody.chunked(&reader);
+    var operation = try backend.transport.open(&request, .{ .body = body });
+    const response = try (try operation.reader()).allocRemaining(allocator, .unlimited);
+    defer allocator.free(response);
+    try std.testing.expectEqualStrings("stream-response", response);
+    try operation.finish();
+    try std.testing.expectError(error.HttpOperationNotActive, operation.finish());
+    operation.abort();
+    operation.cancel();
+    operation.deinit();
+    try backend.finish();
+
+    const observation = backend.observe();
+    try std.testing.expectEqual(@as(usize, 1), observation.request_count);
+    try std.testing.expectEqualStrings("stream-upload", observation.body);
+    try std.testing.expectEqual(@as(usize, "stream-upload".len), observation.body_length);
+    if (factory.capabilities.lifecycle_observable) {
+        try std.testing.expectEqual(@as(usize, 1), observation.finish_count);
+        try std.testing.expectEqual(@as(usize, 0), observation.abort_count);
+        try std.testing.expectEqual(@as(usize, 0), observation.cancel_count);
+        try std.testing.expectEqual(@as(usize, 1), observation.deinit_count);
+    }
+}
+
+fn runLifecycleContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    {
+        var backend = try factory.create(allocator, io, .{
+            .response = .{ .body = "abort" },
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .GET, backend.url);
+        defer request.deinit();
+        var operation = try backend.transport.open(&request, .{});
+        operation.abort();
+        operation.abort();
+        operation.cancel();
+        operation.deinit();
+        try backend.finish();
+        if (factory.capabilities.lifecycle_observable) {
+            const observation = backend.observe();
+            try std.testing.expectEqual(@as(usize, 1), observation.abort_count);
+            try std.testing.expectEqual(@as(usize, 0), observation.cancel_count);
+            try std.testing.expectEqual(@as(usize, 1), observation.deinit_count);
+        }
+    }
+    {
+        var backend = try factory.create(allocator, io, .{
+            .response = .{ .body = "cancel" },
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .GET, backend.url);
+        defer request.deinit();
+        var operation = try backend.transport.open(&request, .{});
+        operation.cancel();
+        operation.cancel();
+        operation.abort();
+        operation.deinit();
+        try backend.finish();
+        if (factory.capabilities.lifecycle_observable) {
+            const observation = backend.observe();
+            try std.testing.expectEqual(@as(usize, 0), observation.abort_count);
+            try std.testing.expectEqual(@as(usize, 1), observation.cancel_count);
+            try std.testing.expectEqual(@as(usize, 1), observation.deinit_count);
+        }
+    }
+}
+
+fn runRequestFramingContracts(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    {
+        var backend = try factory.create(allocator, io, .{ .expect_request = false });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .POST, backend.url);
+        defer request.deinit();
+        try request.setHeader("Content-Length", "99");
+        var source = std.Io.Reader.fixed("body");
+        try std.testing.expectError(
+            error.ConflictingRequestFraming,
+            backend.transport.open(&request, .{
+                .body = core.http.StreamingRequestBody.knownLength(&source, 4),
+            }),
+        );
+        try backend.finish();
+        try std.testing.expect(request.transport_started);
+    }
+    {
+        var backend = try factory.create(allocator, io, .{
+            .allow_peer_failure = true,
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .POST, backend.url);
+        defer request.deinit();
+        var source = std.Io.Reader.fixed("short");
+        try std.testing.expectError(
+            error.RequestBodyTooShort,
+            backend.transport.open(&request, .{
+                .body = core.http.StreamingRequestBody.knownLength(&source, 6),
+            }),
+        );
+        try backend.finish();
+    }
+    {
+        var backend = try factory.create(allocator, io, .{
+            .allow_peer_failure = true,
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .POST, backend.url);
+        defer request.deinit();
+        var source = std.Io.Reader.fixed("long");
+        try std.testing.expectError(
+            error.RequestBodyTooLong,
+            backend.transport.open(&request, .{
+                .body = core.http.StreamingRequestBody.knownLength(&source, 3),
+            }),
+        );
+        try backend.finish();
+    }
+    {
+        var backend = try factory.create(allocator, io, .{ .expect_request = false });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .POST, backend.url);
+        defer request.deinit();
+        request.body = "buffered";
+        var source = std.Io.Reader.fixed("streamed");
+        try std.testing.expectError(
+            error.MultipleRequestBodies,
+            backend.transport.open(&request, .{
+                .body = core.http.StreamingRequestBody.chunked(&source),
+            }),
+        );
+        try backend.finish();
+    }
+}
+
+fn runCancellationContracts(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    {
+        var backend = try factory.create(allocator, io, .{ .expect_request = false });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .GET, backend.url);
+        defer request.deinit();
+        var token = core.http.CancellationToken{};
+        token.cancel();
+        try std.testing.expectError(
+            error.OperationCancelled,
+            backend.transport.open(&request, .{ .cancellation = &token }),
+        );
+        try backend.finish();
+        try std.testing.expect(!request.transport_started);
+    }
+    if (factory.capabilities.cancellation == .cooperative_upload) {
+        var backend = try factory.create(allocator, io, .{
+            .allow_peer_failure = true,
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .POST, backend.url);
+        defer request.deinit();
+        var token = core.http.CancellationToken{};
+        var source = fakes.CancellingReader.init(&token);
+        try std.testing.expectError(
+            error.OperationCancelled,
+            backend.transport.open(&request, .{
+                .body = core.http.StreamingRequestBody.chunked(&source.interface),
+                .cancellation = &token,
+            }),
+        );
+        try backend.finish();
+    }
+}
+
+fn runResponseFramingContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    var backend = try factory.create(allocator, io, .{
+        .response = .{
+            .body = "short",
+            .advertised_content_length = 12,
+        },
+    });
+    defer backend.deinit();
+    var request = core.http.Request.init(allocator, .GET, backend.url);
+    defer request.deinit();
+    var operation = try backend.transport.open(&request, .{});
+    if (operation.finish()) |_| {
+        operation.deinit();
+        return error.ExpectedResponseFramingFailure;
+    } else |_| {}
+    try std.testing.expectEqual(core.http.OperationState.aborted, operation.state);
+    operation.deinit();
+    try backend.finish();
+}
+
+fn runResponseLimitContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    var backend = try factory.create(allocator, io, .{
+        .response = .{ .body = "0123456789abcdef" },
+        .max_response_body = 8,
+    });
+    defer backend.deinit();
+    var request = core.http.Request.init(allocator, .GET, backend.url);
+    defer request.deinit();
+    try std.testing.expectError(
+        error.StreamTooLong,
+        backend.transport.send(&request),
+    );
+    try backend.finish();
+}
+
+const gzip_conformance_body =
+    "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\xff" ++
+    "\x4b\xce\xcf\x4b\xcb\x2f\xca\x4d\xcc\x4b" ++
+    "\x4e\x05\x00\xe7\x15\x15\xe8\x0b\x00\x00\x00";
+
+fn runDecompressionContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+    chunked: bool,
+) !void {
+    const headers = [_]scripted.Header{
+        .{ .name = "Content-Encoding", .value = "gzip" },
+    };
+    var backend = try factory.create(allocator, io, .{
+        .response = .{
+            .headers = &headers,
+            .body = gzip_conformance_body,
+            .chunked = chunked,
+        },
+    });
+    defer backend.deinit();
+    var request = core.http.Request.init(allocator, .GET, backend.url);
+    defer request.deinit();
+    var response = try backend.transport.send(&request);
+    defer response.deinit();
+    try backend.finish();
+    try std.testing.expectEqualStrings("conformance", response.body);
+}
+
+fn runLogicalLargeUploadContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    const logical_length = 8 * 1024 * 1024;
+    var backend = try factory.create(allocator, io, .{});
+    defer backend.deinit();
+    var request = core.http.Request.init(allocator, .PUT, backend.url);
+    defer request.deinit();
+    var source = fakes.RepeatingReader.init('x', logical_length);
+    var operation = try backend.transport.open(&request, .{
+        .body = core.http.StreamingRequestBody.knownLength(
+            &source.interface,
+            logical_length,
+        ),
+    });
+    try operation.finish();
+    operation.deinit();
+    try backend.finish();
+    const observation = backend.observe();
+    try std.testing.expectEqual(@as(usize, logical_length), observation.body_length);
+    try std.testing.expectEqual(@as(usize, 4096), observation.body.len);
+    for (observation.body) |byte| try std.testing.expectEqual(@as(u8, 'x'), byte);
+}
+
+fn runPipelineDispatchContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    var backend = try factory.create(allocator, io, .{
+        .response = .{ .body = "pipeline" },
+    });
+    defer backend.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(io);
+    var telemetry = core.http.TelemetryPolicy.init("azsdk-zig-conformance/0.3.0");
+    var policies = [_]*core.http.HttpPolicy{telemetry.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        core.http.HttpRuntime.init(backend.transport, crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(allocator, .GET, backend.url);
+    defer request.deinit();
+    var response = try pipeline.send(&request);
+    defer response.deinit();
+    try backend.finish();
+    try std.testing.expectEqualStrings("pipeline", response.body);
+    try std.testing.expectEqualStrings(
+        "azsdk-zig-conformance/0.3.0",
+        request.getHeader("User-Agent").?,
+    );
+}
+
+fn runRedirectContracts(allocator: std.mem.Allocator) !void {
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "https://storage.example/blob#fragment" }},
+        },
+        .{ .status = 200, .body = "ok" },
+    });
+    var request = core.http.Request.init(
+        allocator,
+        .POST,
+        "https://registry.example/upload",
+    );
+    defer request.deinit();
+    try request.setHeader("Authorization", "******");
+    try request.setHeader("Cookie", "secret");
+    try request.setHeader("Proxy-Authorization", "secret");
+    try request.setHeader("Host", "registry.example");
+    var replay = core.http.ReplayableBytes.init("payload");
+    var operation = try sequence.asTransport().open(
+        &request,
+        .{ .body = replay.body() },
+    );
+    defer operation.deinit();
+    try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
+    try std.testing.expect(sequence.captured_authorization[0]);
+    try std.testing.expect(!sequence.captured_authorization[1]);
+    try std.testing.expect(sequence.captured_cookie[0]);
+    try std.testing.expect(!sequence.captured_cookie[1]);
+    try std.testing.expect(sequence.captured_proxy_authorization[0]);
+    try std.testing.expect(!sequence.captured_proxy_authorization[1]);
+    try std.testing.expect(sequence.captured_host[0]);
+    try std.testing.expect(!sequence.captured_host[1]);
+    try std.testing.expectEqualStrings("payload", sequence.capturedBody(0));
+    try std.testing.expectEqualStrings("payload", sequence.capturedBody(1));
+    try std.testing.expectEqualStrings(
+        "https://storage.example/blob",
+        sequence.capturedUrl(1),
+    );
+    try operation.finish();
+
+    var one_shot_sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 308,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "/continued" }},
+        },
+        .{ .status = 200, .body = "unexpected" },
+    });
+    var one_shot_request = core.http.Request.init(
+        allocator,
+        .PUT,
+        "https://registry.example/upload",
+    );
+    defer one_shot_request.deinit();
+    var source = std.Io.Reader.fixed("one-shot");
+    var one_shot = try one_shot_sequence.asTransport().open(
+        &one_shot_request,
+        .{
+            .body = core.http.StreamingRequestBody.knownLength(
+                &source,
+                "one-shot".len,
+            ),
+        },
+    );
+    defer one_shot.deinit();
+    try std.testing.expectEqual(@as(u16, 308), one_shot.status_code);
+    try std.testing.expectEqual(@as(usize, 1), one_shot_sequence.call_count);
+    one_shot.abort();
+}
+
+fn runRetryContracts(allocator: std.mem.Allocator) !void {
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var retry = core.http.RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    var policies = [_]*core.http.HttpPolicy{retry.asPolicy()};
+
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 503, .body = "retry" },
+        .{ .status = 200, .body = "ok" },
+    });
+    var pipeline = core.http.HttpPipeline.init(
+        core.http.HttpRuntime.init(sequence.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        allocator,
+        .POST,
+        "https://example.com/upload",
+    );
+    defer request.deinit();
+    var replay = core.http.ReplayableBytes.init("replayable");
+    var operation = try pipeline.open(&request, .{ .body = replay.body() });
+    defer operation.deinit();
+    try std.testing.expectEqual(@as(u16, 200), operation.status_code);
+    try std.testing.expectEqual(@as(usize, 2), sequence.call_count);
+    try std.testing.expectEqualStrings("replayable", sequence.capturedBody(0));
+    try std.testing.expectEqualStrings("replayable", sequence.capturedBody(1));
+    try operation.finish();
+
+    var one_shot_sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 503, .body = "retry" },
+        .{ .status = 200, .body = "unexpected" },
+    });
+    var one_shot_pipeline = core.http.HttpPipeline.init(
+        core.http.HttpRuntime.init(one_shot_sequence.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var one_shot_request = core.http.Request.init(
+        allocator,
+        .POST,
+        "https://example.com/upload",
+    );
+    defer one_shot_request.deinit();
+    var source = std.Io.Reader.fixed("one-shot");
+    var one_shot = try one_shot_pipeline.open(&one_shot_request, .{
+        .body = core.http.StreamingRequestBody.chunked(&source),
+    });
+    defer one_shot.deinit();
+    try std.testing.expectEqual(@as(u16, 503), one_shot.status_code);
+    try std.testing.expectEqual(@as(usize, 1), one_shot_sequence.call_count);
+    one_shot.abort();
+}
+
+fn runPipelineDecompressionContract(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    factory: BackendFactory,
+) !void {
+    const headers = [_]scripted.Header{
+        .{ .name = "Content-Encoding", .value = "gzip" },
+    };
+    var backend = try factory.create(allocator, io, .{
+        .response = .{ .headers = &headers, .body = gzip_conformance_body },
+    });
+    defer backend.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(io);
+    var decompression = core.http.DecompressionPolicy.init();
+    var policies = [_]*core.http.HttpPolicy{decompression.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        core.http.HttpRuntime.init(backend.transport, crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(allocator, .GET, backend.url);
+    defer request.deinit();
+    var response = try pipeline.send(&request);
+    defer response.deinit();
+    try backend.finish();
+    try std.testing.expectEqualStrings("conformance", response.body);
+    try std.testing.expectEqualStrings(
+        "gzip, deflate",
+        request.getHeader("Accept-Encoding").?,
+    );
+}
+
+fn mockStreamingAllocationFixture(allocator: std.mem.Allocator) !void {
+    var mock = core.http.MockTransport.init(allocator, 200, "response");
+    defer mock.deinit();
+    mock.response_headers_list = &.{.{ .name = "x-test", .value = "value" }};
+    var request = core.http.Request.init(allocator, .POST, "https://example.com");
+    defer request.deinit();
+    try request.setHeader("content-type", "application/octet-stream");
+    var source = std.Io.Reader.fixed("request");
+    var operation = try mock.asTransport().open(&request, .{
+        .body = core.http.StreamingRequestBody.knownLength(&source, 7),
+    });
+    defer operation.deinit();
+    try operation.finish();
+}
+
+fn redirectAllocationFixture(allocator: std.mem.Allocator) !void {
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 307,
+            .body = "",
+            .headers = &.{.{ .name = "Location", .value = "https://storage.example/blob" }},
+        },
+        .{ .status = 200, .body = "ok" },
+    });
+    var request = core.http.Request.init(
+        allocator,
+        .PUT,
+        "https://registry.example/upload",
+    );
+    defer request.deinit();
+    request.body = "body";
+    try request.setHeader("Authorization", "******");
+    var response = sequence.asTransport().send(&request) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
+        else => |other| return other,
+    };
+    defer response.deinit();
+}
+
+fn retryAllocationFixture(allocator: std.mem.Allocator) !void {
+    var sequence = core.http.SequenceMockTransport.init(allocator, &.{
+        .{ .status = 503, .body = "retry" },
+        .{ .status = 200, .body = "ok" },
+    });
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var retry = core.http.RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    var policies = [_]*core.http.HttpPolicy{retry.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        core.http.HttpRuntime.init(sequence.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(allocator, .GET, "https://example.com");
+    defer request.deinit();
+    var response = try pipeline.send(&request);
+    defer response.deinit();
+}
+
+const StdBackendState = struct {
+    allocator: std.mem.Allocator,
+    transport: core.http.StdHttpTransport,
+    server: scripted.ScriptedHttpServer = undefined,
+    server_started: bool = false,
+    server_joined: bool = false,
+    url: []u8,
+
+    fn finish(context: *anyopaque) !void {
+        const self: *StdBackendState = @ptrCast(@alignCast(context));
+        if (self.server_started and !self.server_joined) {
+            try self.server.join();
+            self.server_joined = true;
+        }
+    }
+
+    fn observe(context: *anyopaque) Observation {
+        const self: *StdBackendState = @ptrCast(@alignCast(context));
+        if (!self.server_started) return .{};
+        return .{
+            .request_count = if (self.server.request_line.len > 0) 1 else 0,
+            .body = self.server.body(),
+            .body_length = self.server.body_length,
+            .user_agent_count = self.server.headerCount("user-agent"),
+            .accept_encoding_count = self.server.headerCount("accept-encoding"),
+            .host_count = self.server.headerCount("host"),
+            .connection_count = self.server.headerCount("connection"),
+            .accept_count = self.server.headerCount("accept"),
+        };
+    }
+
+    fn destroy(context: *anyopaque) void {
+        const self: *StdBackendState = @ptrCast(@alignCast(context));
+        if (self.server_started) {
+            if (!self.server_joined) self.server.join() catch {};
+            self.server.deinit();
+        }
+        self.transport.deinit();
+        self.allocator.free(self.url);
+        self.allocator.destroy(self);
+    }
+};
+
+fn createStdBackend(
+    _: ?*anyopaque,
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    options: BackendOptions,
+) !BackendInstance {
+    const state = try allocator.create(StdBackendState);
+    errdefer allocator.destroy(state);
+    state.* = .{
+        .allocator = allocator,
+        .transport = core.http.StdHttpTransport.init(allocator, io),
+        .url = undefined,
+    };
+    errdefer state.transport.deinit();
+    if (options.max_response_body) |limit| {
+        state.transport.max_response_body = .limited(limit);
+    }
+    if (options.expect_request) {
+        state.server = try scripted.ScriptedHttpServer.init(
+            allocator,
+            io,
+            options.response,
+        );
+        state.server.allow_peer_failure = options.allow_peer_failure;
+        errdefer state.server.deinit();
+        try state.server.start();
+        state.server_started = true;
+        state.url = try state.server.allocUrl(allocator, "/conformance");
+    } else {
+        state.url = try allocator.dupe(u8, "http://127.0.0.1:1/conformance");
+    }
+    return .{
+        .transport = state.transport.asTransport(),
+        .url = state.url,
+        .context = state,
+        .finishFn = &StdBackendState.finish,
+        .observeFn = &StdBackendState.observe,
+        .deinitFn = &StdBackendState.destroy,
+    };
+}
+
+pub fn standardBackendFactory() BackendFactory {
+    return .{
+        .name = "std.http.Client",
+        .capabilities = .{
+            .response_body_limit = true,
+            .decompression = true,
+            .cancellation = .cooperative_upload,
+            .automatic_request_headers = true,
+            .bounded_memory_logical_large_upload = true,
+        },
+        .createFn = &createStdBackend,
+    };
+}
+
+const MockBackendState = struct {
+    allocator: std.mem.Allocator,
+    transport: core.http.MockTransport,
+    response_headers: []core.http.MockTransport.HeaderPair,
+    url: []u8,
+
+    fn finish(_: *anyopaque) !void {}
+
+    fn observe(context: *anyopaque) Observation {
+        const self: *MockBackendState = @ptrCast(@alignCast(context));
+        return .{
+            .request_count = self.transport.call_count,
+            .body = self.transport.last_body orelse "",
+            .body_length = if (self.transport.last_body) |body| body.len else 0,
+            .user_agent_count = if (self.transport.last_headers.get("User-Agent") != null) 1 else 0,
+            .accept_encoding_count = if (self.transport.last_headers.get("Accept-Encoding") != null) 1 else 0,
+            .accept_count = if (self.transport.last_headers.get("Accept") != null) 1 else 0,
+            .finish_count = self.transport.stream_finish_count,
+            .abort_count = self.transport.stream_abort_count,
+            .cancel_count = self.transport.stream_cancel_count,
+            .deinit_count = self.transport.stream_deinit_count,
+        };
+    }
+
+    fn destroy(context: *anyopaque) void {
+        const self: *MockBackendState = @ptrCast(@alignCast(context));
+        self.transport.deinit();
+        self.allocator.free(self.response_headers);
+        self.allocator.free(self.url);
+        self.allocator.destroy(self);
+    }
+};
+
+fn createMockBackend(
+    _: ?*anyopaque,
+    allocator: std.mem.Allocator,
+    _: std.Io,
+    options: BackendOptions,
+) !BackendInstance {
+    const state = try allocator.create(MockBackendState);
+    errdefer allocator.destroy(state);
+    const pairs = try allocator.alloc(
+        core.http.MockTransport.HeaderPair,
+        options.response.headers.len,
+    );
+    errdefer allocator.free(pairs);
+    for (options.response.headers, pairs) |header, *pair| {
+        pair.* = .{ .name = header.name, .value = header.value };
+    }
+    const url = try allocator.dupe(u8, "https://example.com/conformance");
+    errdefer allocator.free(url);
+    state.* = .{
+        .allocator = allocator,
+        .transport = core.http.MockTransport.init(
+            allocator,
+            options.response.status_code,
+            options.response.body,
+        ),
+        .response_headers = pairs,
+        .url = url,
+    };
+    state.transport.response_headers_list = pairs;
+    return .{
+        .transport = state.transport.asTransport(),
+        .url = state.url,
+        .context = state,
+        .finishFn = &MockBackendState.finish,
+        .observeFn = &MockBackendState.observe,
+        .deinitFn = &MockBackendState.destroy,
+    };
+}
+
+pub fn mockBackendFactory() BackendFactory {
+    return .{
+        .name = "MockTransport",
+        .capabilities = .{
+            .cancellation = .cooperative_upload,
+            .lifecycle_observable = true,
+        },
+        .createFn = &createMockBackend,
+    };
+}
+
+test "standard HTTP transport conforms" {
+    try runRawTransportContracts(
+        std.testing.allocator,
+        std.testing.io,
+        standardBackendFactory(),
+    );
+}
+
+test "mock HTTP transport conforms" {
+    try runRawTransportContracts(
+        std.testing.allocator,
+        std.testing.io,
+        mockBackendFactory(),
+    );
+}
+
+test "Core pipeline contracts conform through standard transport" {
+    try runPipelineContracts(
+        std.testing.allocator,
+        std.testing.io,
+        standardBackendFactory(),
+    );
+}
+
+test "Core pipeline contracts conform through mock transport" {
+    try runPipelineContracts(
+        std.testing.allocator,
+        std.testing.io,
+        mockBackendFactory(),
+    );
+}
+
+test "HTTP conformance allocation failures are leak-free" {
+    try runAllocationFailureContracts();
+}

--- a/conformance/http_transport.zig
+++ b/conformance/http_transport.zig
@@ -410,23 +410,57 @@ fn runResponseFramingContract(
     io: std.Io,
     factory: BackendFactory,
 ) !void {
-    var backend = try factory.create(allocator, io, .{
-        .response = .{
-            .body = "short",
-            .advertised_content_length = 12,
-        },
-    });
-    defer backend.deinit();
-    var request = core.http.Request.init(allocator, .GET, backend.url);
-    defer request.deinit();
-    var operation = try backend.transport.open(&request, .{});
-    if (operation.finish()) |_| {
-        operation.deinit();
-        return error.ExpectedResponseFramingFailure;
-    } else |_| {}
-    try std.testing.expectEqual(core.http.OperationState.aborted, operation.state);
-    operation.deinit();
-    try backend.finish();
+    {
+        var backend = try factory.create(allocator, io, .{
+            .response = .{
+                .body = "short",
+                .advertised_content_length = 12,
+            },
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .GET, backend.url);
+        defer request.deinit();
+        var operation = try backend.transport.open(&request, .{});
+        defer operation.deinit();
+        try std.testing.expectError(
+            error.HttpContentLengthTruncated,
+            operation.finish(),
+        );
+        try std.testing.expectEqual(core.http.OperationState.aborted, operation.state);
+        try backend.finish();
+    }
+    {
+        var backend = try factory.create(allocator, io, .{
+            .response = .{
+                .body = "short",
+                .advertised_content_length = 12,
+            },
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .GET, backend.url);
+        defer request.deinit();
+        try std.testing.expectError(
+            error.HttpContentLengthTruncated,
+            backend.transport.send(&request),
+        );
+        try backend.finish();
+    }
+    {
+        const malformed_headers = [_]scripted.Header{
+            .{ .name = "Content-Length", .value = "not-a-number" },
+        };
+        var backend = try factory.create(allocator, io, .{
+            .response = .{ .headers = &malformed_headers },
+        });
+        defer backend.deinit();
+        var request = core.http.Request.init(allocator, .GET, backend.url);
+        defer request.deinit();
+        try std.testing.expectError(
+            error.HttpHeadersInvalid,
+            backend.transport.open(&request, .{}),
+        );
+        try backend.finish();
+    }
 }
 
 fn runResponseLimitContract(
@@ -780,7 +814,6 @@ const StdBackendState = struct {
     fn destroy(context: *anyopaque) void {
         const self: *StdBackendState = @ptrCast(@alignCast(context));
         if (self.server_started) {
-            if (!self.server_joined) self.server.join() catch {};
             self.server.deinit();
         }
         self.transport.deinit();
@@ -834,6 +867,7 @@ pub fn standardBackendFactory() BackendFactory {
     return .{
         .name = "std.http.Client",
         .capabilities = .{
+            .response_framing_validation = true,
             .response_body_limit = true,
             .decompression = true,
             .cancellation = .cooperative_upload,

--- a/conformance/package_consumer/build.zig
+++ b/conformance/package_consumer/build.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const core = b.dependency("core", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("consumer.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{
+                    .name = "azure_sdk_core",
+                    .module = core.module("azure_sdk_core"),
+                },
+                .{
+                    .name = "azure_sdk_core_http_conformance",
+                    .module = core.module("azure_sdk_core_http_conformance"),
+                },
+                .{
+                    .name = "azure_sdk_core_crypto_conformance",
+                    .module = core.module("azure_sdk_core_crypto_conformance"),
+                },
+            },
+        }),
+    });
+    const test_step = b.step("test", "Test fetched Core conformance modules");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}

--- a/conformance/package_consumer/build.zig.zon
+++ b/conformance/package_consumer/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .core_conformance_consumer,
+    .version = "0.0.0",
+    .fingerprint = 0x90ea4240af59736,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "consumer.zig",
+    },
+}

--- a/conformance/package_consumer/consumer.zig
+++ b/conformance/package_consumer/consumer.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const http = @import("azure_sdk_core_http_conformance");
+const crypto = @import("azure_sdk_core_crypto_conformance");
+
+test "manifest-filtered package exports usable conformance modules" {
+    try http.runRawTransportContracts(
+        std.testing.allocator,
+        std.testing.io,
+        http.mockBackendFactory(),
+    );
+    try crypto.runCryptoContracts(
+        std.testing.allocator,
+        std.testing.io,
+        crypto.standardProviderFactory(),
+    );
+    try std.testing.expectEqualStrings("0.3.0", core.version);
+}

--- a/conformance/scripted_http_server.zig
+++ b/conformance/scripted_http_server.zig
@@ -15,6 +15,13 @@ pub const Response = struct {
     omit_body: bool = false,
 };
 
+const StopInterleaveHooks = struct {
+    stream_active: *std.Io.Event,
+    stop_locked: *std.Io.Event,
+    release_stop: *std.Io.Event,
+    cleanup_entered: *std.Io.Event,
+};
+
 /// A one-request loopback HTTP/1.1 server for deterministic transport tests.
 ///
 /// Request bodies are counted while only a bounded prefix is retained, so
@@ -31,6 +38,7 @@ pub const ScriptedHttpServer = struct {
     mutex: std.Io.Mutex = .init,
     active_stream: ?std.Io.net.Stream = null,
     done: std.Io.Event = .unset,
+    stop_interleave: ?StopInterleaveHooks = null,
     allow_peer_failure: bool = false,
     failure: ?anyerror = null,
     request_line: []u8 = &.{},
@@ -123,18 +131,26 @@ pub const ScriptedHttpServer = struct {
     fn requestStop(self: *ScriptedHttpServer) void {
         self.mutex.lockUncancelable(self.io);
         self.stopping = true;
-        const active_stream = self.active_stream;
+        if (self.active_stream) |stream| {
+            if (self.stop_interleave) |hooks| {
+                hooks.stop_locked.set(self.io);
+                hooks.release_stop.waitUncancelable(self.io);
+            }
+            // Keep the native handle protected until shutdown completes.
+            // Stream cleanup takes the same mutex before clearing and closing.
+            stream.shutdown(self.io, .both) catch {};
+            self.mutex.unlock(self.io);
+            return;
+        }
         self.mutex.unlock(self.io);
 
-        if (active_stream) |stream| {
-            stream.shutdown(self.io, .both) catch {};
-        } else {
-            const wake_stream = self.listener.socket.address.connect(
-                self.io,
-                .{ .mode = .stream },
-            ) catch return;
-            wake_stream.close(self.io);
-        }
+        // The listener remains open until after the server thread joins.
+        // Once `stopping` is set, serve cannot publish a newly accepted stream.
+        const wake_stream = self.listener.socket.address.connect(
+            self.io,
+            .{ .mode = .stream },
+        ) catch return;
+        wake_stream.close(self.io);
     }
 
     fn isStopping(self: *ScriptedHttpServer) bool {
@@ -195,7 +211,9 @@ pub const ScriptedHttpServer = struct {
         }
         self.active_stream = stream;
         self.mutex.unlock(self.io);
+        if (self.stop_interleave) |hooks| hooks.stream_active.set(self.io);
         defer {
+            if (self.stop_interleave) |hooks| hooks.cleanup_entered.set(self.io);
             self.mutex.lockUncancelable(self.io);
             self.active_stream = null;
             self.mutex.unlock(self.io);
@@ -385,4 +403,88 @@ test "scripted server teardown interrupts a stalled request body" {
     try std.testing.expect(
         elapsedNanoseconds(io, start) < 5 * std.time.ns_per_s,
     );
+}
+
+test "requestStop protects stream handle through concurrent cleanup" {
+    const Stopper = struct {
+        fn run(server: *ScriptedHttpServer) void {
+            server.requestStop();
+        }
+    };
+
+    const io = std.testing.io;
+    var stream_active: std.Io.Event = .unset;
+    var stop_locked: std.Io.Event = .unset;
+    var release_stop: std.Io.Event = .unset;
+    var cleanup_entered: std.Io.Event = .unset;
+    var server = try ScriptedHttpServer.init(
+        std.testing.allocator,
+        io,
+        .{},
+    );
+    var server_deinitialized = false;
+    defer if (!server_deinitialized) server.deinit();
+    server.stop_interleave = .{
+        .stream_active = &stream_active,
+        .stop_locked = &stop_locked,
+        .release_stop = &release_stop,
+        .cleanup_entered = &cleanup_entered,
+    };
+    try server.start();
+
+    const client = try server.listener.socket.address.connect(
+        io,
+        .{ .mode = .stream },
+    );
+    var client_closed = false;
+    defer if (!client_closed) client.close(io);
+    var write_buffer: [1024]u8 = undefined;
+    var writer = std.Io.net.Stream.Writer.init(client, io, &write_buffer);
+    try writer.interface.writeAll(
+        "POST /interleave HTTP/1.1\r\n" ++
+            "Host: 127.0.0.1\r\n" ++
+            "Content-Length: 1024\r\n\r\n" ++
+            "x",
+    );
+    try writer.interface.flush();
+    stream_active.waitUncancelable(io);
+
+    server.mutex.lockUncancelable(io);
+    const protected_handle = server.active_stream.?.socket.handle;
+    server.mutex.unlock(io);
+
+    const stopper = try std.Thread.spawn(.{}, Stopper.run, .{&server});
+    var stopper_joined = false;
+    defer if (!stopper_joined) {
+        release_stop.set(io);
+        stopper.join();
+    };
+    stop_locked.waitUncancelable(io);
+    client.close(io);
+    client_closed = true;
+    cleanup_entered.waitUncancelable(io);
+
+    // If cleanup could close between the stop snapshot and shutdown, the OS
+    // could immediately reuse that descriptor for one of these connections.
+    var churn_address: std.Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var churn_listener = try churn_address.listen(io, .{ .reuse_address = true });
+    defer churn_listener.deinit(io);
+    for (0..32) |_| {
+        const churn_client = try churn_listener.socket.address.connect(
+            io,
+            .{ .mode = .stream },
+        );
+        const churn_server = try churn_listener.accept(io);
+        try std.testing.expect(churn_client.socket.handle != protected_handle);
+        try std.testing.expect(churn_server.socket.handle != protected_handle);
+        churn_client.close(io);
+        churn_server.close(io);
+    }
+
+    release_stop.set(io);
+    stopper.join();
+    stopper_joined = true;
+    try server.join();
+    server.deinit();
+    server_deinitialized = true;
 }

--- a/conformance/scripted_http_server.zig
+++ b/conformance/scripted_http_server.zig
@@ -1,0 +1,262 @@
+const std = @import("std");
+
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+pub const Response = struct {
+    status_code: u16 = 200,
+    reason: []const u8 = "OK",
+    headers: []const Header = &.{},
+    body: []const u8 = "",
+    chunked: bool = false,
+    advertised_content_length: ?usize = null,
+    omit_body: bool = false,
+};
+
+/// A one-request loopback HTTP/1.1 server for deterministic transport tests.
+///
+/// Request bodies are counted while only a bounded prefix is retained, so
+/// conformance tests can exercise logical-large streams without allocating
+/// storage proportional to the upload.
+pub const ScriptedHttpServer = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    listener: std.Io.net.Server,
+    response: Response,
+    thread: ?std.Thread = null,
+    joined: bool = false,
+    allow_peer_failure: bool = false,
+    failure: ?anyerror = null,
+    request_line: []u8 = &.{},
+    header_lines: std.ArrayList([]u8) = .empty,
+    body_prefix: [4096]u8 = undefined,
+    body_prefix_len: usize = 0,
+    body_length: usize = 0,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        response: Response,
+    ) !ScriptedHttpServer {
+        var address: std.Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+        return .{
+            .allocator = allocator,
+            .io = io,
+            .listener = try address.listen(io, .{ .reuse_address = true }),
+            .response = response,
+        };
+    }
+
+    pub fn start(self: *ScriptedHttpServer) !void {
+        self.thread = try std.Thread.spawn(.{}, run, .{self});
+    }
+
+    pub fn allocUrl(
+        self: *const ScriptedHttpServer,
+        allocator: std.mem.Allocator,
+        path: []const u8,
+    ) ![]u8 {
+        return std.fmt.allocPrint(
+            allocator,
+            "http://127.0.0.1:{d}{s}",
+            .{ self.listener.socket.address.getPort(), path },
+        );
+    }
+
+    pub fn join(self: *ScriptedHttpServer) !void {
+        if (!self.joined) {
+            if (self.thread) |thread| thread.join();
+            self.joined = true;
+        }
+        if (self.failure) |failure| {
+            if (!self.allow_peer_failure) return failure;
+        }
+    }
+
+    pub fn deinit(self: *ScriptedHttpServer) void {
+        if (!self.joined) {
+            if (self.thread) |thread| thread.join();
+        }
+        self.listener.deinit(self.io);
+        if (self.request_line.len > 0) self.allocator.free(self.request_line);
+        for (self.header_lines.items) |line| self.allocator.free(line);
+        self.header_lines.deinit(self.allocator);
+    }
+
+    pub fn body(self: *const ScriptedHttpServer) []const u8 {
+        return self.body_prefix[0..self.body_prefix_len];
+    }
+
+    pub fn headerCount(self: *const ScriptedHttpServer, name: []const u8) usize {
+        var count: usize = 0;
+        for (self.header_lines.items) |line| {
+            const header = splitHeader(line) orelse continue;
+            if (std.ascii.eqlIgnoreCase(header.name, name)) count += 1;
+        }
+        return count;
+    }
+
+    pub fn headerValue(
+        self: *const ScriptedHttpServer,
+        name: []const u8,
+    ) ?[]const u8 {
+        for (self.header_lines.items) |line| {
+            const header = splitHeader(line) orelse continue;
+            if (std.ascii.eqlIgnoreCase(header.name, name)) return header.value;
+        }
+        return null;
+    }
+
+    fn splitHeader(line: []const u8) ?Header {
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse return null;
+        return .{
+            .name = line[0..colon],
+            .value = std.mem.trim(u8, line[colon + 1 ..], " \t"),
+        };
+    }
+
+    fn run(self: *ScriptedHttpServer) void {
+        self.serve() catch |err| {
+            self.failure = err;
+        };
+    }
+
+    fn serve(self: *ScriptedHttpServer) !void {
+        const stream = try self.listener.accept(self.io);
+        defer stream.close(self.io);
+
+        var read_buffer: [16 * 1024]u8 = undefined;
+        var reader = std.Io.net.Stream.Reader.init(stream, self.io, &read_buffer);
+        var write_buffer: [16 * 1024]u8 = undefined;
+        var writer = std.Io.net.Stream.Writer.init(stream, self.io, &write_buffer);
+
+        const first = (reader.interface.takeDelimiter('\n') catch
+            return error.ServerHeaderReadFailed) orelse
+            return error.ServerHeaderReadFailed;
+        const first_line = std.mem.trimEnd(u8, first, "\r");
+        self.request_line = try self.allocator.dupe(u8, first_line);
+
+        var content_length: ?usize = null;
+        var chunked = false;
+        while (true) {
+            const raw_line = (reader.interface.takeDelimiter('\n') catch
+                return error.ServerHeaderReadFailed) orelse
+                return error.ServerHeaderReadFailed;
+            const line = std.mem.trimEnd(u8, raw_line, "\r");
+            if (line.len == 0) break;
+            try self.header_lines.append(
+                self.allocator,
+                try self.allocator.dupe(u8, line),
+            );
+            const header = splitHeader(line) orelse continue;
+            if (std.ascii.eqlIgnoreCase(header.name, "content-length")) {
+                content_length = try std.fmt.parseInt(usize, header.value, 10);
+            } else if (std.ascii.eqlIgnoreCase(header.name, "transfer-encoding")) {
+                chunked = std.ascii.eqlIgnoreCase(header.value, "chunked");
+            }
+        }
+
+        if (chunked) {
+            try self.readChunkedBody(&reader.interface);
+        } else if (content_length) |length| {
+            try self.readBody(&reader.interface, length);
+        }
+
+        try writer.interface.print(
+            "HTTP/1.1 {d} {s}\r\n",
+            .{ self.response.status_code, self.response.reason },
+        );
+        for (self.response.headers) |header| {
+            try writer.interface.print(
+                "{s}: {s}\r\n",
+                .{ header.name, header.value },
+            );
+        }
+        if (self.response.chunked) {
+            try writer.interface.writeAll(
+                "Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+            );
+            if (!self.response.omit_body and self.response.body.len > 0) {
+                const midpoint = (self.response.body.len + 1) / 2;
+                try writer.interface.print("{x}\r\n", .{midpoint});
+                try writer.interface.writeAll(self.response.body[0..midpoint]);
+                if (midpoint < self.response.body.len) {
+                    try writer.interface.print(
+                        "\r\n{x}\r\n",
+                        .{self.response.body.len - midpoint},
+                    );
+                    try writer.interface.writeAll(self.response.body[midpoint..]);
+                }
+                try writer.interface.writeAll("\r\n");
+            }
+            try writer.interface.writeAll("0\r\n\r\n");
+        } else {
+            const content_length_value = self.response.advertised_content_length orelse
+                self.response.body.len;
+            try writer.interface.print(
+                "Content-Length: {d}\r\nConnection: close\r\n\r\n",
+                .{content_length_value},
+            );
+            if (!self.response.omit_body) {
+                try writer.interface.writeAll(self.response.body);
+            }
+        }
+        try writer.interface.flush();
+    }
+
+    fn readChunkedBody(
+        self: *ScriptedHttpServer,
+        reader: *std.Io.Reader,
+    ) !void {
+        while (true) {
+            const raw_size = (reader.takeDelimiter('\n') catch
+                return error.ServerChunkHeaderReadFailed) orelse
+                return error.ServerChunkHeaderReadFailed;
+            const size_text = std.mem.trim(u8, raw_size, "\r \t");
+            const semicolon = std.mem.indexOfScalar(u8, size_text, ';') orelse
+                size_text.len;
+            const size = try std.fmt.parseInt(usize, size_text[0..semicolon], 16);
+            if (size == 0) {
+                while (true) {
+                    const trailer = (reader.takeDelimiter('\n') catch
+                        return error.ServerChunkTrailerReadFailed) orelse
+                        return error.ServerChunkTrailerReadFailed;
+                    if (std.mem.trimEnd(u8, trailer, "\r").len == 0) break;
+                }
+                return;
+            }
+            try self.readBody(reader, size);
+            var crlf: [2]u8 = undefined;
+            reader.readSliceAll(&crlf) catch
+                return error.ServerChunkTerminatorReadFailed;
+            if (!std.mem.eql(u8, &crlf, "\r\n")) return error.InvalidChunkTerminator;
+        }
+    }
+
+    fn readBody(
+        self: *ScriptedHttpServer,
+        reader: *std.Io.Reader,
+        length: usize,
+    ) !void {
+        var remaining = length;
+        var buffer: [16 * 1024]u8 = undefined;
+        while (remaining > 0) {
+            const amount = @min(remaining, buffer.len);
+            reader.readSliceAll(buffer[0..amount]) catch
+                return error.ServerBodyReadFailed;
+            const prefix_remaining = self.body_prefix.len - self.body_prefix_len;
+            const copy_len = @min(prefix_remaining, amount);
+            if (copy_len > 0) {
+                @memcpy(
+                    self.body_prefix[self.body_prefix_len..][0..copy_len],
+                    buffer[0..copy_len],
+                );
+                self.body_prefix_len += copy_len;
+            }
+            self.body_length += amount;
+            remaining -= amount;
+        }
+    }
+};

--- a/conformance/scripted_http_server.zig
+++ b/conformance/scripted_http_server.zig
@@ -126,10 +126,14 @@ pub const ScriptedHttpServer = struct {
         const active_stream = self.active_stream;
         self.mutex.unlock(self.io);
 
-        const listener_stream = std.Io.net.Stream{ .socket = self.listener.socket };
-        listener_stream.shutdown(self.io, .both) catch {};
         if (active_stream) |stream| {
             stream.shutdown(self.io, .both) catch {};
+        } else {
+            const wake_stream = self.listener.socket.address.connect(
+                self.io,
+                .{ .mode = .stream },
+            ) catch return;
+            wake_stream.close(self.io);
         }
     }
 

--- a/conformance/scripted_http_server.zig
+++ b/conformance/scripted_http_server.zig
@@ -27,6 +27,10 @@ pub const ScriptedHttpServer = struct {
     response: Response,
     thread: ?std.Thread = null,
     joined: bool = false,
+    stopping: bool = false,
+    mutex: std.Io.Mutex = .init,
+    active_stream: ?std.Io.net.Stream = null,
+    done: std.Io.Event = .unset,
     allow_peer_failure: bool = false,
     failure: ?anyerror = null,
     request_line: []u8 = &.{},
@@ -50,6 +54,7 @@ pub const ScriptedHttpServer = struct {
     }
 
     pub fn start(self: *ScriptedHttpServer) !void {
+        if (self.thread != null) return error.ServerAlreadyStarted;
         self.thread = try std.Thread.spawn(.{}, run, .{self});
     }
 
@@ -67,8 +72,15 @@ pub const ScriptedHttpServer = struct {
 
     pub fn join(self: *ScriptedHttpServer) !void {
         if (!self.joined) {
-            if (self.thread) |thread| thread.join();
-            self.joined = true;
+            self.waitForDone() catch |err| switch (err) {
+                error.Timeout, error.Canceled => {
+                    self.requestStop();
+                    try self.waitForDone();
+                    self.joinThread();
+                    return error.ServerJoinTimedOut;
+                },
+            };
+            self.joinThread();
         }
         if (self.failure) |failure| {
             if (!self.allow_peer_failure) return failure;
@@ -76,13 +88,55 @@ pub const ScriptedHttpServer = struct {
     }
 
     pub fn deinit(self: *ScriptedHttpServer) void {
-        if (!self.joined) {
-            if (self.thread) |thread| thread.join();
-        }
+        self.stopAndJoin() catch @panic("scripted HTTP server failed to stop");
         self.listener.deinit(self.io);
         if (self.request_line.len > 0) self.allocator.free(self.request_line);
         for (self.header_lines.items) |line| self.allocator.free(line);
         self.header_lines.deinit(self.allocator);
+    }
+
+    fn stopAndJoin(self: *ScriptedHttpServer) !void {
+        if (self.joined or self.thread == null) return;
+        self.requestStop();
+        try self.waitForDone();
+        self.joinThread();
+    }
+
+    fn waitForDone(self: *ScriptedHttpServer) !void {
+        return self.done.waitTimeout(
+            self.io,
+            .{
+                .duration = .{
+                    .raw = .fromSeconds(2),
+                    .clock = .awake,
+                },
+            },
+        );
+    }
+
+    fn joinThread(self: *ScriptedHttpServer) void {
+        if (self.joined) return;
+        if (self.thread) |thread| thread.join();
+        self.joined = true;
+    }
+
+    fn requestStop(self: *ScriptedHttpServer) void {
+        self.mutex.lockUncancelable(self.io);
+        self.stopping = true;
+        const active_stream = self.active_stream;
+        self.mutex.unlock(self.io);
+
+        const listener_stream = std.Io.net.Stream{ .socket = self.listener.socket };
+        listener_stream.shutdown(self.io, .both) catch {};
+        if (active_stream) |stream| {
+            stream.shutdown(self.io, .both) catch {};
+        }
+    }
+
+    fn isStopping(self: *ScriptedHttpServer) bool {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        return self.stopping;
     }
 
     pub fn body(self: *const ScriptedHttpServer) []const u8 {
@@ -118,14 +172,31 @@ pub const ScriptedHttpServer = struct {
     }
 
     fn run(self: *ScriptedHttpServer) void {
+        defer self.done.set(self.io);
         self.serve() catch |err| {
-            self.failure = err;
+            if (!self.isStopping()) self.failure = err;
         };
     }
 
     fn serve(self: *ScriptedHttpServer) !void {
-        const stream = try self.listener.accept(self.io);
-        defer stream.close(self.io);
+        const stream = self.listener.accept(self.io) catch |err| {
+            if (self.isStopping()) return;
+            return err;
+        };
+        self.mutex.lockUncancelable(self.io);
+        if (self.stopping) {
+            self.mutex.unlock(self.io);
+            stream.close(self.io);
+            return;
+        }
+        self.active_stream = stream;
+        self.mutex.unlock(self.io);
+        defer {
+            self.mutex.lockUncancelable(self.io);
+            self.active_stream = null;
+            self.mutex.unlock(self.io);
+            stream.close(self.io);
+        }
 
         var read_buffer: [16 * 1024]u8 = undefined;
         var reader = std.Io.net.Stream.Reader.init(stream, self.io, &read_buffer);
@@ -260,3 +331,54 @@ pub const ScriptedHttpServer = struct {
         }
     }
 };
+
+fn elapsedNanoseconds(io: std.Io, start: std.Io.Timestamp) i128 {
+    return std.Io.Timestamp.now(io, .awake).toNanoseconds() -
+        start.toNanoseconds();
+}
+
+test "scripted server teardown completes without a client" {
+    const io = std.testing.io;
+    var server = try ScriptedHttpServer.init(
+        std.testing.allocator,
+        io,
+        .{},
+    );
+    try server.start();
+    const start = std.Io.Timestamp.now(io, .awake);
+    server.deinit();
+    try std.testing.expect(
+        elapsedNanoseconds(io, start) < 5 * std.time.ns_per_s,
+    );
+}
+
+test "scripted server teardown interrupts a stalled request body" {
+    const io = std.testing.io;
+    var server = try ScriptedHttpServer.init(
+        std.testing.allocator,
+        io,
+        .{},
+    );
+    try server.start();
+
+    const stream = try server.listener.socket.address.connect(
+        io,
+        .{ .mode = .stream },
+    );
+    defer stream.close(io);
+    var write_buffer: [1024]u8 = undefined;
+    var writer = std.Io.net.Stream.Writer.init(stream, io, &write_buffer);
+    try writer.interface.writeAll(
+        "POST /stalled HTTP/1.1\r\n" ++
+            "Host: 127.0.0.1\r\n" ++
+            "Content-Length: 1024\r\n\r\n" ++
+            "x",
+    );
+    try writer.interface.flush();
+
+    const start = std.Io.Timestamp.now(io, .awake);
+    server.deinit();
+    try std.testing.expect(
+        elapsedNanoseconds(io, start) < 5 * std.time.ns_per_s,
+    );
+}

--- a/conformance/wasi_build_check.zig
+++ b/conformance/wasi_build_check.zig
@@ -1,0 +1,7 @@
+const core = @import("azure_sdk_core");
+
+comptime {
+    _ = core.http.wasi.WasiHttpTransport;
+}
+
+export fn azureSdkCoreWasiBuildCheck() void {}

--- a/http/pipeline.zig
+++ b/http/pipeline.zig
@@ -629,21 +629,6 @@ pub const TracingPolicy = struct {
     }
 };
 
-test "pipeline with telemetry and mock transport" {
-    const allocator = std.testing.allocator;
-    var mock = transport.MockTransport.init(allocator, 200, "ok");
-    defer mock.deinit();
-    var telemetry = TelemetryPolicy.init("azsdk-zig-test/0.1.0");
-    var policy_ptrs = [_]*HttpPolicy{telemetry.asPolicy()};
-    var pipeline_inst = HttpPipeline.init(testingRuntime(mock.asTransport()), &policy_ptrs);
-    var req = Request.init(allocator, .GET, "https://example.com");
-    defer req.deinit();
-    var resp = try pipeline_inst.send(&req);
-    defer resp.deinit();
-    try std.testing.expectEqual(@as(u16, 200), resp.status_code);
-    try std.testing.expectEqualStrings("azsdk-zig-test/0.1.0", req.headers.get("User-Agent").?);
-}
-
 test "pipeline prepares streaming policies without retrying" {
     const allocator = std.testing.allocator;
     var mock = transport.MockTransport.init(allocator, 200, "stream");

--- a/http/transport.zig
+++ b/http/transport.zig
@@ -883,6 +883,8 @@ const StdStreamingOperation = struct {
     request_active: bool,
     response: std.http.Client.Response,
     transfer_reader: *std.Io.Reader,
+    content_length_reader: CheckedContentLengthReader,
+    content_length_checked: bool,
     transfer_buffer: [64]u8,
     // Owned empty reader handed back for responses that carry no body (HEAD,
     // TRACE). It must be a per-operation instance rather than the shared
@@ -921,6 +923,8 @@ const StdStreamingOperation = struct {
             .request_active = false,
             .response = undefined,
             .transfer_reader = undefined,
+            .content_length_reader = undefined,
+            .content_length_checked = false,
             .transfer_buffer = undefined,
             .empty_reader = undefined,
             .upload_read_buffer = undefined,
@@ -967,7 +971,10 @@ const StdStreamingOperation = struct {
         var header_set = try copyResponseHeaders(allocator, &self.response.head);
         errdefer header_set.deinit(allocator);
 
-        self.decompress_buffer = switch (self.response.head.content_encoding) {
+        const transfer_encoding = self.response.head.transfer_encoding;
+        const content_length = self.response.head.content_length;
+        const content_encoding = self.response.head.content_encoding;
+        self.decompress_buffer = switch (content_encoding) {
             .identity => &.{},
             .zstd => try allocator.alloc(
                 u8,
@@ -984,21 +991,28 @@ const StdStreamingOperation = struct {
         // `finishImpl`'s `discardRemaining` writes to owned, writable memory.
         const no_response_body = !self.request.method.responseHasBody();
         if (no_response_body) self.empty_reader = std.Io.Reader.fixed("");
-        self.transfer_reader =
-            if (no_response_body)
-                &self.empty_reader
-            else if (self.response.head.transfer_encoding != .none or
-            self.response.head.content_length != null)
-                &self.request.reader.interface
-            else
-                self.request.reader.in;
+        if (no_response_body) {
+            self.transfer_reader = &self.empty_reader;
+        } else {
+            const std_transfer_reader = self.response.reader(&self.transfer_buffer);
+            if (transfer_encoding == .none and content_length != null) {
+                self.content_length_reader.init(
+                    std_transfer_reader,
+                    content_length.?,
+                );
+                self.content_length_checked = true;
+                self.transfer_reader = &self.content_length_reader.interface;
+            } else {
+                self.transfer_reader = std_transfer_reader;
+            }
+        }
         const body_reader = if (no_response_body)
             &self.empty_reader
         else
-            self.response.readerDecompressing(
-                &self.transfer_buffer,
-                &self.decompress,
+            self.decompress.init(
+                self.transfer_reader,
                 self.decompress_buffer,
+                content_encoding,
             );
         self.operation = .{
             .status_code = status_code,
@@ -1091,13 +1105,13 @@ const StdStreamingOperation = struct {
     fn finishImpl(operation: *HttpOperation) !void {
         const self: *StdStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
         _ = self.operation.body_reader.discardRemaining() catch |err| {
-            const body_error = self.response.bodyErr();
+            const body_error = self.responseBodyError();
             self.releaseRequest(true);
             return body_error orelse err;
         };
         if (self.transfer_reader != self.operation.body_reader) {
             _ = self.transfer_reader.discardRemaining() catch |err| {
-                const body_error = self.response.bodyErr();
+                const body_error = self.responseBodyError();
                 self.releaseRequest(true);
                 return body_error orelse err;
             };
@@ -1112,6 +1126,13 @@ const StdStreamingOperation = struct {
 
     fn bodyErrorImpl(operation: *const HttpOperation) ?anyerror {
         const self: *const StdStreamingOperation = @alignCast(@fieldParentPtr("operation", operation));
+        return self.responseBodyError();
+    }
+
+    fn responseBodyError(self: *const StdStreamingOperation) ?anyerror {
+        if (self.content_length_checked) {
+            if (self.content_length_reader.failure) |failure| return failure;
+        }
         return self.response.bodyErr();
     }
 
@@ -1139,6 +1160,86 @@ const StdStreamingOperation = struct {
         if (self.extra_headers.len > 0) self.allocator.free(self.extra_headers);
         deinitOwnedHeaders(self.allocator, &self.request_headers);
         self.shared_client.release();
+    }
+};
+
+const CheckedContentLengthReader = struct {
+    interface: std.Io.Reader,
+    source: *std.Io.Reader,
+    remaining: u64,
+    failure: ?anyerror = null,
+    buffer: [64]u8,
+
+    fn init(
+        self: *CheckedContentLengthReader,
+        source: *std.Io.Reader,
+        content_length: u64,
+    ) void {
+        self.* = .{
+            .interface = .{
+                .vtable = &.{
+                    .stream = &stream,
+                    .discard = &discard,
+                },
+                .buffer = &self.buffer,
+                .seek = 0,
+                .end = 0,
+            },
+            .source = source,
+            .remaining = content_length,
+            .buffer = undefined,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *CheckedContentLengthReader = @alignCast(
+            @fieldParentPtr("interface", interface),
+        );
+        if (self.remaining == 0) return error.EndOfStream;
+        const count = self.source.stream(
+            writer,
+            limit.min(.limited64(self.remaining)),
+        ) catch |err| switch (err) {
+            error.EndOfStream => {
+                self.failure = error.HttpContentLengthTruncated;
+                return error.ReadFailed;
+            },
+            error.ReadFailed => {
+                self.failure = error.ReadFailed;
+                return error.ReadFailed;
+            },
+            error.WriteFailed => return error.WriteFailed,
+        };
+        self.remaining -= count;
+        return count;
+    }
+
+    fn discard(
+        interface: *std.Io.Reader,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.Error!usize {
+        const self: *CheckedContentLengthReader = @alignCast(
+            @fieldParentPtr("interface", interface),
+        );
+        if (self.remaining == 0) return error.EndOfStream;
+        const count = self.source.discard(
+            limit.min(.limited64(self.remaining)),
+        ) catch |err| switch (err) {
+            error.EndOfStream => {
+                self.failure = error.HttpContentLengthTruncated;
+                return error.ReadFailed;
+            },
+            error.ReadFailed => {
+                self.failure = error.ReadFailed;
+                return error.ReadFailed;
+            },
+        };
+        self.remaining -= count;
+        return count;
     }
 };
 

--- a/http/transport.zig
+++ b/http/transport.zig
@@ -1912,47 +1912,6 @@ test "mock transport" {
     try std.testing.expectEqualStrings("sha256:second", digests[1]);
 }
 
-test "mock streaming transport accepts known and chunked uploads" {
-    const allocator = std.testing.allocator;
-    var mock = MockTransport.init(allocator, 201, "response-data");
-    defer mock.deinit();
-    mock.stream_upload_chunk_size = 3;
-    mock.stream_response_chunk_size = 2;
-
-    {
-        var known_source = std.Io.Reader.fixed("known-body");
-        var known_request = Request.init(allocator, .POST, "https://example.com/known");
-        defer known_request.deinit();
-        var known = try mock.asTransport().open(&known_request, .{
-            .body = .{ .reader = &known_source, .content_length = 10 },
-        });
-        defer known.deinit();
-        try std.testing.expectEqual(@as(u16, 201), known.status_code);
-        try std.testing.expectEqualStrings("known-body", mock.last_body.?);
-        var response_buffer: [32]u8 = undefined;
-        const first_count = try (try known.reader()).readSliceShort(response_buffer[0..3]);
-        try std.testing.expect(first_count > 0);
-        try known.finish();
-    }
-
-    {
-        var chunked_source = std.Io.Reader.fixed("chunked-body");
-        var chunked_request = Request.init(allocator, .POST, "https://example.com/chunked");
-        defer chunked_request.deinit();
-        var chunked = try mock.asTransport().open(&chunked_request, .{
-            .body = .{ .reader = &chunked_source },
-        });
-        defer chunked.deinit();
-        try std.testing.expectEqualStrings("chunked-body", mock.last_body.?);
-        chunked.abort();
-    }
-
-    try std.testing.expectEqual(@as(usize, 2), mock.call_count);
-    try std.testing.expectEqual(@as(usize, 1), mock.stream_finish_count);
-    try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
-    try std.testing.expectEqual(@as(usize, 2), mock.stream_deinit_count);
-}
-
 test "ReplayableBytes rewinds without copying" {
     var replay = ReplayableBytes.init("replay-body");
     var body = replay.body();

--- a/http/wasi_http.zig
+++ b/http/wasi_http.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const transport = @import("transport.zig");
+const adapter = @import("wasi_http_adapter.zig");
 
 comptime {
     if (!(builtin.target.cpu.arch == .wasm32 and builtin.target.os.tag == .wasi))
@@ -104,21 +105,9 @@ inline fn retClear() void {
     @memset(&ret_area, 0);
 }
 
-// ── Transport ──────────────────────────────────────────────────────────
+// ── Canonical host ─────────────────────────────────────────────────────
 
-pub const WasiHttpTransport = struct {
-    allocator: std.mem.Allocator,
-
-    const vtable: transport.HttpTransport.VTable = .{ .send = &sendImpl };
-
-    pub fn init(allocator: std.mem.Allocator) WasiHttpTransport {
-        return .{ .allocator = allocator };
-    }
-
-    pub fn asTransport(self: *WasiHttpTransport) transport.HttpTransport {
-        return .{ .context = self, .vtable = &vtable };
-    }
-
+const CanonicalHost = struct {
     fn methodDisc(m: transport.Method) i32 {
         return switch (m) {
             .GET => 0,
@@ -131,23 +120,15 @@ pub const WasiHttpTransport = struct {
         };
     }
 
-    fn sendImpl(context: *anyopaque, request: *transport.Request) anyerror!transport.Response {
-        const self: *WasiHttpTransport = @ptrCast(@alignCast(context));
-        const allocator = self.allocator;
-
-        if (request.body != null) return error.RequestBodyUnsupported;
-
-        // Split "scheme://authority/path?query".
-        const url = request.url;
-        const sep = std.mem.indexOf(u8, url, "://") orelse return error.InvalidUrl;
-        const scheme = url[0..sep];
-        const after = url[sep + 3 ..];
-        const slash = std.mem.indexOfScalar(u8, after, '/') orelse after.len;
-        const authority = after[0..slash];
-        const path_query: []const u8 = if (slash < after.len) after[slash..] else "/";
-
-        const scheme_disc: i32 = if (std.ascii.eqlIgnoreCase(scheme, "http")) 0 else 1; // default HTTPS
-
+    fn send(
+        _: *CanonicalHost,
+        allocator: std.mem.Allocator,
+        request: adapter.HostRequest,
+    ) !adapter.HostResponse {
+        const scheme_disc: i32 = switch (request.scheme) {
+            .http => 0,
+            .https => 1,
+        };
         // Build headers (skip Host — wasi:http derives it from authority).
         const headers = @"[constructor]fields"();
         var it = request.headers.iterator();
@@ -167,19 +148,24 @@ pub const WasiHttpTransport = struct {
 
         // Build + configure the outgoing request.
         const req_handle = @"[constructor]outgoing-request"(headers);
-        _ = @"[method]outgoing-request.set-method"(req_handle, methodDisc(request.method), 0, 0);
+        _ = @"[method]outgoing-request.set-method"(
+            req_handle,
+            methodDisc(request.method),
+            0,
+            0,
+        );
         _ = @"[method]outgoing-request.set-scheme"(req_handle, 1, scheme_disc, 0, 0);
         _ = @"[method]outgoing-request.set-authority"(
             req_handle,
             1,
-            @intCast(@intFromPtr(authority.ptr)),
-            @intCast(authority.len),
+            @intCast(@intFromPtr(request.authority.ptr)),
+            @intCast(request.authority.len),
         );
         _ = @"[method]outgoing-request.set-path-with-query"(
             req_handle,
             1,
-            @intCast(@intFromPtr(path_query.ptr)),
-            @intCast(path_query.len),
+            @intCast(@intFromPtr(request.path_with_query.ptr)),
+            @intCast(request.path_with_query.len),
         );
 
         // Fire the request: handle(request, none) -> result<own<future>, error-code>.
@@ -241,11 +227,28 @@ pub const WasiHttpTransport = struct {
             try body.appendSlice(allocator, chunk[0..len]);
         }
 
-        return .{
+        return adapter.HostResponse{
             .status_code = status,
-            .headers = std.StringHashMap([]const u8).init(allocator),
             .body = try body.toOwnedSlice(allocator),
-            .allocator = allocator,
         };
+    }
+};
+
+// ── Public transport ───────────────────────────────────────────────────
+
+pub const WasiHttpTransport = struct {
+    inner: adapter.HttpTransportAdapter(CanonicalHost),
+
+    pub fn init(allocator: std.mem.Allocator) WasiHttpTransport {
+        return .{
+            .inner = adapter.HttpTransportAdapter(CanonicalHost).init(
+                allocator,
+                .{},
+            ),
+        };
+    }
+
+    pub fn asTransport(self: *WasiHttpTransport) transport.HttpTransport {
+        return self.inner.asTransport();
     }
 };

--- a/http/wasi_http_adapter.zig
+++ b/http/wasi_http_adapter.zig
@@ -1,0 +1,208 @@
+//! Target-neutral request adaptation for WASI-style HTTP hosts.
+//!
+//! The canonical-ABI extern implementation lives in `wasi_http.zig`. Keeping
+//! URL/header adaptation here permits native tests to inject a fake host
+//! without claiming runtime coverage for a WASI engine.
+
+const std = @import("std");
+const transport = @import("transport.zig");
+
+pub const Scheme = enum {
+    http,
+    https,
+};
+
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+pub const HostRequest = struct {
+    method: transport.Method,
+    scheme: Scheme,
+    authority: []const u8,
+    path_with_query: []const u8,
+    headers: *const std.StringHashMap([]const u8),
+};
+
+pub const HostResponse = struct {
+    status_code: u16,
+    headers: []const Header = &.{},
+    /// Allocated by the host with the allocator passed to `send`.
+    body: []u8,
+};
+
+/// Build an `HttpTransport` around a host value exposing:
+///
+/// `send(allocator, HostRequest) !HostResponse`.
+pub fn HttpTransportAdapter(comptime Host: type) type {
+    return struct {
+        allocator: std.mem.Allocator,
+        host: Host,
+
+        const Self = @This();
+        const vtable: transport.HttpTransport.VTable = .{ .send = &sendImpl };
+
+        pub fn init(allocator: std.mem.Allocator, host: Host) Self {
+            return .{ .allocator = allocator, .host = host };
+        }
+
+        pub fn asTransport(self: *Self) transport.HttpTransport {
+            return .{ .context = self, .vtable = &vtable };
+        }
+
+        fn sendImpl(
+            context: *anyopaque,
+            request: *transport.Request,
+        ) !transport.Response {
+            const self: *Self = @ptrCast(@alignCast(context));
+            if (request.body != null) return error.RequestBodyUnsupported;
+
+            const sep = std.mem.indexOf(u8, request.url, "://") orelse
+                return error.InvalidUrl;
+            const scheme_text = request.url[0..sep];
+            const scheme: Scheme = if (std.ascii.eqlIgnoreCase(scheme_text, "http"))
+                .http
+            else if (std.ascii.eqlIgnoreCase(scheme_text, "https"))
+                .https
+            else
+                return error.InvalidUrl;
+            const after_scheme = request.url[sep + 3 ..];
+            const slash = std.mem.indexOfScalar(u8, after_scheme, '/') orelse
+                after_scheme.len;
+            const authority = after_scheme[0..slash];
+            if (authority.len == 0) return error.InvalidUrl;
+            const path_with_query = if (slash < after_scheme.len)
+                after_scheme[slash..]
+            else
+                "/";
+
+            const host_response = try self.host.send(self.allocator, .{
+                .method = request.method,
+                .scheme = scheme,
+                .authority = authority,
+                .path_with_query = path_with_query,
+                .headers = &request.headers,
+            });
+            errdefer self.allocator.free(host_response.body);
+
+            var headers = std.StringHashMap([]const u8).init(self.allocator);
+            errdefer deinitHeaders(self.allocator, &headers);
+            var ordered = transport.ResponseHeaders.init(self.allocator);
+            errdefer ordered.deinit();
+            for (host_response.headers) |header| {
+                try ordered.append(header.name, header.value);
+                const name = try self.allocator.dupe(u8, header.name);
+                errdefer self.allocator.free(name);
+                const value = try self.allocator.dupe(u8, header.value);
+                errdefer self.allocator.free(value);
+                const entry = try headers.getOrPut(name);
+                if (entry.found_existing) {
+                    self.allocator.free(name);
+                    self.allocator.free(entry.value_ptr.*);
+                } else {
+                    entry.key_ptr.* = name;
+                }
+                entry.value_ptr.* = value;
+            }
+
+            return .{
+                .status_code = host_response.status_code,
+                .headers = headers,
+                .body = host_response.body,
+                .allocator = self.allocator,
+                .response_headers = ordered,
+            };
+        }
+    };
+}
+
+fn deinitHeaders(
+    allocator: std.mem.Allocator,
+    headers: *std.StringHashMap([]const u8),
+) void {
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+        allocator.free(entry.value_ptr.*);
+    }
+    headers.deinit();
+}
+
+test "native fake host exercises target-neutral WASI adaptation" {
+    const FakeHost = struct {
+        calls: usize = 0,
+        method: ?transport.Method = null,
+        scheme: ?Scheme = null,
+        authority: []const u8 = "",
+        path: []const u8 = "",
+        saw_host: bool = false,
+
+        fn send(
+            self: *@This(),
+            allocator: std.mem.Allocator,
+            request: HostRequest,
+        ) !HostResponse {
+            self.calls += 1;
+            self.method = request.method;
+            self.scheme = request.scheme;
+            self.authority = request.authority;
+            self.path = request.path_with_query;
+            var headers = request.headers.iterator();
+            while (headers.next()) |header| {
+                if (std.ascii.eqlIgnoreCase(header.key_ptr.*, "host")) {
+                    self.saw_host = true;
+                }
+            }
+            return .{
+                .status_code = 202,
+                .headers = &.{
+                    .{ .name = "X-Test", .value = "first" },
+                    .{ .name = "x-test", .value = "second" },
+                },
+                .body = try allocator.dupe(u8, "fake-host"),
+            };
+        }
+    };
+
+    var fake = FakeHost{};
+    var adapter = HttpTransportAdapter(*FakeHost).init(
+        std.testing.allocator,
+        &fake,
+    );
+    var request = transport.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com:8443/path?query=yes",
+    );
+    defer request.deinit();
+    try request.setHeader("Host", "ignored.example");
+    var response = try adapter.asTransport().send(&request);
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+    try std.testing.expectEqual(transport.Method.GET, fake.method.?);
+    try std.testing.expectEqual(Scheme.https, fake.scheme.?);
+    try std.testing.expectEqualStrings("example.com:8443", fake.authority);
+    try std.testing.expectEqualStrings("/path?query=yes", fake.path);
+    try std.testing.expect(fake.saw_host);
+    try std.testing.expectEqualStrings("fake-host", response.body);
+    const values = try response.getHeaderValues(std.testing.allocator, "x-test");
+    defer std.testing.allocator.free(values);
+    try std.testing.expectEqual(@as(usize, 2), values.len);
+    try std.testing.expectEqualStrings("first", values[0]);
+    try std.testing.expectEqualStrings("second", values[1]);
+
+    var body_request = transport.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/",
+    );
+    defer body_request.deinit();
+    body_request.body = "unsupported";
+    try std.testing.expectError(
+        error.RequestBodyUnsupported,
+        adapter.asTransport().send(&body_request),
+    );
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+}

--- a/http/wasi_http_adapter.zig
+++ b/http/wasi_http_adapter.zig
@@ -58,24 +58,28 @@ pub fn HttpTransportAdapter(comptime Host: type) type {
             const self: *Self = @ptrCast(@alignCast(context));
             if (request.body != null) return error.RequestBodyUnsupported;
 
-            const sep = std.mem.indexOf(u8, request.url, "://") orelse
-                return error.InvalidUrl;
-            const scheme_text = request.url[0..sep];
-            const scheme: Scheme = if (std.ascii.eqlIgnoreCase(scheme_text, "http"))
+            const uri = std.Uri.parse(request.url) catch return error.InvalidUrl;
+            const scheme: Scheme = if (std.ascii.eqlIgnoreCase(uri.scheme, "http"))
                 .http
-            else if (std.ascii.eqlIgnoreCase(scheme_text, "https"))
+            else if (std.ascii.eqlIgnoreCase(uri.scheme, "https"))
                 .https
             else
                 return error.InvalidUrl;
-            const after_scheme = request.url[sep + 3 ..];
-            const slash = std.mem.indexOfScalar(u8, after_scheme, '/') orelse
-                after_scheme.len;
-            const authority = after_scheme[0..slash];
-            if (authority.len == 0) return error.InvalidUrl;
-            const path_with_query = if (slash < after_scheme.len)
-                after_scheme[slash..]
-            else
-                "/";
+            if (uri.host == null or uri.user != null or uri.password != null)
+                return error.InvalidUrl;
+
+            const authority = try std.fmt.allocPrint(self.allocator, "{f}", .{
+                std.Uri.fmt(&uri, .{ .authority = true, .port = true }),
+            });
+            defer self.allocator.free(authority);
+            const path_with_query = try std.fmt.allocPrint(self.allocator, "{f}", .{
+                std.Uri.fmt(&uri, .{
+                    .path = true,
+                    .query = true,
+                    .fragment = false,
+                }),
+            });
+            defer self.allocator.free(path_with_query);
 
             const host_response = try self.host.send(self.allocator, .{
                 .method = request.method,
@@ -129,44 +133,61 @@ fn deinitHeaders(
     headers.deinit();
 }
 
-test "native fake host exercises target-neutral WASI adaptation" {
-    const FakeHost = struct {
-        calls: usize = 0,
-        method: ?transport.Method = null,
-        scheme: ?Scheme = null,
-        authority: []const u8 = "",
-        path: []const u8 = "",
-        saw_host: bool = false,
+const RecordingHost = struct {
+    calls: usize = 0,
+    method: ?transport.Method = null,
+    scheme: ?Scheme = null,
+    authority: [256]u8 = undefined,
+    authority_len: usize = 0,
+    path: [512]u8 = undefined,
+    path_len: usize = 0,
+    saw_host: bool = false,
 
-        fn send(
-            self: *@This(),
-            allocator: std.mem.Allocator,
-            request: HostRequest,
-        ) !HostResponse {
-            self.calls += 1;
-            self.method = request.method;
-            self.scheme = request.scheme;
-            self.authority = request.authority;
-            self.path = request.path_with_query;
-            var headers = request.headers.iterator();
-            while (headers.next()) |header| {
-                if (std.ascii.eqlIgnoreCase(header.key_ptr.*, "host")) {
-                    self.saw_host = true;
-                }
-            }
-            return .{
-                .status_code = 202,
-                .headers = &.{
-                    .{ .name = "X-Test", .value = "first" },
-                    .{ .name = "x-test", .value = "second" },
-                },
-                .body = try allocator.dupe(u8, "fake-host"),
-            };
+    fn authorityValue(self: *const RecordingHost) []const u8 {
+        return self.authority[0..self.authority_len];
+    }
+
+    fn pathValue(self: *const RecordingHost) []const u8 {
+        return self.path[0..self.path_len];
+    }
+
+    fn send(
+        self: *RecordingHost,
+        allocator: std.mem.Allocator,
+        request: HostRequest,
+    ) !HostResponse {
+        self.calls += 1;
+        self.method = request.method;
+        self.scheme = request.scheme;
+        if (request.authority.len > self.authority.len or
+            request.path_with_query.len > self.path.len)
+        {
+            return error.FakeHostCaptureTooLong;
         }
-    };
+        @memcpy(self.authority[0..request.authority.len], request.authority);
+        self.authority_len = request.authority.len;
+        @memcpy(self.path[0..request.path_with_query.len], request.path_with_query);
+        self.path_len = request.path_with_query.len;
+        var headers = request.headers.iterator();
+        while (headers.next()) |header| {
+            if (std.ascii.eqlIgnoreCase(header.key_ptr.*, "host")) {
+                self.saw_host = true;
+            }
+        }
+        return .{
+            .status_code = 202,
+            .headers = &.{
+                .{ .name = "X-Test", .value = "first" },
+                .{ .name = "x-test", .value = "second" },
+            },
+            .body = try allocator.dupe(u8, "fake-host"),
+        };
+    }
+};
 
-    var fake = FakeHost{};
-    var adapter = HttpTransportAdapter(*FakeHost).init(
+test "native fake host exercises target-neutral WASI adaptation" {
+    var fake = RecordingHost{};
+    var adapter = HttpTransportAdapter(*RecordingHost).init(
         std.testing.allocator,
         &fake,
     );
@@ -183,8 +204,8 @@ test "native fake host exercises target-neutral WASI adaptation" {
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
     try std.testing.expectEqual(transport.Method.GET, fake.method.?);
     try std.testing.expectEqual(Scheme.https, fake.scheme.?);
-    try std.testing.expectEqualStrings("example.com:8443", fake.authority);
-    try std.testing.expectEqualStrings("/path?query=yes", fake.path);
+    try std.testing.expectEqualStrings("example.com:8443", fake.authorityValue());
+    try std.testing.expectEqualStrings("/path?query=yes", fake.pathValue());
     try std.testing.expect(fake.saw_host);
     try std.testing.expectEqualStrings("fake-host", response.body);
     const values = try response.getHeaderValues(std.testing.allocator, "x-test");
@@ -205,4 +226,77 @@ test "native fake host exercises target-neutral WASI adaptation" {
         adapter.asTransport().send(&body_request),
     );
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
+}
+
+test "WASI adapter constructs a root path before a root query" {
+    var fake = RecordingHost{};
+    var adapter = HttpTransportAdapter(*RecordingHost).init(
+        std.testing.allocator,
+        &fake,
+    );
+    var request = transport.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com?api-version=1",
+    );
+    defer request.deinit();
+    var response = try adapter.asTransport().send(&request);
+    defer response.deinit();
+    try std.testing.expectEqualStrings("example.com", fake.authorityValue());
+    try std.testing.expectEqualStrings("/?api-version=1", fake.pathValue());
+}
+
+test "WASI adapter preserves an explicit authority port" {
+    var fake = RecordingHost{};
+    var adapter = HttpTransportAdapter(*RecordingHost).init(
+        std.testing.allocator,
+        &fake,
+    );
+    var request = transport.Request.init(
+        std.testing.allocator,
+        .GET,
+        "http://example.com:8080/path",
+    );
+    defer request.deinit();
+    var response = try adapter.asTransport().send(&request);
+    defer response.deinit();
+    try std.testing.expectEqual(Scheme.http, fake.scheme.?);
+    try std.testing.expectEqualStrings("example.com:8080", fake.authorityValue());
+    try std.testing.expectEqualStrings("/path", fake.pathValue());
+}
+
+test "WASI adapter omits URI fragments from the host request" {
+    var fake = RecordingHost{};
+    var adapter = HttpTransportAdapter(*RecordingHost).init(
+        std.testing.allocator,
+        &fake,
+    );
+    var request = transport.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/path?query=yes#client-only",
+    );
+    defer request.deinit();
+    var response = try adapter.asTransport().send(&request);
+    defer response.deinit();
+    try std.testing.expectEqualStrings("/path?query=yes", fake.pathValue());
+}
+
+test "WASI adapter rejects URI userinfo" {
+    var fake = RecordingHost{};
+    var adapter = HttpTransportAdapter(*RecordingHost).init(
+        std.testing.allocator,
+        &fake,
+    );
+    var request = transport.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://username@example.com/path",
+    );
+    defer request.deinit();
+    try std.testing.expectError(
+        error.InvalidUrl,
+        adapter.asTransport().send(&request),
+    );
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
 }

--- a/wasi_adapter_test.zig
+++ b/wasi_adapter_test.zig
@@ -1,0 +1,3 @@
+test {
+    _ = @import("http/wasi_http_adapter.zig");
+}


### PR DESCRIPTION
## Summary

- export reusable `azure_sdk_core_http_conformance` and `azure_sdk_core_crypto_conformance` test modules with backend factories and explicit capability descriptors
- run raw transport, pipeline, retry/redirect/replay, lifecycle, allocation-failure, bounded-stream, crypto vector, fault, spy, and concurrency contracts in Core CI
- add a bounded-memory scripted HTTP server and shared test fakes with deadline-bounded, listener/stream-unblocking teardown
- parse WASI request URIs with `std.Uri`, omitting fragments, rejecting userinfo, preserving root queries and explicit ports, while retaining a native fake-host seam and wasm32-wasi build-only check
- detect truncated `Content-Length` responses in `StdHttpTransport` and enable its response-framing contract
- archive exactly manifest `.paths`, fetch it, and test all three exported modules through a separate `b.dependency` consumer
- bump `azure_sdk_core` to `0.3.0` and document adapter consumption and coverage boundaries

The WASI check is build-only and does not claim runtime WASI networking, TLS, or trust-provider coverage. Core remains pure Zig and adds no optional adapter dependencies.

## Validation

- `zig fmt --check $(git ls-files '*.zig') $(git ls-files --others --exclude-standard '*.zig') build.zig.zon`
- `zig build --summary all`
- `zig build test --summary all` (235 tests, plus fetched-package consumer)
- `zig build conformance-consumer-check --summary all`
- `zig build package-consumer-check --summary all`
- `zig build wasi-check --summary all`
- package CI passed on Ubuntu, macOS, and Windows

Part of #416

