### PR TITLE
Migrate Storage Queues to HttpRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,32 @@ the complete-SAS `SasQueueClient`.
 
 Release branch: `sdk/storage_queues`. The package depends on
 `azure_sdk_core`, `azure_sdk_storage_common`, and `serde` and starts at
-`0.1.0`.
+`0.2.0`.
+
+All clients use Core's canonical HTTP runtime. `QueueClient` and
+`QueueServiceClient` copy a caller-built `core.http.HttpPipeline`;
+`SasQueueClient` copies a `core.http.HttpRuntime`. The pipeline policy pointers
+and runtime transport/crypto contexts are borrowed and must outlive the clients
+and their operations.
+
+```zig
+var transport = core.http.StdHttpTransport.init(allocator, io);
+defer transport.deinit();
+var crypto_provider = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    transport.asTransport(),
+    crypto_provider.asProvider(),
+);
+var auth_policy = core.http.BearerTokenAuthPolicy.init(
+    allocator,
+    credential,
+    queues.auth_scopes,
+);
+defer auth_policy.deinit();
+var policies = [_]*core.http.HttpPolicy{auth_policy.asPolicy()};
+const pipeline = core.http.HttpPipeline.init(runtime, &policies);
+var client = queues.QueueServiceClient.init(endpoint, pipeline);
+```
 
 See the
 [Storage overview](https://github.com/cataggar/azure-sdk-for-zig/blob/main/sdk/storage/README.md)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,16 +1,16 @@
 .{
     .name = .azure_sdk_storage_queues,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xdb9b891e0be2a42c,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .azure_sdk_storage_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#17d6f1550c53cda7245f07bc487de1dd7a00f265",
-            .hash = "azure_sdk_storage_common-0.2.0-JzoreP9kAAB71S4mgwDVPdCfjSL0auVfrlU8hhaD4O-q",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5291e5d7224b4d69989d403f605345d949c41db7",
+            .hash = "azure_sdk_storage_common-0.3.0-JzoreF0KAQDsbNtEXsub-0AZ1oiyzWJ-CGf1S5XSmQK4",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",

--- a/examples/complete_sas_message.zig
+++ b/examples/complete_sas_message.zig
@@ -17,10 +17,15 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_provider.asProvider(),
+    );
     var client = try queues.SasQueueClient.init(
         allocator,
         sas_url,
-        transport.asTransport(),
+        runtime,
     );
     defer client.deinit();
 

--- a/root.zig
+++ b/root.zig
@@ -7,9 +7,12 @@ pub const SasQueueClient = sas.SasQueueClient;
 pub const CompleteSasQueueClient = sas.CompleteSasQueueClient;
 pub const QueueMessageOutcome = sas.QueueMessageOutcome;
 pub const max_queue_message_bytes = sas.max_queue_message_bytes;
+pub const auth_scopes: []const []const u8 = &.{"https://storage.azure.com/.default"};
 
 test {
     std.testing.refAllDecls(sas);
+    std.testing.refAllDecls(QueueClient);
+    std.testing.refAllDecls(QueueServiceClient);
 }
 
 // ─────────────────────────── Models ───────────────────────────
@@ -31,21 +34,23 @@ pub const QueueClient = struct {
     endpoint: []const u8,
     queue_name: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
+    /// Constructs a queue-scoped client by copying `pipeline`.
+    ///
+    /// The pipeline's policy pointers and runtime backend contexts are
+    /// borrowed and must outlive this client and every operation on it.
     pub fn init(
         endpoint: []const u8,
         queue_name: []const u8,
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        pipeline: core.http.HttpPipeline,
         options: QueueClientOptions,
     ) QueueClient {
-        _ = credential;
         return .{
             .endpoint = endpoint,
             .queue_name = queue_name,
             .api_version = options.api_version,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .pipeline = pipeline,
         };
     }
 
@@ -181,22 +186,22 @@ pub const QueueClient = struct {
 
 pub const QueueServiceClient = struct {
     endpoint: []const u8,
-    credential: *core.credentials.TokenCredential,
-    transport: *core.http.HttpTransport,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
+    /// Constructs a service client by copying `pipeline`.
+    ///
+    /// The pipeline's policy pointers and runtime backend contexts are
+    /// borrowed and must outlive this client, clients derived from it, and
+    /// every operation on those clients.
     pub fn init(
         endpoint: []const u8,
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        pipeline: core.http.HttpPipeline,
     ) QueueServiceClient {
         return .{
             .endpoint = endpoint,
-            .credential = credential,
-            .transport = transport,
             .api_version = "2024-11-04",
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .pipeline = pipeline,
         };
     }
 
@@ -257,7 +262,7 @@ pub const QueueServiceClient = struct {
     }
 
     pub fn getQueueClient(self: *QueueServiceClient, queue_name: []const u8) QueueClient {
-        return QueueClient.init(self.endpoint, queue_name, self.credential, self.transport, .{});
+        return QueueClient.init(self.endpoint, queue_name, self.pipeline, .{});
     }
 };
 
@@ -298,29 +303,118 @@ fn parseMessages(allocator: std.mem.Allocator, body: []const u8) ![]QueueMessage
 
 // ─────────────────────────── Tests ────────────────────────────
 
+const RoutingCryptoProvider = struct {
+    calls: usize = 0,
+    fail: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn provider(self: *@This()) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.calls += 1;
+        if (self.fail) return error.ProviderFailure;
+        @memset(out, 0xa5);
+    }
+
+    fn md5(
+        _: *anyopaque,
+        _: []const u8,
+        _: *core.crypto.Md5Digest,
+    ) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: *core.crypto.Sha256Digest,
+    ) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.UnexpectedCryptoOperation;
+    }
+};
+
 test "QueueClient sendMessage" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 201, "");
     defer mock.deinit();
-
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        mock.asTransport(),
+        crypto_provider.asProvider(),
     );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
 
     var client = QueueClient.init(
         "https://myaccount.queue.core.windows.net",
         "myqueue",
-        cred.asCredential(),
-        mock.asTransport(),
+        core.http.HttpPipeline.init(runtime, &.{}),
         .{},
     );
 
     try client.sendMessage(allocator, "Hello Queue!");
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "myqueue/messages") != null);
+}
+
+test "derived QueueClient preserves runtime crypto and provider failures" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 201, "");
+    defer mock.deinit();
+    var crypto_provider = RoutingCryptoProvider{};
+    const runtime = core.http.HttpRuntime.init(
+        mock.asTransport(),
+        crypto_provider.provider(),
+    );
+    var request_id_policy = core.http.RequestIdPolicy.init();
+    var policies = [_]*core.http.HttpPolicy{request_id_policy.asPolicy()};
+    const pipeline = core.http.HttpPipeline.init(runtime, &policies);
+    var service_client = QueueServiceClient.init(
+        "https://myaccount.queue.core.windows.net",
+        pipeline,
+    );
+    var queue_client = service_client.getQueueClient("myqueue");
+
+    try queue_client.sendMessage(allocator, "first");
+    try std.testing.expectEqual(@as(usize, 1), crypto_provider.calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try std.testing.expect(mock.last_headers.get("x-ms-client-request-id") != null);
+    try std.testing.expectEqual(
+        runtime.crypto.context,
+        queue_client.pipeline.runtime.crypto.context,
+    );
+
+    crypto_provider.fail = true;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        queue_client.sendMessage(allocator, "second"),
+    );
+    try std.testing.expectEqual(@as(usize, 2), crypto_provider.calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
 }
 
 test "QueueClient receiveMessages" {
@@ -330,19 +424,16 @@ test "QueueClient receiveMessages" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
-
-    const identity2 = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        mock.asTransport(),
+        crypto_provider.asProvider(),
     );
-    defer cred_mock.deinit();
-    var cred = identity2.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
 
     var client = QueueClient.init(
         "https://myaccount.queue.core.windows.net",
         "myqueue",
-        cred.asCredential(),
-        mock.asTransport(),
+        core.http.HttpPipeline.init(runtime, &.{}),
         .{},
     );
 

--- a/sas.zig
+++ b/sas.zig
@@ -11,17 +11,19 @@ pub const max_queue_message_bytes: usize = 48 * 1024;
 pub const storage_api_version = "2024-11-04";
 
 /// A Queue client constructed only from an allocator, a complete queue SAS
-/// URL, and a transport. It never accepts a credential or an external
-/// pipeline, so Kusto bearer authentication cannot reach Queue Storage.
+/// URL, and an HTTP runtime. It never accepts a credential or an external
+/// pipeline, so bearer authentication cannot reach Queue Storage.
 pub const SasQueueClient = struct {
     allocator: std.mem.Allocator,
     uri: sas.CompleteSasUri,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 
+    /// Copies `runtime` while borrowing its transport and crypto contexts.
+    /// Both contexts must outlive this client and every operation on it.
     pub fn init(
         allocator: std.mem.Allocator,
         complete_queue_sas_uri: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
     ) !SasQueueClient {
         var uri = try sas.CompleteSasUri.init(allocator, complete_queue_sas_uri);
         errdefer uri.deinit();
@@ -30,7 +32,7 @@ pub const SasQueueClient = struct {
         return .{
             .allocator = allocator,
             .uri = uri,
-            .transport = transport,
+            .runtime = runtime,
         };
     }
 
@@ -67,7 +69,7 @@ pub const SasQueueClient = struct {
         try request.setHeader("Content-Type", "application/xml");
         try request.setHeader("x-ms-version", storage_api_version);
         request.body = body;
-        const outcome = try sas.send(self.transport, &request, null);
+        const outcome = try sas.send(self.runtime, &request, null);
         return switch (outcome) {
             .accepted => |value| if (value.status_code == 201)
                 outcome
@@ -112,10 +114,14 @@ test "SAS queue message preserves SAS, base64 encodes special bytes, and isolate
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
     var client = try SasQueueClient.init(
         allocator,
         "https://account.queue.core.windows.net/queue?sig=a%2Bb%3D&sp=a",
-        transport.asTransport(),
+        core.http.HttpRuntime.init(
+            transport.asTransport(),
+            crypto_provider.asProvider(),
+        ),
     );
     defer client.deinit();
 
@@ -139,10 +145,14 @@ test "SAS queue reports received rejection and validates message size" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 403, "denied");
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
     var client = try SasQueueClient.init(
         allocator,
         "https://account.queue.core.windows.net/queue?sig=opaque",
-        transport.asTransport(),
+        core.http.HttpRuntime.init(
+            transport.asTransport(),
+            crypto_provider.asProvider(),
+        ),
     );
     defer client.deinit();
 
@@ -161,10 +171,14 @@ test "SAS queue requires the protocol success status" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 204, "");
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
     var client = try SasQueueClient.init(
         allocator,
         "https://account.queue.core.windows.net/queue?sig=opaque",
-        transport.asTransport(),
+        core.http.HttpRuntime.init(
+            transport.asTransport(),
+            crypto_provider.asProvider(),
+        ),
     );
     defer client.deinit();
 
@@ -180,10 +194,14 @@ test "SAS queue preserves accepted status when response draining fails" {
     var transport = core.http.MockTransport.init(allocator, 201, "response");
     defer transport.deinit();
     transport.stream_fail_response_after = 0;
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
     var client = try SasQueueClient.init(
         allocator,
         "https://account.queue.core.windows.net/queue?sig=opaque",
-        transport.asTransport(),
+        core.http.HttpRuntime.init(
+            transport.asTransport(),
+            crypto_provider.asProvider(),
+        ),
     );
     defer client.deinit();
 
@@ -201,10 +219,15 @@ test "Queue XML escaping and client diagnostics redact sensitive queries" {
 
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_provider.asProvider(),
+    );
     var client = try SasQueueClient.init(
         allocator,
         "https://account.queue.core.windows.net/queue?sig=secret",
-        transport.asTransport(),
+        runtime,
     );
     defer client.deinit();
     var buffer: [256]u8 = undefined;
@@ -216,7 +239,7 @@ test "Queue XML escaping and client diagnostics redact sensitive queries" {
         SasQueueClient.init(
             allocator,
             "https://account.blob.core.windows.net/container/blob?sig=opaque",
-            transport.asTransport(),
+            runtime,
         ),
     );
 }


### PR DESCRIPTION
Part of #412
Part of #414

## Summary
- replace legacy `HttpTransport` pointer constructors and pipeline literals with canonical `core.http.HttpRuntime` / `core.http.HttpPipeline` construction
- make Queue service/scoped clients copy a caller-supplied pipeline and preserve its runtime, policies, transport, and crypto provider in derived clients
- route complete-URL Queue SAS requests through Storage Common 0.3.0's runtime-taking API
- document borrowed runtime/policy context lifetimes and update the complete-SAS example and Queue authentication example
- add provider spy/failure coverage proving derived-client routing, direct provider error propagation, no standard fallback, and no transport call after provider failure
- bump the package from released `0.1.0` to breaking `0.2.0`

## Exact dependency pins
- Core 0.3.0 commit: `bc77bcacbb64af935ca53d60bf8a351c9592bc41`
- Core hash: `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- Storage Common 0.3.0 commit: `5291e5d7224b4d69989d403f605345d949c41db7`
- Storage Common hash: `azure_sdk_storage_common-0.3.0-JzoreF0KAQDsbNtEXsub-0AZ1oiyzWJ-CGf1S5XSmQK4`

## Validation
- `git ls-files -z -- '*.zig' 'build.zig.zon' | xargs -0 zig fmt --check`
- `zig build`
- `zig build test --summary all` (10/10 passed)
- `zig build examples`
- exact package version and dependency URL/hash checks
- `zig build -l` confirms this package branch has no separate `package-check` step; its `package-test` workflow runs formatting, tests, and examples on Ubuntu, Windows, and macOS

Auto-merge is intentionally disabled.
