### PR TITLE
Migrate Key Vault Secrets client to HttpRuntime

### DIFF
--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -3,4 +3,4 @@ source_repository=https://github.com/Azure/azure-rest-api-specs
 source_commit=6d50d64d3eeca46ecf1b4af80e9994bac920a7d0
 source_path=specification/keyvault/data-plane/Secrets/tspconfig.yaml
 selected_api_version=2026-03-01-preview
-command=(codegen/scripts/sync.sh --output-root <package-output> --azure-sdk-core-commit 763ff49c6e424750508c06886ecb7ef61f3e7000 --azure-sdk-core-hash azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf keyvault_secrets)
+command=(codegen/scripts/sync.sh --output-root <package-output> --azure-sdk-core-commit bc77bcacbb64af935ca53d60bf8a351c9592bc41 --azure-sdk-core-hash azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV keyvault_secrets)

--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -3,4 +3,4 @@ source_repository=https://github.com/Azure/azure-rest-api-specs
 source_commit=6d50d64d3eeca46ecf1b4af80e9994bac920a7d0
 source_path=specification/keyvault/data-plane/Secrets/tspconfig.yaml
 selected_api_version=2026-03-01-preview
-command=(codegen/scripts/sync.sh --output-root=<package-output> --azure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 --azure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf keyvault_secrets)
+command=(codegen/scripts/sync.sh --output-root <package-output> --azure-sdk-core-commit 763ff49c6e424750508c06886ecb7ef61f3e7000 --azure-sdk-core-hash azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf keyvault_secrets)

--- a/.azure-sdk-generator
+++ b/.azure-sdk-generator
@@ -1,0 +1,6 @@
+generator_commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4
+source_repository=https://github.com/Azure/azure-rest-api-specs
+source_commit=6d50d64d3eeca46ecf1b4af80e9994bac920a7d0
+source_path=specification/keyvault/data-plane/Secrets/tspconfig.yaml
+selected_api_version=2026-03-01-preview
+command=(codegen/scripts/sync.sh --output-root=<package-output> --azure-sdk-core-commit=763ff49c6e424750508c06886ecb7ef61f3e7000 --azure-sdk-core-hash=azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf keyvault_secrets)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#763ff49c6e424750508c06886ecb7ef61f3e7000",
-            .hash = "azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_rest_keyvault_secrets,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xad641d6d073a99c,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#763ff49c6e424750508c06886ecb7ef61f3e7000",
+            .hash = "azure_sdk_core-0.2.0-eFY0EiXXBgATS3gwrSMyZSpIDyYi2SWWTJ6NsfZ9-lGf",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",

--- a/src/clients.zig
+++ b/src/clients.zig
@@ -20,78 +20,31 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
     return false;
 }
 const default_api_version = "2026-03-01-preview";
-const auth_scopes: []const []const u8 = &.{"https://vault.azure.net/.default"};
 
 /// The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
 pub const KeyVaultClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !KeyVaultClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) KeyVaultClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
     }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
-    }
     /// The SET operation adds a secret to the Azure Key Vault. If the named secret already exists, Azure Key Vault creates a new version of that secret. This operation requires the secrets/set permission.
     pub fn setSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, parameters: models.SecretSetParameters) !models.SecretBundle {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}", .{ self.endpoint, encoded_path_0 });
@@ -125,6 +78,7 @@ pub const KeyVaultClient = struct {
     }
     /// The DELETE operation applies to any secret stored in Azure Key Vault. DELETE cannot be applied to an individual version of a secret. This operation requires the secrets/delete permission.
     pub fn deleteSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.DeletedSecretBundle {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}", .{ self.endpoint, encoded_path_0 });
@@ -154,6 +108,7 @@ pub const KeyVaultClient = struct {
     }
     /// The UPDATE operation changes specified attributes of an existing stored secret. Attributes that are not specified in the request are left unchanged. The value of a secret itself cannot be changed. This operation requires the secrets/set permission.
     pub fn updateSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, secret_version: []const u8, parameters: models.SecretUpdateParameters) !models.SecretBundle {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, secret_version);
@@ -189,6 +144,7 @@ pub const KeyVaultClient = struct {
     }
     /// The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires the secrets/get permission.
     pub fn getSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, secret_version: []const u8, out_content_type: ?enums.ContentType) !models.SecretBundle {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const encoded_path_1 = try core.url.encodePathSegment(alloc, secret_version);
@@ -203,9 +159,9 @@ pub const KeyVaultClient = struct {
         defer alloc.free(encoded_query_0);
         try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
         has_query = true;
-        if (out_content_type) |v| {
+        if (out_content_type) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            const enc = try core.url.percentEncode(alloc, v.toWire());
+            const enc = try core.url.percentEncode(alloc, query_value.toWire());
             defer alloc.free(enc);
             try url_buf.print(alloc, "{s}outContentType={s}", .{ sep, enc });
             has_query = true;
@@ -227,6 +183,7 @@ pub const KeyVaultClient = struct {
     }
     /// The Get Secrets operation is applicable to the entire vault. However, only the base secret identifier and its attributes are provided in the response. Individual secret versions are not listed in the response. This operation requires the secrets/list permission.
     pub fn getSecrets(self: *@This(), alloc: std.mem.Allocator, maxresults: ?i32) !core.pager.PipelinePager(models.SecretItem) {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/secrets", .{self.endpoint});
         defer alloc.free(base_url);
         var url_buf: std.ArrayList(u8) = .empty;
@@ -237,9 +194,9 @@ pub const KeyVaultClient = struct {
         defer alloc.free(encoded_query_0);
         try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
         has_query = true;
-        if (maxresults) |v| {
+        if (maxresults) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            try url_buf.print(alloc, "{s}maxresults={d}", .{ sep, v });
+            try url_buf.print(alloc, "{s}maxresults={d}", .{ sep, query_value });
             has_query = true;
         }
         const url = try url_buf.toOwnedSlice(alloc);
@@ -254,6 +211,7 @@ pub const KeyVaultClient = struct {
     }
     /// The full secret identifier and attributes are provided in the response. No values are returned for the secrets. This operations requires the secrets/list permission.
     pub fn getSecretVersions(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8, maxresults: ?i32) !core.pager.PipelinePager(models.SecretItem) {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}/versions", .{ self.endpoint, encoded_path_0 });
@@ -266,9 +224,9 @@ pub const KeyVaultClient = struct {
         defer alloc.free(encoded_query_0);
         try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
         has_query = true;
-        if (maxresults) |v| {
+        if (maxresults) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            try url_buf.print(alloc, "{s}maxresults={d}", .{ sep, v });
+            try url_buf.print(alloc, "{s}maxresults={d}", .{ sep, query_value });
             has_query = true;
         }
         const url = try url_buf.toOwnedSlice(alloc);
@@ -283,6 +241,7 @@ pub const KeyVaultClient = struct {
     }
     /// The Get Deleted Secrets operation returns the secrets that have been deleted for a vault enabled for soft-delete. This operation requires the secrets/list permission.
     pub fn getDeletedSecrets(self: *@This(), alloc: std.mem.Allocator, maxresults: ?i32) !core.pager.PipelinePager(models.DeletedSecretItem) {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets", .{self.endpoint});
         defer alloc.free(base_url);
         var url_buf: std.ArrayList(u8) = .empty;
@@ -293,9 +252,9 @@ pub const KeyVaultClient = struct {
         defer alloc.free(encoded_query_0);
         try url_buf.print(alloc, "{s}api-version={s}", .{ if (has_query) "&" else "?", encoded_query_0 });
         has_query = true;
-        if (maxresults) |v| {
+        if (maxresults) |query_value| {
             const sep: []const u8 = if (has_query) "&" else "?";
-            try url_buf.print(alloc, "{s}maxresults={d}", .{ sep, v });
+            try url_buf.print(alloc, "{s}maxresults={d}", .{ sep, query_value });
             has_query = true;
         }
         const url = try url_buf.toOwnedSlice(alloc);
@@ -310,6 +269,7 @@ pub const KeyVaultClient = struct {
     }
     /// The Get Deleted Secret operation returns the specified deleted secret along with its attributes. This operation requires the secrets/get permission.
     pub fn getDeletedSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.DeletedSecretBundle {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets/{s}", .{ self.endpoint, encoded_path_0 });
@@ -339,6 +299,7 @@ pub const KeyVaultClient = struct {
     }
     /// The purge deleted secret operation removes the secret permanently, without the possibility of recovery. This operation can only be enabled on a soft-delete enabled vault. This operation requires the secrets/purge permission.
     pub fn purgeDeletedSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !void {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets/{s}", .{ self.endpoint, encoded_path_0 });
@@ -367,6 +328,7 @@ pub const KeyVaultClient = struct {
     }
     /// Recovers the deleted secret in the specified vault. This operation can only be performed on a soft-delete enabled vault. This operation requires the secrets/recover permission.
     pub fn recoverDeletedSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.SecretBundle {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/deletedsecrets/{s}/recover", .{ self.endpoint, encoded_path_0 });
@@ -396,6 +358,7 @@ pub const KeyVaultClient = struct {
     }
     /// Requests that a backup of the specified secret be downloaded to the client. All versions of the secret will be downloaded. This operation requires the secrets/backup permission.
     pub fn backupSecret(self: *@This(), alloc: std.mem.Allocator, secret_name: []const u8) !models.BackupSecretResult {
+        @setEvalBranchQuota(100_000);
         const encoded_path_0 = try core.url.encodePathSegment(alloc, secret_name);
         defer alloc.free(encoded_path_0);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/secrets/{s}/backup", .{ self.endpoint, encoded_path_0 });
@@ -425,6 +388,7 @@ pub const KeyVaultClient = struct {
     }
     /// Restores a backed up secret, and all its versions, to a vault. This operation requires the secrets/restore permission.
     pub fn restoreSecret(self: *@This(), alloc: std.mem.Allocator, parameters: models.SecretRestoreParameters) !models.SecretBundle {
+        @setEvalBranchQuota(100_000);
         const base_url = try std.fmt.allocPrint(alloc, "{s}/secrets/restore", .{self.endpoint});
         defer alloc.free(base_url);
         var url_buf: std.ArrayList(u8) = .empty;

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -44,6 +44,10 @@ pub const DeletionRecoveryLevel = union(enum) {
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
     }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
 };
 
 /// The media type (MIME type).
@@ -72,6 +76,10 @@ pub const ContentType = union(enum) {
     pub fn toWire(self: @This()) []const u8 {
         return core.open_enum.toWire(self, wire_names);
     }
+
+    pub fn fromWire(allocator: std.mem.Allocator, s: []const u8) !@This() {
+        return core.open_enum.fromWire(@This(), wire_names, allocator, s);
+    }
 };
 
 /// The available API versions.
@@ -83,4 +91,39 @@ pub const Versions = enum {
     v2025_07_01,
     v2026_01_01_preview,
     v2026_03_01_preview,
+
+    pub fn toWire(self: @This()) []const u8 {
+        return switch (self) {
+            .@"v7.5" => "7.5",
+            .@"v7.6_preview.2" => "7.6-preview.2",
+            .@"v7.6" => "7.6",
+            .v2025_06_01_preview => "2025-06-01-preview",
+            .v2025_07_01 => "2025-07-01",
+            .v2026_01_01_preview => "2026-01-01-preview",
+            .v2026_03_01_preview => "2026-03-01-preview",
+        };
+    }
+
+    pub fn fromWire(s: []const u8) ?@This() {
+        if (std.mem.eql(u8, s, "7.5")) return .@"v7.5";
+        if (std.mem.eql(u8, s, "7.6-preview.2")) return .@"v7.6_preview.2";
+        if (std.mem.eql(u8, s, "7.6")) return .@"v7.6";
+        if (std.mem.eql(u8, s, "2025-06-01-preview")) return .v2025_06_01_preview;
+        if (std.mem.eql(u8, s, "2025-07-01")) return .v2025_07_01;
+        if (std.mem.eql(u8, s, "2026-01-01-preview")) return .v2026_01_01_preview;
+        if (std.mem.eql(u8, s, "2026-03-01-preview")) return .v2026_03_01_preview;
+        return null;
+    }
+
+    pub fn zerdeDeserialize(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        deserializer: anytype,
+    ) @TypeOf(deserializer.*).Error!T {
+        return core.fixed_enum.deserialize(T, allocator, deserializer);
+    }
+
+    pub fn zerdeSerialize(self: @This(), serializer: anytype) !void {
+        return core.fixed_enum.serialize(self, serializer);
+    }
 };

--- a/src/models.zig
+++ b/src/models.zig
@@ -88,7 +88,7 @@ pub const KeyVaultErrorError = struct {
     /// The error message.
     message: ?[]const u8 = null,
     /// The key vault server error.
-    inner_error: ?KeyVaultErrorError = null,
+    inner_error: ?*const KeyVaultErrorError = null,
 
     pub const serde = .{
         .rename_all = .camel_case,


### PR DESCRIPTION
Part of #412

## Summary
- regenerate Key Vault Secrets with the merged PR #419 emitter while preserving the `2026-03-01-preview` contract
- replace legacy `core.pipeline`, owned policy/credential construction, and duplicate client initializers with canonical `core.http.HttpPipeline`
- bump the breaking package version from `0.1.0` to `0.2.0`
- record exact generator/spec provenance and the executable canonical sync command
- pin the final immutable `azure_sdk_core` 0.3.0 release

## Final Core pin
- tag: `azure_sdk_core/v0.3.0`
- commit: `bc77bcacbb64af935ca53d60bf8a351c9592bc41`
- hash: `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`

## Validation
- verified the existing release sequence ends at `azure_rest_keyvault_secrets/v0.1.0`; `azure_rest_keyvault_secrets/v0.2.0` is absent and monotonic
- verified `azure_sdk_core/v0.3.0` resolves to the pinned commit and `zig fetch` resolves the recorded package hash
- replayed the exact `.azure-sdk-generator` command from generator `c83a1cbef5f728d7530fdec4a724cc453233cfa4` and Azure REST specs `6d50d64d3eeca46ecf1b4af80e9994bac920a7d0`
- every generator-owned source file matched; `build.zig.zon` was the expected documented operator-managed skip and retains its paths and final Core pin
- `zig fmt --check` across tracked Zig and zon files
- `zig build`
- `zig build test --summary all` (1 test)
- no examples or live compile target are configured on this package branch

Auto-merge is intentionally disabled.
