### PR TITLE
Migrate Azure DevOps clients to HttpRuntime

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,8 +1,8 @@
-generator_commit=5ec3759d9bf33e1047fcbd884e8ad66519f60156
+generator_commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4
 source_repository=https://github.com/cataggar/vsts-rest-api-specs
 source_commit=30b2105a165ce0f057e6adafe5f5e5b9b71502b7
 source_branch=typespec
 source_path=typespec/specs
 selected_api_version=7.2
 api_areas=44
-command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=3acfe9d5779b98d2ffcbddbf4112348e11de7122 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY generate-devops-package)
+command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf generate-devops-package)

--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -5,4 +5,4 @@ source_branch=typespec
 source_path=typespec/specs
 selected_api_version=7.2
 api_areas=44
-command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf -Ddevops-generator-commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4 -Ddevops-spec-commit=30b2105a165ce0f057e6adafe5f5e5b9b71502b7 generate-devops-package)
+command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=bc77bcacbb64af935ca53d60bf8a351c9592bc41 -Dazure-sdk-core-hash=azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV -Ddevops-generator-commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4 -Ddevops-spec-commit=30b2105a165ce0f057e6adafe5f5e5b9b71502b7 generate-devops-package)

--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -5,4 +5,4 @@ source_branch=typespec
 source_path=typespec/specs
 selected_api_version=7.2
 api_areas=44
-command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf generate-devops-package)
+command=(node codegen/devops/build-devops-models.mjs <specs-dir> <model-dir> && cd codegen/cli && zig build -Ddevops-models=<model-dir> -Ddevops-output=<package-output> -Dazure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 -Dazure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf -Ddevops-generator-commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4 -Ddevops-spec-commit=30b2105a165ce0f057e6adafe5f5e5b9b71502b7 generate-devops-package)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#763ff49c6e424750508c06886ecb7ef61f3e7000",
+            .hash = "azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#763ff49c6e424750508c06886ecb7ef61f3e7000",
-            .hash = "azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/src/account/clients.zig
+++ b/src/account/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://app.vssps.visualstudio.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const AccountClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !AccountClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) AccountClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn accounts(self: *@This()) Accounts {
@@ -103,7 +55,7 @@ pub const AccountClient = struct {
 pub const Accounts = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of accounts for a specific owner or a specific member. One of the following parameters is required: ownerId, memberId.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, owner_id: ?[]const u8, member_id: ?[]const u8, properties: ?[]const u8) !models.AccountList {
         @setEvalBranchQuota(100_000);

--- a/src/advanced_security/clients.zig
+++ b/src/advanced_security/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://advsec.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const AdvancedSecurityClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !AdvancedSecurityClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) AdvancedSecurityClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn filtersSettings(self: *@This()) FiltersSettings {
@@ -231,7 +183,7 @@ pub const AdvancedSecurityClient = struct {
 pub const FiltersSettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets all advanced filters for the organization.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_deleted: ?bool, keywords: ?[]const u8) !models.AdvancedFilterList {
         @setEvalBranchQuota(100_000);
@@ -411,7 +363,7 @@ pub const FiltersSettings = struct {
 pub const SummaryDashboard = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -867,7 +819,7 @@ pub const SummaryDashboard = struct {
 pub const Alerts = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -1242,7 +1194,7 @@ pub const Alerts = struct {
 pub const Instances = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get instances of an alert on a branch specified with @ref. If @ref is not provided, return instances of an alert on default branch(if the alert exist in default branch) or latest affected branch.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, alert_id: i64, repository: []const u8, ref: ?[]const u8) !models.AlertAnalysisInstanceList {
         @setEvalBranchQuota(100_000);
@@ -1291,7 +1243,7 @@ pub const Instances = struct {
 pub const Metadata2 = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get an alert metadata.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, alert_id: i64, repository: []const u8) !models.AlertMetadata {
         @setEvalBranchQuota(100_000);
@@ -1333,7 +1285,7 @@ pub const Metadata2 = struct {
 pub const MetadataBatch = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get alerts metadata.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, body: models.AlertMetadataBatchRequest) !models.AlertMetadataList {
         @setEvalBranchQuota(100_000);
@@ -1377,7 +1329,7 @@ pub const MetadataBatch = struct {
 pub const AlertsBatch = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get alerts by alert IDs Currently supports fetching secret alerts only.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, body: models.AlertBatchRequest) !models.AlertList {
         @setEvalBranchQuota(100_000);
@@ -1421,7 +1373,7 @@ pub const AlertsBatch = struct {
 pub const Analysis = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -1515,7 +1467,7 @@ pub const Analysis = struct {
 pub const PipelineAnalyses = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Soft-deletes analysis data for all pipelines in a repository, cleaning up the associated Advanced Security alerts.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -1554,7 +1506,7 @@ pub const PipelineAnalyses = struct {
 pub const PipelineAnalysis = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Soft-deletes analysis data for a specific pipeline, cleaning up the associated Advanced Security alerts.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, ado_pipeline_id: i32) !void {
         @setEvalBranchQuota(100_000);
@@ -1595,7 +1547,7 @@ pub const PipelineAnalysis = struct {
 pub const OrgEnablement = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the current status of Advanced Security for the organization
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_all_properties: ?bool) !models.OrgEnablementSettings {
         @setEvalBranchQuota(100_000);
@@ -1669,7 +1621,7 @@ pub const OrgEnablement = struct {
 pub const MeterUsageOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get commiters used when calculating billing information.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, plan: enums.GetRequestPlan, billing_date: ?[]const u8) !models.MeterUsageForPlan {
         @setEvalBranchQuota(100_000);
@@ -1716,7 +1668,7 @@ pub const MeterUsageOperations = struct {
 pub const OrgMeterUsageEstimate = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Estimate the pushers that would be added to the customer's usage if Advanced Security was enabled for this organization.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, plan: ?enums.GetRequestPlan1) !models.MeterUsageEstimate {
         @setEvalBranchQuota(100_000);
@@ -1759,7 +1711,7 @@ pub const OrgMeterUsageEstimate = struct {
 pub const ProjectEnablement = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the current status of Advanced Security for a project
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, include_all_properties: ?bool) !models.ProjectEnablementSettings {
         @setEvalBranchQuota(100_000);
@@ -1837,7 +1789,7 @@ pub const ProjectEnablement = struct {
 pub const ProjectMeterUsageEstimate = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Estimate the pushers that would be added to the customer's usage if Advanced Security was enabled for this project.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan: ?enums.GetRequestPlan2) !models.MeterUsageEstimate {
         @setEvalBranchQuota(100_000);
@@ -1882,7 +1834,7 @@ pub const ProjectMeterUsageEstimate = struct {
 pub const RepoEnablement = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Determines if Code Security, Secret Protection, and their features are enabled for the repository.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, include_all_properties: ?bool) !models.RepoEnablementSettings {
         @setEvalBranchQuota(100_000);
@@ -1964,7 +1916,7 @@ pub const RepoEnablement = struct {
 pub const RepoMeterUsageEstimate = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Estimate the pushers that would be added to the customer's usage if Advanced Security was enabled for this repository.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8, plan: ?enums.GetRequestPlan3) !models.MeterUsageEstimate {
         @setEvalBranchQuota(100_000);

--- a/src/approvals_and_checks/clients.zig
+++ b/src/approvals_and_checks/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ApprovalsAndChecksClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ApprovalsAndChecksClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ApprovalsAndChecksClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn pipelinePermissions(self: *@This()) PipelinePermissions {
@@ -127,7 +79,7 @@ pub const ApprovalsAndChecksClient = struct {
 pub const PipelinePermissions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Batch API to authorize/unauthorize a list of definitions for a multiple resources.
     pub fn updatePipelinePermisionsForResources(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: []const models.ResourcePipelinePermissions) !models.ResourcePipelinePermissionsList {
         @setEvalBranchQuota(100_000);
@@ -245,7 +197,7 @@ pub const PipelinePermissions = struct {
 pub const CheckConfigurations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get Check configuration by resource type and id
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, resource_type: ?[]const u8, resource_id: ?[]const u8, @"$expand": ?enums.ListRequestExpand) !models.CheckConfigurationList {
         @setEvalBranchQuota(100_000);
@@ -495,7 +447,7 @@ pub const CheckConfigurations = struct {
 pub const CheckEvaluations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Initiate an evaluation for a check in a pipeline
     pub fn evaluate(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.EvaluateRequestExpand, body: models.CheckSuiteRequest) !models.CheckSuite {
         @setEvalBranchQuota(100_000);
@@ -630,7 +582,7 @@ pub const CheckEvaluations = struct {
 pub const Approvals = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// List Approvals. This can be used to get a set of pending approvals in a pipeline, on an user or for a resource..
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, approval_ids: ?[]const u8, @"$expand": ?enums.QueryRequestExpand, assigned_to: ?[]const u8, state: ?enums.QueryRequestState, top: ?i32) !models.ApprovalList {
         @setEvalBranchQuota(100_000);

--- a/src/artifacts/clients.zig
+++ b/src/artifacts/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://feeds.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ArtifactsClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ArtifactsClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ArtifactsClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn serviceSettings(self: *@This()) ServiceSettings {
@@ -159,7 +111,7 @@ pub const ArtifactsClient = struct {
 pub const ServiceSettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all service-wide feed creation and administration permissions.
     pub fn getGlobalPermissions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_ids: ?bool) !models.GlobalPermissionList {
         @setEvalBranchQuota(100_000);
@@ -234,7 +186,7 @@ pub const ServiceSettings = struct {
 pub const ChangeTracking = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Query to determine which feeds have changed since the last call, tracked through the provided continuationToken. Only changes to a feed itself are returned and impact the continuationToken, not additions or alterations to packages within the feeds. If the project parameter is present, gets all feed changes in the given project. If omitted, gets all feed changes in the organization.
     pub fn getFeedChanges(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, include_deleted: ?bool, continuation_token: ?i64, batch_size: ?i32) !models.FeedChangesResponse {
         @setEvalBranchQuota(100_000);
@@ -365,7 +317,7 @@ pub const ChangeTracking = struct {
 pub const FeedRecycleBin = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Query for feeds within the recycle bin. If the project parameter is present, gets all feeds in recycle bin in the given project. If omitted, gets all feeds in recycle bin in the organization.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.FeedList {
         @setEvalBranchQuota(100_000);
@@ -473,7 +425,7 @@ pub const FeedRecycleBin = struct {
 pub const FeedManagement = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all feeds in an account where you have the provided role access. If the project parameter is present, gets all feeds in the given project. If omitted, gets all feeds in the organization.
     pub fn getFeeds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, feed_role: ?enums.GetFeedsRequestFeedRole, include_deleted_upstreams: ?bool, include_urls: ?bool) !models.FeedList {
         @setEvalBranchQuota(100_000);
@@ -951,7 +903,7 @@ pub const FeedManagement = struct {
 pub const ArtifactDetails = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetBadgeResult = union(enum) {
         status_200: struct {
@@ -1417,7 +1369,7 @@ pub const ArtifactDetails = struct {
 pub const RecycleBin = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Queues a job to remove all package versions from a feed's recycle bin
     pub fn emptyRecycleBin(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8) !models.OperationReference {
         @setEvalBranchQuota(100_000);
@@ -1650,7 +1602,7 @@ pub const RecycleBin = struct {
 pub const RetentionPolicies = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Delete the retention policy for a feed. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
     pub fn deleteRetentionPolicy(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, project: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -1761,7 +1713,7 @@ pub const RetentionPolicies = struct {
 pub const Provenance = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Creates a session, a wrapper around a feed that can store additional metadata on the packages published to it.
     pub fn createSession(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, protocol: []const u8, project: []const u8, body: models.SessionRequest) !models.SessionResponse {
         @setEvalBranchQuota(100_000);

--- a/src/artifacts_package_types/clients.zig
+++ b/src/artifacts_package_types/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://pkgs.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ArtifactsPackageTypesClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ArtifactsPackageTypesClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ArtifactsPackageTypesClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn cargo(self: *@This()) Cargo {
@@ -143,7 +95,7 @@ pub const ArtifactsPackageTypesClient = struct {
 pub const Cargo = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the upstreaming behavior of a package within the context of a feed
     pub fn getUpstreamingBehavior(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed: []const u8, package_name: []const u8, project: []const u8) !models.UpstreamingBehavior {
         @setEvalBranchQuota(100_000);
@@ -536,7 +488,7 @@ pub const Cargo = struct {
 pub const Maven = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DownloadPackageResult = union(enum) {
         status_200: struct {
@@ -1013,7 +965,7 @@ pub const Maven = struct {
 pub const Npm = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DownloadScopedPackageResult = union(enum) {
         status_200: struct {
@@ -2025,7 +1977,7 @@ pub const Npm = struct {
 pub const NuGet = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DownloadPackageResult = union(enum) {
         status_200: struct {
@@ -2490,7 +2442,7 @@ pub const NuGet = struct {
 pub const Python = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DownloadPackageResult = union(enum) {
         status_200: struct {
@@ -2950,7 +2902,7 @@ pub const Python = struct {
 pub const Universal = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Delete a package version from a feed's recycle bin. The project parameter must be supplied if the feed was created in a project. If the feed is not associated with any project, omit the project parameter from the request.
     pub fn deletePackageVersion(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, feed_id: []const u8, package_name: []const u8, package_version: []const u8, project: []const u8) !models.Package {
         @setEvalBranchQuota(100_000);

--- a/src/audit/clients.zig
+++ b/src/audit/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://auditservice.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const AuditClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !AuditClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) AuditClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn actions(self: *@This()) Actions {
@@ -127,7 +79,7 @@ pub const AuditClient = struct {
 pub const Actions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all auditable actions filterable by area.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, area_name: ?[]const u8) !models.AuditActionInfoList {
         @setEvalBranchQuota(100_000);
@@ -170,7 +122,7 @@ pub const Actions = struct {
 pub const AuditLog = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Queries audit log entries
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, start_time: ?[]const u8, end_time: ?[]const u8, batch_size: ?i32, continuation_token: ?[]const u8, skip_aggregation: ?bool) !models.AuditLogQueryResult {
         @setEvalBranchQuota(100_000);
@@ -237,7 +189,7 @@ pub const AuditLog = struct {
 pub const DownloadLog = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DownloadLogResult = union(enum) {
         status_200: struct {
@@ -318,7 +270,7 @@ pub const DownloadLog = struct {
 pub const Streams = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Return all Audit Streams scoped to an organization
     pub fn queryAllStreams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.AuditStreamList {
         @setEvalBranchQuota(100_000);

--- a/src/build/clients.zig
+++ b/src/build/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const BuildClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !BuildClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) BuildClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn controllers(self: *@This()) Controllers {
@@ -319,7 +271,7 @@ pub const BuildClient = struct {
 pub const Controllers = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets controller, optionally filtered by name
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, name: ?[]const u8) !models.BuildControllerList {
         @setEvalBranchQuota(100_000);
@@ -394,7 +346,7 @@ pub const Controllers = struct {
 pub const ResourceUsage = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets information about build resources in the system.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.BuildResourceUsage {
         @setEvalBranchQuota(100_000);
@@ -430,7 +382,7 @@ pub const ResourceUsage = struct {
 pub const History = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the retention history for the project collection. This includes pipelines that have custom retention rules that may prevent the retention job from cleaning them up, runs per pipeline with retention type, files associated with pipelines owned by the collection with retention type, and the number of files per pipeline.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, days_to_lookback: ?i32) !models.BuildRetentionHistory {
         @setEvalBranchQuota(100_000);
@@ -471,7 +423,7 @@ pub const History = struct {
 pub const Badge = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -602,7 +554,7 @@ pub const Badge = struct {
 pub const Authorizedresources = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": ?[]const u8, id: ?[]const u8) !models.DefinitionResourceReferenceList {
         @setEvalBranchQuota(100_000);
@@ -690,7 +642,7 @@ pub const Authorizedresources = struct {
 pub const Builds = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -1515,7 +1467,7 @@ pub const Builds = struct {
 pub const Attachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -1626,7 +1578,7 @@ pub const Attachments = struct {
 pub const Artifacts = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets all artifacts for a build.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) !models.BuildArtifactList {
         @setEvalBranchQuota(100_000);
@@ -1704,7 +1656,7 @@ pub const Artifacts = struct {
 pub const Properties = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets properties for a build.
     pub fn getBuildProperties(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, filter: ?[]const u8) !models.PropertiesCollection {
         @setEvalBranchQuota(100_000);
@@ -1868,7 +1820,7 @@ pub const Properties = struct {
 pub const Report = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -1941,7 +1893,7 @@ pub const Report = struct {
 pub const Stages = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Update a build stage
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, build_id: i32, stage_ref_name: []const u8, project: []const u8, body: models.UpdateStageParameters) !void {
         @setEvalBranchQuota(100_000);
@@ -1986,7 +1938,7 @@ pub const Stages = struct {
 pub const Tags = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the tags for a build.
     pub fn getBuildTags(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) ![]const []const u8 {
         @setEvalBranchQuota(100_000);
@@ -2427,7 +2379,7 @@ pub const Tags = struct {
 pub const TimelineOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets details for a build
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, timeline_id: []const u8, change_id: ?i32, plan_id: ?[]const u8) !models.Timeline {
         @setEvalBranchQuota(100_000);
@@ -2481,7 +2433,7 @@ pub const TimelineOperations = struct {
 pub const StageTimeline = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the timeline for a build filtered to a specific stage.
     pub fn getBuildStageTimeline(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, timeline_id: []const u8, stage_name: []const u8, change_id: ?i32, plan_id: ?[]const u8) !models.Timeline {
         @setEvalBranchQuota(100_000);
@@ -2585,7 +2537,7 @@ pub const StageTimeline = struct {
 pub const Definitions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -3013,7 +2965,7 @@ pub const Definitions = struct {
 pub const Metrics = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets build metrics for a definition.
     pub fn getDefinitionMetrics(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32, min_metrics_time: ?[]const u8) !models.BuildMetricList {
         @setEvalBranchQuota(100_000);
@@ -3101,7 +3053,7 @@ pub const Metrics = struct {
 pub const Resources = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32) !models.DefinitionResourceReferenceList {
         @setEvalBranchQuota(100_000);
@@ -3179,7 +3131,7 @@ pub const Resources = struct {
 pub const Yaml = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Converts a definition to YAML, optionally at a specific revision.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: i32, revision: ?i32, min_metrics_time: ?[]const u8, property_filters: ?[]const u8, include_latest_builds: ?bool) !models.YamlBuild {
         @setEvalBranchQuota(100_000);
@@ -3243,7 +3195,7 @@ pub const Yaml = struct {
 pub const Templates = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets all definition templates.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BuildDefinitionTemplateList {
         @setEvalBranchQuota(100_000);
@@ -3386,7 +3338,7 @@ pub const Templates = struct {
 pub const Folders = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Deletes a definition folder. Definitions and their corresponding builds will also be deleted.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, path: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -3548,7 +3500,7 @@ pub const Folders = struct {
 pub const GeneralSettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets pipeline general settings.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.PipelineGeneralSettings {
         @setEvalBranchQuota(100_000);
@@ -3622,7 +3574,7 @@ pub const GeneralSettings = struct {
 pub const Latest = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the latest build for a definition, optionally scoped to a specific branch.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition: []const u8, branch_name: ?[]const u8) !models.Build {
         @setEvalBranchQuota(100_000);
@@ -3669,7 +3621,7 @@ pub const Latest = struct {
 pub const Options = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets all build definition options supported by the system.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BuildOptionDefinitionList {
         @setEvalBranchQuota(100_000);
@@ -3707,7 +3659,7 @@ pub const Options = struct {
 pub const Retention = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the project's retention settings.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.ProjectRetentionSetting {
         @setEvalBranchQuota(100_000);
@@ -3781,7 +3733,7 @@ pub const Retention = struct {
 pub const Leases = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Removes specific retention leases.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, ids: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -3966,7 +3918,7 @@ pub const Leases = struct {
 pub const Settings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the build settings.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BuildSettings {
         @setEvalBranchQuota(100_000);
@@ -4040,7 +3992,7 @@ pub const Settings = struct {
 pub const Status = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -4133,7 +4085,7 @@ pub const Status = struct {
 pub const SourceProviders = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetFileContentsResult = union(enum) {
         status_200: struct {

--- a/src/core/clients.zig
+++ b/src/core/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const CoreClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !CoreClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) CoreClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn processes(self: *@This()) Processes {
@@ -135,7 +87,7 @@ pub const CoreClient = struct {
 pub const Processes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of processes.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.ProcessList {
         @setEvalBranchQuota(100_000);
@@ -203,7 +155,7 @@ pub const Processes = struct {
 pub const Projects = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all projects in the organization that the authenticated user has access to.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, state_filter: ?enums.ListRequestStateFilter, @"$top": ?i32, @"$skip": ?i32, continuation_token: ?i32, get_default_team_image_url: ?bool) !models.TeamProjectReferenceList {
         @setEvalBranchQuota(100_000);
@@ -484,7 +436,7 @@ pub const Projects = struct {
 pub const Avatar = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Removes the avatar for the project.
     pub fn removeProjectAvatar(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -556,7 +508,7 @@ pub const Avatar = struct {
 pub const CategorizedTeams = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets list of user readable teams in a project and teams user is member of (excluded from readable list).
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, @"$expand_identity": ?bool, @"$top": ?i32, @"$skip": ?i32) !models.CategorizedWebApiTeams {
         @setEvalBranchQuota(100_000);
@@ -609,7 +561,7 @@ pub const CategorizedTeams = struct {
 pub const Teams = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of teams.
     pub fn getTeams(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project_id: []const u8, @"$mine": ?bool, @"$top": ?i32, @"$skip": ?i32, @"$expand_identity": ?bool) !models.WebApiTeamList {
         @setEvalBranchQuota(100_000);

--- a/src/dashboard/clients.zig
+++ b/src/dashboard/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const DashboardClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !DashboardClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) DashboardClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn widgetTypes(self: *@This()) WidgetTypes {
@@ -119,7 +71,7 @@ pub const DashboardClient = struct {
 pub const WidgetTypes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all available widget metadata in alphabetical order, including widgets marked with isVisibleFromCatalog == false.
     pub fn getWidgetTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"$scope": enums.GetWidgetTypesRequestScope, project: []const u8) !models.WidgetTypesResponse {
         @setEvalBranchQuota(100_000);
@@ -195,7 +147,7 @@ pub const WidgetTypes = struct {
 pub const Dashboards = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of dashboards under a project.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.DashboardList {
         @setEvalBranchQuota(100_000);
@@ -422,7 +374,7 @@ pub const Dashboards = struct {
 pub const Widgets = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetWidgetsResult = union(enum) {
         status_200: struct {

--- a/src/delegated_auth/clients.zig
+++ b/src/delegated_auth/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vssps.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const DelegatedAuthorizationClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !DelegatedAuthorizationClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) DelegatedAuthorizationClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn registrationSecret(self: *@This()) RegistrationSecret {
@@ -103,7 +55,7 @@ pub const DelegatedAuthorizationClient = struct {
 pub const RegistrationSecret = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Create Alternative Secret for the ADO OAuth App Registration
     pub fn create(self: *@This(), alloc: std.mem.Allocator, registration_id: []const u8) !models.JsonWebToken {
         @setEvalBranchQuota(100_000);

--- a/src/distributed_task/clients.zig
+++ b/src/distributed_task/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const DistributedTaskClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !DistributedTaskClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) DistributedTaskClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn elasticpools(self: *@This()) Elasticpools {
@@ -263,7 +215,7 @@ pub const DistributedTaskClient = struct {
 pub const Elasticpools = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of all Elastic Pools.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.ElasticPoolList {
         @setEvalBranchQuota(100_000);
@@ -422,7 +374,7 @@ pub const Elasticpools = struct {
 pub const Elasticpoollogs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get elastic pool diagnostics logs for a specified Elastic Pool.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, @"$top": ?i32) !models.ElasticPoolLogList {
         @setEvalBranchQuota(100_000);
@@ -465,7 +417,7 @@ pub const Elasticpoollogs = struct {
 pub const Nodes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of ElasticNodes currently in the ElasticPool
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, @"$state": ?enums.ListRequestState) !models.ElasticNodeList {
         @setEvalBranchQuota(100_000);
@@ -548,7 +500,7 @@ pub const Nodes = struct {
 pub const Webhooks = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Triggers a pipeline run of pipelines which have a webhook resource defined with specified WebHook Name property of the WebHook service connection.
     pub fn receiveExternalEvent(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, web_hook_id: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -585,7 +537,7 @@ pub const Webhooks = struct {
 pub const Events = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Send a pipeline job event to be processed by the execution plan.
     pub fn postEvent(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_identifier: []const u8, hub_name: []const u8, plan_id: []const u8, body: models.JobEvent) !void {
         @setEvalBranchQuota(100_000);
@@ -630,7 +582,7 @@ pub const Events = struct {
 pub const Oidctoken = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_identifier: []const u8, hub_name: []const u8, plan_id: []const u8, job_id: []const u8, service_connection_id: ?[]const u8, body: std.json.ArrayHashMap([]const u8)) !models.TaskHubOidcToken {
         @setEvalBranchQuota(100_000);
@@ -685,7 +637,7 @@ pub const Oidctoken = struct {
 pub const Logs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Create a log and connect it to a pipeline run's execution plan.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_identifier: []const u8, hub_name: []const u8, plan_id: []const u8, body: models.TaskLog) !models.TaskLog {
         @setEvalBranchQuota(100_000);
@@ -771,7 +723,7 @@ pub const Logs = struct {
 pub const Records = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Update timeline records if they already exist, otherwise create new ones for the same timeline.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_identifier: []const u8, hub_name: []const u8, plan_id: []const u8, timeline_id: []const u8, body: models.VssJsonCollectionWrapper) !models.TimelineRecordList {
         @setEvalBranchQuota(100_000);
@@ -819,7 +771,7 @@ pub const Records = struct {
 pub const Agentclouds = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.TaskAgentCloudList {
         @setEvalBranchQuota(100_000);
@@ -989,7 +941,7 @@ pub const Agentclouds = struct {
 pub const Requests = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, agent_cloud_id: i32) !models.TaskAgentCloudRequestList {
         @setEvalBranchQuota(100_000);
@@ -1027,7 +979,7 @@ pub const Requests = struct {
 pub const Agentcloudtypes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get agent cloud types.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.TaskAgentCloudTypeList {
         @setEvalBranchQuota(100_000);
@@ -1063,7 +1015,7 @@ pub const Agentcloudtypes = struct {
 pub const Pools = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of agent pools.
     pub fn getAgentPoolsByIds(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_ids: []const u8, action_filter: ?enums.GetAgentPoolsByIdsRequestActionFilter) !models.TaskAgentPoolList {
         @setEvalBranchQuota(100_000);
@@ -1257,7 +1209,7 @@ pub const Pools = struct {
 pub const Agents = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of agents.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_id: i32, agent_name: ?[]const u8, include_capabilities: ?bool, include_assigned_request: ?bool, include_last_completed_request: ?bool, property_filters: ?[]const u8, demands: ?[]const u8) !models.TaskAgentList {
         @setEvalBranchQuota(100_000);
@@ -1532,7 +1484,7 @@ pub const Agents = struct {
 pub const Poolpermissions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const HasPoolPermissionsResult = union(enum) {
         status_200: struct {
@@ -1590,7 +1542,7 @@ pub const Poolpermissions = struct {
 pub const Variablegroups = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Add a variable group.
     pub fn shareVariableGroup(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, variable_group_id: i32, body: []const models.VariableGroupProjectReference) !void {
         @setEvalBranchQuota(100_000);
@@ -1811,7 +1763,7 @@ pub const Variablegroups = struct {
 pub const Yamlschema = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// GET the Yaml schema used for Yaml file validation.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, validate_task_names: ?bool) !models.GetResponse {
         @setEvalBranchQuota(100_000);
@@ -1852,7 +1804,7 @@ pub const Yamlschema = struct {
 pub const Deploymentgroups = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -2111,7 +2063,7 @@ pub const Deploymentgroups = struct {
 pub const Targets = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -2357,7 +2309,7 @@ pub const Targets = struct {
 pub const Queues = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of agent queues by pool ids
     pub fn getAgentQueuesForPools(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, pool_ids: []const u8, project: []const u8, action_filter: ?enums.GetAgentQueuesForPoolsRequestActionFilter) !models.TaskAgentQueueList {
         @setEvalBranchQuota(100_000);
@@ -2521,7 +2473,7 @@ pub const Queues = struct {
 pub const Securefiles = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get secure files
     pub fn getSecureFilesByNames(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, secure_file_names: []const u8, include_download_tickets: ?bool, action_filter: ?enums.GetSecureFilesByNamesRequestActionFilter) !models.SecureFileList {
         @setEvalBranchQuota(100_000);
@@ -2769,7 +2721,7 @@ pub const Securefiles = struct {
 pub const Taskgroups = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {

--- a/src/environments/clients.zig
+++ b/src/environments/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const EnvironmentsClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !EnvironmentsClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) EnvironmentsClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn environments(self: *@This()) Environments {
@@ -143,7 +95,7 @@ pub const EnvironmentsClient = struct {
 pub const Environments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -374,7 +326,7 @@ pub const Environments = struct {
 pub const Environmentdeploymentrecords = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -452,7 +404,7 @@ pub const Environmentdeploymentrecords = struct {
 pub const Kubernetes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, environment_id: i32, body: models.KubernetesResourcePatchParameters) !models.KubernetesResource {
         @setEvalBranchQuota(100_000);
@@ -605,7 +557,7 @@ pub const Kubernetes = struct {
 pub const Vmresource = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -846,7 +798,7 @@ pub const Vmresource = struct {
 pub const Pool = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, environment_id: i32) !models.TaskAgentPoolReference {
         @setEvalBranchQuota(100_000);
@@ -886,7 +838,7 @@ pub const Pool = struct {
 pub const Environmentaccesstoken = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GenerateEnvironmentAccessTokenResult = union(enum) {
         status_200: struct {

--- a/src/extension_management/clients.zig
+++ b/src/extension_management/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://extmgmt.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ExtensionManagementClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ExtensionManagementClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ExtensionManagementClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn installedExtensions(self: *@This()) InstalledExtensions {
@@ -103,7 +55,7 @@ pub const ExtensionManagementClient = struct {
 pub const InstalledExtensions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// List the installed extensions in the account / project collection.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, include_disabled_extensions: ?bool, include_errors: ?bool, asset_types: ?[]const u8, include_installation_issues: ?bool) !models.InstalledExtensionList {
         @setEvalBranchQuota(100_000);

--- a/src/favorite/clients.zig
+++ b/src/favorite/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const FavoriteClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !FavoriteClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) FavoriteClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn favorites(self: *@This()) Favorites {
@@ -103,7 +55,7 @@ pub const FavoriteClient = struct {
 pub const Favorites = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn getFavorites(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, artifact_type: ?[]const u8, artifact_scope_type: ?[]const u8, artifact_scope_id: ?[]const u8, include_extended_details: ?bool) !models.FavoriteList {
         @setEvalBranchQuota(100_000);

--- a/src/git/clients.zig
+++ b/src/git/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const GitClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !GitClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) GitClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn repositories(self: *@This()) Repositories {
@@ -391,7 +343,7 @@ pub const GitClient = struct {
 pub const Repositories = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve deleted git repositories.
     pub fn getDeletedRepositories(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.GitDeletedRepositoryList {
         @setEvalBranchQuota(100_000);
@@ -727,7 +679,7 @@ pub const Repositories = struct {
 pub const RefsFavorites = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the refs favorites for a repo and an identity.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: ?[]const u8, identity_id: ?[]const u8) !models.GitRefFavoriteList {
         @setEvalBranchQuota(100_000);
@@ -882,7 +834,7 @@ pub const RefsFavorites = struct {
 pub const RefsFavoritesForProject = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, identity_id: ?[]const u8) !models.GitRefFavoriteList {
         @setEvalBranchQuota(100_000);
@@ -927,7 +879,7 @@ pub const RefsFavoritesForProject = struct {
 pub const PolicyConfigurations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -1024,7 +976,7 @@ pub const PolicyConfigurations = struct {
 pub const PullRequests = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve all pull requests matching a specified criteria. Please note that description field will be truncated up to 400 symbols in the result.
     pub fn getPullRequestsByProject(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, search_criteria_creator_id: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_labels: ?[]const []const u8, search_criteria_max_time: ?[]const u8, search_criteria_min_time: ?[]const u8, @"search_criteria.query_time_range_type": ?enums.GetPullRequestsByProjectRequestSearchCriteriaQueryTimeRangeType, search_criteria_repository_id: ?[]const u8, search_criteria_reviewer_id: ?[]const u8, search_criteria_source_ref_name: ?[]const u8, search_criteria_source_repository_id: ?[]const u8, @"search_criteria.status": ?enums.GetPullRequestsByProjectRequestSearchCriteriaStatus, @"search_criteria.tags_filter_operator": ?enums.GetPullRequestsByProjectRequestSearchCriteriaTagsFilterOperator, search_criteria_target_ref_name: ?[]const u8, search_criteria_title: ?[]const u8, max_comment_length: ?i32, @"$skip": ?i32, @"$top": ?i32) !models.GitPullRequestList {
         @setEvalBranchQuota(100_000);
@@ -1512,7 +1464,7 @@ pub const PullRequests = struct {
 pub const AnnotatedTags = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Create an annotated tag. Repositories have both a name and an identifier. Identifiers are globally unique, but several projects may contain a repository of the same name. You don't need to include the project if you specify a repository by ID. However, if you specify a repository by name, you must also specify the project (by name or ID).
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8, body: models.GitAnnotatedTag) !models.GitAnnotatedTag {
         @setEvalBranchQuota(100_000);
@@ -1592,7 +1544,7 @@ pub const AnnotatedTags = struct {
 pub const Blobs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetBlobsZipResult = union(enum) {
         status_200: struct {
@@ -1756,7 +1708,7 @@ pub const Blobs = struct {
 pub const CherryPicks = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve information about a cherry pick operation for a specific branch. This operation is expensive due to the underlying object structure, so this API only looks at the 1000 most recent cherry pick operations.
     pub fn getCherryPickForRefName(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8, ref_name: []const u8) !models.GitCherryPick {
         @setEvalBranchQuota(100_000);
@@ -1874,7 +1826,7 @@ pub const CherryPicks = struct {
 pub const Commits = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve a list of commits associated with a particular push.
     pub fn getPushCommits(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, push_id: i32, project: []const u8, top: ?i32, skip: ?i32, include_links: ?bool) !models.GitCommitRefList {
         @setEvalBranchQuota(100_000);
@@ -2071,7 +2023,7 @@ pub const Commits = struct {
 pub const Statuses = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get statuses associated with the Git commit.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, commit_id: []const u8, repository_id: []const u8, project: []const u8, top: ?i32, skip: ?i32, latest_only: ?bool) !models.GitStatusList {
         @setEvalBranchQuota(100_000);
@@ -2168,7 +2120,7 @@ pub const Statuses = struct {
 pub const Diffs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Find the closest common commit (the merge base) between base and target commits, and get the diff between either the base and target commits or common and target commits.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, diff_common_commit: ?bool, @"$top": ?i32, @"$skip": ?i32, base_version: ?[]const u8, base_version_options: ?enums.GetRequestBaseVersionOptions, base_version_type: ?enums.GetRequestBaseVersionType, target_version: ?[]const u8, target_version_options: ?enums.GetRequestTargetVersionOptions, target_version_type: ?enums.GetRequestTargetVersionType) !models.GitCommitDiffs {
         @setEvalBranchQuota(100_000);
@@ -2265,7 +2217,7 @@ pub const Diffs = struct {
 pub const ImportRequests = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve import requests for a repository.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8, include_abandoned: ?bool) !models.GitImportRequestList {
         @setEvalBranchQuota(100_000);
@@ -2424,7 +2376,7 @@ pub const ImportRequests = struct {
 pub const Items = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get Item Metadata and/or Content for a collection of items. The download parameter is to indicate whether the content should be available as a download or just sent as a stream in the response. Doesn't apply to zipped content which is always returned as a download.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, scope_path: ?[]const u8, recursion_level: ?enums.ListRequestRecursionLevel, include_content_metadata: ?bool, latest_processed_change: ?bool, download: ?bool, include_links: ?bool, @"$format": ?[]const u8, version_descriptor_version: ?[]const u8, @"version_descriptor.version_options": ?enums.ListRequestVersionDescriptorVersionOptions, @"version_descriptor.version_type": ?enums.ListRequestVersionDescriptorVersionType, zip_for_unix: ?bool) !models.GitItemList {
         @setEvalBranchQuota(100_000);
@@ -2569,7 +2521,7 @@ pub const Items = struct {
 pub const PullRequestQuery = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// This API is used to find what pull requests are related to a given commit. It can be used to either find the pull request that created a particular merge commit or it can be used to find all pull requests that have ever merged a particular commit. The input is a list of queries which each contain a list of commits. For each commit that you search against, you will get back a dictionary of commit -> pull requests.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, body: models.GitPullRequestQuery) !models.GitPullRequestQuery {
         @setEvalBranchQuota(100_000);
@@ -2613,7 +2565,7 @@ pub const PullRequestQuery = struct {
 pub const PullRequestAttachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -2797,7 +2749,7 @@ pub const PullRequestAttachments = struct {
 pub const PullRequestCommits = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetPullRequestCommitsResult = union(enum) {
         status_200: struct {
@@ -2925,7 +2877,7 @@ pub const PullRequestCommits = struct {
 pub const PullRequestIterations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the list of iterations for the specified pull request.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, include_commits: ?bool) !models.GitPullRequestIterationList {
         @setEvalBranchQuota(100_000);
@@ -3010,7 +2962,7 @@ pub const PullRequestIterations = struct {
 pub const PullRequestIterationChanges = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve the changes made in a pull request between two iterations.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8, @"$top": ?i32, @"$skip": ?i32, @"$compare_to": ?i32) !models.GitPullRequestIterationChanges {
         @setEvalBranchQuota(100_000);
@@ -3069,7 +3021,7 @@ pub const PullRequestIterationChanges = struct {
 pub const PullRequestIterationStatuses = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all the statuses associated with a pull request iteration.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, iteration_id: i32, project: []const u8) !models.GitPullRequestStatusList {
         @setEvalBranchQuota(100_000);
@@ -3275,7 +3227,7 @@ pub const PullRequestIterationStatuses = struct {
 pub const PullRequestLabels = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all the labels (tags) assigned to a pull request.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, project_id: ?[]const u8) !models.WebApiTagDefinitionList {
         @setEvalBranchQuota(100_000);
@@ -3460,7 +3412,7 @@ pub const PullRequestLabels = struct {
 pub const PullRequestProperties = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get external properties of the pull request.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.PropertiesCollection {
         @setEvalBranchQuota(100_000);
@@ -3542,7 +3494,7 @@ pub const PullRequestProperties = struct {
 pub const PullRequestReviewers = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve the reviewers for a pull request
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.IdentityRefWithVoteList {
         @setEvalBranchQuota(100_000);
@@ -3862,7 +3814,7 @@ pub const PullRequestReviewers = struct {
 pub const PullRequestShare = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Sends an e-mail notification about a specific pull request to a set of recipients
     pub fn sharePullRequest(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, body: models.ShareNotificationContext) !void {
         @setEvalBranchQuota(100_000);
@@ -3907,7 +3859,7 @@ pub const PullRequestShare = struct {
 pub const PullRequestStatuses = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all the statuses associated with a pull request.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.GitPullRequestStatusList {
         @setEvalBranchQuota(100_000);
@@ -4103,7 +4055,7 @@ pub const PullRequestStatuses = struct {
 pub const PullRequestThreads = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve all threads in a pull request.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8, @"$iteration": ?i32, @"$base_iteration": ?i32) !models.GitPullRequestCommentThreadList {
         @setEvalBranchQuota(100_000);
@@ -4285,7 +4237,7 @@ pub const PullRequestThreads = struct {
 pub const PullRequestThreadComments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve all comments associated with a specific thread in a pull request.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, project: []const u8) !models.CommentList {
         @setEvalBranchQuota(100_000);
@@ -4494,7 +4446,7 @@ pub const PullRequestThreadComments = struct {
 pub const PullRequestCommentLikes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Delete a like on a comment.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, thread_id: i32, comment_id: i32, project: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -4618,7 +4570,7 @@ pub const PullRequestCommentLikes = struct {
 pub const PullRequestWorkItems = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve a list of work items associated with a pull request.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, pull_request_id: i32, project: []const u8) !models.ResourceRefList {
         @setEvalBranchQuota(100_000);
@@ -4660,7 +4612,7 @@ pub const PullRequestWorkItems = struct {
 pub const Pushes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieves pushes associated with the specified repository.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, @"$skip": ?i32, @"$top": ?i32, search_criteria_from_date: ?[]const u8, search_criteria_include_links: ?bool, search_criteria_include_ref_updates: ?bool, search_criteria_pusher_id: ?[]const u8, search_criteria_ref_name: ?[]const u8, search_criteria_to_date: ?[]const u8) !models.GitPushList {
         @setEvalBranchQuota(100_000);
@@ -4832,7 +4784,7 @@ pub const Pushes = struct {
 pub const Refs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -5048,7 +5000,7 @@ pub const Refs = struct {
 pub const Reverts = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve information about a revert operation for a specific branch.
     pub fn getRevertForRefName(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_id: []const u8, ref_name: []const u8) !models.GitRevert {
         @setEvalBranchQuota(100_000);
@@ -5166,7 +5118,7 @@ pub const Reverts = struct {
 pub const Stats = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve statistics about all branches within a repository.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, base_version_descriptor_version: ?[]const u8, @"base_version_descriptor.version_options": ?enums.ListRequestBaseVersionDescriptorVersionOptions, @"base_version_descriptor.version_type": ?enums.ListRequestBaseVersionDescriptorVersionType) !models.GitBranchStatsList {
         @setEvalBranchQuota(100_000);
@@ -5227,7 +5179,7 @@ pub const Stats = struct {
 pub const Suggestions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve a pull request suggestion for a particular repository or team project.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_id: []const u8, project: []const u8, prefer_compare_branch: ?bool) !models.GitSuggestionList {
         @setEvalBranchQuota(100_000);
@@ -5272,7 +5224,7 @@ pub const Suggestions = struct {
 pub const Trees = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -5366,7 +5318,7 @@ pub const Trees = struct {
 pub const MergeBases = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Find the merge bases of two commits, optionally across forks. If otherRepositoryId is not specified, the merge bases will only be calculated within the context of the local repositoryNameOrId.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, commit_id: []const u8, other_commit_id: []const u8, project: []const u8, other_collection_id: ?[]const u8, other_repository_id: ?[]const u8) !models.GitCommitRefList {
         @setEvalBranchQuota(100_000);
@@ -5426,7 +5378,7 @@ pub const MergeBases = struct {
 pub const Forks = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve all forks of a repository in the collection.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, repository_name_or_id: []const u8, collection_id: []const u8, project: []const u8, include_links: ?bool) !models.GitRepositoryRefList {
         @setEvalBranchQuota(100_000);
@@ -5601,7 +5553,7 @@ pub const Forks = struct {
 pub const Merges = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Request a git merge operation. Currently we support merging only 2 commits.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository_name_or_id: []const u8, include_links: ?bool, body: models.GitMergeParameters) !models.GitMerge {
         @setEvalBranchQuota(100_000);

--- a/src/graph/clients.zig
+++ b/src/graph/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vssps.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const GraphClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !GraphClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) GraphClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn descriptors(self: *@This()) Descriptors {
@@ -191,7 +143,7 @@ pub const GraphClient = struct {
 pub const Descriptors = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Resolve a storage key to a descriptor
     pub fn get(self: *@This(), alloc: std.mem.Allocator, storage_key: []const u8, organization: []const u8) !models.GraphDescriptorResult {
         @setEvalBranchQuota(100_000);
@@ -229,7 +181,7 @@ pub const Descriptors = struct {
 pub const Groups = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -459,7 +411,7 @@ pub const Groups = struct {
 pub const Memberships = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CheckMembershipExistenceResult = union(enum) {
         status_200: struct {
@@ -671,7 +623,7 @@ pub const Memberships = struct {
 pub const MembershipStates = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Check whether a subject is active or inactive.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subject_descriptor: []const u8) !models.GraphMembershipState {
         @setEvalBranchQuota(100_000);
@@ -709,7 +661,7 @@ pub const MembershipStates = struct {
 pub const RequestAccess = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn requestAccess(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.JToken) !void {
         @setEvalBranchQuota(100_000);
@@ -748,7 +700,7 @@ pub const RequestAccess = struct {
 pub const ServicePrincipals = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -928,7 +880,7 @@ pub const ServicePrincipals = struct {
 pub const StorageKeys = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Resolve a descriptor to a storage key.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, subject_descriptor: []const u8, organization: []const u8) !models.GraphStorageKeyResult {
         @setEvalBranchQuota(100_000);
@@ -966,7 +918,7 @@ pub const StorageKeys = struct {
 pub const SubjectLookup = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Resolve descriptors to users, groups or scopes (Subjects) in a batch.
     pub fn lookupSubjects(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.GraphSubjectLookup) !std.json.ArrayHashMap(models.GraphSubject) {
         @setEvalBranchQuota(100_000);
@@ -1006,7 +958,7 @@ pub const SubjectLookup = struct {
 pub const SubjectQuery = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Search for Azure Devops users, or/and groups. Results will be returned in a batch with no more than 100 graph subjects.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.GraphSubjectQuery) !models.GraphSubjectList {
         @setEvalBranchQuota(100_000);
@@ -1046,7 +998,7 @@ pub const SubjectQuery = struct {
 pub const Avatars = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, subject_descriptor: []const u8, organization: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -1164,7 +1116,7 @@ pub const Avatars = struct {
 pub const Users = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -1387,7 +1339,7 @@ pub const Users = struct {
 pub const ProviderInfo = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, user_descriptor: []const u8, organization: []const u8) !models.GraphProviderInfo {
         @setEvalBranchQuota(100_000);

--- a/src/hooks/clients.zig
+++ b/src/hooks/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ServiceHooksClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ServiceHooksClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ServiceHooksClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn consumers(self: *@This()) Consumers {
@@ -135,7 +87,7 @@ pub const ServiceHooksClient = struct {
 pub const Consumers = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of available service hook consumer services. Optionally filter by consumers that support at least one event type from the specific publisher.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8) !models.ConsumerList {
         @setEvalBranchQuota(100_000);
@@ -297,7 +249,7 @@ pub const Consumers = struct {
 pub const Notifications = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Query for notifications. A notification includes details about the event, the request to and the response from the consumer service.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.NotificationsQuery) !models.NotificationsQuery {
         @setEvalBranchQuota(100_000);
@@ -461,7 +413,7 @@ pub const Notifications = struct {
 pub const Publishers = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of publishers.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.PublisherList {
         @setEvalBranchQuota(100_000);
@@ -665,7 +617,7 @@ pub const Publishers = struct {
 pub const Subscriptions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of subscriptions.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8, event_type: ?[]const u8, consumer_id: ?[]const u8, consumer_action_id: ?[]const u8) !models.SubscriptionList {
         @setEvalBranchQuota(100_000);
@@ -896,7 +848,7 @@ pub const Subscriptions = struct {
 pub const Diagnostics = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, subscription_id: []const u8) !models.SubscriptionDiagnostics {
         @setEvalBranchQuota(100_000);

--- a/src/ims/clients.zig
+++ b/src/ims/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vssps.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const IdentityClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !IdentityClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) IdentityClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn identities(self: *@This()) Identities {
@@ -103,7 +55,7 @@ pub const IdentityClient = struct {
 pub const Identities = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Resolve legacy identity information for use with older APIs such as the Security APIs
     pub fn readIdentities(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, descriptors: ?[]const u8, identity_ids: ?[]const u8, subject_descriptors: ?[]const u8, search_filter: ?[]const u8, filter_value: ?[]const u8, query_membership: ?enums.ReadIdentitiesRequestQueryMembership) !models.IdentityList {
         @setEvalBranchQuota(100_000);

--- a/src/member_entitlement_management/clients.zig
+++ b/src/member_entitlement_management/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vsaex.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const MemberEntitlementManagementClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !MemberEntitlementManagementClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) MemberEntitlementManagementClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn groupEntitlements(self: *@This()) GroupEntitlements {
@@ -143,7 +95,7 @@ pub const MemberEntitlementManagementClient = struct {
 pub const GroupEntitlements = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the group entitlements for an account.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.GroupEntitlementList {
         @setEvalBranchQuota(100_000);
@@ -339,7 +291,7 @@ pub const GroupEntitlements = struct {
 pub const Members = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get direct members of a Group.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, group_id: []const u8, max_results: ?i32, paging_token: ?[]const u8) !models.PagedGraphMemberList {
         @setEvalBranchQuota(100_000);
@@ -455,7 +407,7 @@ pub const Members = struct {
 pub const MemberEntitlements = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const SearchMemberEntitlementsResult = union(enum) {
         status_200: struct {
@@ -545,7 +497,7 @@ pub const MemberEntitlements = struct {
 pub const ServicePrincipalEntitlements = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Edit the entitlements (License, Extensions, Projects, Teams etc) for one or more service principals.
     pub fn updateServicePrincipalEntitlements(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.JsonPatchDocument) !models.ServicePrincipalEntitlementOperationReference {
         @setEvalBranchQuota(100_000);
@@ -718,7 +670,7 @@ pub const ServicePrincipalEntitlements = struct {
 pub const UserEntitlements = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a paged set of user entitlements matching the filter and sort criteria built with properties that match the select input.
     pub fn searchUserEntitlements(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, continuation_token: ?[]const u8, select: ?enums.SearchUserEntitlementsRequestSelect, @"$filter": ?[]const u8, @"$order_by": ?[]const u8) !models.PagedUserEntitlementsList {
         @setEvalBranchQuota(100_000);
@@ -954,7 +906,7 @@ pub const UserEntitlements = struct {
 pub const UserEntitlementSummary = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get summary of Licenses, Extension, Projects, Groups and their assignments in the collection.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, select: ?[]const u8) !models.UsersSummary {
         @setEvalBranchQuota(100_000);

--- a/src/notification/clients.zig
+++ b/src/notification/clients.zig
@@ -20,74 +20,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
     return false;
 }
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const NotificationClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !NotificationClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) NotificationClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn diagnosticLogs(self: *@This()) DiagnosticLogs {
@@ -142,7 +94,7 @@ pub const NotificationClient = struct {
 pub const DiagnosticLogs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of diagnostic logs for this service.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, source: []const u8, organization: []const u8, entry_id: []const u8, start_time: ?[]const u8, end_time: ?[]const u8) !models.INotificationDiagnosticLogList {
         @setEvalBranchQuota(100_000);
@@ -196,7 +148,7 @@ pub const DiagnosticLogs = struct {
 pub const EventTypes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// List available event types for this service. Optionally filter by only event types for the specified publisher.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, publisher_id: ?[]const u8) !models.NotificationEventTypeList {
         @setEvalBranchQuota(100_000);
@@ -271,7 +223,7 @@ pub const EventTypes = struct {
 pub const Settings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.NotificationAdminSettings {
         @setEvalBranchQuota(100_000);
@@ -341,7 +293,7 @@ pub const Settings = struct {
 pub const Subscribers = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get delivery preferences of a notifications subscriber.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, subscriber_id: []const u8, organization: []const u8) !models.NotificationSubscriber {
         @setEvalBranchQuota(100_000);
@@ -415,7 +367,7 @@ pub const Subscribers = struct {
 pub const Subscriptions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Query for subscriptions. A subscription is returned if it matches one or more of the specified conditions.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.SubscriptionQuery) !models.NotificationSubscriptionList {
         @setEvalBranchQuota(100_000);
@@ -714,7 +666,7 @@ pub const Subscriptions = struct {
 pub const Diagnostics = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the diagnostics settings for a subscription.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, subscription_id: []const u8, organization: []const u8) !models.SubscriptionDiagnostics {
         @setEvalBranchQuota(100_000);

--- a/src/operations/clients.zig
+++ b/src/operations/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const OperationsClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !OperationsClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) OperationsClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn operations(self: *@This()) Operations {
@@ -103,7 +55,7 @@ pub const OperationsClient = struct {
 pub const Operations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets an operation from the operationId using the given pluginId. Some scenarios don’t require a pluginId. If a pluginId is not included in the call then just the operationId will be used to find an operation.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, operation_id: []const u8, organization: []const u8, plugin_id: ?[]const u8) !models.Operation {
         @setEvalBranchQuota(100_000);

--- a/src/permissions_report/clients.zig
+++ b/src/permissions_report/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const PermissionsReportClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !PermissionsReportClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) PermissionsReportClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn permissionsReportOperations(self: *@This()) PermissionsReportOperations {
@@ -111,7 +63,7 @@ pub const PermissionsReportClient = struct {
 pub const PermissionsReportOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of permissions reports
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.PermissionsReportList {
         @setEvalBranchQuota(100_000);
@@ -213,7 +165,7 @@ pub const PermissionsReportOperations = struct {
 pub const PermissionsReportDownload = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DownloadResult = union(enum) {
         status_200: struct {

--- a/src/pipelines/clients.zig
+++ b/src/pipelines/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const PipelinesClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !PipelinesClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) PipelinesClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn pipelines(self: *@This()) Pipelines {
@@ -135,7 +87,7 @@ pub const PipelinesClient = struct {
 pub const Pipelines = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -293,7 +245,7 @@ pub const Pipelines = struct {
 pub const Preview = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Queues a dry run of the pipeline and returns an object containing the final yaml.
     pub fn preview(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, pipeline_version: ?i32, body: models.RunPipelineParameters) !models.PreviewRun {
         @setEvalBranchQuota(100_000);
@@ -342,7 +294,7 @@ pub const Preview = struct {
 pub const Runs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets top 10000 runs for a particular pipeline.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32) !models.RunList {
         @setEvalBranchQuota(100_000);
@@ -461,7 +413,7 @@ pub const Runs = struct {
 pub const Artifacts = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a specific artifact from a pipeline run
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, run_id: i32, artifact_name: []const u8, @"$expand": ?enums.GetRequestExpand) !models.Artifact {
         @setEvalBranchQuota(100_000);
@@ -514,7 +466,7 @@ pub const Artifacts = struct {
 pub const Logs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of logs from a pipeline run.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, run_id: i32, @"$expand": ?enums.ListRequestExpand) !models.LogCollection {
         @setEvalBranchQuota(100_000);

--- a/src/policy/clients.zig
+++ b/src/policy/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const PolicyClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !PolicyClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) PolicyClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn configurations(self: *@This()) Configurations {
@@ -127,7 +79,7 @@ pub const PolicyClient = struct {
 pub const Configurations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -358,7 +310,7 @@ pub const Configurations = struct {
 pub const Revisions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve all revisions for a given policy.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, configuration_id: i32, @"$top": ?i32, @"$skip": ?i32) !models.PolicyConfigurationList {
         @setEvalBranchQuota(100_000);
@@ -444,7 +396,7 @@ pub const Revisions = struct {
 pub const Evaluations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieves a list of all the policy evaluation statuses for a specific pull request. Evaluations are retrieved using an artifact ID which uniquely identifies the pull request. To generate an artifact ID for a pull request, use this template: ``` vstfs:///CodeReview/CodeReviewId/{projectId}/{pullRequestId} ```
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, artifact_id: []const u8, include_not_applicable: ?bool, @"$top": ?i32, @"$skip": ?i32) !models.PolicyEvaluationRecordList {
         @setEvalBranchQuota(100_000);
@@ -569,7 +521,7 @@ pub const Evaluations = struct {
 pub const Types = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieve all available policy types.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.PolicyTypeList {
         @setEvalBranchQuota(100_000);

--- a/src/processadmin/clients.zig
+++ b/src/processadmin/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const WorkItemTrackingProcessTemplateClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !WorkItemTrackingProcessTemplateClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) WorkItemTrackingProcessTemplateClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn behaviors(self: *@This()) Behaviors {
@@ -111,7 +63,7 @@ pub const WorkItemTrackingProcessTemplateClient = struct {
 pub const Behaviors = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of behaviors for the process.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8) !models.AdminBehaviorList {
         @setEvalBranchQuota(100_000);
@@ -149,7 +101,7 @@ pub const Behaviors = struct {
 pub const Processes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ExportProcessTemplateResult = union(enum) {
         status_200: struct {

--- a/src/processes/clients.zig
+++ b/src/processes/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const WorkItemTrackingClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !WorkItemTrackingClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) WorkItemTrackingClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn processes(self: *@This()) Processes {
@@ -199,7 +151,7 @@ pub const WorkItemTrackingClient = struct {
 pub const Processes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get list of all processes including system and inherited.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"$expand": ?enums.ListRequestExpand) !models.ProcessInfoList {
         @setEvalBranchQuota(100_000);
@@ -382,7 +334,7 @@ pub const Processes = struct {
 pub const Behaviors = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of all behaviors in the process.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, @"$expand": ?enums.ListRequestExpand1) !models.ProcessBehaviorList {
         @setEvalBranchQuota(100_000);
@@ -575,7 +527,7 @@ pub const Behaviors = struct {
 pub const WorkItemTypes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of all work item types in a process.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, @"$expand": ?enums.ListRequestExpand2) !models.ProcessWorkItemTypeList {
         @setEvalBranchQuota(100_000);
@@ -768,7 +720,7 @@ pub const WorkItemTypes = struct {
 pub const Fields = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of all fields in a work item type.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.ProcessWorkItemTypeFieldList {
         @setEvalBranchQuota(100_000);
@@ -964,7 +916,7 @@ pub const Fields = struct {
 pub const Layout = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the form layout.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.FormLayout {
         @setEvalBranchQuota(100_000);
@@ -1004,7 +956,7 @@ pub const Layout = struct {
 pub const Controls = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Creates a control in a group.
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, group_id: []const u8, body: models.Control) !models.Control {
         @setEvalBranchQuota(100_000);
@@ -1178,7 +1130,7 @@ pub const Controls = struct {
 pub const Pages = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Updates a page on the work item form
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, body: models.Page) !models.Page {
         @setEvalBranchQuota(100_000);
@@ -1295,7 +1247,7 @@ pub const Pages = struct {
 pub const Groups = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Adds a group to the work item form.
     pub fn add(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8, page_id: []const u8, section_id: []const u8, body: models.Group) !models.Group {
         @setEvalBranchQuota(100_000);
@@ -1474,7 +1426,7 @@ pub const Groups = struct {
 pub const SystemControls = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets edited system controls for a work item type in a process. To get all system controls (base + edited) use layout API(s)
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.ControlList {
         @setEvalBranchQuota(100_000);
@@ -1590,7 +1542,7 @@ pub const SystemControls = struct {
 pub const Rules = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of all rules in the work item type of the process.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.ProcessRuleList {
         @setEvalBranchQuota(100_000);
@@ -1779,7 +1731,7 @@ pub const Rules = struct {
 pub const States = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of all state definitions in a work item type of the process.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name: []const u8) !models.WorkItemStateResultModelList {
         @setEvalBranchQuota(100_000);
@@ -2008,7 +1960,7 @@ pub const States = struct {
 pub const WorkItemTypesBehaviors = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of all behaviors for the work item type of the process.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, process_id: []const u8, wit_ref_name_for_behaviors: []const u8) !models.WorkItemTypeBehaviorList {
         @setEvalBranchQuota(100_000);
@@ -2195,7 +2147,7 @@ pub const WorkItemTypesBehaviors = struct {
 pub const Lists = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns meta data of the picklist.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.PickListMetadataList {
         @setEvalBranchQuota(100_000);

--- a/src/profile/clients.zig
+++ b/src/profile/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://app.vssps.visualstudio.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ProfileClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ProfileClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ProfileClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn profiles(self: *@This()) Profiles {
@@ -103,7 +55,7 @@ pub const ProfileClient = struct {
 pub const Profiles = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets a user profile.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, id: []const u8, details: ?bool, with_attributes: ?bool, partition: ?[]const u8, core_attributes: ?[]const u8, force_refresh: ?bool) !models.Profile {
         @setEvalBranchQuota(100_000);

--- a/src/release/clients.zig
+++ b/src/release/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vsrm.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ReleaseClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ReleaseClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ReleaseClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn approvals(self: *@This()) Approvals {
@@ -159,7 +111,7 @@ pub const ReleaseClient = struct {
 pub const Approvals = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of approvals
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, assigned_to_filter: ?[]const u8, status_filter: ?enums.ListRequestStatusFilter, release_ids_filter: ?[]const u8, type_filter: ?enums.ListRequestTypeFilter, top: ?i32, continuation_token: ?i32, query_order: ?enums.ListRequestQueryOrder, include_my_group_approvals: ?bool) !models.ReleaseApprovalList {
         @setEvalBranchQuota(100_000);
@@ -285,7 +237,7 @@ pub const Approvals = struct {
 pub const Definitions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -704,7 +656,7 @@ pub const Definitions = struct {
 pub const Deployments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of deployments
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, definition_id: ?i32, definition_environment_id: ?i32, created_by: ?[]const u8, min_modified_time: ?[]const u8, max_modified_time: ?[]const u8, deployment_status: ?enums.ListRequestDeploymentStatus, operation_status: ?enums.ListRequestOperationStatus, latest_attempts_only: ?bool, query_order: ?enums.ListRequestQueryOrder2, @"$top": ?i32, continuation_token: ?i32, created_for: ?[]const u8, min_started_time: ?[]const u8, max_started_time: ?[]const u8, source_branch: ?[]const u8) !models.DeploymentList {
         @setEvalBranchQuota(100_000);
@@ -837,7 +789,7 @@ pub const Deployments = struct {
 pub const Folders = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Deletes a definition folder for given folder name and path and all it's existing definitions.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, path: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -993,7 +945,7 @@ pub const Folders = struct {
 pub const Gates = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Updates the gate for a deployment.
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, gate_step_id: i32, body: models.GateUpdateMetadata) !models.ReleaseGates {
         @setEvalBranchQuota(100_000);
@@ -1037,7 +989,7 @@ pub const Gates = struct {
 pub const Releases = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetReleaseRevisionResult = union(enum) {
         status_200: struct {
@@ -1606,7 +1558,7 @@ pub const Releases = struct {
 pub const Attachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetReleaseTaskAttachmentContentResult = union(enum) {
         status_200: struct {
@@ -1844,7 +1796,7 @@ pub const Attachments = struct {
 pub const ManualInterventions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// List all manual interventions for a given release.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32) !models.ManualInterventionList {
         @setEvalBranchQuota(100_000);

--- a/src/resource_usage/clients.zig
+++ b/src/resource_usage/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.1-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ResourceUsageClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ResourceUsageClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ResourceUsageClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn teamProjectCollection(self: *@This()) TeamProjectCollection {
@@ -111,7 +63,7 @@ pub const ResourceUsageClient = struct {
 pub const TeamProjectCollection = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !std.json.ArrayHashMap(models.Usage) {
         @setEvalBranchQuota(100_000);
@@ -147,7 +99,7 @@ pub const TeamProjectCollection = struct {
 pub const Project = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the Project Level limits and Usage for a project.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !std.json.ArrayHashMap(models.Usage) {
         @setEvalBranchQuota(100_000);

--- a/src/search/clients.zig
+++ b/src/search/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://almsearch.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const SearchClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !SearchClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) SearchClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn packageSearchResults(self: *@This()) PackageSearchResults {
@@ -143,7 +95,7 @@ pub const SearchClient = struct {
 pub const PackageSearchResults = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const FetchPackageSearchResultsResult = union(enum) {
         status_200: struct {
@@ -209,7 +161,7 @@ pub const PackageSearchResults = struct {
 pub const CodeSearchResults = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Provides a set of results for the search text.
     pub fn fetchCodeSearchResults(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.CodeSearchRequest) !models.CodeSearchResponse {
         @setEvalBranchQuota(100_000);
@@ -251,7 +203,7 @@ pub const CodeSearchResults = struct {
 pub const Repositories = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Provides status of Repository.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, repository: []const u8) !models.RepositoryStatusResponse {
         @setEvalBranchQuota(100_000);
@@ -291,7 +243,7 @@ pub const Repositories = struct {
 pub const Tfvc = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Provides status of TFVC Repository.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.TfvcRepositoryStatusResponse {
         @setEvalBranchQuota(100_000);
@@ -329,7 +281,7 @@ pub const Tfvc = struct {
 pub const WikiSearchResults = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Provides a set of results for the search request.
     pub fn fetchWikiSearchResults(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.WikiSearchRequest) !models.WikiSearchResponse {
         @setEvalBranchQuota(100_000);
@@ -371,7 +323,7 @@ pub const WikiSearchResults = struct {
 pub const WorkItemSearchResults = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Provides a set of results for the search text.
     pub fn fetchWorkItemSearchResults(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.WorkItemSearchRequest) !models.WorkItemSearchResponse {
         @setEvalBranchQuota(100_000);

--- a/src/security/clients.zig
+++ b/src/security/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const SecurityClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !SecurityClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) SecurityClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn accessControlEntries(self: *@This()) AccessControlEntries {
@@ -127,7 +79,7 @@ pub const SecurityClient = struct {
 pub const AccessControlEntries = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const RemoveAccessControlEntriesResult = union(enum) {
         status_200: struct {
@@ -233,7 +185,7 @@ pub const AccessControlEntries = struct {
 pub const AccessControlLists = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const RemoveAccessControlListsResult = union(enum) {
         status_200: struct {
@@ -392,7 +344,7 @@ pub const AccessControlLists = struct {
 pub const Permissions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Removes the specified permissions on a security token for a user or group.
     pub fn removePermission(self: *@This(), alloc: std.mem.Allocator, security_namespace_id: []const u8, descriptor: []const u8, organization: []const u8, permissions: i32, token: ?[]const u8) !models.AccessControlEntry {
         @setEvalBranchQuota(100_000);
@@ -530,7 +482,7 @@ pub const Permissions = struct {
 pub const SecurityNamespaces = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// List all security namespaces or just the specified namespace.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, security_namespace_id: []const u8, local_only: ?bool) !models.SecurityNamespaceDescriptionList {
         @setEvalBranchQuota(100_000);

--- a/src/security_roles/clients.zig
+++ b/src/security_roles/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const SecurityRolesClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !SecurityRolesClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) SecurityRolesClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn roleassignments(self: *@This()) Roleassignments {
@@ -111,7 +63,7 @@ pub const SecurityRolesClient = struct {
 pub const Roleassignments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get role assignments for the resource
     pub fn list(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, resource_id: []const u8, organization: []const u8) !models.RoleAssignmentList {
         @setEvalBranchQuota(100_000);
@@ -306,7 +258,7 @@ pub const Roleassignments = struct {
 pub const Roledefinitions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, scope_id: []const u8, organization: []const u8) !models.SecurityRoleList {
         @setEvalBranchQuota(100_000);

--- a/src/service_endpoint/clients.zig
+++ b/src/service_endpoint/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const ServiceEndpointClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !ServiceEndpointClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) ServiceEndpointClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn endpoints(self: *@This()) Endpoints {
@@ -127,7 +79,7 @@ pub const ServiceEndpointClient = struct {
 pub const Endpoints = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Creates a new service endpoint
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, body: models.ServiceEndpoint) !models.ServiceEndpoint {
         @setEvalBranchQuota(100_000);
@@ -472,7 +424,7 @@ pub const Endpoints = struct {
 pub const Types = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get service endpoint types.
     pub fn getServiceEndpointTypes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, @"type": ?[]const u8, scheme: ?[]const u8) !models.ServiceEndpointTypeList {
         @setEvalBranchQuota(100_000);
@@ -556,7 +508,7 @@ pub const Types = struct {
 pub const Executionhistory = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get service endpoint execution records.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, endpoint_id: []const u8, top: ?i32, continuation_token: ?i64) !models.ServiceEndpointExecutionRecordList {
         @setEvalBranchQuota(100_000);
@@ -606,7 +558,7 @@ pub const Executionhistory = struct {
 pub const Endpointproxy = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Use ExecuteServiceEndpointRequest API Instead
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.DataSourceBinding) ![]const []const u8 {
         @setEvalBranchQuota(100_000);

--- a/src/status/clients.zig
+++ b/src/status/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://status.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const StatusClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !StatusClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) StatusClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn health(self: *@This()) Health {
@@ -103,7 +55,7 @@ pub const StatusClient = struct {
 pub const Health = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Queries status information for the service all-up, or scoped to a particular service and/or geography
     pub fn get(self: *@This(), alloc: std.mem.Allocator, services: ?[]const u8, geographies: ?[]const u8) !models.ServiceStatus {
         @setEvalBranchQuota(100_000);

--- a/src/symbol/clients.zig
+++ b/src/symbol/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://artifacts.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const SymbolClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !SymbolClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) SymbolClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn availability(self: *@This()) Availability {
@@ -135,7 +87,7 @@ pub const SymbolClient = struct {
 pub const Availability = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Check the availability of symbol service. This includes checking for feature flag, and possibly license in future. Note this is NOT an anonymous endpoint, and the caller will be redirected to authentication before hitting it.
     pub fn checkAvailability(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -170,7 +122,7 @@ pub const Availability = struct {
 pub const Client = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -269,7 +221,7 @@ pub const Client = struct {
 pub const Requests = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetRequestsRequestNameResult = union(enum) {
         status_200: struct {
@@ -782,7 +734,7 @@ pub const Requests = struct {
 pub const Contents = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -849,7 +801,7 @@ pub const Contents = struct {
 pub const Symsrv = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {

--- a/src/test/clients.zig
+++ b/src/test/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const TestClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !TestClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) TestClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn codeCoverage(self: *@This()) CodeCoverage {
@@ -183,7 +135,7 @@ pub const TestClient = struct {
 pub const CodeCoverage = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get code coverage data for a build.
     pub fn getBuildCodeCoverage(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, flags: i32) !models.BuildCoverageList {
         @setEvalBranchQuota(100_000);
@@ -261,7 +213,7 @@ pub const CodeCoverage = struct {
 pub const Points = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of test points.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, wit_fields: ?[]const u8, configuration_id: ?[]const u8, test_case_id: ?[]const u8, test_point_ids: ?[]const u8, include_point_details: ?bool, @"$skip": ?i32, @"$top": ?i32) !models.TestPointList {
         @setEvalBranchQuota(100_000);
@@ -479,7 +431,7 @@ pub const Points = struct {
 pub const TestSuites = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all test cases in a suite.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32) !models.SuiteTestCaseList {
         @setEvalBranchQuota(100_000);
@@ -676,7 +628,7 @@ pub const TestSuites = struct {
 pub const ResultRetentionSettingsOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get test result retention settings
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.ResultRetentionSettings {
         @setEvalBranchQuota(100_000);
@@ -750,7 +702,7 @@ pub const ResultRetentionSettingsOperations = struct {
 pub const TestHistory = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get history of a test method using TestHistoryQuery
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestHistoryQuery) !models.TestHistoryQuery {
         @setEvalBranchQuota(100_000);
@@ -792,7 +744,7 @@ pub const TestHistory = struct {
 pub const Runs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of test runs.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_uri: ?[]const u8, owner: ?[]const u8, tmi_run_id: ?[]const u8, plan_id: ?i32, include_run_details: ?bool, automated: ?bool, @"$skip": ?i32, @"$top": ?i32) !models.TestRunList {
         @setEvalBranchQuota(100_000);
@@ -1056,7 +1008,7 @@ pub const Runs = struct {
 pub const Attachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetTestRunAttachmentZipResult = union(enum) {
         status_200: struct {
@@ -1338,7 +1290,7 @@ pub const Attachments = struct {
 pub const Results = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get test results for a test run.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, details_to_include: ?enums.ListRequestDetailsToInclude, @"$skip": ?i32, @"$top": ?i32, outcomes: ?[]const u8) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
@@ -1521,7 +1473,7 @@ pub const Results = struct {
 pub const Iterations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get iterations for a result
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32, include_action_results: ?bool) !models.TestIterationDetailsModelList {
         @setEvalBranchQuota(100_000);
@@ -1611,7 +1563,7 @@ pub const Iterations = struct {
 pub const TestCases = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Delete a test case.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, test_case_id: i32) !void {
         @setEvalBranchQuota(100_000);
@@ -1650,7 +1602,7 @@ pub const TestCases = struct {
 pub const Session = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of test sessions
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, period: ?i32, all_sessions: ?bool, include_all_properties: ?bool, source: ?enums.ListRequestSource, include_only_completed_sessions: ?bool) !models.TestSessionList {
         @setEvalBranchQuota(100_000);

--- a/src/test_plan/clients.zig
+++ b/src/test_plan/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const TestPlanClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !TestPlanClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) TestPlanClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn testSuites(self: *@This()) TestSuites {
@@ -199,7 +151,7 @@ pub const TestPlanClient = struct {
 pub const TestSuites = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetTestSuitesForPlanResult = union(enum) {
         status_200: struct {
@@ -472,7 +424,7 @@ pub const TestSuites = struct {
 pub const Configurations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -684,7 +636,7 @@ pub const Configurations = struct {
 pub const TestPlans = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -913,7 +865,7 @@ pub const TestPlans = struct {
 pub const SuiteTestCase = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetTestCaseListResult = union(enum) {
         status_200: struct {
@@ -1200,7 +1152,7 @@ pub const SuiteTestCase = struct {
 pub const TestPointOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a particular Test Point from a suite.
     pub fn getPoints(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, plan_id: i32, suite_id: i32, point_id: []const u8, return_identity_ref: ?bool, include_point_details: ?bool) !models.TestPointList {
         @setEvalBranchQuota(100_000);
@@ -1306,7 +1258,7 @@ pub const TestPointOperations = struct {
 pub const TestPlanClone = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Clone test plan
     pub fn cloneTestPlan(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deep_clone: ?bool, body: models.CloneTestPlanParams) !models.CloneTestPlanOperationInformation {
         @setEvalBranchQuota(100_000);
@@ -1387,7 +1339,7 @@ pub const TestPlanClone = struct {
 pub const TestPlanRecycleBin = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -1495,7 +1447,7 @@ pub const TestPlanRecycleBin = struct {
 pub const TestSuiteRecycleBinOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetDeletedTestSuitesForPlanResult = union(enum) {
         status_200: struct {
@@ -1694,7 +1646,7 @@ pub const TestSuiteRecycleBinOperations = struct {
 pub const TestSuiteEntry = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of test suite entries in the test suite.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, suite_id: i32, suite_entry_type: ?enums.ListRequestSuiteEntryType) !models.SuiteEntryList {
         @setEvalBranchQuota(100_000);
@@ -1779,7 +1731,7 @@ pub const TestSuiteEntry = struct {
 pub const TestSuiteClone = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Clone test suite
     pub fn cloneTestSuite(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, deep_clone: ?bool, body: models.CloneTestSuiteParams) !models.CloneTestSuiteOperationInformation {
         @setEvalBranchQuota(100_000);
@@ -1860,7 +1812,7 @@ pub const TestSuiteClone = struct {
 pub const TestCases = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Delete a test case.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, test_case_id: i32) !void {
         @setEvalBranchQuota(100_000);
@@ -1899,7 +1851,7 @@ pub const TestCases = struct {
 pub const TestCaseClone = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn cloneTestCase(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.CloneTestCaseParams) !models.CloneTestCaseOperationInformation {
         @setEvalBranchQuota(100_000);
@@ -1975,7 +1927,7 @@ pub const TestCaseClone = struct {
 pub const Variables = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {

--- a/src/test_results/clients.zig
+++ b/src/test_results/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vstmr.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const TestResultsClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !TestResultsClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) TestResultsClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn codecoverage(self: *@This()) Codecoverage {
@@ -423,7 +375,7 @@ pub const TestResultsClient = struct {
 pub const Codecoverage = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// http://(tfsserver):8080/tfs/DefaultCollection/_apis/test/CodeCoverage?buildId=10&deltaBuildId=9 Request: build id and delta build id (optional)
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, delta_build_id: ?i32) !models.CodeCoverageSummary {
         @setEvalBranchQuota(100_000);
@@ -575,7 +527,7 @@ pub const Codecoverage = struct {
 pub const Filecoverage = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -644,7 +596,7 @@ pub const Filecoverage = struct {
 pub const Status = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -716,7 +668,7 @@ pub const Status = struct {
 pub const Extensionfields = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns List of custom test fields for the given custom test field scope.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, scope_filter: enums.QueryRequestScopeFilter) !models.CustomTestFieldDefinitionList {
         @setEvalBranchQuota(100_000);
@@ -863,7 +815,7 @@ pub const Extensionfields = struct {
 pub const Metrics = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get summary of test results.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, stage_name: ?[]const u8, phase_name: ?[]const u8, job_name: ?[]const u8, metric_names: ?[]const u8, group_by_node: ?bool) !models.PipelineTestMetrics {
         @setEvalBranchQuota(100_000);
@@ -936,7 +888,7 @@ pub const Metrics = struct {
 pub const Resultdetailsbybuild = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, publish_context: ?[]const u8, group_by: ?[]const u8, @"$filter": ?[]const u8, @"$orderby": ?[]const u8, should_include_results: ?bool, query_run_summary_for_in_progress: ?bool) !models.TestResultsDetails {
         @setEvalBranchQuota(100_000);
@@ -1014,7 +966,7 @@ pub const Resultdetailsbybuild = struct {
 pub const Resultdetailsbyrelease = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, release_env_id: i32, publish_context: ?[]const u8, group_by: ?[]const u8, @"$filter": ?[]const u8, @"$orderby": ?[]const u8, should_include_results: ?bool, query_run_summary_for_in_progress: ?bool) !models.TestResultsDetails {
         @setEvalBranchQuota(100_000);
@@ -1094,7 +1046,7 @@ pub const Resultdetailsbyrelease = struct {
 pub const Resultgroupsbybuild = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -1178,7 +1130,7 @@ pub const Resultgroupsbybuild = struct {
 pub const Resultgroupsbyrelease = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -1267,7 +1219,7 @@ pub const Resultgroupsbyrelease = struct {
 pub const Results = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn getTestResultsByQuery(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultsQuery) !models.TestResultsQuery {
         @setEvalBranchQuota(100_000);
@@ -1547,7 +1499,7 @@ pub const Results = struct {
 pub const History = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.ResultsFilter) !models.TestResultHistory {
         @setEvalBranchQuota(100_000);
@@ -1589,7 +1541,7 @@ pub const History = struct {
 pub const ResultMetaData = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get list of test Result meta data details for corresponding testcasereferenceId
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, details_to_include: ?enums.QueryRequestDetailsToInclude, body: []const []const u8) !models.TestResultMetaDataList {
         @setEvalBranchQuota(100_000);
@@ -1676,7 +1628,7 @@ pub const ResultMetaData = struct {
 pub const TestHistory = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get history of a test method using TestHistoryQuery
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestHistoryQuery) !models.TestHistoryQuery {
         @setEvalBranchQuota(100_000);
@@ -1718,7 +1670,7 @@ pub const TestHistory = struct {
 pub const Workitems = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DeleteResult = union(enum) {
         status_200: struct {
@@ -1917,7 +1869,7 @@ pub const Workitems = struct {
 pub const Resultsbybuild = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -2009,7 +1961,7 @@ pub const Resultsbybuild = struct {
 pub const Resultsbypipeline = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of results.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, stage_name: ?[]const u8, phase_name: ?[]const u8, job_name: ?[]const u8, outcomes: ?[]const u8, include_all_build_runs: ?bool, @"$top": ?i32, continuation_token: ?[]const u8) !models.ShallowTestCaseResultList {
         @setEvalBranchQuota(100_000);
@@ -2088,7 +2040,7 @@ pub const Resultsbypipeline = struct {
 pub const Resultsbyrelease = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -2185,7 +2137,7 @@ pub const Resultsbyrelease = struct {
 pub const ResultsgroupDetails = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all the available groups details and for these groups get failed and aborted results.
     pub fn testResultsGroupDetails(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, stage_name: ?[]const u8, phase_name: ?[]const u8, job_name: ?[]const u8, should_include_failed_and_aborted_results: ?bool, query_group_summary_for_in_progress: ?bool) !models.TestResultsDetails {
         @setEvalBranchQuota(100_000);
@@ -2256,7 +2208,7 @@ pub const ResultsgroupDetails = struct {
 pub const Resultsummarybybuild = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32, publish_context: ?[]const u8, include_failure_details: ?bool, build_to_compare_branch_name: ?[]const u8, build_to_compare_build_system: ?[]const u8, build_to_compare_definition_id: ?i32, build_to_compare_id: ?i32, build_to_compare_number: ?[]const u8, build_to_compare_repository_id: ?[]const u8, build_to_compare_uri: ?[]const u8) !models.TestResultSummary {
         @setEvalBranchQuota(100_000);
@@ -2353,7 +2305,7 @@ pub const Resultsummarybybuild = struct {
 pub const Resultsummarybypipeline = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get summary of test results.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, pipeline_id: i32, stage_name: ?[]const u8, phase_name: ?[]const u8, job_name: ?[]const u8, include_failure_details: ?bool) !models.TestResultSummary {
         @setEvalBranchQuota(100_000);
@@ -2419,7 +2371,7 @@ pub const Resultsummarybypipeline = struct {
 pub const Resultsummarybyrelease = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn queryTestResultsReportForRelease(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, release_id: i32, release_env_id: i32, publish_context: ?[]const u8, include_failure_details: ?bool, release_to_compare_attempt: ?i32, release_to_compare_creation_date: ?[]const u8, release_to_compare_definition_id: ?i32, release_to_compare_environment_creation_date: ?[]const u8, release_to_compare_environment_definition_id: ?i32, release_to_compare_environment_definition_name: ?[]const u8, release_to_compare_environment_id: ?i32, release_to_compare_environment_name: ?[]const u8, release_to_compare_id: ?i32, release_to_compare_name: ?[]const u8) !models.TestResultSummary {
         @setEvalBranchQuota(100_000);
@@ -2569,7 +2521,7 @@ pub const Resultsummarybyrelease = struct {
 pub const Resultsummarybyrequirement = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_ids: ?[]const u8, body: models.TestResultsContext) !models.TestSummaryForWorkItemList {
         @setEvalBranchQuota(100_000);
@@ -2618,7 +2570,7 @@ pub const Resultsummarybyrequirement = struct {
 pub const ResultTrendByBuild = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultTrendFilter) !models.AggregatedDataForResultTrendList {
         @setEvalBranchQuota(100_000);
@@ -2660,7 +2612,7 @@ pub const ResultTrendByBuild = struct {
 pub const ResultTrendByRelease = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TestResultTrendFilter) !models.AggregatedDataForResultTrendList {
         @setEvalBranchQuota(100_000);
@@ -2702,7 +2654,7 @@ pub const ResultTrendByRelease = struct {
 pub const Runs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_uri: ?[]const u8, owner: ?[]const u8, tmi_run_id: ?[]const u8, plan_id: ?i32, include_run_details: ?bool, automated: ?bool, @"$skip": ?i32, @"$top": ?i32) !models.TestRunList {
         @setEvalBranchQuota(100_000);
@@ -2937,7 +2889,7 @@ pub const Runs = struct {
 pub const Attachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetTestRunAttachmentZipResult = union(enum) {
         status_200: struct {
@@ -3291,7 +3243,7 @@ pub const Attachments = struct {
 pub const MessageLogs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get test run message logs
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) !models.TestMessageLogDetailsList {
         @setEvalBranchQuota(100_000);
@@ -3331,7 +3283,7 @@ pub const MessageLogs = struct {
 pub const ResultDocument = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn publishTestResultDocument(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: models.TestResultDocument) !models.TestResultDocument {
         @setEvalBranchQuota(100_000);
@@ -3375,7 +3327,7 @@ pub const ResultDocument = struct {
 pub const Testlog = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get list of test result attachments reference
     pub fn getTestResultLogs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, result_id: i32, directory_path: ?[]const u8, file_name_prefix: ?[]const u8, fetch_meta_data: ?bool, top: ?i32, continuation_token: ?[]const u8) !models.TestLogList {
         @setEvalBranchQuota(100_000);
@@ -3572,7 +3524,7 @@ pub const Testlog = struct {
 pub const Testlogstoreendpoint = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get SAS Uri of a test results attachment
     pub fn getTestLogStoreEndpointDetailsForResultLog(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, result_id: i32, file_path: []const u8) !models.TestLogStoreEndpointDetails {
         @setEvalBranchQuota(100_000);
@@ -3839,7 +3791,7 @@ pub const Testlogstoreendpoint = struct {
 pub const Bugs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_case_result_id: i32) !models.WorkItemReferenceList {
         @setEvalBranchQuota(100_000);
@@ -3881,7 +3833,7 @@ pub const Bugs = struct {
 pub const SimilarTestResults = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the list of results whose failure matches with the provided one.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, test_result_id: i32, test_sub_result_id: i32, @"$top": ?i32, continuation_token: ?[]const u8) !models.TestCaseResultList {
         @setEvalBranchQuota(100_000);
@@ -3931,7 +3883,7 @@ pub const SimilarTestResults = struct {
 pub const Runsummary = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get test run summary, used when we want to get summary of a run by outcome. Test run should be in completed state.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) !models.TestRunStatistic {
         @setEvalBranchQuota(100_000);
@@ -3971,7 +3923,7 @@ pub const Runsummary = struct {
 pub const Statistics = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get test run statistics , used when we want to get summary of a run by outcome.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32) !models.TestRunStatistic {
         @setEvalBranchQuota(100_000);
@@ -4011,7 +3963,7 @@ pub const Statistics = struct {
 pub const Tags = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Update tags of a run, Tags can be Added and Deleted
     pub fn update(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, body: models.TestTagsUpdateModel) !models.TestTagList {
         @setEvalBranchQuota(100_000);
@@ -4089,7 +4041,7 @@ pub const Tags = struct {
 pub const Testattachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Deletes the attachment with the specified filename for the specified runId from the LogStore.
     pub fn delete(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, run_id: i32, filename: []const u8) !void {
         @setEvalBranchQuota(100_000);
@@ -4241,7 +4193,7 @@ pub const Testattachments = struct {
 pub const Settings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get TestResultsSettings data
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, settings_type: ?enums.GetRequestSettingsType) !models.TestResultsSettings {
         @setEvalBranchQuota(100_000);
@@ -4322,7 +4274,7 @@ pub const Settings = struct {
 pub const Tagsummary = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all the tags in a build.
     pub fn getTestTagSummaryForBuild(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, build_id: i32) !models.TestTagSummary {
         @setEvalBranchQuota(100_000);
@@ -4362,7 +4314,7 @@ pub const Tagsummary = struct {
 pub const Testai = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CompleteGitHubAuthResult = union(enum) {
         status_200: struct {
@@ -4422,7 +4374,7 @@ pub const Testai = struct {
 pub const Testfailuretype = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the list of test failure types.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.TestResultFailureTypeList {
         @setEvalBranchQuota(100_000);
@@ -4529,7 +4481,7 @@ pub const Testfailuretype = struct {
 pub const Testsettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateResult = union(enum) {
         status_200: struct {

--- a/src/tfvc/clients.zig
+++ b/src/tfvc/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const TfvcClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !TfvcClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) TfvcClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn changesets(self: *@This()) Changesets {
@@ -135,7 +87,7 @@ pub const TfvcClient = struct {
 pub const Changesets = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetChangesetChangesResult = union(enum) {
         status_200: struct {
@@ -574,7 +526,7 @@ pub const Changesets = struct {
 pub const Labels = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get items under a label.
     pub fn getLabelItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, label_id: []const u8, @"$top": ?i32, @"$skip": ?i32) !models.TfvcItemList {
         @setEvalBranchQuota(100_000);
@@ -774,7 +726,7 @@ pub const Labels = struct {
 pub const Shelvesets = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a single deep shelveset.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, shelveset_id: []const u8, request_data_include_details: ?bool, request_data_include_links: ?bool, request_data_include_work_items: ?bool, request_data_max_change_count: ?i32, request_data_max_comment_length: ?i32, request_data_name: ?[]const u8, request_data_owner: ?[]const u8) !models.TfvcShelveset {
         @setEvalBranchQuota(100_000);
@@ -931,7 +883,7 @@ pub const Shelvesets = struct {
 pub const Branches = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get branch hierarchies below the specified scopePath
     pub fn getBranchRefs(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, scope_path: []const u8, project: []const u8, include_deleted: ?bool, include_links: ?bool) !models.TfvcBranchRefList {
         @setEvalBranchQuota(100_000);
@@ -983,7 +935,7 @@ pub const Branches = struct {
 pub const Items = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetItemsBatchResult = union(enum) {
         status_200: struct {

--- a/src/token_admin/clients.zig
+++ b/src/token_admin/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vssps.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const TokenAdminClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !TokenAdminClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) TokenAdminClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn personalAccessTokens(self: *@This()) PersonalAccessTokens {
@@ -119,7 +71,7 @@ pub const TokenAdminClient = struct {
 pub const PersonalAccessTokens = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const ListResult = union(enum) {
         status_200: struct {
@@ -227,7 +179,7 @@ pub const PersonalAccessTokens = struct {
 pub const RevocationRules = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateResult = union(enum) {
         status_201: struct {
@@ -306,7 +258,7 @@ pub const RevocationRules = struct {
 pub const Revocations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const RevokeAuthorizationsResult = union(enum) {
         status_204: struct {

--- a/src/tokens/clients.zig
+++ b/src/tokens/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://vssps.dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const TokensClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !TokensClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) TokensClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn pats(self: *@This()) Pats {
@@ -103,7 +55,7 @@ pub const TokensClient = struct {
 pub const Pats = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Revokes a personal access token (PAT) by authorizationId.
     pub fn revoke(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, authorization_id: []const u8) !void {
         @setEvalBranchQuota(100_000);

--- a/src/wiki/clients.zig
+++ b/src/wiki/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const WikiClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !WikiClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) WikiClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn wikis(self: *@This()) Wikis {
@@ -143,7 +95,7 @@ pub const WikiClient = struct {
 pub const Wikis = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets all wikis in a project or collection.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WikiV2List {
         @setEvalBranchQuota(100_000);
@@ -323,7 +275,7 @@ pub const Wikis = struct {
 pub const Attachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateResult = union(enum) {
         status_201: struct {
@@ -416,7 +368,7 @@ pub const Attachments = struct {
 pub const PageMoves = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateResult = union(enum) {
         status_201: struct {
@@ -514,7 +466,7 @@ pub const PageMoves = struct {
 pub const Pages = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DeletePageResult = union(enum) {
         status_200: struct {
@@ -1208,7 +1160,7 @@ pub const Pages = struct {
 pub const PageStats = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns page detail corresponding to Page ID.
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, wiki_identifier: []const u8, page_id: i32, page_views_for_days: ?i32) !models.WikiPageDetail {
         @setEvalBranchQuota(100_000);
@@ -1255,7 +1207,7 @@ pub const PageStats = struct {
 pub const PagesBatch = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns pageable list of Wiki Pages
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, wiki_identifier: []const u8, version_descriptor_version: ?[]const u8, @"version_descriptor.version_options": ?enums.GetRequestVersionDescriptorVersionOptions, @"version_descriptor.version_type": ?enums.GetRequestVersionDescriptorVersionType, body: models.WikiPagesBatchRequest) !models.WikiPageDetailList {
         @setEvalBranchQuota(100_000);

--- a/src/wit/clients.zig
+++ b/src/wit/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const WorkItemTrackingClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !WorkItemTrackingClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) WorkItemTrackingClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn artifactLinkTypes(self: *@This()) ArtifactLinkTypes {
@@ -351,7 +303,7 @@ pub const WorkItemTrackingClient = struct {
 pub const ArtifactLinkTypes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the list of work item tracking outbound artifact link types.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.WorkArtifactLinkList {
         @setEvalBranchQuota(100_000);
@@ -387,7 +339,7 @@ pub const ArtifactLinkTypes = struct {
 pub const WorkItemIcons = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -493,7 +445,7 @@ pub const WorkItemIcons = struct {
 pub const WorkItemRelationTypes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the work item relation types.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.WorkItemRelationTypeList {
         @setEvalBranchQuota(100_000);
@@ -561,7 +513,7 @@ pub const WorkItemRelationTypes = struct {
 pub const WorkItemTransitions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the next state on the given work item IDs.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, ids: []const u8, action: ?[]const u8) !models.WorkItemNextStateOnTransitionList {
         @setEvalBranchQuota(100_000);
@@ -608,7 +560,7 @@ pub const WorkItemTransitions = struct {
 pub const AccountMyWorkRecentActivity = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets recent work item activities
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8) !models.AccountRecentActivityWorkItemModel2List {
         @setEvalBranchQuota(100_000);
@@ -644,7 +596,7 @@ pub const AccountMyWorkRecentActivity = struct {
 pub const GithubConnections = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets a list of github connections
     pub fn getGithubConnections(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.GitHubConnectionModelList {
         @setEvalBranchQuota(100_000);
@@ -754,7 +706,7 @@ pub const GithubConnections = struct {
 pub const ArtifactUriQueryOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Queries work items linked to a given list of artifact URI.
     pub fn query(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.ArtifactUriQuery) !models.ArtifactUriQueryResult {
         @setEvalBranchQuota(100_000);
@@ -796,7 +748,7 @@ pub const ArtifactUriQueryOperations = struct {
 pub const Attachments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {
@@ -1008,7 +960,7 @@ pub const Attachments = struct {
 pub const ClassificationNodes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets root classification nodes under the project.
     pub fn getRootNodes(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$depth": ?i32) !models.WorkItemClassificationNodeList {
         @setEvalBranchQuota(100_000);
@@ -1212,7 +1164,7 @@ pub const ClassificationNodes = struct {
 pub const Fields = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns information for all fields. The project ID/name parameter is optional.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.ListRequestExpand) !models.WorkItemField2List {
         @setEvalBranchQuota(100_000);
@@ -1398,7 +1350,7 @@ pub const Fields = struct {
 pub const ProjectProcessMigration = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Migrates a project to a different process within the same OOB type. For example, you can only migrate a project from agile/custom-agile to agile/custom-agile.
     pub fn migrateProjectsProcess(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.ProcessIdModel) !models.ProcessMigrationResultModel {
         @setEvalBranchQuota(100_000);
@@ -1440,7 +1392,7 @@ pub const ProjectProcessMigration = struct {
 pub const Queries = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets the root queries and their children
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"$expand": ?enums.ListRequestExpand1, @"$depth": ?i32, @"$include_deleted": ?bool) !models.QueryHierarchyItemList {
         @setEvalBranchQuota(100_000);
@@ -1706,7 +1658,7 @@ pub const Queries = struct {
 pub const Recyclebin = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets a list of the IDs and the URLs of the deleted the work items in the Recycle Bin.
     pub fn getDeletedWorkItemShallowReferences(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemDeleteShallowReferenceList {
         @setEvalBranchQuota(100_000);
@@ -1849,7 +1801,7 @@ pub const Recyclebin = struct {
 pub const ReportingWorkItemLinks = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a batch of work item links
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, link_types: ?[]const u8, types: ?[]const u8, continuation_token: ?[]const u8, start_date_time: ?[]const u8) !models.ReportingWorkItemLinksBatch {
         @setEvalBranchQuota(100_000);
@@ -1915,7 +1867,7 @@ pub const ReportingWorkItemLinks = struct {
 pub const ReportingWorkItemRevisions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a batch of work item revisions with the option of including deleted items
     pub fn readReportingRevisionsGet(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, fields: ?[]const u8, types: ?[]const u8, continuation_token: ?[]const u8, start_date_time: ?[]const u8, include_identity_ref: ?bool, include_deleted: ?bool, include_tag_ref: ?bool, include_latest_only: ?bool, @"$expand": ?enums.ReadReportingRevisionsGetRequestExpand, include_discussion_changes_only: ?bool, @"$max_page_size": ?i32) !models.ReportingWorkItemRevisionsBatch {
         @setEvalBranchQuota(100_000);
@@ -2075,7 +2027,7 @@ pub const ReportingWorkItemRevisions = struct {
 pub const WorkItemRevisionsDiscussions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn readReportingDiscussions(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, continuation_token: ?[]const u8, @"$max_page_size": ?i32) !models.ReportingWorkItemRevisionsBatch {
         @setEvalBranchQuota(100_000);
@@ -2125,7 +2077,7 @@ pub const WorkItemRevisionsDiscussions = struct {
 pub const SendMail = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// RESTful method to send mail for selected/queried work items.
     pub fn sendMail(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.SendMailBody) !void {
         @setEvalBranchQuota(100_000);
@@ -2166,7 +2118,7 @@ pub const SendMail = struct {
 pub const Tags = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all the tags for the project.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemTagDefinitionList {
         @setEvalBranchQuota(100_000);
@@ -2309,7 +2261,7 @@ pub const Tags = struct {
 pub const TempQueries = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Creates a temporary query Learn more about Work Item Query Language (WIQL) syntax [here](https://docs.microsoft.com/en-us/vsts/collaborate/wiql-syntax?toc=/vsts/work/track/toc.json&bc=/vsts/work/track/breadcrumb/toc.json&view=vsts).
     pub fn create(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, body: models.TemporaryQueryRequestModel) !models.TemporaryQueryResponseModel {
         @setEvalBranchQuota(100_000);
@@ -2351,7 +2303,7 @@ pub const TempQueries = struct {
 pub const WorkItems = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of work items (Maximum 200)
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, ids: []const u8, project: []const u8, fields: ?[]const u8, as_of: ?[]const u8, @"$expand": ?enums.ListRequestExpand2, error_policy: ?enums.ListRequestErrorPolicy) !models.WorkItemList {
         @setEvalBranchQuota(100_000);
@@ -2762,7 +2714,7 @@ pub const WorkItems = struct {
 pub const Revisions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the list of fully hydrated work item revisions, paged.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, project: []const u8, @"$top": ?i32, @"$skip": ?i32, @"$expand": ?enums.ListRequestExpand3) !models.WorkItemList {
         @setEvalBranchQuota(100_000);
@@ -2862,7 +2814,7 @@ pub const Revisions = struct {
 pub const Updates = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the deltas between work item revisions
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, id: i32, project: []const u8, @"$top": ?i32, @"$skip": ?i32) !models.WorkItemUpdateList {
         @setEvalBranchQuota(100_000);
@@ -2948,7 +2900,7 @@ pub const Updates = struct {
 pub const Comments = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns a list of work item comments by ids.
     pub fn getCommentsBatch(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, ids: []const u8, include_deleted: ?bool, @"$expand": ?enums.GetCommentsBatchRequestExpand) !models.CommentList {
         @setEvalBranchQuota(100_000);
@@ -3165,7 +3117,7 @@ pub const Comments = struct {
 pub const CommentsReactions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets reactions of a comment.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32) !models.CommentReactionList {
         @setEvalBranchQuota(100_000);
@@ -3283,7 +3235,7 @@ pub const CommentsReactions = struct {
 pub const CommentReactionsEngagedUsers = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get users who reacted on the comment.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32, reaction_type: enums.ListRequestReactionType, @"$top": ?i32, @"$skip": ?i32) !models.IdentityRefList {
         @setEvalBranchQuota(100_000);
@@ -3337,7 +3289,7 @@ pub const CommentReactionsEngagedUsers = struct {
 pub const CommentsVersions = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, work_item_id: i32, comment_id: i32) !models.CommentVersionList {
         @setEvalBranchQuota(100_000);
@@ -3417,7 +3369,7 @@ pub const CommentsVersions = struct {
 pub const WorkItemTypeCategories = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get all work item type categories.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemTypeCategoryList {
         @setEvalBranchQuota(100_000);
@@ -3489,7 +3441,7 @@ pub const WorkItemTypeCategories = struct {
 pub const WorkItemTypes = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the list of work item types
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.WorkItemTypeList {
         @setEvalBranchQuota(100_000);
@@ -3561,7 +3513,7 @@ pub const WorkItemTypes = struct {
 pub const WorkItemTypesField = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a list of fields for a work item type with detailed references.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8, @"$expand": ?enums.ListRequestExpand4) !models.WorkItemTypeFieldWithReferencesList {
         @setEvalBranchQuota(100_000);
@@ -3651,7 +3603,7 @@ pub const WorkItemTypesField = struct {
 pub const WorkItemTypeStates = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the state names and colors for a work item type.
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, @"type": []const u8) !models.WorkItemStateColorList {
         @setEvalBranchQuota(100_000);
@@ -3691,7 +3643,7 @@ pub const WorkItemTypeStates = struct {
 pub const Templates = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets template
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, workitemtypename: ?[]const u8) !models.WorkItemTemplateReferenceList {
         @setEvalBranchQuota(100_000);
@@ -3887,7 +3839,7 @@ pub const Templates = struct {
 pub const WiqlOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetResult = union(enum) {
         status_200: struct {

--- a/src/work/clients.zig
+++ b/src/work/clients.zig
@@ -21,74 +21,26 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
 }
 const default_endpoint = "https://dev.azure.com";
 const default_api_version = "7.2-preview";
-const auth_scopes: []const []const u8 = &.{"{endpoint}/.default"};
 
 pub const WorkClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8 = default_endpoint,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8 = default_endpoint,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !WorkClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) WorkClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn boardcolumns(self: *@This()) Boardcolumns {
@@ -303,7 +255,7 @@ pub const WorkClient = struct {
 pub const Boardcolumns = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get available board columns in a project
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BoardSuggestedValueList {
         @setEvalBranchQuota(100_000);
@@ -341,7 +293,7 @@ pub const Boardcolumns = struct {
 pub const Boardrows = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get available board rows in a project
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.BoardSuggestedValueList {
         @setEvalBranchQuota(100_000);
@@ -379,7 +331,7 @@ pub const Boardrows = struct {
 pub const Iterationcapacities = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get an iteration's capacity for all teams in iteration
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, iteration_id: []const u8) !models.IterationCapacity {
         @setEvalBranchQuota(100_000);
@@ -419,7 +371,7 @@ pub const Iterationcapacities = struct {
 pub const Plans = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get the information for all the plans configured for the given team
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.PlanList {
         @setEvalBranchQuota(100_000);
@@ -598,7 +550,7 @@ pub const Plans = struct {
 pub const Deliverytimeline = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get Delivery View Data
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, id: []const u8, revision: ?i32, start_date: ?[]const u8, end_date: ?[]const u8) !models.DeliveryViewData {
         @setEvalBranchQuota(100_000);
@@ -657,7 +609,7 @@ pub const Deliverytimeline = struct {
 pub const PredefinedQueries = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Retrieves the set of known queries
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.PredefinedQueryList {
         @setEvalBranchQuota(100_000);
@@ -739,7 +691,7 @@ pub const PredefinedQueries = struct {
 pub const Processconfiguration = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get process configuration
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8) !models.ProcessConfiguration {
         @setEvalBranchQuota(100_000);
@@ -777,7 +729,7 @@ pub const Processconfiguration = struct {
 pub const Backlogconfiguration = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Gets backlog configuration for a team
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.BacklogConfiguration {
         @setEvalBranchQuota(100_000);
@@ -817,7 +769,7 @@ pub const Backlogconfiguration = struct {
 pub const Backlogs = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// List all backlog levels
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.BacklogLevelConfigurationList {
         @setEvalBranchQuota(100_000);
@@ -929,7 +881,7 @@ pub const Backlogs = struct {
 pub const Boards = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get boards
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.BoardReferenceList {
         @setEvalBranchQuota(100_000);
@@ -1045,7 +997,7 @@ pub const Boards = struct {
 pub const Boardusersettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get board user settings for a board id
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardUserSettings {
         @setEvalBranchQuota(100_000);
@@ -1127,7 +1079,7 @@ pub const Boardusersettings = struct {
 pub const Cardrulesettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get board card Rule settings for the board id or board by name
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardCardRuleSettings {
         @setEvalBranchQuota(100_000);
@@ -1246,7 +1198,7 @@ pub const Cardrulesettings = struct {
 pub const Cardsettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get board card settings for the board id or board by name
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardCardSettings {
         @setEvalBranchQuota(100_000);
@@ -1365,7 +1317,7 @@ pub const Cardsettings = struct {
 pub const Chartimages = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const GetBoardChartImageResult = union(enum) {
         status_200: struct {
@@ -1608,7 +1560,7 @@ pub const Chartimages = struct {
 pub const Charts = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get board charts
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardChartReferenceList {
         @setEvalBranchQuota(100_000);
@@ -1730,7 +1682,7 @@ pub const Charts = struct {
 pub const Columns = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get columns on a board
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardColumnList {
         @setEvalBranchQuota(100_000);
@@ -1812,7 +1764,7 @@ pub const Columns = struct {
 pub const Rows = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get rows on a board
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, board: []const u8, team: []const u8) !models.BoardRowList {
         @setEvalBranchQuota(100_000);
@@ -1894,7 +1846,7 @@ pub const Rows = struct {
 pub const Boardparents = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Returns the list of parent field filter model for the given list of workitem ids
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, child_backlog_context_category_ref_name: []const u8, workitem_ids: []const u8, team: []const u8) !models.ParentChildWIMapList {
         @setEvalBranchQuota(100_000);
@@ -1942,7 +1894,7 @@ pub const Boardparents = struct {
 pub const Workitemsorder = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Reorder Sprint Backlog/Taskboard Work Items
     pub fn reorderIterationWorkItems(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, iteration_id: []const u8, body: models.ReorderOperation) !models.ReorderResultList {
         @setEvalBranchQuota(100_000);
@@ -2026,7 +1978,7 @@ pub const Workitemsorder = struct {
 pub const TaskboardColumnsOperations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.TaskboardColumns {
         @setEvalBranchQuota(100_000);
@@ -2104,7 +2056,7 @@ pub const TaskboardColumnsOperations = struct {
 pub const TaskboardWorkItems = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, iteration_id: []const u8) !models.TaskboardWorkItemColumnList {
         @setEvalBranchQuota(100_000);
@@ -2187,7 +2139,7 @@ pub const TaskboardWorkItems = struct {
 pub const Teamsettings = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a team's settings
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.TeamSetting {
         @setEvalBranchQuota(100_000);
@@ -2265,7 +2217,7 @@ pub const Teamsettings = struct {
 pub const Iterations = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a team's iterations using timeframe filter
     pub fn list(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8, @"$timeframe": ?[]const u8) !models.TeamSettingsIterationList {
         @setEvalBranchQuota(100_000);
@@ -2457,7 +2409,7 @@ pub const Iterations = struct {
 pub const Capacities = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a team's capacity including total capacity and days off
     pub fn getCapacitiesWithIdentityRefAndTotals(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, iteration_id: []const u8, team: []const u8) !models.TeamCapacity {
         @setEvalBranchQuota(100_000);
@@ -2619,7 +2571,7 @@ pub const Capacities = struct {
 pub const Teamdaysoff = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get team's days off for an iteration
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, iteration_id: []const u8, team: []const u8) !models.TeamSettingsDaysOff {
         @setEvalBranchQuota(100_000);
@@ -2701,7 +2653,7 @@ pub const Teamdaysoff = struct {
 pub const Teamfieldvalues = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     /// Get a collection of team field values
     pub fn get(self: *@This(), alloc: std.mem.Allocator, organization: []const u8, project: []const u8, team: []const u8) !models.TeamFieldValues {
         @setEvalBranchQuota(100_000);


### PR DESCRIPTION
Part of #412

## Summary
- rebuild the 44 Azure DevOps 7.2 code models from the branch-pinned TypeSpec source and regenerate with merged PR #419
- replace legacy `core.pipeline`, owned policy/credential construction, and duplicate client initializers in every API area with canonical `core.http.HttpPipeline`
- update complete generator provenance while preserving the 7.2 contract and package version `0.1.0`
- pin the final immutable `azure_sdk_core` 0.3.0 release

## Final Core pin
- commit: `bc77bcacbb64af935ca53d60bf8a351c9592bc41`
- hash: `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`

## Validation
- rebuilt all 44 code-model areas from `cataggar/vsts-rest-api-specs@30b2105a165ce0f057e6adafe5f5e5b9b71502b7` using generator `c83a1cbef5f728d7530fdec4a724cc453233cfa4`
- exact final-pin replay matched all 183 generated package files; provenance fields matched with the corrected complete command
- `zig fmt --check` across tracked Zig and zon files
- `zig build`
- `zig build test --summary all` (3 tests)
- no examples or live compile target are configured on this package branch

Auto-merge is intentionally disabled.
