### PR TITLE
Migrate Storage Blobs to HttpRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,17 @@ Azure Blob Storage clients, including `BlobClient`, `BlobContainerClient`, and
 the complete-SAS `SasBlobClient`.
 
 Release branch: `sdk/storage_blobs`. The package depends on
-`azure_sdk_core`, `azure_sdk_storage_common`, and `serde` and starts at
-`0.1.0`.
+`azure_sdk_core`, `azure_sdk_storage_common`, and `serde`.
+
+Clients take a caller-built `core.http.HttpPipeline`. The pipeline copies its
+`HttpRuntime` descriptors by value while borrowing the transport, crypto,
+policy, and credential contexts; those contexts must outlive the client and
+all derived clients and open operations. The package does not install a
+standard crypto fallback.
+
+`SasBlobClient.init` accepts the same runtime directly and uses Storage
+Common's credential-isolated SAS sender; it never attaches the caller's
+credential policies.
 
 See the
 [Storage overview](https://github.com/cataggar/azure-sdk-for-zig/blob/main/sdk/storage/README.md)
@@ -25,13 +34,24 @@ Metadata names must be valid C# identifiers. Anything else is rejected with
 the wire, so `Metadata.get` is case-insensitive.
 
 ```zig
-var container = try blobs.BlobContainerClient.init(allocator, .{
-    .credential = credential,
-    .transport = transport,
+var crypto_provider = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    transport.asTransport(),
+    crypto_provider.asProvider(),
+);
+var auth_policy = core.http.BearerTokenAuthPolicy.init(
+    allocator,
+    credential,
+    blobs.auth_scopes,
+);
+defer auth_policy.deinit();
+var policies = [_]*core.http.HttpPolicy{auth_policy.asPolicy()};
+const pipeline = core.http.HttpPipeline.init(runtime, &policies);
+
+var container = blobs.BlobContainerClient.init(pipeline, .{
     .endpoint = "https://myaccount.blob.core.windows.net",
     .container_name = "checkpoints",
 });
-defer container.deinit();
 
 var blob = container.getBlobClient("ns/hub/$Default/checkpoint/0");
 const result = try blob.uploadConditional(allocator, "", .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,16 +1,16 @@
 .{
     .name = .azure_sdk_storage_blobs,
-    .version = "0.2.0",
+    .version = "0.3.0",
     .fingerprint = 0xd9bbf92976469923,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .azure_sdk_storage_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#17d6f1550c53cda7245f07bc487de1dd7a00f265",
-            .hash = "azure_sdk_storage_common-0.2.0-JzoreP9kAAB71S4mgwDVPdCfjSL0auVfrlU8hhaD4O-q",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5291e5d7224b4d69989d403f605345d949c41db7",
+            .hash = "azure_sdk_storage_common-0.3.0-JzoreF0KAQDsbNtEXsub-0AZ1oiyzWJ-CGf1S5XSmQK4",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/container_client.zig
+++ b/container_client.zig
@@ -180,57 +180,22 @@ pub const BlobContainerClient = struct {
     endpoint: []const u8,
     container_name: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy = null,
-    policy_ptrs: []*core.pipeline.HttpPolicy = &.{},
-    allocator: ?std.mem.Allocator = null,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8,
         container_name: []const u8,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8,
-        container_name: []const u8,
-        api_version: []const u8 = default_api_version,
-    };
-
-    /// Build a client that authenticates every request with `options.credential`.
+    /// Build a client over a caller-owned pipeline.
     ///
-    /// Call `deinit` to release the authentication policy.
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !BlobContainerClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .endpoint = options.endpoint,
-            .container_name = options.container_name,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .allocator = allocator,
-            .pipeline = .{ .policies = policy_ptrs, .transport_impl = options.transport },
-        };
-    }
-
-    /// Build a client over a caller-owned pipeline, for example one that
-    /// already carries a shared key or SAS policy.
-    pub fn initWithPipeline(
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    /// The pipeline and its runtime descriptors are copied by value. Their
+    /// borrowed transport, crypto, policy, and credential contexts must
+    /// outlive this client and every blob client derived from it.
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) BlobContainerClient {
         return .{
             .endpoint = options.endpoint,
@@ -238,19 +203,6 @@ pub const BlobContainerClient = struct {
             .api_version = options.api_version,
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *BlobContainerClient) void {
-        const allocator = self.allocator orelse return;
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            allocator.destroy(auth_policy);
-            self.auth_policy = null;
-        }
-        if (self.policy_ptrs.len > 0) {
-            allocator.free(self.policy_ptrs);
-            self.policy_ptrs = &.{};
-        }
     }
 
     /// PUT /container?restype=container
@@ -471,7 +423,7 @@ pub const BlobClient = struct {
     container_name: []const u8,
     blob_name: []const u8,
     api_version: []const u8 = default_api_version,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     /// GET /container/blob
     pub fn download(self: *BlobClient, allocator: std.mem.Allocator) ![]const u8 {
@@ -952,10 +904,18 @@ fn decodeXmlText(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
 // ─────────────────────────── Tests ────────────────────────────
 
 const testing = std.testing;
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
 
-fn testContainer(transport: *core.http.HttpTransport) BlobContainerClient {
-    return BlobContainerClient.initWithPipeline(
-        .{ .policies = &.{}, .transport_impl = transport },
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(
+        transport,
+        testing_crypto_provider.asProvider(),
+    );
+}
+
+fn testContainer(transport: core.http.HttpTransport) BlobContainerClient {
+    return BlobContainerClient.init(
+        core.http.HttpPipeline.init(testRuntime(transport), &.{}),
         .{
             .endpoint = "https://myaccount.blob.core.windows.net",
             .container_name = "checkpoints",
@@ -974,6 +934,22 @@ test "isValidMetadataName accepts C# identifiers and rejects the rest" {
     try testing.expect(!isValidMetadataName("has-dash"));
     try testing.expect(!isValidMetadataName("has space"));
     try testing.expect(!isValidMetadataName("dot.name"));
+}
+
+test "derived blob client preserves the container runtime" {
+    var mock = core.http.MockTransport.init(testing.allocator, 200, "");
+    defer mock.deinit();
+    var container = testContainer(mock.asTransport());
+    const blob = container.getBlobClient("blob");
+
+    try testing.expectEqual(
+        container.pipeline.runtime.transport.context,
+        blob.pipeline.runtime.transport.context,
+    );
+    try testing.expectEqual(
+        container.pipeline.runtime.crypto.context,
+        blob.pipeline.runtime.crypto.context,
+    );
 }
 
 test "uploadConditional emits one x-ms-meta header per entry" {
@@ -1144,7 +1120,7 @@ test "metadata round-trips from upload through getProperties" {
     var read_mock = core.http.MockTransport.init(allocator, 200, "");
     defer read_mock.deinit();
     read_mock.response_headers_list = &echoed;
-    blob.pipeline = .{ .policies = &.{}, .transport_impl = read_mock.asTransport() };
+    blob.pipeline = core.http.HttpPipeline.init(testRuntime(read_mock.asTransport()), &.{});
 
     const properties = try blob.getProperties(allocator);
     defer properties.deinit(allocator);
@@ -1225,7 +1201,7 @@ test "container create and delete target restype=container" {
 
     var delete_mock = core.http.MockTransport.init(allocator, 202, "");
     defer delete_mock.deinit();
-    container.pipeline = .{ .policies = &.{}, .transport_impl = delete_mock.asTransport() };
+    container.pipeline = core.http.HttpPipeline.init(testRuntime(delete_mock.asTransport()), &.{});
     try container.deleteContainer(allocator);
     try testing.expectEqual(core.http.Method.DELETE, delete_mock.last_method.?);
 }
@@ -1243,7 +1219,7 @@ test "download and upload round trip through the container client" {
 
     var download_mock = core.http.MockTransport.init(allocator, 200, "hello");
     defer download_mock.deinit();
-    blob.pipeline = .{ .policies = &.{}, .transport_impl = download_mock.asTransport() };
+    blob.pipeline = core.http.HttpPipeline.init(testRuntime(download_mock.asTransport()), &.{});
     const data = try blob.download(allocator);
     defer allocator.free(data);
     try testing.expectEqualStrings("hello", data);
@@ -1317,7 +1293,10 @@ const ScriptedTransport = struct {
     bodies: []const []const u8,
     index: usize = 0,
     urls: std.ArrayList([]u8) = .empty,
-    transport: core.http.HttpTransport = .{ .sendFn = &sendImpl },
+
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &sendImpl,
+    };
 
     fn init(allocator: std.mem.Allocator, bodies: []const []const u8) ScriptedTransport {
         return .{ .allocator = allocator, .bodies = bodies };
@@ -1328,15 +1307,15 @@ const ScriptedTransport = struct {
         self.urls.deinit(self.allocator);
     }
 
-    fn asTransport(self: *ScriptedTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *ScriptedTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn sendImpl(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
     ) anyerror!core.http.Response {
-        const self: *ScriptedTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *ScriptedTransport = @ptrCast(@alignCast(context));
         try self.urls.append(self.allocator, try self.allocator.dupe(u8, request.url));
         const body = self.bodies[@min(self.index, self.bodies.len - 1)];
         self.index += 1;

--- a/convenience.zig
+++ b/convenience.zig
@@ -75,7 +75,7 @@ pub fn containerExists(container: *Container, alloc: std.mem.Allocator, options:
 }
 
 fn existsRequest(
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     alloc: std.mem.Allocator,
     api_version: []const u8,
     url: []const u8,
@@ -332,7 +332,7 @@ pub fn uploadBlockBlob(
 /// status equals `expected`. Only the status line is inspected, so callers are
 /// insulated from optional/omitted Azure response headers.
 fn sendExpect(
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     req: *core.http.Request,
     expected: u16,
     ctx: []const u8,
@@ -396,6 +396,7 @@ test {
 // `stageBlock` / `commitBlockList` / `upload` parsers require.
 
 const testing = std.testing;
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
 const test_api_version = "2024-11-04";
 const test_blob_endpoint = "https://acct.blob.core.windows.net/cont/blob";
 const test_container_endpoint = "https://acct.blob.core.windows.net/cont";
@@ -407,15 +408,17 @@ const RecordedCall = struct {
 };
 
 const MockTransport = struct {
-    transport: core.http.HttpTransport,
     alloc: std.mem.Allocator,
     status: u16,
     body: []const u8,
     calls: std.ArrayList(RecordedCall),
 
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &sendImpl,
+    };
+
     fn init(alloc: std.mem.Allocator, status: u16, body: []const u8) MockTransport {
         return .{
-            .transport = .{ .sendFn = &sendImpl, .openFn = null },
             .alloc = alloc,
             .status = status,
             .body = body,
@@ -431,8 +434,18 @@ const MockTransport = struct {
         self.calls.deinit(self.alloc);
     }
 
-    fn pipeline(self: *MockTransport) core.pipeline.HttpPipeline {
-        return .{ .policies = &.{}, .transport_impl = &self.transport };
+    fn asTransport(self: *MockTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn pipeline(self: *MockTransport) core.http.HttpPipeline {
+        return core.http.HttpPipeline.init(
+            core.http.HttpRuntime.init(
+                self.asTransport(),
+                testing_crypto_provider.asProvider(),
+            ),
+            &.{},
+        );
     }
 
     fn blobClient(self: *MockTransport) Blob {
@@ -447,8 +460,8 @@ const MockTransport = struct {
         return .{ .endpoint = test_blob_endpoint, .api_version = test_api_version, .pipeline = self.pipeline() };
     }
 
-    fn sendImpl(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *MockTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(context: *anyopaque, request: *core.http.Request) !core.http.Response {
+        const self: *MockTransport = @ptrCast(@alignCast(context));
         try self.calls.append(self.alloc, .{
             .method = request.method,
             .url = try self.alloc.dupe(u8, request.url),

--- a/examples/blob_convenience_live.zig
+++ b/examples/blob_convenience_live.zig
@@ -45,6 +45,19 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_provider.asProvider(),
+    );
+    var auth_policy = core.http.BearerTokenAuthPolicy.init(
+        allocator,
+        env_cred.asCredential(),
+        blobs.auth_scopes,
+    );
+    defer auth_policy.deinit();
+    var policies = [_]*core.http.HttpPolicy{auth_policy.asPolicy()};
+    const pipeline = core.http.HttpPipeline.init(runtime, &policies);
 
     var stdout_file = std.Io.File.stdout();
     var buffer: [4096]u8 = undefined;
@@ -59,12 +72,9 @@ pub fn main(init: std.process.Init) !void {
     );
     defer allocator.free(blob_endpoint);
 
-    var client = try blobs.BlobClient.init(allocator, .{
-        .credential = env_cred.asCredential(),
-        .transport = transport.asTransport(),
+    var client = blobs.BlobClient.init(pipeline, .{
         .endpoint = blob_endpoint,
     });
-    defer client.deinit();
 
     var blob = client.blob();
     var block_blob = client.blockBlob();

--- a/examples/complete_sas_upload.zig
+++ b/examples/complete_sas_upload.zig
@@ -17,10 +17,15 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_provider.asProvider(),
+    );
     var client = try blobs.SasBlobClient.init(
         allocator,
         sas_url,
-        transport.asTransport(),
+        runtime,
     );
     defer client.deinit();
 

--- a/examples/list_blobs_live.zig
+++ b/examples/list_blobs_live.zig
@@ -38,6 +38,19 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_provider.asProvider(),
+    );
+    var auth_policy = core.http.BearerTokenAuthPolicy.init(
+        allocator,
+        env_cred.asCredential(),
+        blobs.auth_scopes,
+    );
+    defer auth_policy.deinit();
+    var policies = [_]*core.http.HttpPolicy{auth_policy.asPolicy()};
+    const pipeline = core.http.HttpPipeline.init(runtime, &policies);
 
     var stdout_file = std.Io.File.stdout();
     var buffer: [4096]u8 = undefined;
@@ -46,12 +59,9 @@ pub fn main(init: std.process.Init) !void {
     defer out.flush() catch {};
 
     // ── Service.listContainers ────────────────────────────────────────
-    var service_client = try blobs.BlobClient.init(allocator, .{
-        .credential = env_cred.asCredential(),
-        .transport = transport.asTransport(),
+    var service_client = blobs.BlobClient.init(pipeline, .{
         .endpoint = endpoint,
     });
-    defer service_client.deinit();
 
     try out.print("listContainers @ {s}\n", .{endpoint});
     var svc = service_client.service();
@@ -75,12 +85,9 @@ pub fn main(init: std.process.Init) !void {
     );
     defer allocator.free(container_endpoint);
 
-    var container_client = try blobs.BlobClient.init(allocator, .{
-        .credential = env_cred.asCredential(),
-        .transport = transport.asTransport(),
+    var container_client = blobs.BlobClient.init(pipeline, .{
         .endpoint = container_endpoint,
     });
-    defer container_client.deinit();
 
     try out.print("listBlobs @ {s}\n", .{container_endpoint});
     var cnt = container_client.container();

--- a/sas.zig
+++ b/sas.zig
@@ -111,17 +111,19 @@ pub const BlobUploadOutcome = union(enum) {
 };
 
 /// A Blob client constructed only from an allocator, a complete SAS URL, and
-/// a transport. It deliberately has no credential or caller-supplied
+/// an HTTP runtime. It deliberately has no credential or caller-supplied
 /// pipeline: every request uses an empty-policy, no-redirect pipeline.
 pub const SasBlobClient = struct {
     allocator: std.mem.Allocator,
     uri: sas.CompleteSasUri,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 
+    /// The runtime descriptors are copied by value and borrow their backend
+    /// contexts. Those contexts must outlive this client and every upload.
     pub fn init(
         allocator: std.mem.Allocator,
         complete_sas_uri: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
     ) !SasBlobClient {
         var uri = try sas.CompleteSasUri.init(allocator, complete_sas_uri);
         errdefer uri.deinit();
@@ -130,7 +132,7 @@ pub const SasBlobClient = struct {
         return .{
             .allocator = allocator,
             .uri = uri,
-            .transport = transport,
+            .runtime = runtime,
         };
     }
 
@@ -199,7 +201,7 @@ pub const SasBlobClient = struct {
                     .content_length = block_length,
                 },
             };
-            const outcome = sas.send(self.transport, &request, streaming_body) catch |err|
+            const outcome = sas.send(self.runtime, &request, streaming_body) catch |err|
                 return localFailureAfterBlocks(err, .put_block, block_index);
             switch (outcome) {
                 .accepted => {},
@@ -229,7 +231,7 @@ pub const SasBlobClient = struct {
         request.setHeader("x-ms-blob-content-type", options.content_type) catch |err|
             return localFailureAfterBlocks(err, .put_block_list, block_index);
         request.body = commit_body;
-        const outcome = sas.send(self.transport, &request, null) catch |err|
+        const outcome = sas.send(self.runtime, &request, null) catch |err|
             return localFailureAfterBlocks(err, .put_block_list, block_index);
         return mapOutcome(outcome, .put_block_list);
     }
@@ -325,7 +327,7 @@ pub const SasBlobClient = struct {
                 request.setHeader("x-ms-version", storage_api_version) catch |err|
                     return localFailureAfterBlocks(err, .put_block, staged_blocks);
                 request.body = block[0..used];
-                break :blk sas.send(self.transport, &request, null) catch |err|
+                break :blk sas.send(self.runtime, &request, null) catch |err|
                     return localFailureAfterBlocks(err, .put_block, staged_blocks);
             };
             switch (outcome) {
@@ -357,7 +359,7 @@ pub const SasBlobClient = struct {
         request.setHeader("x-ms-blob-content-type", options.content_type) catch |err|
             return localFailureAfterBlocks(err, .put_block_list, staged_blocks);
         request.body = commit.items;
-        const outcome = sas.send(self.transport, &request, null) catch |err|
+        const outcome = sas.send(self.runtime, &request, null) catch |err|
             return localFailureAfterBlocks(err, .put_block_list, staged_blocks);
         return mapOutcome(outcome, .put_block_list);
     }
@@ -375,7 +377,7 @@ pub const SasBlobClient = struct {
         try request.setHeader("x-ms-version", storage_api_version);
         return mapOutcome(
             try sas.send(
-                self.transport,
+                self.runtime,
                 &request,
                 .{ .reader = reader, .content_length = size },
             ),
@@ -394,7 +396,7 @@ pub const SasBlobClient = struct {
         try request.setHeader("x-ms-blob-type", "BlockBlob");
         try request.setHeader("x-ms-version", storage_api_version);
         request.body = bytes;
-        return mapOutcome(try sas.send(self.transport, &request, null), .put_blob);
+        return mapOutcome(try sas.send(self.runtime, &request, null), .put_blob);
     }
 };
 
@@ -635,37 +637,40 @@ fn ensureExhausted(reader: *std.Io.Reader) !void {
 
 const CommitFailureTransport = struct {
     allocator: std.mem.Allocator,
-    transport: core.http.HttpTransport,
     fail_on_call: usize,
     call_count: usize = 0,
     operation: core.http.HttpOperation = undefined,
     response_reader: std.Io.Reader = undefined,
 
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &sendImpl,
+        .open = &openImpl,
+    };
+
     fn init(allocator: std.mem.Allocator, fail_on_call: usize) CommitFailureTransport {
         return .{
             .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
             .fail_on_call = fail_on_call,
         };
     }
 
-    fn asTransport(self: *CommitFailureTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *CommitFailureTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn sendImpl(
-        _: *core.http.HttpTransport,
+        _: *anyopaque,
         _: *core.http.Request,
     ) !core.http.Response {
         return error.TestUnexpectedSend;
     }
 
     fn openImpl(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         _: *core.http.Request,
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        const self: *CommitFailureTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *CommitFailureTransport = @ptrCast(@alignCast(context));
         self.call_count += 1;
         if (self.call_count == self.fail_on_call)
             return error.InjectedCommitFailure;
@@ -694,6 +699,23 @@ const CommitFailureTransport = struct {
     fn deinitImpl(operation: *core.http.HttpOperation) void {
         const self: *CommitFailureTransport = @alignCast(@fieldParentPtr("operation", operation));
         self.operation.headers.deinit();
+    }
+};
+
+const BufferedOnlyTransport = struct {
+    inner: *core.http.MockTransport,
+
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &sendImpl,
+    };
+
+    fn asTransport(self: *BufferedOnlyTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn sendImpl(context: *anyopaque, request: *core.http.Request) !core.http.Response {
+        const self: *BufferedOnlyTransport = @ptrCast(@alignCast(context));
+        return self.inner.asTransport().send(request);
     }
 };
 
@@ -733,16 +755,34 @@ const BoundedReadSource = struct {
     }
 };
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(
+        transport,
+        testing_crypto_provider.asProvider(),
+    );
+}
+
 test "SAS blob upload preserves query, isolates credentials, and drains response" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 201, "done");
     defer transport.deinit();
+    const runtime = testRuntime(transport.asTransport());
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=a%2Bb%3D&sp=rw",
-        transport.asTransport(),
+        runtime,
     );
     defer client.deinit();
+    try std.testing.expectEqual(
+        runtime.transport.context,
+        client.runtime.transport.context,
+    );
+    try std.testing.expectEqual(
+        runtime.crypto.context,
+        client.runtime.crypto.context,
+    );
 
     const outcome = try client.uploadBytes("payload", .{ .content_type = "text/plain" });
     try std.testing.expect(outcome.isAccepted());
@@ -760,11 +800,11 @@ test "SAS blob byte uploads support buffered-only transports" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
-    transport.transport.openFn = null;
+    var buffered_only = BufferedOnlyTransport{ .inner = &transport };
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        transport.asTransport(),
+        testRuntime(buffered_only.asTransport()),
     );
     defer client.deinit();
 
@@ -792,7 +832,7 @@ test "SAS blob block upload orders deterministic IDs and bounds reads" {
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sp=w&sig=opaque%2Bvalue",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -821,7 +861,7 @@ test "SAS blob unknown-length block stream commits buffered blocks" {
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -851,7 +891,7 @@ test "SAS blob returns known rejections and unknown transport outcomes" {
     var rejected_client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        rejected_transport.asTransport(),
+        testRuntime(rejected_transport.asTransport()),
     );
     defer rejected_client.deinit();
     const rejected = try rejected_client.uploadBytes("x", .{});
@@ -869,7 +909,7 @@ test "SAS blob returns known rejections and unknown transport outcomes" {
     var unknown_client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        unknown_transport.asTransport(),
+        testRuntime(unknown_transport.asTransport()),
     );
     defer unknown_client.deinit();
     var unknown_reader = std.Io.Reader.fixed("x");
@@ -890,7 +930,7 @@ test "SAS blob rejects a host-changing redirect without another request" {
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -910,7 +950,7 @@ test "SAS blob does not commit after an unknown commit transport failure" {
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -937,7 +977,7 @@ test "SAS blob block reader stays bounded and short sources are unknown" {
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -964,7 +1004,7 @@ test "SAS blob reports extra source data after staging as incomplete" {
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=opaque",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -991,7 +1031,7 @@ test "SAS blob validates limits and redacts diagnostics" {
     var client = try SasBlobClient.init(
         allocator,
         "https://account.blob.core.windows.net/container/blob?sig=secret",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -1017,7 +1057,7 @@ test "SAS blob validates limits and redacts diagnostics" {
         SasBlobClient.init(
             allocator,
             "https://account.queue.core.windows.net/queue?sig=opaque",
-            transport.asTransport(),
+            testRuntime(transport.asTransport()),
         ),
     );
 }

--- a/src/clients.zig
+++ b/src/clients.zig
@@ -20,74 +20,28 @@ fn responseStatusExpected(status: u16, expected: []const u16) bool {
     return false;
 }
 const default_api_version = "2026-06-06";
-const auth_scopes: []const []const u8 = &.{"https://storage.azure.com/.default"};
-
 pub const BlobClient = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
-    allocator: std.mem.Allocator,
-    auth_policy: ?*core.pipeline.BearerTokenAuthPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
-        credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         endpoint: []const u8,
         api_version: []const u8 = default_api_version,
     };
 
-    pub const PipelineOptions = struct {
-        endpoint: []const u8,
-        api_version: []const u8 = default_api_version,
-    };
-
-    pub fn init(allocator: std.mem.Allocator, options: InitOptions) !BlobClient {
-        const auth_policy = try allocator.create(core.pipeline.BearerTokenAuthPolicy);
-        errdefer allocator.destroy(auth_policy);
-        auth_policy.* = core.pipeline.BearerTokenAuthPolicy.init(
-            allocator,
-            options.credential,
-            auth_scopes,
-        );
-
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
-        errdefer allocator.free(policy_ptrs);
-        policy_ptrs[0] = auth_policy.asPolicy();
-
-        return .{
-            .allocator = allocator,
-            .endpoint = options.endpoint,
-            .api_version = options.api_version,
-            .auth_policy = auth_policy,
-            .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
-        };
-    }
-    pub fn initWithPipeline(
-        allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
-        options: PipelineOptions,
+    /// The pipeline and its runtime descriptors are copied by value. Their
+    /// borrowed transport, crypto, policy, and credential contexts must
+    /// outlive this client and every client derived from it.
+    pub fn init(
+        pipeline: core.http.HttpPipeline,
+        options: InitOptions,
     ) BlobClient {
         return .{
-            .allocator = allocator,
             .endpoint = options.endpoint,
             .api_version = options.api_version,
-            .auth_policy = null,
-            .policy_ptrs = &.{},
             .pipeline = pipeline,
         };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        if (self.auth_policy) |auth_policy| {
-            auth_policy.deinit();
-            self.allocator.destroy(auth_policy);
-            self.allocator.free(self.policy_ptrs);
-        }
     }
 
     pub fn service(self: *@This()) Service {
@@ -142,7 +96,7 @@ pub const BlobClient = struct {
 pub const Service = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const SetPropertiesResult = union(enum) {
         status_202: struct {
@@ -799,7 +753,7 @@ pub const Service = struct {
 pub const Container = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateResult = union(enum) {
         status_201: struct {
@@ -2474,7 +2428,7 @@ pub const Container = struct {
 pub const Blob = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const DownloadResult = union(enum) {
         status_200: struct {
@@ -5804,7 +5758,7 @@ pub const Blob = struct {
 pub const AppendBlob = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateResult = union(enum) {
         status_201: struct {
@@ -6414,7 +6368,7 @@ pub const AppendBlob = struct {
 pub const BlockBlob = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const UploadResult = union(enum) {
         status_201: struct {
@@ -7839,7 +7793,7 @@ pub const BlockBlob = struct {
 pub const PageBlob = struct {
     endpoint: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const CreateResult = union(enum) {
         status_201: struct {

--- a/src/clients_test.zig
+++ b/src/clients_test.zig
@@ -9,3 +9,203 @@
 //! existing copy. Add tests freely.
 
 const std = @import("std");
+const core = @import("azure_sdk_core");
+const clients = @import("clients.zig");
+
+const CryptoSpy = struct {
+    random_calls: usize = 0,
+    fail_random: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn asProvider(self: *CryptoSpy) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *CryptoSpy = @ptrCast(@alignCast(context));
+        self.random_calls += 1;
+        if (self.fail_random) return error.SelectedCryptoFailure;
+        @memset(out, 0xa5);
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.UnexpectedCryptoOperation;
+    }
+};
+
+const RuntimeCredential = struct {
+    credential: core.credentials.TokenCredential = .{
+        .getTokenFn = &getToken,
+    },
+    calls: usize = 0,
+
+    fn asCredential(self: *RuntimeCredential) *core.credentials.TokenCredential {
+        return &self.credential;
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        _: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+        runtime: core.http.HttpRuntime,
+    ) !core.credentials.AccessToken {
+        const self: *RuntimeCredential = @alignCast(
+            @fieldParentPtr("credential", credential),
+        );
+        self.calls += 1;
+        var byte: [1]u8 = undefined;
+        try runtime.crypto.randomBytes(&byte);
+        return .{
+            .token = "runtime-token",
+            .expires_on = 7_258_118_400,
+        };
+    }
+};
+
+fn authenticatedPipeline(
+    allocator: std.mem.Allocator,
+    runtime: core.http.HttpRuntime,
+    credential: *RuntimeCredential,
+    auth_policy: *core.http.BearerTokenAuthPolicy,
+    policies: *[1]*core.http.HttpPolicy,
+) core.http.HttpPipeline {
+    auth_policy.* = core.http.BearerTokenAuthPolicy.init(
+        allocator,
+        credential.asCredential(),
+        &.{"https://storage.azure.com/.default"},
+    );
+    policies[0] = auth_policy.asPolicy();
+    return core.http.HttpPipeline.init(runtime, policies);
+}
+
+test "generated client preserves runtime and routes selected crypto provider" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "");
+    defer transport.deinit();
+    var crypto_spy = CryptoSpy{};
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_spy.asProvider(),
+    );
+    var credential = RuntimeCredential{};
+    var auth_policy: core.http.BearerTokenAuthPolicy = undefined;
+    defer auth_policy.deinit();
+    var policies: [1]*core.http.HttpPolicy = undefined;
+    const pipeline = authenticatedPipeline(
+        allocator,
+        runtime,
+        &credential,
+        &auth_policy,
+        &policies,
+    );
+
+    var client = clients.BlobClient.init(pipeline, .{
+        .endpoint = "https://account.blob.core.windows.net",
+    });
+    inline for (.{
+        client.service(),
+        client.container(),
+        client.blob(),
+        client.appendBlob(),
+        client.blockBlob(),
+        client.pageBlob(),
+    }) |derived| {
+        try std.testing.expectEqual(
+            runtime.transport.context,
+            derived.pipeline.runtime.transport.context,
+        );
+        try std.testing.expectEqual(
+            runtime.crypto.context,
+            derived.pipeline.runtime.crypto.context,
+        );
+    }
+
+    var request = core.http.Request.init(
+        allocator,
+        .HEAD,
+        "https://account.blob.core.windows.net?comp=properties",
+    );
+    defer request.deinit();
+    var response = try client.pipeline.send(&request);
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), crypto_spy.random_calls);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    try std.testing.expectEqualStrings(
+        "Bearer " ++ "runtime-token",
+        transport.last_headers.get("Authorization").?,
+    );
+}
+
+test "generated client propagates selected provider failure before transport" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "");
+    defer transport.deinit();
+    var crypto_spy = CryptoSpy{ .fail_random = true };
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_spy.asProvider(),
+    );
+    var credential = RuntimeCredential{};
+    var auth_policy: core.http.BearerTokenAuthPolicy = undefined;
+    defer auth_policy.deinit();
+    var policies: [1]*core.http.HttpPolicy = undefined;
+    const pipeline = authenticatedPipeline(
+        allocator,
+        runtime,
+        &credential,
+        &auth_policy,
+        &policies,
+    );
+    var client = clients.BlobClient.init(pipeline, .{
+        .endpoint = "https://account.blob.core.windows.net",
+    });
+
+    var request = core.http.Request.init(
+        allocator,
+        .HEAD,
+        "https://account.blob.core.windows.net?comp=properties",
+    );
+    defer request.deinit();
+    try request.setHeader("Authorization", "unchanged");
+    try std.testing.expectError(
+        error.SelectedCryptoFailure,
+        client.pipeline.send(&request),
+    );
+
+    try std.testing.expectEqualStrings(
+        "unchanged",
+        request.getHeader("Authorization").?,
+    );
+    try std.testing.expectEqual(@as(usize, 1), crypto_spy.random_calls);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}


### PR DESCRIPTION
Part of #412
Part of #414

## Summary
- replace generated and handwritten Blob/Container client transport-owning constructors with the canonical caller-owned `core.http.HttpPipeline` construction path
- migrate complete-SAS uploads, convenience helpers, custom test transports, examples, and derived clients to `core.http.HttpRuntime` and copyable transport/provider descriptors
- preserve the borrowed runtime-context lifetime contract across every generated sub-client and container-derived blob client
- prove the selected crypto backend is routed through credential acquisition, and that provider failure leaves authorization unchanged and prevents transport dispatch
- bump `azure_sdk_storage_blobs` from released `0.2.0` to breaking `0.3.0`

## Released dependency pins
- `azure_sdk_core` 0.3.0: `bc77bcacbb64af935ca53d60bf8a351c9592bc41` / `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- `azure_sdk_storage_common` 0.3.0: `5291e5d7224b4d69989d403f605345d949c41db7` / `azure_sdk_storage_common-0.3.0-JzoreF0KAQDsbNtEXsub-0AZ1oiyzWJ-CGf1S5XSmQK4`

## Validation
- verified both release tags resolve to the pinned commits and `azure_sdk_storage_blobs/v0.3.0` is unused
- `zig fmt --check build.zig build.zig.zon root.zig sas.zig convenience.zig container_client.zig src/*.zig examples/*.zig`
- `zig build`
- `zig build test --summary all` (49/49 tests passed; all examples compile)
- `zig build examples --summary all`
- `zig build -l` confirms no package-check step is configured on this package branch

Auto-merge is intentionally disabled.
