### PR TITLE
Migrate Container Registry SDK to HttpRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,18 @@ operations, status unions, and custom-pipeline scenarios.
 
 ```zig
 const acr = @import("azure_sdk_container_registry");
+const core = @import("azure_sdk_core");
+
+var transport = core.http.StdHttpTransport.init(allocator, io);
+defer transport.deinit();
+var crypto = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    transport.asTransport(),
+    crypto.asProvider(),
+);
 
 var client = try acr.ContainerRegistryClient.init(allocator, registry_endpoint, .{
-    .transport = transport,
+    .runtime = runtime,
     .authentication = .{ .credential = credential },
 });
 defer client.deinit();
@@ -94,7 +103,7 @@ var content = try acr.ContainerRegistryContentClient.init(
     registry_endpoint,
     "team/app",
     .{
-        .transport = transport,
+        .runtime = runtime,
         .authentication = .{ .credential = credential },
     },
 );
@@ -165,7 +174,7 @@ var blobs = try acr.BlobDownloadClient.init(
     registry_endpoint,
     "team/app",
     .{
-        .transport = transport,
+        .runtime = runtime,
         .authentication = .{ .credential = credential },
     },
 );
@@ -207,6 +216,21 @@ Long-lived clients use bounded LRU caches: 128 routes, 128 scoped access
 tokens, and 32 refresh tokens. Tokens that reach the configured expiry skew
 are pruned before lookup or insertion.
 
+All clients use the canonical `core.http.HttpRuntime` construction path.
+Runtime, transport, and crypto provider descriptors are copied by value; their
+backend contexts are borrowed and must outlive clients, credential calls, and
+open streaming operations. HTTP transport and crypto providers are independent,
+so either backend can be replaced without replacing the other. Digest helpers
+also require the selected provider:
+
+```zig
+const digest = try acr.computeSha256Digest(runtime.crypto, bytes);
+```
+
+Provider and allocation failures propagate directly. The SDK does not silently
+fall back to `std.crypto`, and it does not return partially computed digests or
+successful transfer results after a provider failure.
+
 Local development uses relative package dependencies. The canonical package
 split changes the common dependency to `azure_sdk_core`. Release branches
 replace local paths with immutable Core and
@@ -215,8 +239,9 @@ replace local paths with immutable Core and
 
 ## Ownership and lifetime rules
 
-- Clients own their copied endpoint/repository/auth-policy state and must be
-  deinitialized before their borrowed transport and credential.
+- Clients own their copied endpoint/repository/auth-policy/runtime descriptor
+  state and must be deinitialized before the borrowed transport context,
+  crypto-provider context, and credential.
 - Pagers borrow the originating client pipeline. Keep the client alive until
   `pager.deinit()`, and deinitialize every page result before requesting or
   discarding more pages.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,16 +1,16 @@
 .{
     .name = .azure_sdk_container_registry,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0x29fb8cf06d809db5,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .azure_rest_container_registry = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#74edeaeab52a886692fa39e9270284ac24f579c1",
-            .hash = "azure_rest_container_registry-0.1.0-k4rjoQrxAQCyZbHiXlrbwWt7kHEnf2HoOEaOG06j_ekz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#37378097448f4a9ffa7d49e18fc596d2d237133b",
+            .hash = "azure_rest_container_registry-0.2.0-k4rjoaT3AQCAPIOmbAJh84O2t0aAuAECnnNxRN4rhTgQ",
         },
     },
     .paths = .{

--- a/examples/anonymous_read.zig
+++ b/examples/anonymous_read.zig
@@ -19,12 +19,13 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(init.gpa, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
     var content = try acr.ContainerRegistryContentClient.init(
         init.gpa,
         endpoint,
         repository,
         .{
-            .transport = transport.asTransport(),
+            .runtime = .init(transport.asTransport(), crypto.asProvider()),
             .authentication = .anonymous,
         },
     );

--- a/examples/oci_push_pull.zig
+++ b/examples/oci_push_pull.zig
@@ -42,8 +42,14 @@ pub fn main(init: std.process.Init) !void {
     defer config.deinit();
     var layer = try content.uploadBlobBytes(layer_bytes, .{});
     defer layer.deinit();
-    const expected_config_digest = acr.computeSha256Digest(config_bytes);
-    const expected_layer_digest = acr.computeSha256Digest(layer_bytes);
+    const expected_config_digest = try acr.computeSha256Digest(
+        session.runtime().crypto,
+        config_bytes,
+    );
+    const expected_layer_digest = try acr.computeSha256Digest(
+        session.runtime().crypto,
+        layer_bytes,
+    );
     if (config.size != config_bytes.len or
         !try acr.sha256DigestsEqual(config.digest, &expected_config_digest))
     {
@@ -82,7 +88,10 @@ pub fn main(init: std.process.Init) !void {
     defer downloaded.deinit(init.gpa);
     if (!std.mem.eql(u8, manifest_bytes, downloaded.bytes))
         return error.ContainerRegistryManifestRoundTripMismatch;
-    const expected_manifest_digest = acr.computeSha256Digest(manifest_bytes);
+    const expected_manifest_digest = try acr.computeSha256Digest(
+        session.runtime().crypto,
+        manifest_bytes,
+    );
     if (!try acr.sha256DigestsEqual(
         uploaded.digest,
         &expected_manifest_digest,

--- a/examples/support.zig
+++ b/examples/support.zig
@@ -8,6 +8,7 @@ pub const repository_environment = "AZURE_CONTAINER_REGISTRY_REPOSITORY";
 pub const AuthenticatedSession = struct {
     allocator: std.mem.Allocator,
     transport: core.http.StdHttpTransport,
+    crypto: core.crypto.StdCryptoProvider,
     credential: core.identity.DefaultAzureCredential,
 
     pub fn create(
@@ -20,10 +21,10 @@ pub const AuthenticatedSession = struct {
         self.allocator = allocator;
         self.transport = core.http.StdHttpTransport.init(allocator, io);
         errdefer self.transport.deinit();
+        self.crypto = core.crypto.StdCryptoProvider.init(io);
         self.credential = try core.identity.DefaultAzureCredential.init(
             allocator,
             io,
-            self.transport.asTransport(),
             env,
         );
         return self;
@@ -33,9 +34,13 @@ pub const AuthenticatedSession = struct {
         self: *AuthenticatedSession,
     ) acr.ContainerRegistryClientOptions {
         return .{
-            .transport = self.transport.asTransport(),
+            .runtime = self.runtime(),
             .authentication = .{ .credential = self.credential.asCredential() },
         };
+    }
+
+    pub fn runtime(self: *AuthenticatedSession) core.http.HttpRuntime {
+        return .init(self.transport.asTransport(), self.crypto.asProvider());
     }
 
     pub fn deinit(self: *AuthenticatedSession) void {

--- a/live_tests/main.zig
+++ b/live_tests/main.zig
@@ -39,6 +39,7 @@ const Config = struct {
 const LiveSession = struct {
     allocator: std.mem.Allocator,
     transport: ObservingTransport,
+    crypto: core.crypto.StdCryptoProvider,
     credential: core.identity.DefaultAzureCredential,
 
     fn create(
@@ -52,10 +53,10 @@ const LiveSession = struct {
         self.allocator = allocator;
         self.transport = try ObservingTransport.init(allocator, io, endpoint);
         errdefer self.transport.deinit();
+        self.crypto = core.crypto.StdCryptoProvider.init(io);
         self.credential = try core.identity.DefaultAzureCredential.init(
             allocator,
             io,
-            self.transport.asTransport(),
             env,
         );
         return self;
@@ -63,7 +64,10 @@ const LiveSession = struct {
 
     fn options(self: *LiveSession) acr.ContainerRegistryClientOptions {
         return .{
-            .transport = self.transport.asTransport(),
+            .runtime = .init(
+                self.transport.asTransport(),
+                self.crypto.asProvider(),
+            ),
             .authentication = .{ .credential = self.credential.asCredential() },
         };
     }
@@ -424,7 +428,6 @@ const ObservingTransport = struct {
     allocator: std.mem.Allocator,
     endpoint: []u8,
     standard: core.http.StdHttpTransport,
-    transport: core.http.HttpTransport,
     redirect_count: usize = 0,
     inject_range_failure: bool = false,
     range_failure_injected: bool = false,
@@ -440,12 +443,14 @@ const ObservingTransport = struct {
             .allocator = allocator,
             .endpoint = try allocator.dupe(u8, endpoint),
             .standard = core.http.StdHttpTransport.init(allocator, io),
-            .transport = .{ .sendFn = &send, .openFn = &open },
         };
     }
 
-    fn asTransport(self: *ObservingTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *ObservingTransport) core.http.HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = &send, .open = &open },
+        };
     }
 
     fn deinit(self: *ObservingTransport) void {
@@ -455,22 +460,20 @@ const ObservingTransport = struct {
     }
 
     fn send(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
     ) !core.http.Response {
-        const self: *ObservingTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+        const self: *ObservingTransport = @ptrCast(@alignCast(context));
         const base = self.standard.asTransport();
-        return base.sendFn(base, request);
+        return base.vtable.send(base.context, request);
     }
 
     fn open(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        const self: *ObservingTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+        const self: *ObservingTransport = @ptrCast(@alignCast(context));
         const range = request.getHeader("Range");
         if (range != null and self.isRegistryUrl(request.url) and
             self.range_request_count < self.range_starts.len)
@@ -479,7 +482,7 @@ const ObservingTransport = struct {
             self.range_request_count += 1;
         }
         const base = self.standard.asTransport();
-        const operation = try base.openFn.?(base, request, options);
+        const operation = try base.vtable.open.?(base.context, request, options);
         if (operation.status_code == 307 and self.isRegistryUrl(request.url))
             self.redirect_count += 1;
         if (self.inject_range_failure and !self.range_failure_injected and

--- a/src/auth_policy.zig
+++ b/src/auth_policy.zig
@@ -6,10 +6,17 @@ const BearerChallenge = challenge_mod.BearerChallenge;
 const Request = core.http.Request;
 const Response = core.http.Response;
 const HttpOperation = core.http.HttpOperation;
-const HttpPolicy = core.pipeline.HttpPolicy;
+const HttpPolicy = core.http.HttpPolicy;
+const HttpRuntime = core.http.HttpRuntime;
 const HttpTransport = core.http.HttpTransport;
 const OpenOptions = core.http.OpenOptions;
 const CancellationToken = core.http.CancellationToken;
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(transport: HttpTransport) HttpRuntime {
+    return .init(transport, testing_crypto_provider.asProvider());
+}
 
 const default_aad_scope = "https://containerregistry.azure.net/.default";
 const default_api_version = "2021-07-01";
@@ -308,7 +315,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
         const self: *ChallengeAuthenticationPolicy =
             @alignCast(@fieldParentPtr("policy", policy));
@@ -328,14 +335,14 @@ pub const ChallengeAuthenticationPolicy = struct {
                 first_attempt_token = try self.acquireAccessTokenVersioned(
                     challenge,
                     null,
-                    final_transport,
+                    runtime,
                 );
                 try authorization.setBearer(request, first_attempt_token.?.value);
                 sdk_authorized = true;
             }
         }
 
-        var response = try callNext(request, next, final_transport);
+        var response = try callNext(request, next, runtime);
         if (response.status_code != 401) return response;
 
         if (!sdk_authorized and request.getHeader("Authorization") != null)
@@ -360,7 +367,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         const token = self.acquireAccessTokenVersioned(
             &challenge,
             null,
-            final_transport,
+            runtime,
         ) catch |err| {
             response.deinit();
             return err;
@@ -372,13 +379,17 @@ pub const ChallengeAuthenticationPolicy = struct {
         };
 
         response.deinit();
-        const replay = try callNext(request, next, final_transport);
+        const replay = try callNext(request, next, runtime);
         if (replay.status_code == 401)
             self.invalidateAccessToken(&challenge, token);
         return replay;
     }
 
-    fn prepareImpl(policy: *HttpPolicy, request: *Request) !void {
+    fn prepareImpl(
+        policy: *HttpPolicy,
+        request: *Request,
+        _: HttpRuntime,
+    ) !void {
         const self: *ChallengeAuthenticationPolicy =
             @alignCast(@fieldParentPtr("policy", policy));
         try self.validateRequestUrl(request.url);
@@ -389,7 +400,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         request: *Request,
         options: OpenOptions,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !*HttpOperation {
         const self: *ChallengeAuthenticationPolicy =
             @alignCast(@fieldParentPtr("policy", policy));
@@ -410,7 +421,7 @@ pub const ChallengeAuthenticationPolicy = struct {
                 first_attempt_token = try self.acquireAccessTokenVersioned(
                     challenge,
                     options.cancellation,
-                    final_transport,
+                    runtime,
                 );
                 try authorization.setBearer(request, first_attempt_token.?.value);
                 sdk_authorized = true;
@@ -421,7 +432,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             request,
             options,
             next,
-            final_transport,
+            runtime,
         );
         defer if (owned_operation) |operation| operation.deinit();
         var operation = owned_operation.?;
@@ -447,7 +458,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         const token = try self.acquireAccessTokenVersioned(
             &challenge,
             options.cancellation,
-            final_transport,
+            runtime,
         );
         defer token.deinit(self.allocator);
         try authorization.setBearer(request, token.value);
@@ -463,7 +474,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             request,
             replay_options,
             next,
-            final_transport,
+            runtime,
         );
         owned_operation = operation;
         if (operation.status_code == 401)
@@ -476,12 +487,12 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) ![]u8 {
         return (try self.acquireAccessTokenVersioned(
             challenge,
             cancellation,
-            transport,
+            runtime,
         )).value;
     }
 
@@ -489,7 +500,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !AcquiredAccessToken {
         try checkCancelled(cancellation);
         const current_time = self.now();
@@ -519,7 +530,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.mutex.unlock(self.io);
             return err;
         };
-        self.startFlightWorkerLocked(flight, transport) catch |err| {
+        self.startFlightWorkerLocked(flight, runtime) catch |err| {
             self.removeFlightLocked(flight);
             self.mutex.unlock(self.io);
             return err;
@@ -533,7 +544,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) ![]u8 {
         try checkCancelled(cancellation);
         const current_time = self.now();
@@ -558,7 +569,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             self.mutex.unlock(self.io);
             return err;
         };
-        self.startFlightWorkerLocked(flight, transport) catch |err| {
+        self.startFlightWorkerLocked(flight, runtime) catch |err| {
             self.removeFlightLocked(flight);
             self.mutex.unlock(self.io);
             return err;
@@ -571,7 +582,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         self: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) ![]u8 {
         return switch (self.authentication) {
             .anonymous => self.exchangeAccessToken(
@@ -579,7 +590,7 @@ pub const ChallengeAuthenticationPolicy = struct {
                 "",
                 .password,
                 cancellation,
-                transport,
+                runtime,
             ),
             .credential => blk: {
                 var retried = false;
@@ -587,7 +598,7 @@ pub const ChallengeAuthenticationPolicy = struct {
                     const refresh_token = try self.acquireRefreshToken(
                         challenge,
                         cancellation,
-                        transport,
+                        runtime,
                     );
                     defer self.allocator.free(refresh_token);
                     const access_token = self.exchangeAccessToken(
@@ -595,7 +606,7 @@ pub const ChallengeAuthenticationPolicy = struct {
                         refresh_token,
                         .refresh_token,
                         cancellation,
-                        transport,
+                        runtime,
                     ) catch |err| {
                         if (!isRefreshTokenRejection(err)) return err;
                         self.invalidateRefreshToken(challenge, refresh_token);
@@ -614,7 +625,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         challenge: *const BearerChallenge,
         aad_token: []const u8,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) ![]u8 {
         const url = try self.tokenUrl(challenge.realm, "/oauth2/exchange");
         defer self.allocator.free(url);
@@ -634,7 +645,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             "refresh_token",
             false,
             cancellation,
-            transport,
+            runtime,
         );
     }
 
@@ -649,7 +660,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         refresh_token: []const u8,
         grant: AccessGrant,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) ![]u8 {
         const url = try self.tokenUrl(challenge.realm, "/oauth2/token");
         defer self.allocator.free(url);
@@ -667,7 +678,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             "access_token",
             grant == .refresh_token,
             cancellation,
-            transport,
+            runtime,
         );
     }
 
@@ -678,7 +689,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         response_field: []const u8,
         classify_refresh_rejection: bool,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) ![]u8 {
         try checkCancelled(cancellation);
         var request = Request.init(self.allocator, .POST, url);
@@ -688,7 +699,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         try request.setHeader("Accept", "application/json");
         try request.setHeader("Content-Type", "application/x-www-form-urlencoded");
 
-        var response = try transport.send(&request);
+        var response = try runtime.transport.send(&request);
         defer response.deinit();
         try checkCancelled(cancellation);
         if (response.status_code == 401) return error.AcrTokenEndpointUnauthorized;
@@ -1068,37 +1079,37 @@ pub const ChallengeAuthenticationPolicy = struct {
     fn startFlightWorkerLocked(
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !void {
         std.debug.assert(flight.worker == null);
         flight.worker = try std.Thread.spawn(
             .{},
             runFlightWorker,
-            .{ self, flight, transport },
+            .{ self, flight, runtime },
         );
     }
 
     fn runFlightWorker(
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) void {
         switch (flight.kind) {
-            .refresh => self.runRefreshFlight(flight, transport),
-            .access => self.runAccessFlight(flight, transport),
+            .refresh => self.runRefreshFlight(flight, runtime),
+            .access => self.runAccessFlight(flight, runtime),
         }
     }
 
     fn runAccessFlight(
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) void {
         const challenge = flight.challenge(self.allocator);
         const token = self.requestAccessToken(
             &challenge,
             null,
-            transport,
+            runtime,
         ) catch |err| {
             self.publishFlightFailure(flight, err);
             return;
@@ -1132,7 +1143,7 @@ pub const ChallengeAuthenticationPolicy = struct {
     fn runRefreshFlight(
         self: *ChallengeAuthenticationPolicy,
         flight: *TokenFlight,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) void {
         const credential = switch (self.authentication) {
             .credential => |value| value,
@@ -1145,6 +1156,7 @@ pub const ChallengeAuthenticationPolicy = struct {
         var aad_token = credential.getToken(
             .{ .scopes = &scopes },
             core.context.Context.none,
+            runtime,
         ) catch |err| {
             self.publishFlightFailure(flight, err);
             return;
@@ -1156,7 +1168,7 @@ pub const ChallengeAuthenticationPolicy = struct {
             &challenge,
             aad_token.token,
             null,
-            transport,
+            runtime,
         ) catch |err| {
             self.publishFlightFailure(flight, err);
             return;
@@ -1378,20 +1390,20 @@ pub const ChallengeAuthenticationPolicy = struct {
 fn callNext(
     request: *Request,
     next: []*HttpPolicy,
-    final_transport: *HttpTransport,
+    runtime: HttpRuntime,
 ) !Response {
-    if (next.len == 0) return final_transport.send(request);
-    return next[0].process(request, next[1..], final_transport);
+    if (next.len == 0) return runtime.transport.send(request);
+    return next[0].process(request, next[1..], runtime);
 }
 
 fn callNextOpen(
     request: *Request,
     options: OpenOptions,
     next: []*HttpPolicy,
-    final_transport: *HttpTransport,
+    runtime: HttpRuntime,
 ) !*HttpOperation {
-    if (next.len == 0) return final_transport.open(request, options);
-    return next[0].open(request, options, next[1..], final_transport);
+    if (next.len == 0) return runtime.transport.open(request, options);
+    return next[0].open(request, options, next[1..], runtime);
 }
 
 fn parseChallengeFromResponse(
@@ -1782,6 +1794,7 @@ const TestCredential = struct {
         credential: *core.credentials.TokenCredential,
         _: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         const self: *TestCredential =
             @alignCast(@fieldParentPtr("credential", credential));
@@ -1883,15 +1896,12 @@ fn countCapturedUrl(
 fn sendBuffered(
     allocator: std.mem.Allocator,
     policy: *ChallengeAuthenticationPolicy,
-    transport: *HttpTransport,
+    runtime: HttpRuntime,
     method: core.http.Method,
     url: []const u8,
 ) !Response {
     var policies = [_]*HttpPolicy{policy.asPolicy()};
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport,
-    };
+    var pipeline = core.http.HttpPipeline.init(runtime, &policies);
     var request = Request.init(allocator, method, url);
     defer request.deinit();
     return pipeline.send(&request);
@@ -1932,7 +1942,6 @@ const ParallelAccessTransport = struct {
     exchange_calls: std.atomic.Value(usize) = .init(0),
     access_calls: std.atomic.Value(usize) = .init(0),
     access_release: std.Io.Semaphore = .{},
-    transport: HttpTransport,
 
     fn init(
         allocator: std.mem.Allocator,
@@ -1945,17 +1954,18 @@ const ParallelAccessTransport = struct {
             .refresh_body = refresh_body,
             .access_one_body = access_one_body,
             .access_two_body = access_two_body,
-            .transport = .{ .sendFn = &sendImpl },
         };
     }
 
-    fn asTransport(self: *ParallelAccessTransport) *HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *ParallelAccessTransport) HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = &sendImpl },
+        };
     }
 
-    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *ParallelAccessTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(context: *anyopaque, request: *Request) !Response {
+        const self: *ParallelAccessTransport = @ptrCast(@alignCast(context));
         if (std.mem.indexOf(u8, request.url, "/oauth2/exchange") != null) {
             _ = self.exchange_calls.fetchAdd(1, .monotonic);
             return testResponse(self.allocator, 200, self.refresh_body);
@@ -1993,23 +2003,23 @@ const CancelAfterOpenPolicy = struct {
         _: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        return callNext(request, next, final_transport);
+        return callNext(request, next, runtime);
     }
 
-    fn prepareImpl(_: *HttpPolicy, _: *Request) !void {}
+    fn prepareImpl(_: *HttpPolicy, _: *Request, _: HttpRuntime) !void {}
 
     fn openImpl(
         policy: *HttpPolicy,
         request: *Request,
         options: OpenOptions,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !*HttpOperation {
         const self: *CancelAfterOpenPolicy =
             @alignCast(@fieldParentPtr("policy", policy));
-        const operation = try callNextOpen(request, options, next, final_transport);
+        const operation = try callNextOpen(request, options, next, runtime);
         self.cancellation.cancel();
         return operation;
     }
@@ -2021,7 +2031,6 @@ const BlockingTokenTransport = struct {
     entered: std.Io.Semaphore = .{},
     release: std.Io.Semaphore = .{},
     calls: std.atomic.Value(usize) = .init(0),
-    transport: HttpTransport,
 
     fn init(
         allocator: std.mem.Allocator,
@@ -2030,17 +2039,18 @@ const BlockingTokenTransport = struct {
         return .{
             .allocator = allocator,
             .response_body = response_body,
-            .transport = .{ .sendFn = &sendImpl },
         };
     }
 
-    fn asTransport(self: *BlockingTokenTransport) *HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *BlockingTokenTransport) HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = &sendImpl },
+        };
     }
 
-    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *BlockingTokenTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(context: *anyopaque, request: *Request) !Response {
+        const self: *BlockingTokenTransport = @ptrCast(@alignCast(context));
         if (std.mem.indexOf(u8, request.url, "/oauth2/token") == null)
             return error.UnexpectedMockRequest;
         _ = self.calls.fetchAdd(1, .monotonic);
@@ -2066,7 +2076,6 @@ const DelayedUnauthorizedTransport = struct {
     token_one_requests: std.atomic.Value(usize) = .init(0),
     token_two_requests: std.atomic.Value(usize) = .init(0),
     token_requests: std.atomic.Value(usize) = .init(0),
-    transport: HttpTransport,
 
     fn init(
         allocator: std.mem.Allocator,
@@ -2081,17 +2090,18 @@ const DelayedUnauthorizedTransport = struct {
             .token_one = token_one,
             .token_two = token_two,
             .token_two_body = token_two_body,
-            .transport = .{ .sendFn = &sendImpl },
         };
     }
 
-    fn asTransport(self: *DelayedUnauthorizedTransport) *HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *DelayedUnauthorizedTransport) HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = &sendImpl },
+        };
     }
 
-    fn sendImpl(transport: *HttpTransport, request: *Request) !Response {
-        const self: *DelayedUnauthorizedTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(context: *anyopaque, request: *Request) !Response {
+        const self: *DelayedUnauthorizedTransport = @ptrCast(@alignCast(context));
         if (std.mem.indexOf(u8, request.url, "/oauth2/token") != null) {
             _ = self.token_requests.fetchAdd(1, .monotonic);
             return testResponse(self.allocator, 200, self.token_two_body);
@@ -2129,7 +2139,7 @@ fn bearerTokenMatches(authorization: []const u8, token: []const u8) bool {
 const AuthRaceRequest = struct {
     allocator: std.mem.Allocator,
     policy: *ChallengeAuthenticationPolicy,
-    transport: *HttpTransport,
+    runtime: HttpRuntime,
     path: RequestPath,
     status_code: ?u16 = null,
     authorization_restored: bool = false,
@@ -2137,10 +2147,7 @@ const AuthRaceRequest = struct {
 
     fn run(self: *@This()) void {
         var policies = [_]*HttpPolicy{self.policy.asPolicy()};
-        var pipeline = core.pipeline.HttpPipeline{
-            .policies = &policies,
-            .transport_impl = self.transport,
-        };
+        var pipeline = core.http.HttpPipeline.init(self.runtime, &policies);
         var request = Request.init(
             self.allocator,
             .GET,
@@ -2231,7 +2238,7 @@ test "authenticated challenge flow uses form encoding and caches both tokens" {
     var first = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/team/image/manifests/latest",
     );
@@ -2256,7 +2263,7 @@ test "authenticated challenge flow uses form encoding and caches both tokens" {
     var second = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/team/image/manifests/latest?reference=other",
     );
@@ -2312,7 +2319,7 @@ test "explicit anonymous mode obtains an anonymous scoped token" {
     var response = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/_catalog",
     );
@@ -2360,7 +2367,7 @@ test "authenticated credential failures never downgrade to anonymous" {
         sendBuffered(
             allocator,
             &policy,
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .GET,
             "https://registry.example/v2/_catalog",
         ),
@@ -2423,7 +2430,7 @@ test "expired refresh and access tokens are refreshed before sending" {
     var first = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/one/manifests/latest",
     );
@@ -2432,7 +2439,7 @@ test "expired refresh and access tokens are refreshed before sending" {
     var second = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/one/manifests/latest",
     );
@@ -2501,7 +2508,7 @@ test "401 invalidates one scoped access token and replays exactly once" {
     var first = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/one/manifests/latest",
     );
@@ -2509,7 +2516,7 @@ test "401 invalidates one scoped access token and replays exactly once" {
     var second = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/one/manifests/latest",
     );
@@ -2582,10 +2589,10 @@ test "buffered request reuse restores SDK authorization across invalidation and 
     );
     defer policy.deinit();
     var policies = [_]*HttpPolicy{policy.asPolicy()};
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        testingRuntime(transport.asTransport()),
+        &policies,
+    );
     var request = Request.init(
         allocator,
         .GET,
@@ -2686,7 +2693,7 @@ test "repository scopes use isolated access token cache entries" {
     var one = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/one/manifests/latest",
     );
@@ -2694,7 +2701,7 @@ test "repository scopes use isolated access token cache entries" {
     var two = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/two/manifests/latest",
     );
@@ -2761,7 +2768,7 @@ test "concurrent token acquisition is single flight" {
     const AcquireContext = struct {
         policy: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         token: ?[]u8 = null,
         err: ?anyerror = null,
 
@@ -2769,7 +2776,7 @@ test "concurrent token acquisition is single flight" {
             self.token = self.policy.acquireAccessToken(
                 self.challenge,
                 null,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 self.err = err;
                 return;
@@ -2780,7 +2787,7 @@ test "concurrent token acquisition is single flight" {
     var first = AcquireContext{
         .policy = &policy,
         .challenge = &challenge,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     var second = first;
     const first_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&first});
@@ -2822,7 +2829,7 @@ test "untrusted request and challenge hosts never receive tokens" {
         sendBuffered(
             allocator,
             &policy,
-            untrusted_transport.asTransport(),
+            testingRuntime(untrusted_transport.asTransport()),
             .GET,
             "https://evil.example/v2/_catalog",
         ),
@@ -2848,7 +2855,7 @@ test "untrusted request and challenge hosts never receive tokens" {
         sendBuffered(
             allocator,
             &policy,
-            malicious_transport.asTransport(),
+            testingRuntime(malicious_transport.asTransport()),
             .GET,
             "https://registry.example/v2/_catalog",
         ),
@@ -2891,7 +2898,7 @@ test "token bootstrap redirects cannot forward AAD credentials" {
         sendBuffered(
             allocator,
             &policy,
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .GET,
             "https://registry.example/v2/_catalog",
         ),
@@ -2956,13 +2963,13 @@ test "refresh token cache keys include the challenge tenant" {
     const first_token = try policy.acquireAccessToken(
         &first,
         null,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
     );
     defer allocator.free(first_token);
     const second_token = try policy.acquireAccessToken(
         &second,
         null,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
     );
     defer allocator.free(second_token);
 
@@ -3023,7 +3030,7 @@ test "a replayed 401 is returned without a second replay" {
     var response = try sendBuffered(
         allocator,
         &policy,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .GET,
         "https://registry.example/v2/_catalog",
     );
@@ -3057,10 +3064,10 @@ test "non-rewindable streaming bodies are not replayed" {
     );
     defer policy.deinit();
     var policies = [_]*HttpPolicy{policy.asPolicy()};
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        testingRuntime(transport.asTransport()),
+        &policies,
+    );
     var request = Request.init(
         allocator,
         .PATCH,
@@ -3109,10 +3116,10 @@ test "rewindable streaming bodies are replayed once after authentication" {
     );
     defer policy.deinit();
     var policies = [_]*HttpPolicy{policy.asPolicy()};
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        testingRuntime(transport.asTransport()),
+        &policies,
+    );
     var request = Request.init(
         allocator,
         .PATCH,
@@ -3144,10 +3151,10 @@ test "streaming cancellation is preserved before transport" {
     );
     defer policy.deinit();
     var policies = [_]*HttpPolicy{policy.asPolicy()};
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        testingRuntime(transport.asTransport()),
+        &policies,
+    );
     var request = Request.init(allocator, .GET, "https://registry.example/v2/_catalog");
     defer request.deinit();
     var cancellation = CancellationToken{};
@@ -3184,10 +3191,10 @@ test "streaming challenge cancellation aborts and deinitializes the active opera
     var cancellation = CancellationToken{};
     var cancel_policy = CancelAfterOpenPolicy.init(&cancellation);
     var policies = [_]*HttpPolicy{ policy.asPolicy(), &cancel_policy.policy };
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        testingRuntime(transport.asTransport()),
+        &policies,
+    );
     var request = Request.init(allocator, .GET, "https://registry.example/v2/_catalog");
     defer request.deinit();
 
@@ -3250,10 +3257,10 @@ test "streaming request reuse restores SDK authorization across invalidation and
     );
     defer policy.deinit();
     var policies = [_]*HttpPolicy{policy.asPolicy()};
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        testingRuntime(transport.asTransport()),
+        &policies,
+    );
     var request = Request.init(allocator, .GET, "https://registry.example/v2/_catalog");
     defer request.deinit();
 
@@ -3355,13 +3362,13 @@ test "delayed unauthorized response preserves a newer same-key access token" {
         var delayed = AuthRaceRequest{
             .allocator = allocator,
             .policy = &policy,
-            .transport = transport.asTransport(),
+            .runtime = testingRuntime(transport.asTransport()),
             .path = path,
         };
         var refresher = AuthRaceRequest{
             .allocator = allocator,
             .policy = &policy,
-            .transport = transport.asTransport(),
+            .runtime = testingRuntime(transport.asTransport()),
             .path = path,
         };
         const delayed_thread = try std.Thread.spawn(
@@ -3451,7 +3458,7 @@ test "trusted origins compare HTTPS host and effective port" {
         sendBuffered(
             allocator,
             &default_policy,
-            unused_transport.asTransport(),
+            testingRuntime(unused_transport.asTransport()),
             .GET,
             "https://registry.example:8443/v2/_catalog",
         ),
@@ -3480,7 +3487,7 @@ test "trusted origins compare HTTPS host and effective port" {
         sendBuffered(
             allocator,
             &default_policy,
-            untrusted_transport.asTransport(),
+            testingRuntime(untrusted_transport.asTransport()),
             .GET,
             "https://registry.example/v2/_catalog",
         ),
@@ -3499,7 +3506,7 @@ test "trusted origins compare HTTPS host and effective port" {
         sendBuffered(
             allocator,
             &hostname_policy,
-            unused_transport.asTransport(),
+            testingRuntime(unused_transport.asTransport()),
             .GET,
             "https://auth.example:8443/v2/_catalog",
         ),
@@ -3536,7 +3543,7 @@ test "trusted origins compare HTTPS host and effective port" {
     var response = try sendBuffered(
         allocator,
         &explicit_policy,
-        explicit_transport.asTransport(),
+        testingRuntime(explicit_transport.asTransport()),
         .GET,
         "https://REGISTRY.example:8443/v2/_catalog",
     );
@@ -3608,7 +3615,7 @@ test "cached refresh rejection invalidates exact token and recovers once" {
     const token = try policy.acquireAccessToken(
         &challenge,
         null,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
     );
     defer allocator.free(token);
     try std.testing.expectEqualStrings(access_token, token);
@@ -3680,7 +3687,11 @@ test "refresh rejection retry is bounded and unrelated failures are not retried"
 
     try std.testing.expectError(
         error.AcrRefreshTokenRejected,
-        policy.acquireAccessToken(&challenge, null, transport.asTransport()),
+        policy.acquireAccessToken(
+            &challenge,
+            null,
+            testingRuntime(transport.asTransport()),
+        ),
     );
     try std.testing.expectEqual(@as(usize, 3), transport.call_count);
     try std.testing.expectEqual(@as(usize, 1), credential.calls.load(.monotonic));
@@ -3718,7 +3729,7 @@ test "refresh rejection retry is bounded and unrelated failures are not retried"
         unrelated_policy.acquireAccessToken(
             &challenge,
             null,
-            unrelated_transport.asTransport(),
+            testingRuntime(unrelated_transport.asTransport()),
         ),
     );
     try std.testing.expectEqual(@as(usize, 1), unrelated_transport.call_count);
@@ -3761,7 +3772,7 @@ test "token endpoint preserves authentication rejection classification" {
             "access_token",
             true,
             null,
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
         ),
     );
     try std.testing.expectError(
@@ -3772,7 +3783,7 @@ test "token endpoint preserves authentication rejection classification" {
             "access_token",
             true,
             null,
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
         ),
     );
     try std.testing.expectError(
@@ -3783,7 +3794,7 @@ test "token endpoint preserves authentication rejection classification" {
             "access_token",
             true,
             null,
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
         ),
     );
     try std.testing.expectEqual(@as(usize, 3), transport.call_count);
@@ -4135,7 +4146,7 @@ test "different access keys refresh concurrently while sharing refresh flight" {
     const AcquireContext = struct {
         policy: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         token: ?[]u8 = null,
         err: ?anyerror = null,
 
@@ -4143,7 +4154,7 @@ test "different access keys refresh concurrently while sharing refresh flight" {
             self.token = self.policy.acquireAccessToken(
                 self.challenge,
                 null,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 self.err = err;
                 return;
@@ -4153,12 +4164,12 @@ test "different access keys refresh concurrently while sharing refresh flight" {
     var first = AcquireContext{
         .policy = &policy,
         .challenge = &challenge_one,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     var second = AcquireContext{
         .policy = &policy,
         .challenge = &challenge_two,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     const first_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&first});
     const second_thread = std.Thread.spawn(.{}, AcquireContext.run, .{&second}) catch |err| {
@@ -4226,14 +4237,14 @@ test "same-key flight wakes waiters with the leader failure" {
     const AcquireContext = struct {
         policy: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         err: ?anyerror = null,
 
         fn run(self: *@This()) void {
             const token = self.policy.acquireAccessToken(
                 self.challenge,
                 null,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 self.err = err;
                 return;
@@ -4244,7 +4255,7 @@ test "same-key flight wakes waiters with the leader failure" {
     var first = AcquireContext{
         .policy = &policy,
         .challenge = &challenge,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     var second = first;
     const first_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&first});
@@ -4308,7 +4319,7 @@ test "cancelled refresh flight leader does not fail a non-cancelled follower" {
         policy: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         token: ?[]u8 = null,
         err: ?anyerror = null,
 
@@ -4316,7 +4327,7 @@ test "cancelled refresh flight leader does not fail a non-cancelled follower" {
             self.token = self.policy.acquireRefreshToken(
                 self.challenge,
                 self.cancellation,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 self.err = err;
                 return;
@@ -4327,13 +4338,13 @@ test "cancelled refresh flight leader does not fail a non-cancelled follower" {
         .policy = &policy,
         .challenge = &leader_challenge,
         .cancellation = &cancellation,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     var follower = AcquireContext{
         .policy = &policy,
         .challenge = &follower_challenge,
         .cancellation = null,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     const leader_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&leader});
     entered.waitUncancelable(policy.io);
@@ -4396,7 +4407,7 @@ test "cancelled access flight leader does not fail a non-cancelled follower" {
         policy: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         token: ?[]u8 = null,
         err: ?anyerror = null,
 
@@ -4404,7 +4415,7 @@ test "cancelled access flight leader does not fail a non-cancelled follower" {
             self.token = self.policy.acquireAccessToken(
                 self.challenge,
                 self.cancellation,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 self.err = err;
                 return;
@@ -4415,13 +4426,13 @@ test "cancelled access flight leader does not fail a non-cancelled follower" {
         .policy = &policy,
         .challenge = &leader_challenge,
         .cancellation = &cancellation,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     var follower = AcquireContext{
         .policy = &policy,
         .challenge = &follower_challenge,
         .cancellation = null,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     const leader_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&leader});
     transport.entered.waitUncancelable(policy.io);
@@ -4482,14 +4493,14 @@ test "policy deinit joins orphaned shared work after participant cancellation" {
         policy: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: *const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         err: ?anyerror = null,
 
         fn run(self: *@This()) void {
             const token = self.policy.acquireAccessToken(
                 self.challenge,
                 self.cancellation,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 self.err = err;
                 return;
@@ -4501,7 +4512,7 @@ test "policy deinit joins orphaned shared work after participant cancellation" {
         .policy = &policy,
         .challenge = &challenge,
         .cancellation = &cancellation,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     const acquire_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&acquire});
     transport.entered.waitUncancelable(policy.io);
@@ -4590,7 +4601,7 @@ test "cancelling a same-key waiter leaves the leader race safe" {
         policy: *ChallengeAuthenticationPolicy,
         challenge: *const BearerChallenge,
         cancellation: ?*const CancellationToken,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         token: ?[]u8 = null,
         err: ?anyerror = null,
 
@@ -4598,7 +4609,7 @@ test "cancelling a same-key waiter leaves the leader race safe" {
             self.token = self.policy.acquireAccessToken(
                 self.challenge,
                 self.cancellation,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 self.err = err;
                 return;
@@ -4609,13 +4620,13 @@ test "cancelling a same-key waiter leaves the leader race safe" {
         .policy = &policy,
         .challenge = &challenge,
         .cancellation = null,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     var waiter = AcquireContext{
         .policy = &policy,
         .challenge = &challenge,
         .cancellation = &cancellation,
-        .transport = transport.asTransport(),
+        .runtime = testingRuntime(transport.asTransport()),
     };
     const leader_thread = try std.Thread.spawn(.{}, AcquireContext.run, .{&leader});
     entered.waitUncancelable(policy.io);

--- a/src/blob_download.zig
+++ b/src/blob_download.zig
@@ -113,6 +113,7 @@ pub const BlobDownloadStream = struct {
 
     fn init(
         allocator: std.mem.Allocator,
+        provider: core.crypto.CryptoProvider,
         operation: *core.http.HttpOperation,
         requested_digest: []const u8,
         service_digest: ?[]const u8,
@@ -134,7 +135,9 @@ pub const BlobDownloadStream = struct {
             .digest = owned_digest,
             .content_length = content_length,
             .decoded_content_length = decoded_content_length,
-            .reader_impl = ValidatingReader.init(
+            .reader_impl = try ValidatingReader.init(
+                allocator,
+                provider,
                 operation,
                 owned_digest,
                 owned_service_digest,
@@ -215,6 +218,7 @@ pub const BlobDownloadStream = struct {
 
     pub fn deinit(self: *BlobDownloadStream) void {
         self.operation.deinit();
+        self.reader_impl.deinit();
         if (self.reader_impl.service_digest) |value| self.allocator.free(value);
         self.allocator.free(self.digest);
         self.* = undefined;
@@ -229,19 +233,21 @@ const ValidatingReader = struct {
     service_digest: ?[]u8,
     expected_length: ?u64,
     cancellation: ?*const core.http.CancellationToken,
-    hasher: digest_mod.Sha256Digest = .{},
+    hasher: digest_mod.Sha256Digest,
     computed_digest: [digest_mod.sha256_formatted_length]u8 = undefined,
     total: u64 = 0,
     complete: bool = false,
     failure: ?anyerror = null,
 
     fn init(
+        allocator: std.mem.Allocator,
+        provider: core.crypto.CryptoProvider,
         operation: *core.http.HttpOperation,
         requested_digest: []const u8,
         service_digest: ?[]u8,
         expected_length: ?u64,
         cancellation: ?*const core.http.CancellationToken,
-    ) ValidatingReader {
+    ) !ValidatingReader {
         return .{
             .interface = .{
                 .vtable = &.{ .stream = &stream },
@@ -255,7 +261,12 @@ const ValidatingReader = struct {
             .service_digest = service_digest,
             .expected_length = expected_length,
             .cancellation = cancellation,
+            .hasher = try digest_mod.Sha256Digest.init(allocator, provider),
         };
+    }
+
+    fn deinit(self: *ValidatingReader) void {
+        self.hasher.deinit();
     }
 
     fn stream(
@@ -288,8 +299,11 @@ const ValidatingReader = struct {
             }
         }
         self.checkCancellation() catch return error.ReadFailed;
+        self.hasher.update(buffer[0..count]) catch |err| {
+            self.failure = err;
+            return error.ReadFailed;
+        };
         try writer.writeAll(buffer[0..count]);
-        self.hasher.update(buffer[0..count]);
         self.total += count;
         return count;
     }
@@ -311,7 +325,10 @@ const ValidatingReader = struct {
                 return error.ContentLengthMismatch;
             }
         }
-        self.computed_digest = self.hasher.final();
+        self.computed_digest = self.hasher.final() catch |err| {
+            self.failure = err;
+            return err;
+        };
         if (!std.ascii.eqlIgnoreCase(&self.computed_digest, self.requested_digest)) {
             self.failure = error.RequestedDigestMismatch;
             return error.RequestedDigestMismatch;
@@ -469,6 +486,7 @@ pub const BlobDownloadClient = struct {
 
         const stream = try BlobDownloadStream.init(
             self.allocator,
+            self.pipeline().runtime.crypto,
             operation,
             requested_digest,
             service_digest,
@@ -503,7 +521,11 @@ pub const BlobDownloadClient = struct {
         if (options.range_size == 0) return error.InvalidRangeSize;
         try checkCancellation(options.cancellation);
 
-        var hasher = digest_mod.Sha256Digest{};
+        var hasher = try digest_mod.Sha256Digest.init(
+            self.allocator,
+            self.pipeline().runtime.crypto,
+        );
+        defer hasher.deinit();
         var confirmed: u64 = 0;
         var total_size: ?u64 = null;
         var retries: u32 = 0;
@@ -683,7 +705,7 @@ pub const BlobDownloadClient = struct {
             }
         }
 
-        const computed = hasher.final();
+        const computed = try hasher.final();
         if (!std.ascii.eqlIgnoreCase(&computed, requested_digest))
             return error.RequestedDigestMismatch;
         const owned_digest = try self.allocator.dupe(u8, &computed);
@@ -694,7 +716,7 @@ pub const BlobDownloadClient = struct {
         } };
     }
 
-    fn pipeline(self: *BlobDownloadClient) *core.pipeline.HttpPipeline {
+    fn pipeline(self: *BlobDownloadClient) *core.http.HttpPipeline {
         return &self.registry_client.protocolClient().pipeline;
     }
 
@@ -945,8 +967,8 @@ fn copyOperationBody(
             return;
         }
         try checkCancellationAndCancel(cancellation, operation);
+        try hasher.update(buffer[0..count]);
         try writer.writeAll(buffer[0..count]);
-        hasher.update(buffer[0..count]);
         confirmed.* += count;
         copied += count;
     }

--- a/src/blob_download_test.zig
+++ b/src/blob_download_test.zig
@@ -8,6 +8,13 @@ const isRetryableDownloadError = blob_download.isRetryableDownloadError;
 const isRetryableStatus = blob_download.isRetryableStatus;
 const copy_buffer_size: usize = 64 * 1024;
 
+fn testDigest(bytes: []const u8) ![digest_mod.sha256_formatted_length]u8 {
+    return digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        bytes,
+    );
+}
+
 fn checkCancellation(cancellation: ?*const core.http.CancellationToken) !void {
     if (cancellation) |token| {
         if (token.isCancelled()) return error.OperationCancelled;
@@ -16,14 +23,14 @@ fn checkCancellation(cancellation: ?*const core.http.CancellationToken) !void {
 
 fn testClient(
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
+    transport: core.http.HttpTransport,
 ) !BlobDownloadClient {
     return BlobDownloadClient.init(
         allocator,
         "https://registry.example",
         "team/app",
         .{
-            .transport = transport,
+            .runtime = @import("test_runtime.zig").init(transport),
             .authentication = .anonymous,
         },
     );
@@ -109,7 +116,6 @@ const DownloadTestTransport = struct {
 
     allocator: std.mem.Allocator,
     responses: []const ResponseSpec,
-    transport: core.http.HttpTransport,
     call_count: usize = 0,
     ranges: [32][96]u8 = undefined,
     range_lengths: [32]usize = .{0} ** 32,
@@ -131,12 +137,14 @@ const DownloadTestTransport = struct {
         return .{
             .allocator = allocator,
             .responses = responses,
-            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
 
-    fn asTransport(self: *DownloadTestTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *DownloadTestTransport) core.http.HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = &sendImpl, .open = &openImpl },
+        };
     }
 
     fn capturedRange(self: *const DownloadTestTransport, index: usize) []const u8 {
@@ -172,11 +180,10 @@ const DownloadTestTransport = struct {
     }
 
     fn sendImpl(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
     ) !core.http.Response {
-        const self: *DownloadTestTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+        const self: *DownloadTestTransport = @ptrCast(@alignCast(context));
         const index = try self.capture(request);
         const spec = self.responses[index];
         if (spec.open_error) |failure| return failure;
@@ -194,12 +201,11 @@ const DownloadTestTransport = struct {
     }
 
     fn openImpl(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        const self: *DownloadTestTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+        const self: *DownloadTestTransport = @ptrCast(@alignCast(context));
         try checkCancellation(options.cancellation);
         const index = try self.capture(request);
         const spec = self.responses[index];
@@ -394,7 +400,7 @@ const DownloadTestReader = struct {
 test "buffered blob download validates exact identity bytes and bound" {
     const allocator = std.testing.allocator;
     const body = "small blob";
-    const expected_digest = digest_mod.computeSha256Digest(body);
+    const expected_digest = try testDigest(body);
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "10" },
         .{ .name = "Docker-Content-Digest", .value = &expected_digest },
@@ -423,10 +429,44 @@ test "buffered blob download validates exact identity bytes and bound" {
     try std.testing.expectEqual(@as(usize, 1), transport.stream_abort_count);
 }
 
+test "blob download uses selected provider and propagates final failure" {
+    const allocator = std.testing.allocator;
+    const body = "provider-backed download";
+    const expected_digest = try testDigest(body);
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Content-Length", .value = "24" },
+        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
+    };
+    var transport = core.http.MockTransport.init(allocator, 200, body);
+    defer transport.deinit();
+    transport.response_headers_list = &headers;
+    var spy = @import("crypto_test_provider.zig").Spy.init(std.testing.io);
+    spy.failure = .final;
+    var client = try BlobDownloadClient.init(
+        allocator,
+        "https://registry.example",
+        "team/app",
+        .{
+            .runtime = .init(transport.asTransport(), spy.asProvider()),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+
+    try std.testing.expectError(
+        error.InjectedCryptoFailure,
+        client.downloadBlob(&expected_digest, .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 1), spy.sha256_init_calls);
+    try std.testing.expect(spy.update_calls > 0);
+    try std.testing.expectEqual(@as(usize, 1), spy.final_calls);
+    try std.testing.expectEqual(@as(usize, 1), transport.stream_abort_count);
+}
+
 test "buffered and streaming downloads distinguish identity and compressed lengths" {
     const allocator = std.testing.allocator;
     const body = "decoded bytes";
-    const expected_digest = digest_mod.computeSha256Digest(body);
+    const expected_digest = try testDigest(body);
     var headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "3" },
         .{ .name = "Content-Encoding", .value = "gzip" },
@@ -452,7 +492,7 @@ test "buffered and streaming downloads distinguish identity and compressed lengt
 test "streaming blob ownership supports finish abort cancellation and exact failures" {
     const allocator = std.testing.allocator;
     const body = "streamed";
-    const expected_digest = digest_mod.computeSha256Digest(body);
+    const expected_digest = try testDigest(body);
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "8" },
     };
@@ -514,7 +554,7 @@ test "streaming blob ownership supports finish abort cancellation and exact fail
 test "blob response content length headers are required unique and numeric" {
     const allocator = std.testing.allocator;
     const body = "length";
-    const digest = digest_mod.computeSha256Digest(body);
+    const digest = try testDigest(body);
     var transport = core.http.MockTransport.init(allocator, 200, body);
     defer transport.deinit();
     var client = try testClient(allocator, transport.asTransport());
@@ -554,7 +594,7 @@ test "blob response content length headers are required unique and numeric" {
 test "sequential ranged download validates 206 ranges and exact digest" {
     const allocator = std.testing.allocator;
     const body = "abcdefghij";
-    const expected_digest = digest_mod.computeSha256Digest(body);
+    const expected_digest = try testDigest(body);
     const headers_1 = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "4" },
         .{ .name = "Content-Range", .value = "bytes 0-3/10" },
@@ -596,7 +636,7 @@ test "sequential ranged download validates 206 ranges and exact digest" {
 test "ranged download accepts full 200 and terminal 416" {
     const allocator = std.testing.allocator;
     const body = "full body";
-    const expected_digest = digest_mod.computeSha256Digest(body);
+    const expected_digest = try testDigest(body);
     const full_headers = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "9" },
     };
@@ -617,7 +657,7 @@ test "ranged download accepts full 200 and terminal 416" {
     try std.testing.expectEqualStrings(body, output.writer.buffered());
     try std.testing.expectEqualStrings("bytes=0-3", full_transport.capturedRange(0));
 
-    const empty_digest = digest_mod.computeSha256Digest("");
+    const empty_digest = try testDigest("");
     const empty_headers = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "0" },
         .{ .name = "Content-Range", .value = "bytes */0" },
@@ -660,8 +700,8 @@ test "ranged download accepts full 200 and terminal 416" {
 
 test "ranged and fallback downloads validate optional service digest and full bytes" {
     const allocator = std.testing.allocator;
-    const requested_digest = digest_mod.computeSha256Digest("range");
-    const other_digest = digest_mod.computeSha256Digest("other");
+    const requested_digest = try testDigest("range");
+    const other_digest = try testDigest("other");
     const range_headers = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "5" },
         .{ .name = "Content-Range", .value = "bytes 0-4/5" },
@@ -770,7 +810,7 @@ test "ranged and fallback downloads validate optional service digest and full by
 test "partial ranged reads resume at confirmed writer offset without duplication" {
     const allocator = std.testing.allocator;
     const body = "abcdefghij";
-    const expected_digest = digest_mod.computeSha256Digest(body);
+    const expected_digest = try testDigest(body);
     const first_headers = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "6" },
         .{ .name = "Content-Range", .value = "bytes 0-5/10" },
@@ -816,7 +856,7 @@ test "partial ranged reads resume at confirmed writer offset without duplication
 test "range retries classify open status and read failures without broad fallback" {
     const allocator = std.testing.allocator;
     const body = "retry";
-    const expected_digest = digest_mod.computeSha256Digest(body);
+    const expected_digest = try testDigest(body);
     const headers = [_]DownloadTestTransport.Header{
         .{ .name = "Content-Length", .value = "5" },
         .{ .name = "Content-Range", .value = "bytes 0-4/5" },
@@ -854,7 +894,7 @@ test "range retries classify open status and read failures without broad fallbac
 
 test "range validation rejects malformed offsets spans lengths encodings and totals" {
     const allocator = std.testing.allocator;
-    const digest = digest_mod.computeSha256Digest("abcd");
+    const digest = try testDigest("abcd");
     var output: std.Io.Writer.Allocating = .init(allocator);
     defer output.deinit();
 
@@ -958,8 +998,8 @@ test "range validation rejects malformed offsets spans lengths encodings and tot
 test "direct blob downloads allow absent service digest and validate present digests" {
     const allocator = std.testing.allocator;
     const body = "digest bytes";
-    const requested_digest = digest_mod.computeSha256Digest(body);
-    const other_digest = digest_mod.computeSha256Digest("other");
+    const requested_digest = try testDigest(body);
+    const other_digest = try testDigest("other");
     const missing_headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "12" },
     };
@@ -1019,7 +1059,7 @@ test "direct blob downloads allow absent service digest and validate present dig
 
 test "blob download preserves structured ACR service errors" {
     const allocator = std.testing.allocator;
-    const digest = digest_mod.computeSha256Digest("missing");
+    const digest = try testDigest("missing");
     const body =
         "{\"errors\":[{\"code\":\"BLOB_UNKNOWN\",\"message\":\"missing blob\"}]}";
     var transport = core.http.MockTransport.init(allocator, 404, body);
@@ -1041,7 +1081,7 @@ test "blob download preserves structured ACR service errors" {
 
 test "cross-origin blob redirects strip credentials and insecure redirects fail" {
     const allocator = std.testing.allocator;
-    const digest = digest_mod.computeSha256Digest("redirected");
+    const digest = try testDigest("redirected");
     const redirect_headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Location", .value = "https://storage.example/blob#fragment" },
     };
@@ -1097,8 +1137,8 @@ test "cross-origin blob redirects strip credentials and insecure redirects fail"
 test "redirected blob downloads allow absent service digest and validate present digests" {
     const allocator = std.testing.allocator;
     const body = "redirected";
-    const requested_digest = digest_mod.computeSha256Digest(body);
-    const other_digest = digest_mod.computeSha256Digest("other");
+    const requested_digest = try testDigest(body);
+    const other_digest = try testDigest("other");
 
     try expectRedirectedBlobDownload(
         allocator,
@@ -1133,7 +1173,7 @@ test "redirected blob downloads allow absent service digest and validate present
 test "ranged resume restarts from registry instead of retaining redirect continuation" {
     const allocator = std.testing.allocator;
     const body = "abcd";
-    const digest = digest_mod.computeSha256Digest(body);
+    const digest = try testDigest(body);
     const redirect_1 = [_]DownloadTestTransport.Header{
         .{ .name = "Location", .value = "https://storage-one.example/blob" },
     };
@@ -1199,7 +1239,7 @@ test "large ranged writer path keeps SDK copy and request sizes bounded" {
     const body = try allocator.alloc(u8, 140 * 1024);
     defer allocator.free(body);
     for (body, 0..) |*byte, index| byte.* = @truncate(index);
-    const digest = digest_mod.computeSha256Digest(body);
+    const digest = try testDigest(body);
     var range_1_buffer: [64]u8 = undefined;
     const range_1 = try std.fmt.bufPrint(
         &range_1_buffer,
@@ -1260,7 +1300,7 @@ test "large ranged writer path keeps SDK copy and request sizes bounded" {
 
 fn bufferedAllocationFixture(allocator: std.mem.Allocator) !void {
     const body = "allocation";
-    const digest = digest_mod.computeSha256Digest(body);
+    const digest = try testDigest(body);
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "10" },
         .{ .name = "Docker-Content-Digest", .value = &digest },

--- a/src/blob_upload.zig
+++ b/src/blob_upload.zig
@@ -35,7 +35,7 @@ pub const BlobUploadResponse = service_error.Result(BlobUploadResult);
 
 pub const UploadContext = struct {
     allocator: std.mem.Allocator,
-    pipeline: *core.pipeline.HttpPipeline,
+    pipeline: *core.http.HttpPipeline,
     endpoint: []const u8,
     api_version: []const u8,
     repository_name: []const u8,
@@ -52,6 +52,12 @@ pub fn upload(
     const buffer = try context.allocator.alloc(u8, options.chunk_size);
     defer context.allocator.free(buffer);
 
+    var digest = try digest_mod.Sha256Digest.init(
+        context.allocator,
+        context.pipeline.runtime.crypto,
+    );
+    defer digest.deinit();
+
     var start_result = try startUpload(context, options);
     switch (start_result) {
         .err => |failure| return .{ .err = failure },
@@ -60,7 +66,6 @@ pub fn upload(
             start_result = undefined;
             defer session.deinit();
 
-            var digest = digest_mod.Sha256Digest{};
             var total: u64 = 0;
             while (true) {
                 checkCancelled(options.cancellation) catch |err| {
@@ -104,7 +109,9 @@ pub fn upload(
                 total += count;
             }
 
-            const computed_digest = digest.final();
+            const computed_digest = digest.final() catch |err| {
+                return failAfterCleanup(context, &session, err);
+            };
             const completion_result = completeUpload(
                 context,
                 &session,
@@ -286,10 +293,6 @@ fn uploadChunk(
             attempt_start,
             @as(u64, @intCast(attempt.len)),
         ) catch return error.BlobUploadTooLarge;
-        const digest_snapshot = digest.*;
-        const cursor_snapshot = cursor;
-        digest.update(attempt);
-
         const request_url = try buildContinuationUrl(
             context,
             session.location,
@@ -328,8 +331,6 @@ fn uploadChunk(
                 .cancellation = options.cancellation,
             },
         ) catch |err| {
-            digest.* = digest_snapshot;
-            cursor = cursor_snapshot;
             if (err == error.OperationCancelled) return err;
             if (!request.transport_started) {
                 if (!isRetryablePreTransportError(err) or
@@ -394,6 +395,7 @@ fn uploadChunk(
                 request_url,
             );
             errdefer context.allocator.free(next_location);
+            try digest.update(attempt);
             try operation.finish();
             session.replaceLocation(next_location);
             session.confirmed_offset = response_offset;
@@ -401,8 +403,6 @@ fn uploadChunk(
             return .{ .ok = {} };
         }
 
-        digest.* = digest_snapshot;
-        cursor = cursor_snapshot;
         if (operation.status_code == 416) {
             const range = try requiredHeader(
                 context.allocator,
@@ -510,7 +510,7 @@ fn applyRecoveredOffset(
         return error.ServerUploadOffsetDiverged;
     const delta: usize = @intCast(recovered_offset - current_offset);
     if (delta > 0) {
-        digest.update(chunk[cursor.* .. cursor.* + delta]);
+        try digest.update(chunk[cursor.* .. cursor.* + delta]);
         cursor.* += delta;
     }
     session.confirmed_offset = recovered_offset;
@@ -1191,10 +1191,11 @@ test "cleanup uses standard bodiless DELETE framing and reports its own failure"
     defer session.deinit();
     var transport = core.http.StdHttpTransport.init(allocator, io);
     defer transport.deinit();
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    var crypto = core.crypto.StdCryptoProvider.init(io);
+    var pipeline = core.http.HttpPipeline.init(
+        .init(transport.asTransport(), crypto.asProvider()),
+        &.{},
+    );
 
     const thread = try std.Thread.spawn(.{}, CleanupTestServer.run, .{&server_context});
     const cleanup_result = cleanupUpload(.{

--- a/src/blob_upload.zig
+++ b/src/blob_upload.zig
@@ -394,10 +394,9 @@ fn uploadChunk(
                 operation,
                 request_url,
             );
-            errdefer context.allocator.free(next_location);
+            session.replaceLocation(next_location);
             try digest.update(attempt);
             try operation.finish();
-            session.replaceLocation(next_location);
             session.confirmed_offset = response_offset;
             cursor = chunk.len;
             return .{ .ok = {} };

--- a/src/blob_upload_test.zig
+++ b/src/blob_upload_test.zig
@@ -303,7 +303,7 @@ test "blob upload propagates incremental provider failure and cleans session" {
         } },
         .{ .response = .{
             .status = 202,
-            .headers = successHeaders("/upload/id", "0-15", "id"),
+            .headers = successHeaders("/upload/new-id", "0-15", "id"),
         } },
         .{ .response = .{ .status = 204 } },
     };
@@ -330,6 +330,10 @@ test "blob upload propagates incremental provider failure and cleans session" {
     try std.testing.expectEqual(@as(usize, 1), spy.update_calls);
     try std.testing.expectEqual(@as(usize, 3), transport.call_count);
     try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
+    try std.testing.expectEqualStrings(
+        "https://registry.example/upload/new-id?api-version=2021-07-01",
+        transport.captures[2].urlSlice(),
+    );
 }
 
 fn expectUpload(

--- a/src/blob_upload_test.zig
+++ b/src/blob_upload_test.zig
@@ -11,6 +11,13 @@ const UploadContext = upload_mod.UploadContext;
 const max_chunk_size = upload_mod.max_chunk_size;
 const upload = upload_mod.upload;
 
+fn testDigest(bytes: []const u8) ![digest_mod.sha256_formatted_length]u8 {
+    return digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        bytes,
+    );
+}
+
 const TestHeader = struct {
     name: []const u8,
     value: []const u8,
@@ -62,7 +69,6 @@ const TestCapture = struct {
 const ScriptedTransport = struct {
     allocator: std.mem.Allocator,
     actions: []const TestAction,
-    transport: core.http.HttpTransport,
     call_count: usize = 0,
     captures: [64]TestCapture = [_]TestCapture{.{}} ** 64,
     finish_count: usize = 0,
@@ -77,28 +83,29 @@ const ScriptedTransport = struct {
         return .{
             .allocator = allocator,
             .actions = actions,
-            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
 
-    fn asTransport(self: *ScriptedTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *ScriptedTransport) core.http.HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = &sendImpl, .open = &openImpl },
+        };
     }
 
     fn sendImpl(
-        _: *core.http.HttpTransport,
+        _: *anyopaque,
         _: *core.http.Request,
     ) !core.http.Response {
         return error.UnexpectedBufferedSend;
     }
 
     fn openImpl(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        const self: *ScriptedTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
+        const self: *ScriptedTransport = @ptrCast(@alignCast(context));
         if (self.call_count >= self.actions.len)
             return error.NoScriptedResponse;
         if (self.call_count >= self.captures.len)
@@ -273,10 +280,10 @@ fn testUpload(
     reader: *std.Io.Reader,
     options: BlobUploadOptions,
 ) !BlobUploadResponse {
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        @import("test_runtime.zig").init(transport.asTransport()),
+        &.{},
+    );
     return upload(.{
         .allocator = allocator,
         .pipeline = &pipeline,
@@ -284,6 +291,45 @@ fn testUpload(
         .api_version = "2021-07-01",
         .repository_name = "team/app",
     }, reader, options);
+}
+
+test "blob upload propagates incremental provider failure and cleans session" {
+    const allocator = std.testing.allocator;
+    const bytes = "provider failure";
+    const actions = [_]TestAction{
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-0", "id"),
+        } },
+        .{ .response = .{
+            .status = 202,
+            .headers = successHeaders("/upload/id", "0-15", "id"),
+        } },
+        .{ .response = .{ .status = 204 } },
+    };
+    var transport = ScriptedTransport.init(allocator, &actions);
+    var spy = @import("crypto_test_provider.zig").Spy.init(std.testing.io);
+    spy.failure = .update;
+    var pipeline = core.http.HttpPipeline.init(
+        .init(transport.asTransport(), spy.asProvider()),
+        &.{},
+    );
+    var reader = std.Io.Reader.fixed(bytes);
+
+    try std.testing.expectError(
+        error.InjectedCryptoFailure,
+        upload(.{
+            .allocator = allocator,
+            .pipeline = &pipeline,
+            .endpoint = "https://registry.example",
+            .api_version = "2021-07-01",
+            .repository_name = "team/app",
+        }, &reader, .{ .chunk_size = bytes.len }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), spy.sha256_init_calls);
+    try std.testing.expectEqual(@as(usize, 1), spy.update_calls);
+    try std.testing.expectEqual(@as(usize, 3), transport.call_count);
+    try std.testing.expectEqual(core.http.Method.DELETE, transport.captures[2].method);
 }
 
 fn expectUpload(
@@ -329,7 +375,7 @@ fn completionHeaders(
 
 test "blob upload accepts empty content" {
     const allocator = std.testing.allocator;
-    const digest = digest_mod.computeSha256Digest("");
+    const digest = try testDigest("");
     const complete_headers = completionHeaders(
         "/v2/team/app/blobs/empty",
         "0-0",
@@ -363,7 +409,7 @@ test "blob upload accepts empty content" {
 
 test "content client exposes high-level blob upload" {
     const allocator = std.testing.allocator;
-    const digest = digest_mod.computeSha256Digest("public");
+    const digest = try testDigest("public");
     const complete_headers = completionHeaders("/blob/final", "0-5", &digest);
     const actions = [_]TestAction{
         .{ .response = .{
@@ -382,7 +428,7 @@ test "content client exposes high-level blob upload" {
         "https://registry.example",
         "team/app",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -397,7 +443,7 @@ test "content client exposes high-level blob upload" {
 test "blob upload sends one exact ranged chunk" {
     const allocator = std.testing.allocator;
     const bytes = "hello";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders(
         "/v2/team/app/blobs/final",
         "0-4",
@@ -429,7 +475,7 @@ test "blob upload sends one exact ranged chunk" {
 test "blob upload sends sequential multiple chunks" {
     const allocator = std.testing.allocator;
     const bytes = "abcdefghij";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-9", &digest);
     const actions = [_]TestAction{
         .{ .response = .{
@@ -470,7 +516,7 @@ test "blob upload sends sequential multiple chunks" {
 test "blob upload exact chunk boundary does not send an empty patch" {
     const allocator = std.testing.allocator;
     const bytes = "abcdefgh";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-7", &digest);
     const actions = [_]TestAction{
         .{ .response = .{
@@ -543,7 +589,7 @@ const PartialReader = struct {
 test "blob upload supports non-seekable partial readers" {
     const allocator = std.testing.allocator;
     const bytes = "partial-reader";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-13", &digest);
     const actions = [_]TestAction{
         .{ .response = .{
@@ -580,7 +626,7 @@ test "blob upload supports non-seekable partial readers" {
 }
 
 const FailBeforeTransportPolicy = struct {
-    policy: core.pipeline.HttpPolicy,
+    policy: core.http.HttpPolicy,
     remaining_failures: usize,
     failure_count: usize = 0,
 
@@ -595,28 +641,32 @@ const FailBeforeTransportPolicy = struct {
         };
     }
 
-    fn asPolicy(self: *FailBeforeTransportPolicy) *core.pipeline.HttpPolicy {
+    fn asPolicy(self: *FailBeforeTransportPolicy) *core.http.HttpPolicy {
         return &self.policy;
     }
 
-    fn prepareImpl(_: *core.pipeline.HttpPolicy, _: *core.http.Request) !void {}
+    fn prepareImpl(
+        _: *core.http.HttpPolicy,
+        _: *core.http.Request,
+        _: core.http.HttpRuntime,
+    ) !void {}
 
     fn processImpl(
-        _: *core.pipeline.HttpPolicy,
+        _: *core.http.HttpPolicy,
         request: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) !core.http.Response {
-        if (next.len == 0) return transport.send(request);
-        return next[0].process(request, next[1..], transport);
+        if (next.len == 0) return runtime.transport.send(request);
+        return next[0].process(request, next[1..], runtime);
     }
 
     fn openImpl(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         request: *core.http.Request,
         options: core.http.OpenOptions,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) !*core.http.HttpOperation {
         const self: *FailBeforeTransportPolicy =
             @alignCast(@fieldParentPtr("policy", policy));
@@ -625,15 +675,15 @@ const FailBeforeTransportPolicy = struct {
             self.failure_count += 1;
             return error.InjectedPreTransportFailure;
         }
-        if (next.len == 0) return transport.open(request, options);
-        return next[0].open(request, options, next[1..], transport);
+        if (next.len == 0) return runtime.transport.open(request, options);
+        return next[0].open(request, options, next[1..], runtime);
     }
 };
 
 test "blob upload retries failures before transport starts" {
     const allocator = std.testing.allocator;
     const bytes = "retry";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-4", &digest);
     const actions = [_]TestAction{
         .{ .response = .{
@@ -648,11 +698,11 @@ test "blob upload retries failures before transport starts" {
     };
     var transport = ScriptedTransport.init(allocator, &actions);
     var failure_policy = FailBeforeTransportPolicy.init(1);
-    var policies = [_]*core.pipeline.HttpPolicy{failure_policy.asPolicy()};
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &policies,
-        .transport_impl = transport.asTransport(),
-    };
+    var policies = [_]*core.http.HttpPolicy{failure_policy.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        @import("test_runtime.zig").init(transport.asTransport()),
+        &policies,
+    );
     var reader = std.Io.Reader.fixed(bytes);
     var response = try upload(.{
         .allocator = allocator,
@@ -672,7 +722,7 @@ test "blob upload retries failures before transport starts" {
 test "blob upload recovers a fully accepted uncertain chunk" {
     const allocator = std.testing.allocator;
     const bytes = "recover";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-6", &digest);
     const status_headers = [_]TestHeader{
         .{ .name = "Range", .value = "bytes=0-6" },
@@ -703,7 +753,7 @@ test "blob upload recovers a fully accepted uncertain chunk" {
 test "blob upload resumes the confirmed suffix after uncertain transport" {
     const allocator = std.testing.allocator;
     const bytes = "abcdef";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-5", &digest);
     const status_headers = [_]TestHeader{
         .{ .name = "Range", .value = "0-1" },
@@ -742,7 +792,7 @@ test "blob upload resumes the confirmed suffix after uncertain transport" {
 test "blob upload restores digest and chunk cursor before retry" {
     const allocator = std.testing.allocator;
     const bytes = "abcdefgh";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-7", &digest);
     const status_headers = [_]TestHeader{
         .{ .name = "Range", .value = "0-3" },
@@ -881,7 +931,7 @@ test "blob upload validates every continuation Location origin" {
 
 test "blob upload origin comparison includes effective HTTPS port" {
     const allocator = std.testing.allocator;
-    const digest = digest_mod.computeSha256Digest("");
+    const digest = try testDigest("");
     const complete_headers = completionHeaders(
         "https://REGISTRY.example:8443/blob/final",
         "0-0",
@@ -899,10 +949,10 @@ test "blob upload origin comparison includes effective HTTPS port" {
         .{ .response = .{ .status = 201, .headers = &complete_headers } },
     };
     var transport = ScriptedTransport.init(allocator, &actions);
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        @import("test_runtime.zig").init(transport.asTransport()),
+        &.{},
+    );
     var reader = std.Io.Reader.fixed("");
     var response = try upload(.{
         .allocator = allocator,
@@ -923,10 +973,10 @@ test "blob upload origin comparison includes effective HTTPS port" {
         .{ .response = .{ .status = 202, .headers = &wrong_port_headers } },
     };
     var wrong_transport = ScriptedTransport.init(allocator, &wrong_actions);
-    var wrong_pipeline = core.pipeline.HttpPipeline{
-        .policies = &.{},
-        .transport_impl = wrong_transport.asTransport(),
-    };
+    var wrong_pipeline = core.http.HttpPipeline.init(
+        @import("test_runtime.zig").init(wrong_transport.asTransport()),
+        &.{},
+    );
     var wrong_reader = std.Io.Reader.fixed("");
     try std.testing.expectError(
         error.UntrustedUploadLocation,
@@ -943,7 +993,7 @@ test "blob upload origin comparison includes effective HTTPS port" {
 test "blob upload recovers uncertain completion through upload status" {
     const allocator = std.testing.allocator;
     const bytes = "done";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-3", &digest);
     const status_headers = [_]TestHeader{
         .{ .name = "Range", .value = "0-3" },
@@ -974,7 +1024,7 @@ test "blob upload recovers uncertain completion through upload status" {
 test "blob upload verifies the final blob when completion closed the session" {
     const allocator = std.testing.allocator;
     const bytes = "done";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const head_headers = [_]TestHeader{
         .{ .name = "Docker-Content-Digest", .value = &digest },
         .{ .name = "Content-Length", .value = "4" },
@@ -1006,7 +1056,7 @@ test "blob upload verifies the final blob when completion closed the session" {
 test "blob upload rejects a mismatched final service digest" {
     const allocator = std.testing.allocator;
     const bytes = "expected";
-    const wrong_digest = digest_mod.computeSha256Digest("different");
+    const wrong_digest = try testDigest("different");
     const complete_headers = completionHeaders(
         "/blob/final",
         "0-7",
@@ -1217,7 +1267,7 @@ test "blob upload accepts a seekable reader at its current position" {
     const allocator = std.testing.allocator;
     const bytes = "prefix-content";
     const uploaded = "content";
-    const digest = digest_mod.computeSha256Digest(uploaded);
+    const digest = try testDigest(uploaded);
     const complete_headers = completionHeaders("/blob/final", "0-6", &digest);
     const actions = [_]TestAction{
         .{ .response = .{
@@ -1249,7 +1299,7 @@ test "blob upload accepts a seekable reader at its current position" {
 test "blob upload resumes from a 416 confirmed range" {
     const allocator = std.testing.allocator;
     const bytes = "abcdef";
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders("/blob/final", "0-5", &digest);
     const range_headers = [_]TestHeader{
         .{ .name = "Location", .value = "/upload/id?_state=range" },
@@ -1383,7 +1433,7 @@ test "blob upload allocations stay bounded by one configured chunk" {
     const bytes = try backing.alloc(u8, chunk_size * 3 + 17);
     defer backing.free(bytes);
     @memset(bytes, 'x');
-    const digest = digest_mod.computeSha256Digest(bytes);
+    const digest = try testDigest(bytes);
     const complete_headers = completionHeaders(
         "/blob/final",
         "0-196624",
@@ -1432,7 +1482,6 @@ test "blob upload allocations stay bounded by one configured chunk" {
 
 const AllocationTransport = struct {
     allocator: std.mem.Allocator,
-    transport: core.http.HttpTransport,
     finish_count: usize = 0,
     abort_count: usize = 0,
     deinit_count: usize = 0,
@@ -1440,29 +1489,30 @@ const AllocationTransport = struct {
     fn init(allocator: std.mem.Allocator) AllocationTransport {
         return .{
             .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl, .openFn = &openImpl },
         };
     }
 
-    fn asTransport(self: *AllocationTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *AllocationTransport) core.http.HttpTransport {
+        return .{
+            .context = self,
+            .vtable = &.{ .send = &sendImpl, .open = &openImpl },
+        };
     }
 
     fn sendImpl(
-        _: *core.http.HttpTransport,
+        _: *anyopaque,
         _: *core.http.Request,
     ) !core.http.Response {
         return error.UnexpectedBufferedSend;
     }
 
     fn openImpl(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
         _: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        const self: *AllocationTransport =
-            @alignCast(@fieldParentPtr("transport", transport));
-        const empty_digest = digest_mod.computeSha256Digest("");
+        const self: *AllocationTransport = @ptrCast(@alignCast(context));
+        const empty_digest = try testDigest("");
         return switch (request.method) {
             .POST => AllocationOperation.create(self, 202, &.{
                 .{ .name = "Location", .value = "/upload/id" },
@@ -1548,10 +1598,10 @@ const AllocationOperation = struct {
 
 fn uploadAllocationFixture(allocator: std.mem.Allocator) !void {
     var transport = AllocationTransport.init(std.testing.allocator);
-    var pipeline = core.pipeline.HttpPipeline{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    var pipeline = core.http.HttpPipeline.init(
+        @import("test_runtime.zig").init(transport.asTransport()),
+        &.{},
+    );
     var reader = std.Io.Reader.fixed("");
     var response = upload(.{
         .allocator = allocator,

--- a/src/client.zig
+++ b/src/client.zig
@@ -38,7 +38,7 @@ pub const ListTagPropertiesOptions = struct {
 };
 
 pub const ContainerRegistryClientOptions = struct {
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
     authentication: auth.Authentication,
     api_version: []const u8 = "2021-07-01",
     authentication_options: auth.Options = .{},
@@ -48,8 +48,8 @@ pub const ContainerRegistryClientOptions = struct {
 pub const ContainerRegistryClient = struct {
     allocator: std.mem.Allocator,
     auth_policy: *auth.ChallengeAuthenticationPolicy,
-    policy_ptrs: []*core.pipeline.HttpPolicy,
-    pipeline: core.pipeline.HttpPipeline,
+    policy_ptrs: []*core.http.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
     endpoint: []const u8,
     api_version: []const u8,
     protocol_client: protocol.ContainerRegistryClient,
@@ -71,14 +71,11 @@ pub const ContainerRegistryClient = struct {
         );
         errdefer auth_policy.deinit();
 
-        const policy_ptrs = try allocator.alloc(*core.pipeline.HttpPolicy, 1);
+        const policy_ptrs = try allocator.alloc(*core.http.HttpPolicy, 1);
         errdefer allocator.free(policy_ptrs);
         policy_ptrs[0] = auth_policy.asPolicy();
 
-        const pipeline = core.pipeline.HttpPipeline{
-            .policies = policy_ptrs,
-            .transport_impl = options.transport,
-        };
+        const pipeline = core.http.HttpPipeline.init(options.runtime, policy_ptrs);
         return .{
             .allocator = allocator,
             .auth_policy = auth_policy,
@@ -86,8 +83,7 @@ pub const ContainerRegistryClient = struct {
             .pipeline = pipeline,
             .endpoint = auth_policy.endpoint,
             .api_version = auth_policy.api_version,
-            .protocol_client = protocol.ContainerRegistryClient.initWithPipeline(
-                allocator,
+            .protocol_client = protocol.ContainerRegistryClient.init(
                 pipeline,
                 .{
                     .endpoint = auth_policy.endpoint,
@@ -98,7 +94,6 @@ pub const ContainerRegistryClient = struct {
     }
 
     pub fn deinit(self: *ContainerRegistryClient) void {
-        self.protocol_client.deinit();
         self.allocator.free(self.policy_ptrs);
         self.auth_policy.deinit();
         self.allocator.destroy(self.auth_policy);
@@ -576,7 +571,7 @@ test "ContainerRegistryClient drives generated protocol APIs through challenge a
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );

--- a/src/content_client.zig
+++ b/src/content_client.zig
@@ -154,7 +154,10 @@ pub const ContainerRegistryContentClient = struct {
     ) !UploadManifestResponse {
         if (manifest.len > max_manifest_size) return error.ManifestTooLarge;
 
-        const computed = digest_mod.computeSha256Digest(manifest);
+        const computed = try digest_mod.computeSha256Digest(
+            self.pipeline().runtime.crypto,
+            manifest,
+        );
         const reference = options.reference orelse computed[0..];
         const reference_kind = try validateManifestReference(reference);
         if (reference_kind == .digest and
@@ -253,6 +256,7 @@ pub const ContainerRegistryContentClient = struct {
 
         const buffered = try readManifestBody(
             self.allocator,
+            self.pipeline().runtime.crypto,
             operation,
             capacity_hint,
             expected_length,
@@ -352,7 +356,7 @@ pub const ContainerRegistryContentClient = struct {
         return self.uploadBlob(&reader, options);
     }
 
-    fn pipeline(self: *ContainerRegistryContentClient) *core.pipeline.HttpPipeline {
+    fn pipeline(self: *ContainerRegistryContentClient) *core.http.HttpPipeline {
         return &self.registry_client.protocolClient().pipeline;
     }
 
@@ -549,6 +553,7 @@ const BufferedManifest = struct {
 
 fn readManifestBody(
     allocator: std.mem.Allocator,
+    provider: core.crypto.CryptoProvider,
     operation: *core.http.HttpOperation,
     capacity_hint: usize,
     expected_length: ?usize,
@@ -559,7 +564,8 @@ fn readManifestBody(
         try body.ensureTotalCapacityPrecise(allocator, capacity_hint);
     }
 
-    var digest = digest_mod.Sha256Digest{};
+    var digest = try digest_mod.Sha256Digest.init(allocator, provider);
+    defer digest.deinit();
     const reader = try operation.reader();
     var buffer: [16 * 1024]u8 = undefined;
     var total: usize = 0;
@@ -574,16 +580,17 @@ fn readManifestBody(
             if (count > length -| total) return error.ContentLengthMismatch;
         }
         try body.appendSlice(allocator, buffer[0..count]);
-        digest.update(buffer[0..count]);
+        try digest.update(buffer[0..count]);
         total += count;
     }
     if (expected_length) |length| {
         if (total != length) return error.ContentLengthMismatch;
     }
 
+    const computed_digest = try digest.final();
     return .{
         .bytes = try body.toOwnedSlice(allocator),
-        .digest = digest.final(),
+        .digest = computed_digest,
     };
 }
 
@@ -596,14 +603,14 @@ fn hasPayloadDeinit(comptime T: type) bool {
 
 fn testClient(
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
+    transport: core.http.HttpTransport,
 ) !ContainerRegistryContentClient {
     return ContainerRegistryContentClient.init(
         allocator,
         "https://registry.example",
         "team/app",
         .{
-            .transport = transport,
+            .runtime = @import("test_runtime.zig").init(transport),
             .authentication = .anonymous,
         },
     );
@@ -621,10 +628,70 @@ fn capturedHeader(
     return null;
 }
 
+test "manifest upload uses selected runtime crypto provider" {
+    const allocator = std.testing.allocator;
+    const manifest = "{\"schemaVersion\":2}\n";
+    var spy = @import("crypto_test_provider.zig").Spy.init(std.testing.io);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
+    const headers = [_]core.http.MockTransport.HeaderPair{
+        .{ .name = "Docker-Content-Digest", .value = &expected_digest },
+    };
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    transport.response_headers_list = &headers;
+    var client = try ContainerRegistryContentClient.init(
+        allocator,
+        "https://registry.example",
+        "team/app",
+        .{
+            .runtime = .init(transport.asTransport(), spy.asProvider()),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+
+    var result = try client.uploadManifest(manifest, .{ .reference = "v1" });
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), spy.sha256_calls);
+    try std.testing.expectEqual(@as(usize, 0), spy.sha256_init_calls);
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+}
+
+test "manifest crypto failure happens before transport" {
+    const allocator = std.testing.allocator;
+    var spy = @import("crypto_test_provider.zig").Spy.init(std.testing.io);
+    spy.failure = .sha256;
+    var transport = core.http.MockTransport.init(allocator, 201, "");
+    defer transport.deinit();
+    var client = try ContainerRegistryContentClient.init(
+        allocator,
+        "https://registry.example",
+        "team/app",
+        .{
+            .runtime = .init(transport.asTransport(), spy.asProvider()),
+            .authentication = .anonymous,
+        },
+    );
+    defer client.deinit();
+
+    try std.testing.expectError(
+        error.InjectedCryptoFailure,
+        client.uploadManifest("{\"schemaVersion\":2}", .{ .reference = "v1" }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), spy.sha256_calls);
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
+
 test "upload preserves exact bytes with OCI default and tag reference" {
     const allocator = std.testing.allocator;
     const manifest = "{\"schemaVersion\":2, \"layers\":[]}\n";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Docker-Content-Digest", .value = &expected_digest },
     };
@@ -652,7 +719,10 @@ test "upload preserves exact bytes with OCI default and tag reference" {
 test "upload supports Docker media type and digest reference" {
     const allocator = std.testing.allocator;
     const manifest = "{\"schemaVersion\":2,\"mediaType\":\"docker\"}";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Docker-Content-Digest", .value = &expected_digest },
     };
@@ -681,8 +751,14 @@ test "upload supports Docker media type and digest reference" {
 test "upload validates references and returned digest" {
     const allocator = std.testing.allocator;
     const manifest = "{\"schemaVersion\":2}";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
-    const other_digest = digest_mod.computeSha256Digest("{\"schemaVersion\":1}");
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
+    const other_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        "{\"schemaVersion\":1}",
+    );
     var returned_digest: []const u8 = &other_digest;
     var headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Docker-Content-Digest", .value = returned_digest },
@@ -729,7 +805,10 @@ test "upload validates references and returned digest" {
 test "download sends mature Accept list and preserves owned metadata" {
     const allocator = std.testing.allocator;
     const manifest = "{\"schemaVersion\":2}\n";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
     const content_length = "20";
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = content_length },
@@ -771,8 +850,14 @@ test "download sends mature Accept list and preserves owned metadata" {
 test "download validates reference returned digest and required headers" {
     const allocator = std.testing.allocator;
     const manifest = "{\"schemaVersion\":2}";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
-    const other_digest = digest_mod.computeSha256Digest("{\"schemaVersion\":1}");
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
+    const other_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        "{\"schemaVersion\":1}",
+    );
     const valid_headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "19" },
         .{ .name = "Docker-Content-Digest", .value = &expected_digest },
@@ -874,7 +959,10 @@ test "download validates reference returned digest and required headers" {
 test "download treats compressed content length as an encoded hint" {
     const allocator = std.testing.allocator;
     const manifest = "{\"schemaVersion\":2}";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
     const gzip_headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Encoding", .value = "gzip" },
         .{ .name = "Content-Length", .value = "11" },
@@ -927,7 +1015,10 @@ test "manifest size limit allows boundary and rejects declared and streamed exce
     const boundary = try allocator.alloc(u8, max_manifest_size);
     defer allocator.free(boundary);
     @memset(boundary, 'x');
-    const boundary_digest = digest_mod.computeSha256Digest(boundary);
+    const boundary_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        boundary,
+    );
     const boundary_headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "4194304" },
         .{ .name = "Docker-Content-Digest", .value = &boundary_digest },
@@ -1013,7 +1104,10 @@ test "manifest size limit allows boundary and rejects declared and streamed exce
 
 test "delete requires digest and treats missing manifests as success" {
     const allocator = std.testing.allocator;
-    const digest = digest_mod.computeSha256Digest("manifest");
+    const digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        "manifest",
+    );
     var transport = core.http.MockTransport.init(allocator, 202, "");
     defer transport.deinit();
     var client = try testClient(allocator, transport.asTransport());
@@ -1152,7 +1246,10 @@ test "streaming manifest operations expose shared structured ACR errors" {
 test "replayable upload integrates challenge auth and same-origin redirects" {
     const allocator = std.testing.allocator;
     const manifest = "{\"schemaVersion\":2,\"redirected\":true}";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
     const redirect_headers = [_]core.http.MockTransport.HeaderPair{
         .{
             .name = "Location",
@@ -1204,7 +1301,10 @@ test "replayable upload integrates challenge auth and same-origin redirects" {
 
 fn uploadAllocationTest(allocator: std.mem.Allocator) !void {
     const manifest = "{\"schemaVersion\":2}";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Docker-Content-Digest", .value = &expected_digest },
     };
@@ -1227,7 +1327,10 @@ test "manifest upload is leak free across allocation failures" {
 
 fn downloadAllocationTest(allocator: std.mem.Allocator) !void {
     const manifest = "{\"schemaVersion\":2}";
-    const expected_digest = digest_mod.computeSha256Digest(manifest);
+    const expected_digest = try digest_mod.computeSha256Digest(
+        @import("test_runtime.zig").crypto(),
+        manifest,
+    );
     const headers = [_]core.http.MockTransport.HeaderPair{
         .{ .name = "Content-Length", .value = "19" },
         .{ .name = "Docker-Content-Digest", .value = &expected_digest },

--- a/src/crypto_test_provider.zig
+++ b/src/crypto_test_provider.zig
@@ -1,0 +1,122 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+pub const FailurePoint = enum {
+    none,
+    sha256,
+    sha256_init,
+    update,
+    final,
+};
+
+pub const Spy = struct {
+    standard: core.crypto.StdCryptoProvider,
+    failure: FailurePoint = .none,
+    sha256_calls: usize = 0,
+    sha256_init_calls: usize = 0,
+    update_calls: usize = 0,
+    final_calls: usize = 0,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    pub fn init(io: std.Io) Spy {
+        return .{ .standard = core.crypto.StdCryptoProvider.init(io) };
+    }
+
+    pub fn asProvider(self: *Spy) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *Spy = @ptrCast(@alignCast(context));
+        try self.standard.asProvider().randomBytes(out);
+    }
+
+    fn md5(
+        context: *anyopaque,
+        data: []const u8,
+        out: *core.crypto.Md5Digest,
+    ) !void {
+        const self: *Spy = @ptrCast(@alignCast(context));
+        out.* = try self.standard.asProvider().md5(data);
+    }
+
+    fn sha256(
+        context: *anyopaque,
+        data: []const u8,
+        out: *core.crypto.Sha256Digest,
+    ) !void {
+        const self: *Spy = @ptrCast(@alignCast(context));
+        self.sha256_calls += 1;
+        if (self.failure == .sha256) return error.InjectedCryptoFailure;
+        out.* = try self.standard.asProvider().sha256(data);
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self: *Spy = @ptrCast(@alignCast(context));
+        out.* = try self.standard.asProvider().hmacSha256(key, message);
+    }
+
+    fn sha256Init(
+        context: *anyopaque,
+        allocator: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        const self: *Spy = @ptrCast(@alignCast(context));
+        self.sha256_init_calls += 1;
+        if (self.failure == .sha256_init) return error.InjectedCryptoFailure;
+
+        var inner = try self.standard.asProvider().sha256Init(allocator);
+        errdefer inner.deinit();
+        const state = try allocator.create(Operation);
+        state.* = .{
+            .allocator = allocator,
+            .owner = self,
+            .inner = inner,
+        };
+        return .{ .context = state, .vtable = &Operation.vtable };
+    }
+};
+
+const Operation = struct {
+    allocator: std.mem.Allocator,
+    owner: *Spy,
+    inner: core.crypto.Sha256Operation,
+
+    const vtable: core.crypto.Sha256Operation.VTable = .{
+        .update = &update,
+        .final = &final,
+        .deinit = &deinit,
+    };
+
+    fn update(context: *anyopaque, data: []const u8) !void {
+        const self: *Operation = @ptrCast(@alignCast(context));
+        self.owner.update_calls += 1;
+        if (self.owner.failure == .update) return error.InjectedCryptoFailure;
+        try self.inner.update(data);
+    }
+
+    fn final(context: *anyopaque, out: *core.crypto.Sha256Digest) !void {
+        const self: *Operation = @ptrCast(@alignCast(context));
+        self.owner.final_calls += 1;
+        if (self.owner.failure == .final) return error.InjectedCryptoFailure;
+        out.* = try self.inner.final();
+    }
+
+    fn deinit(context: *anyopaque) void {
+        const self: *Operation = @ptrCast(@alignCast(context));
+        self.inner.deinit();
+        const allocator = self.allocator;
+        allocator.destroy(self);
+    }
+};

--- a/src/digest.zig
+++ b/src/digest.zig
@@ -1,36 +1,51 @@
 const std = @import("std");
+const core = @import("azure_sdk_core");
 
-const Sha256 = std.crypto.hash.sha2.Sha256;
-
-pub const sha256_digest_length = Sha256.digest_length;
+pub const sha256_digest_length = @sizeOf(core.crypto.Sha256Digest);
 pub const sha256_formatted_length = "sha256:".len + (sha256_digest_length * 2);
 
-/// Incremental SHA-256 computation with canonical OCI/Docker digest formatting.
+/// Single-owner incremental SHA-256 computation using the selected runtime
+/// crypto provider. Call `deinit` exactly once.
 pub const Sha256Digest = struct {
-    hasher: Sha256 = Sha256.init(.{}),
+    operation: core.crypto.Sha256Operation,
 
-    pub fn update(self: *Sha256Digest, bytes: []const u8) void {
-        self.hasher.update(bytes);
+    pub fn init(
+        allocator: std.mem.Allocator,
+        provider: core.crypto.CryptoProvider,
+    ) !Sha256Digest {
+        return .{ .operation = try provider.sha256Init(allocator) };
     }
 
-    pub fn finalBytes(self: *Sha256Digest) [sha256_digest_length]u8 {
-        return self.hasher.finalResult();
+    pub fn deinit(self: *Sha256Digest) void {
+        self.operation.deinit();
+        self.* = undefined;
     }
 
-    pub fn final(self: *Sha256Digest) [sha256_formatted_length]u8 {
-        return formatSha256Digest(self.finalBytes());
+    pub fn update(self: *Sha256Digest, bytes: []const u8) !void {
+        try self.operation.update(bytes);
+    }
+
+    pub fn finalBytes(self: *Sha256Digest) !core.crypto.Sha256Digest {
+        return self.operation.final();
+    }
+
+    pub fn final(self: *Sha256Digest) ![sha256_formatted_length]u8 {
+        return formatSha256Digest(try self.finalBytes());
     }
 };
 
 /// Computes the canonical lowercase `sha256:<hex>` digest for exact bytes.
-pub fn computeSha256Digest(bytes: []const u8) [sha256_formatted_length]u8 {
-    var digest = Sha256Digest{};
-    digest.update(bytes);
-    return digest.final();
+pub fn computeSha256Digest(
+    provider: core.crypto.CryptoProvider,
+    bytes: []const u8,
+) ![sha256_formatted_length]u8 {
+    return formatSha256Digest(try provider.sha256(bytes));
 }
 
 /// Formats a SHA-256 hash as canonical lowercase `sha256:<hex>`.
-pub fn formatSha256Digest(hash: [sha256_digest_length]u8) [sha256_formatted_length]u8 {
+pub fn formatSha256Digest(
+    hash: core.crypto.Sha256Digest,
+) [sha256_formatted_length]u8 {
     const hex = "0123456789abcdef";
     var formatted: [sha256_formatted_length]u8 = undefined;
     @memcpy(formatted[0.."sha256:".len], "sha256:");
@@ -67,21 +82,25 @@ pub fn sha256DigestsEqual(left: []const u8, right: []const u8) !bool {
     return std.ascii.eqlIgnoreCase(left, right);
 }
 
-test "incremental digest preserves exact bytes" {
-    var incremental = Sha256Digest{};
-    incremental.update("{\"schemaVersion\":");
-    incremental.update("2}\n");
-    const actual = incremental.final();
+test "incremental digest preserves exact bytes through provider" {
+    var provider_impl = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const provider = provider_impl.asProvider();
+    var incremental = try Sha256Digest.init(std.testing.allocator, provider);
+    defer incremental.deinit();
+    try incremental.update("{\"schemaVersion\":");
+    try incremental.update("2}\n");
+    const actual = try incremental.final();
 
-    const expected = computeSha256Digest("{\"schemaVersion\":2}\n");
+    const expected = try computeSha256Digest(provider, "{\"schemaVersion\":2}\n");
     try std.testing.expectEqualSlices(u8, &expected, &actual);
 
-    const without_newline = computeSha256Digest("{\"schemaVersion\":2}");
+    const without_newline = try computeSha256Digest(provider, "{\"schemaVersion\":2}");
     try std.testing.expect(!std.mem.eql(u8, &expected, &without_newline));
 }
 
 test "digest formatting is canonical and validation is case insensitive" {
-    const digest = computeSha256Digest("");
+    var provider_impl = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const digest = try computeSha256Digest(provider_impl.asProvider(), "");
     try std.testing.expectEqualStrings(
         "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         &digest,

--- a/src/link_pager.zig
+++ b/src/link_pager.zig
@@ -5,7 +5,7 @@ const service_error = @import("service_error.zig");
 pub fn LinkPager(comptime Page: type) type {
     return struct {
         allocator: std.mem.Allocator,
-        pipeline: core.pipeline.HttpPipeline,
+        pipeline: core.http.HttpPipeline,
         trusted_origin: []u8,
         next_url: ?[]u8,
         parsePage: *const fn (std.mem.Allocator, []const u8) anyerror!Page,
@@ -15,7 +15,7 @@ pub fn LinkPager(comptime Page: type) type {
 
         pub fn init(
             allocator: std.mem.Allocator,
-            pipeline: core.pipeline.HttpPipeline,
+            pipeline: core.http.HttpPipeline,
             trusted_origin: []const u8,
             initial_url: []const u8,
             parsePage: *const fn (std.mem.Allocator, []const u8) anyerror!Page,

--- a/src/metadata_test.zig
+++ b/src/metadata_test.zig
@@ -56,7 +56,7 @@ test "repository pager follows a relative Link anonymously" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -116,7 +116,7 @@ test "Link pager accepts valueless extensions and quoted-pair escapes" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -160,7 +160,7 @@ test "anonymous metadata reads use challenge authentication" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -206,7 +206,7 @@ test "manifest pager follows an absolute same-origin Link" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -278,7 +278,7 @@ test "tag pager follows a query-relative Link" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -378,7 +378,7 @@ test "Link pager rejects unsafe and malformed continuations before sending" {
             std.testing.allocator,
             "https://registry.example",
             .{
-                .transport = transport.asTransport(),
+                .runtime = @import("test_runtime.zig").init(transport.asTransport()),
                 .authentication = .anonymous,
             },
         );
@@ -420,7 +420,7 @@ test "Link pager never sends credentials to an additionally trusted origin" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
             .authentication_options = .{
                 .expected_hosts = &.{"evil.example"},
@@ -454,7 +454,7 @@ test "metadata deletes return idempotent outcomes on every surface" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -526,7 +526,7 @@ test "metadata CRUD preserves flags paths and structured not-found errors" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -671,7 +671,7 @@ test "authenticated metadata writes use challenge authentication" {
         allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .{ .credential = &credential.credential },
         },
     );
@@ -710,7 +710,7 @@ test "malformed ACR errors retain status and raw body" {
         std.testing.allocator,
         "https://registry.example",
         .{
-            .transport = transport.asTransport(),
+            .runtime = @import("test_runtime.zig").init(transport.asTransport()),
             .authentication = .anonymous,
         },
     );
@@ -806,6 +806,7 @@ const TestCredential = struct {
         credential: *core.credentials.TokenCredential,
         _: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         const self: *TestCredential =
             @alignCast(@fieldParentPtr("credential", credential));

--- a/src/test_runtime.zig
+++ b/src/test_runtime.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+pub fn init(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(transport, crypto_provider.asProvider());
+}
+
+pub fn crypto() core.crypto.CryptoProvider {
+    return crypto_provider.asProvider();
+}


### PR DESCRIPTION
Part of #412
Part of #414

## Summary

- make `core.http.HttpRuntime` the breaking canonical construction dependency for metadata, content, and blob download clients
- migrate the ACR challenge authentication policy, credential acquisition, protocol client, pagers, buffered requests, and streaming operations to the current `core.http.HttpPipeline` policy/runtime API
- copy runtime/provider descriptors while borrowing their transport and crypto contexts, preserving cancellation, redirect, retry, response ownership, operation cleanup, resumable upload recovery, and ranged download behavior
- route one-shot and incremental SHA-256 work through `runtime.crypto`; digest helpers now require a `CryptoProvider` and production has no direct `std.crypto` fallback
- keep transport and crypto independently selectable; add provider spy/failure coverage for manifest hashing, incremental upload cleanup, and streaming download finalization
- update examples, live tests, custom transports, ownership docs, and package version for the breaking API

## Dependency pins

- `azure_sdk_core` 0.3.0: `git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41`
  - hash: `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- `azure_rest_container_registry` 0.2.0: `git+https://github.com/cataggar/azure-sdk-for-zig.git#37378097448f4a9ffa7d49e18fc596d2d237133b`
  - hash: `azure_rest_container_registry-0.2.0-k4rjoaT3AQCAPIOmbAJh84O2t0aAuAECnnNxRN4rhTgQ`

Package version is bumped from 0.1.0 to 0.2.0; the only existing package tag is `azure_sdk_container_registry/v0.1.0`.

## Validation

- `zig fmt --check src examples live_tests build.zig`
- `zig build`
- `zig build test --summary all` — 117/117 passed
- `zig build examples`
- `zig build live-test --summary all` — compiled and skipped the unconfigured opt-in live test (0 passed, 1 skipped)
- no additional package-check build step is defined on this package branch
