### PR TITLE
Migrate Data Tables to HttpRuntime and CryptoProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 Hand-written, idiomatic Zig conveniences for **Azure Storage Tables**.
 
-Release branch: `sdk/data_tables`. The package starts at `0.1.0` and currently
-preserves its prototype `TableClient`, `TableServiceClient`, and `TableEntity`
-exports while the parity roadmap in
+Release branch: `sdk/data_tables`. Version `0.2.0` preserves the prototype
+`TableClient`, `TableServiceClient`, and `TableEntity` exports while the parity roadmap in
 [tracker #148](https://github.com/cataggar/azure-sdk-for-zig/issues/148) is
 implemented.
 
@@ -32,12 +31,14 @@ immutable upstream commit every time it is regenerated. A generic Storage
 `x-ms-version` is not a substitute for a Tables contract version.
 
 The SDK pins generated package commit
-`67d001426e73385a944a1bacde8d482b81dbf5ae` and Zig package hash
-`azure_rest_data_tables-0.1.0-CqXnR3B2AQBJhSOC2e17bpbGPj5hN9RjLcpQ01OfFGkf`,
-and re-exports its public root as `protocol`. Its provenance records upstream
-spec commit `0744f52a86919d243ba2225e55bdb9c87bf521a5`, generator commit
-`f5dde2c7aa95e7a5ac496793b5527c9a212d642c`, and stable API version
-`2019-02-02`.
+`799b35f81a0478045ec8faca7eb0e1b41c5fafe0` and Zig package hash
+`azure_rest_data_tables-0.1.0-CqXnR-ZzAQD4MTM5hBpINSq2sdV70SMD2lKjSN1-9loh`,
+and Core commit `bc77bcacbb64af935ca53d60bf8a351c9592bc41` with hash
+`azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`.
+It re-exports the REST package public root as `protocol`. The REST provenance
+records upstream spec commit `0744f52a86919d243ba2225e55bdb9c87bf521a5`,
+generator commit `c83a1cbef5f728d7530fdec4a724cc453233cfa4`, and stable
+API version `2019-02-02`.
 
 `ProtocolClient` is the shared validated bridge to generated calls. It
 normalizes endpoint paths while preserving SAS query bytes, maps metadata,
@@ -60,7 +61,7 @@ source commit above, extracts all stable `Data.Tables.Versions` entries from
 `$batch`. If it reports a changed source, update the fixture and generator,
 regenerate `rest/data_tables`, update provenance and the SDK's immutable REST
 commit/hash together, then repeat the checks. The second command regenerates
-with generator commit `f5dde2c7aa95e7a5ac496793b5527c9a212d642c` and performs
+with generator commit `c83a1cbef5f728d7530fdec4a724cc453233cfa4` and performs
 an exact diff against `rest/data_tables`; it removes only its generated output
 under the supplied codegen worktree. It never selects a generic Storage API
 version.
@@ -70,8 +71,11 @@ version.
 Create owning token-authenticated clients with
 `TableServiceClient.initWithToken` or `TableClient.initWithToken`. Both copy
 their endpoint, API version, telemetry application ID, default client request
-ID, and policy pointer list. The credential, transport, and policy objects
-remain borrowed and must outlive the client. The bearer policy requests
+ID, and policy pointer list. Every constructor takes a canonical
+`core.http.HttpRuntime`; its transport and crypto descriptors are copied by
+value while their backend contexts remain borrowed. The credential, runtime
+contexts, and policy objects must outlive the client and all in-flight calls.
+The bearer policy requests
 `https://storage.azure.com/.default`. Token-authenticated constructors require
 HTTPS, including for custom and private endpoint hosts. HTTP remains available
 to future explicit emulator Shared Key and no-token constructors.
@@ -86,7 +90,10 @@ Derived clients share the parent's bearer-token cache and transport.
 `SharedKeyCredential.init` validates and decodes an account key, and
 `initWithSharedKey` uses the Table-only `SharedKeyLite` canonical form. The
 signer runs after retry, so it applies a current `x-ms-date`, API version, and
-signature to every attempt. Use `initWithSasUrl` only with a complete signed
+signature to every attempt. Shared Key, connection-string, account SAS, and
+table SAS signing all use the crypto provider selected by the client's
+`HttpRuntime`; provider failures are returned without a standard-provider
+fallback. Use `initWithSasUrl` only with a complete signed
 URL; its query bytes are retained verbatim and the pipeline has no
 `Authorization` policy. Client formatting omits all query strings.
 
@@ -123,7 +130,8 @@ authentication and caller policies run on every retry.
 Initialized clients may be moved because policy objects and their type-erased
 pointers live in allocator-owned stable storage. Calls that share a pipeline
 must nevertheless be serialized: the bearer-token cache and standard HTTP
-transport are mutable and not thread-safe. Callers may provide external
+transport are mutable and not thread-safe. Crypto provider contexts must be
+concurrent-safe or caller-serialized. Callers may provide external
 synchronization when sharing a client or using multiple derived clients.
 
 The canonical TypeSpec does not model `$batch`; the generated provenance and

--- a/README.md
+++ b/README.md
@@ -240,7 +240,10 @@ outcome-unknown.
 serialize immediately; matching `*Dynamic` methods accept `DynamicEntity`.
 `delete` accepts keys and a required `If-Match` value. Submission validates a
 nonempty group of at most 100 unique targets in one partition and enforces the
-4 MiB complete MIME payload limit before transport.
+4 MiB complete MIME payload limit before transport. Automatic multipart
+boundaries use `HttpRuntime.crypto`; a provider error is returned before
+transport dispatch. Explicit `TransactionOptions.boundaries` remain available
+for deterministic fixtures and bypass provider randomness.
 
 `TableClient.submitTransactionResult` returns ordered inner status/ETag
 results or a `TableError` whose `operation_index` is zero-based. Batch POSTs

--- a/auth.zig
+++ b/auth.zig
@@ -3,6 +3,16 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
+fn wipe(bytes: []u8) void {
+    const volatile_bytes: []volatile u8 = bytes;
+    @memset(volatile_bytes, 0);
+}
+
+fn wipeAndFree(allocator: std.mem.Allocator, bytes: []u8) void {
+    wipe(bytes);
+    allocator.free(bytes);
+}
+
 /// Microsoft Entra scope for Azure Storage data-plane requests.
 pub const storage_scope = "https://storage.azure.com/.default";
 
@@ -21,7 +31,7 @@ pub const SharedKeyCredential = struct {
             error.OutOfMemory => return err,
             else => return error.InvalidAccountKey,
         };
-        errdefer allocator.free(key);
+        errdefer wipeAndFree(allocator, key);
         if (key.len == 0) return error.InvalidAccountKey;
         return .{
             .allocator = allocator,
@@ -32,7 +42,7 @@ pub const SharedKeyCredential = struct {
 
     pub fn deinit(self: *SharedKeyCredential) void {
         self.allocator.free(self.account_name);
-        self.allocator.free(self.key);
+        wipeAndFree(self.allocator, self.key);
         self.* = undefined;
     }
 
@@ -42,9 +52,9 @@ pub const SharedKeyCredential = struct {
             error.OutOfMemory => return err,
             else => return error.InvalidAccountKey,
         };
-        errdefer self.allocator.free(replacement);
+        errdefer wipeAndFree(self.allocator, replacement);
         if (replacement.len == 0) return error.InvalidAccountKey;
-        self.allocator.free(self.key);
+        wipeAndFree(self.allocator, self.key);
         self.key = replacement;
     }
 
@@ -56,9 +66,15 @@ pub const SharedKeyCredential = struct {
     pub fn sign(
         self: *const SharedKeyCredential,
         allocator: std.mem.Allocator,
+        crypto_provider: core.crypto.CryptoProvider,
         canonical: []const u8,
     ) ![]u8 {
-        return core.base64.hmacSha256Base64(allocator, self.key, canonical);
+        return core.base64.hmacSha256Base64(
+            allocator,
+            crypto_provider,
+            self.key,
+            canonical,
+        );
     }
 
     pub fn format(_: SharedKeyCredential, writer: anytype) !void {
@@ -71,21 +87,21 @@ pub const SharedKeyCredential = struct {
 pub const SharedKeyLitePolicy = struct {
     credential: *SharedKeyCredential,
     api_version: []const u8,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     pub fn init(credential: *SharedKeyCredential, api_version: []const u8) SharedKeyLitePolicy {
         return .{ .credential = credential, .api_version = api_version };
     }
 
-    pub fn asPolicy(self: *SharedKeyLitePolicy) *core.pipeline.HttpPolicy {
+    pub fn asPolicy(self: *SharedKeyLitePolicy) *core.http.HttpPolicy {
         return &self.policy;
     }
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         request: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *SharedKeyLitePolicy = @alignCast(@fieldParentPtr("policy", policy));
         var date: [32]u8 = undefined;
@@ -110,17 +126,21 @@ pub const SharedKeyLitePolicy = struct {
             .{ date_value, canonical },
         );
         defer request.allocator.free(to_sign);
-        const signature = try self.credential.sign(request.allocator, to_sign);
-        defer request.allocator.free(signature);
+        const signature = try self.credential.sign(
+            request.allocator,
+            runtime.crypto,
+            to_sign,
+        );
+        defer wipeAndFree(request.allocator, signature);
         const authorization = try std.fmt.allocPrint(
             request.allocator,
             "SharedKeyLite {s}:{s}",
             .{ self.credential.account_name, signature },
         );
-        defer request.allocator.free(authorization);
+        defer wipeAndFree(request.allocator, authorization);
         try request.setHeader("Authorization", authorization);
-        if (next.len == 0) return transport.send(request);
-        return next[0].process(request, next[1..], transport);
+        if (next.len == 0) return runtime.transport.send(request);
+        return next[0].process(request, next[1..], runtime);
     }
 };
 
@@ -212,8 +232,65 @@ fn formatHttpDate(buffer: *[32]u8, timestamp: i64) []const u8 {
     ) catch unreachable;
 }
 
+const TestCryptoProvider = struct {
+    calls: usize = 0,
+    fail: bool = false,
+    key: [64]u8 = undefined,
+    key_len: usize = 0,
+    message: [512]u8 = undefined,
+    message_len: usize = 0,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn provider(self: *@This()) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(_: *anyopaque, _: []u8) !void {
+        return error.Unused;
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.Unused;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.Unused;
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.calls += 1;
+        self.key_len = key.len;
+        @memcpy(self.key[0..key.len], key);
+        self.message_len = message.len;
+        @memcpy(self.message[0..message.len], message);
+        @memset(out, 0xa5);
+        if (self.fail) return error.ProviderFailure;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.Unused;
+    }
+};
+
 test "published Tables SharedKeyLite vector" {
     const allocator = std.testing.allocator;
+    var provider = core.crypto.StdCryptoProvider.init(std.testing.io);
     const resource = try canonicalizedResource(
         allocator,
         "account-name",
@@ -223,11 +300,82 @@ test "published Tables SharedKeyLite vector" {
     try std.testing.expectEqualStrings("/account-name/?comp=properties", resource);
     const signature = try core.base64.hmacSha256Base64(
         allocator,
+        provider.asProvider(),
         "account-key",
         "Thu, 23 Apr 2020 09:43:37 GMT\n/account-name/?comp=properties",
     );
     defer allocator.free(signature);
     try std.testing.expectEqualStrings("tW8SGePdivpFOEJfTxikbSwjdDWkpxSTfFtqUMED3v8=", signature);
+}
+
+test "SharedKeyLite uses the selected runtime crypto provider" {
+    const allocator = std.testing.allocator;
+    var credential = try SharedKeyCredential.init(
+        allocator,
+        "account",
+        "YWNjb3VudC1rZXk=",
+    );
+    defer credential.deinit();
+    var policy = SharedKeyLitePolicy.init(&credential, "2019-02-02");
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+    var spy = TestCryptoProvider{};
+    var policies = [_]*core.http.HttpPolicy{policy.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        .init(mock.asTransport(), spy.provider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        allocator,
+        .GET,
+        "https://account.table.core.windows.net/Tables?comp=list",
+    );
+    defer request.deinit();
+
+    var response = try pipeline.send(&request);
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), spy.calls);
+    try std.testing.expectEqualStrings("account-key", spy.key[0..spy.key_len]);
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        spy.message[0..spy.message_len],
+        "\n/account/Tables?comp=list",
+    ));
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
+test "SharedKeyLite provider failure preserves authorization and skips transport" {
+    const allocator = std.testing.allocator;
+    var credential = try SharedKeyCredential.init(
+        allocator,
+        "account",
+        "YWNjb3VudC1rZXk=",
+    );
+    defer credential.deinit();
+    var policy = SharedKeyLitePolicy.init(&credential, "2019-02-02");
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+    var fault = TestCryptoProvider{ .fail = true };
+    var policies = [_]*core.http.HttpPolicy{policy.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        .init(mock.asTransport(), fault.provider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        allocator,
+        .GET,
+        "https://account.table.core.windows.net/Tables",
+    );
+    defer request.deinit();
+    try request.setHeader("Authorization", "unchanged");
+
+    try std.testing.expectError(error.ProviderFailure, pipeline.send(&request));
+    try std.testing.expectEqualStrings(
+        "unchanged",
+        request.getHeader("Authorization").?,
+    );
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
 }
 
 test "canonical resource includes paths and only decoded comp" {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,20 +1,20 @@
 .{
     .name = .azure_sdk_data_tables,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xc49b80127477f0d5,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
             .hash = "serde-1.0.1-1DszT-e9DABp6u1PoDvGFzeGaST2hRp2KGtGn_CkIl0J",
         },
         .azure_rest_data_tables = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#9d53208a5f68c41ede6125a2953153e28844b191",
-            .hash = "azure_rest_data_tables-0.1.0-CqXnR3B2AQDISEBCn4ampGQnCUB0Ze-QsiaxHEKklDNC",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#799b35f81a0478045ec8faca7eb0e1b41c5fafe0",
+            .hash = "azure_rest_data_tables-0.1.0-CqXnR-ZzAQD4MTM5hBpINSq2sdV70SMD2lKjSN1-9loh",
         },
     },
     .paths = .{

--- a/client.zig
+++ b/client.zig
@@ -1,5 +1,11 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 const auth = @import("auth.zig");
 const connection_string = @import("connection_string.zig");
 const entity = @import("entity.zig");
@@ -19,8 +25,9 @@ const transaction = @import("transaction.zig");
 /// A direct token client owns stable pipeline state. A client returned by
 /// `TableServiceClient.getTableClient` borrows that state and must be
 /// deinitialized before its parent. The credential, transport, and caller
-/// policy objects are always borrowed. Calls sharing pipeline state must be
-/// serialized because the token cache and standard transport are mutable.
+/// policy objects and runtime backend contexts are always borrowed and must
+/// outlive the client and in-flight calls. Calls sharing pipeline state must
+/// be serialized because the token cache and standard transport are mutable.
 pub const TableClient = struct {
     allocator: std.mem.Allocator,
     protocol: protocol_client.ProtocolClient,
@@ -36,7 +43,7 @@ pub const TableClient = struct {
         endpoint: []const u8,
         table_name: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableClient {
         try request.validateTableName(table_name);
@@ -44,7 +51,7 @@ pub const TableClient = struct {
         const state = try pipeline.PipelineState.create(
             allocator,
             credential,
-            transport,
+            runtime,
             init_options,
         );
         errdefer state.deinit();
@@ -65,7 +72,7 @@ pub const TableClient = struct {
         endpoint: []const u8,
         table_name: []const u8,
         credential: *auth.SharedKeyCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableClient {
         try request.validateTableName(table_name);
@@ -73,7 +80,7 @@ pub const TableClient = struct {
         const state = try pipeline.PipelineState.createSharedKey(
             allocator,
             credential,
-            transport,
+            runtime,
             init_options,
         );
         errdefer state.deinit();
@@ -86,12 +93,12 @@ pub const TableClient = struct {
         allocator: std.mem.Allocator,
         complete_sas_url: []const u8,
         table_name: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableClient {
         try request.validateTableName(table_name);
         try request.validateSasEndpoint(complete_sas_url);
-        const state = try pipeline.PipelineState.createNoAuth(allocator, transport, init_options);
+        const state = try pipeline.PipelineState.createNoAuth(allocator, runtime, init_options);
         errdefer state.deinit();
         const service_endpoint = try serviceEndpointFromSasUrl(
             allocator,
@@ -108,7 +115,7 @@ pub const TableClient = struct {
         allocator: std.mem.Allocator,
         value: []const u8,
         table_name: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableClient {
         var parsed = try connection_string.parse(allocator, value);
@@ -118,11 +125,11 @@ pub const TableClient = struct {
             errdefer allocator.destroy(credential);
             credential.* = try auth.SharedKeyCredential.init(allocator, parsed.account_name, key);
             errdefer credential.deinit();
-            var result = try initWithSharedKey(allocator, parsed.endpoint, table_name, credential, transport, init_options);
+            var result = try initWithSharedKey(allocator, parsed.endpoint, table_name, credential, runtime, init_options);
             result.owned_credential = credential;
             return result;
         }
-        return initWithSasUrl(allocator, parsed.endpoint, table_name, transport, init_options);
+        return initWithSasUrl(allocator, parsed.endpoint, table_name, runtime, init_options);
     }
 
     /// Internal constructor for service-derived clients.
@@ -205,7 +212,11 @@ pub const TableClient = struct {
         } else if (!std.ascii.eqlIgnoreCase(values.tableName, self.table_name)) {
             return error.SasTableNameMismatch;
         }
-        var parameters = try values.sign(allocator, credential);
+        var parameters = try values.sign(
+            allocator,
+            credential,
+            self.pipeline_state.pipeline.runtime.crypto,
+        );
         defer parameters.deinit();
         const table_url = try std.fmt.allocPrint(
             allocator,
@@ -987,6 +998,7 @@ const TestCredential = struct {
         credential: *core.credentials.TokenCredential,
         _: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         const self: *TestCredential = @alignCast(
             @fieldParentPtr("credential", credential),
@@ -998,31 +1010,31 @@ const TestCredential = struct {
 
 const PreTransportOncePolicy = struct {
     calls: usize = 0,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         req: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *PreTransportOncePolicy = @alignCast(@fieldParentPtr("policy", policy));
         self.calls += 1;
         if (self.calls == 1) return error.InjectedPreTransportFailure;
-        if (next.len == 0) return transport.send(req);
-        return next[0].process(req, next[1..], transport);
+        if (next.len == 0) return runtime.transport.send(req);
+        return next[0].process(req, next[1..], runtime);
     }
 };
 
 const AlwaysFailPreTransportPolicy = struct {
     calls: usize = 0,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         _: *core.http.Request,
-        _: []*core.pipeline.HttpPolicy,
-        _: *core.http.HttpTransport,
+        _: []*core.http.HttpPolicy,
+        _: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *AlwaysFailPreTransportPolicy = @alignCast(
             @fieldParentPtr("policy", policy),
@@ -1034,19 +1046,18 @@ const AlwaysFailPreTransportPolicy = struct {
 
 const FailingMutationTransport = struct {
     calls: usize = 0,
-    transport: core.http.HttpTransport = .{ .sendFn = &send },
 
-    fn asTransport(self: *FailingMutationTransport) *core.http.HttpTransport {
-        return &self.transport;
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
+
+    fn asTransport(self: *FailingMutationTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn send(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         _: *core.http.Request,
     ) anyerror!core.http.Response {
-        const self: *FailingMutationTransport = @alignCast(
-            @fieldParentPtr("transport", transport),
-        );
+        const self: *FailingMutationTransport = @ptrCast(@alignCast(context));
         self.calls += 1;
         return error.InjectedTransportFailure;
     }
@@ -1118,7 +1129,7 @@ test "typed and dynamic add share EDM wire behavior and preserve metadata" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1165,7 +1176,7 @@ test "typed and dynamic add update and upsert payloads omit Timestamp exactly" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1217,7 +1228,7 @@ test "dynamic read retains Timestamp but read-then-update omits it" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1257,7 +1268,7 @@ test "get supports full minimal and no metadata responses" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1304,7 +1315,7 @@ test "conditional delete preserves service failure and wildcard success" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1341,7 +1352,7 @@ test "typed and dynamic update and upsert use generated merge and replace operat
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1403,7 +1414,7 @@ test "update existence and ETag failures remain structured while upsert creates"
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1464,7 +1475,7 @@ test "merge preserves omitted properties and replace removes them by wire operat
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1497,7 +1508,7 @@ test "conditional mutation retries before transport and classifies ambiguity aft
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{ .retry = .{
             .max_retries = 2,
             .initial_delay_ms = 0,
@@ -1546,7 +1557,7 @@ test "conditional mutation retries before transport and classifies ambiguity aft
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        tight_mock.asTransport(),
+        testingRuntime(tight_mock.asTransport()),
         .{
             .operation_timeout_ms = 1,
             .retry = .{
@@ -1573,7 +1584,7 @@ test "conditional mutation retries before transport and classifies ambiguity aft
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        failing.asTransport(),
+        testingRuntime(failing.asTransport()),
         .{ .retry = .{
             .max_retries = 2,
             .initial_delay_ms = 0,
@@ -1594,7 +1605,7 @@ test "conditional mutation retries before transport and classifies ambiguity aft
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        safe_failing.asTransport(),
+        testingRuntime(safe_failing.asTransport()),
         .{ .retry = .{
             .max_retries = 2,
             .initial_delay_ms = 0,
@@ -1623,7 +1634,7 @@ test "entity constraints and malformed success fail locally" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1697,7 +1708,7 @@ test "entity query pager survives moving its source client" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     var entity_pager = try table_client.queryEntities(SimpleEntity, allocator, .{});
@@ -1755,7 +1766,7 @@ test "original raw entity method signatures remain source compatible" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=compatibility-secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1797,7 +1808,7 @@ test "raw calls do not copy large response bodies while typed adapters capture" 
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=no-copy-secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1869,7 +1880,7 @@ fn testEntityCrudAllocationFailures(allocator: std.mem.Allocator) !void {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=allocation-secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{ .retry = .{ .max_retries = 0 } },
     );
     defer client.deinit();
@@ -1898,7 +1909,7 @@ fn testEntityMutationAllocationFailures(allocator: std.mem.Allocator) !void {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=allocation-secret",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{ .retry = .{ .max_retries = 0 } },
     );
     defer client.deinit();
@@ -1934,7 +1945,7 @@ test "token client survives moves and applies all client options" {
         "https://myaccount.table.core.windows.net",
         "MyTable",
         credential.asCredential(),
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{
             .api_version = "2020-test",
             .telemetry = .{ .application_id = "my-app/1.0" },
@@ -1956,7 +1967,7 @@ test "token client survives moves and applies all client options" {
         mock.last_headers.get("x-ms-client-request-id").?,
     );
     try std.testing.expectEqualStrings(
-        "my-app/1.0 azsdk-zig-data-tables/0.1.0",
+        "my-app/1.0 azsdk-zig-data-tables/0.2.0",
         mock.last_headers.get("User-Agent").?,
     );
     try std.testing.expectEqualStrings(
@@ -1975,7 +1986,7 @@ fn testAllocationFailures(allocator: std.mem.Allocator) !void {
         "https://myaccount.table.core.windows.net",
         "MyTable",
         credential.asCredential(),
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{
             .telemetry = .{ .application_id = "allocation-test" },
             .client_request_id = "allocation-request-id",
@@ -2005,7 +2016,7 @@ test "token client rejects HTTP before credential and transport use" {
             "http://127.0.0.1:10002/devstoreaccount1",
             "MyTable",
             credential.asCredential(),
-            mock.asTransport(),
+            testingRuntime(mock.asTransport()),
             .{},
         ),
     );
@@ -2024,7 +2035,7 @@ test "token client accepts HTTPS custom private endpoint" {
         "HTTPS://tables.internal.example:8443/private/path",
         "MyTable",
         credential.asCredential(),
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer table_client.deinit();
@@ -2053,7 +2064,7 @@ test "Shared Key and SAS constructors have isolated authentication behavior" {
         "https://account.table.core.windows.net",
         "Table123",
         &credential,
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer shared.deinit();
@@ -2070,7 +2081,7 @@ test "Shared Key and SAS constructors have isolated authentication behavior" {
         allocator,
         "https://account.table.core.windows.net?sv=1%2F2&sig=a+b%3D&sp=r",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer sas.deinit();
@@ -2087,7 +2098,7 @@ fn testSasOperationAllocationFailures(allocator: std.mem.Allocator) !void {
         allocator,
         "https://account.table.core.windows.net/Table123?sv=1%2F2&sig=allocation+SECRET%3D&sp=r&tn=Table123",
         "Table123",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{ .retry = .{ .max_retries = 0 } },
     );
     defer sas.deinit();
@@ -2118,7 +2129,7 @@ test "table SAS URL is exact and full URL initializes a credential-free client" 
         "https://fakeaccount.table.core.windows.net",
         "People",
         &credential,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer shared.deinit();
@@ -2143,7 +2154,7 @@ test "table SAS URL is exact and full URL initializes a credential-free client" 
         allocator,
         sas_url,
         "People",
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer anonymous.deinit();
@@ -2192,7 +2203,7 @@ test "account SAS preserves a custom account path equal to the table name" {
         allocator,
         account_sas,
         "People",
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer table.deinit();
@@ -2223,7 +2234,7 @@ test "table SAS scope uses decoded case-insensitive tn without changing query by
         allocator,
         table_sas,
         "People",
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer table.deinit();
@@ -2254,7 +2265,7 @@ test "table SAS scope rejects mismatched duplicate and malformed tn" {
             allocator,
             "https://account.table.core.windows.net/Other?sv=1&tn=Other&sig=x",
             "People",
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
     );
@@ -2264,7 +2275,7 @@ test "table SAS scope rejects mismatched duplicate and malformed tn" {
             allocator,
             "https://account.table.core.windows.net/People?tn=People&TN=%50eople&sig=x",
             "People",
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
     );
@@ -2274,7 +2285,7 @@ test "table SAS scope rejects mismatched duplicate and malformed tn" {
             allocator,
             "https://account.table.core.windows.net?tn=People&sig=x",
             "People",
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
     );
@@ -2284,7 +2295,7 @@ test "table SAS scope rejects mismatched duplicate and malformed tn" {
             allocator,
             "https://account.table.core.windows.net/People?t%ZZ=People&sig=x",
             "People",
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
     );
@@ -2294,7 +2305,7 @@ test "table SAS scope rejects mismatched duplicate and malformed tn" {
             allocator,
             "https://account.table.core.windows.net/People?tn=Peop%ZZle&sig=x",
             "People",
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
     );
@@ -2316,7 +2327,7 @@ test "stored access policies use generated XML and preserve response metadata" {
         "https://account.table.core.windows.net",
         "People",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer table_client.deinit();
@@ -2416,7 +2427,7 @@ test "stored access policy limits preserve empty zero and five lists" {
         "https://account.table.core.windows.net",
         "People",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer table_client.deinit();
@@ -2524,7 +2535,7 @@ test "stored policy identifiers generate SAS and policy calls use every auth mod
         "https://account.table.core.windows.net",
         "People",
         &shared_credential,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer shared.deinit();
@@ -2552,7 +2563,7 @@ test "stored policy identifiers generate SAS and policy calls use every auth mod
         allocator,
         sas_url,
         "People",
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer anonymous.deinit();
@@ -2581,7 +2592,7 @@ test "stored policy malformed XML and service failures remain distinct" {
         "https://account.table.core.windows.net",
         "People",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer table_client.deinit();
@@ -2628,7 +2639,7 @@ fn testAccessPolicyAllocationFailures(allocator: std.mem.Allocator) !void {
         "https://account.table.core.windows.net",
         "People",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{ .retry = .{ .max_retries = 0 } },
     );
     defer table_client.deinit();

--- a/connection_string.zig
+++ b/connection_string.zig
@@ -8,6 +8,12 @@ pub const development_account_name = "devstoreaccount1";
 pub const development_account_key =
     "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
+fn wipeAndFree(allocator: std.mem.Allocator, bytes: []u8) void {
+    const volatile_bytes: []volatile u8 = bytes;
+    @memset(volatile_bytes, 0);
+    allocator.free(bytes);
+}
+
 pub const Parsed = struct {
     allocator: std.mem.Allocator,
     endpoint: []u8,
@@ -16,10 +22,10 @@ pub const Parsed = struct {
     sas: ?[]u8 = null,
 
     pub fn deinit(self: *Parsed) void {
-        self.allocator.free(self.endpoint);
+        wipeAndFree(self.allocator, self.endpoint);
         self.allocator.free(self.account_name);
-        if (self.account_key) |value| self.allocator.free(value);
-        if (self.sas) |value| self.allocator.free(value);
+        if (self.account_key) |value| wipeAndFree(self.allocator, value);
+        if (self.sas) |value| wipeAndFree(self.allocator, value);
         self.* = undefined;
     }
 
@@ -105,7 +111,7 @@ pub fn parse(allocator: std.mem.Allocator, value: []const u8) !Parsed {
     if (account_key) |key| {
         const decoded = @import("azure_sdk_core").base64.decode(allocator, key) catch
             return error.InvalidAccountKey;
-        defer allocator.free(decoded);
+        defer wipeAndFree(allocator, decoded);
         if (decoded.len == 0) return error.InvalidAccountKey;
     }
     if (table_endpoint != null and suffix != null)
@@ -172,6 +178,53 @@ fn development(allocator: std.mem.Allocator) !Parsed {
     };
 }
 
+const TestCryptoProvider = struct {
+    inner: core.crypto.CryptoProvider,
+    hmac_calls: usize = 0,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn provider(self: *@This()) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(_: *anyopaque, _: []u8) !void {
+        return error.Unused;
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.Unused;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.Unused;
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.hmac_calls += 1;
+        out.* = try self.inner.hmacSha256(key, message);
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.Unused;
+    }
+};
+
 test "parse documented Storage and Azurite connection strings" {
     const allocator = std.testing.allocator;
     var azure = try parse(allocator, "DefaultEndpointsProtocol=https;AccountName=account;AccountKey=YQ==;EndpointSuffix=core.windows.net");
@@ -202,18 +255,31 @@ test "parse documented Storage and Azurite connection strings" {
 
 test "documented Azurite account key signs the SharedKeyLite vector" {
     const allocator = std.testing.allocator;
+    var provider = core.crypto.StdCryptoProvider.init(std.testing.io);
     const key = try core.base64.decode(allocator, development_account_key);
-    defer allocator.free(key);
+    defer wipeAndFree(allocator, key);
     const signature = try core.base64.hmacSha256Base64(
         allocator,
+        provider.asProvider(),
         key,
         "Thu, 23 Apr 2020 09:43:37 GMT\n/devstoreaccount1/?comp=properties",
     );
-    defer allocator.free(signature);
+    defer wipeAndFree(allocator, signature);
     try std.testing.expectEqualStrings(
         "DKy2WIvWLvpXbgT2cc0NqjkcHYoV3AdwfcMHgV8UYd8=",
         signature,
     );
+
+    var selected = TestCryptoProvider{ .inner = provider.asProvider() };
+    const selected_signature = try core.base64.hmacSha256Base64(
+        allocator,
+        selected.provider(),
+        key,
+        "Thu, 23 Apr 2020 09:43:37 GMT\n/devstoreaccount1/?comp=properties",
+    );
+    defer wipeAndFree(allocator, selected_signature);
+    try std.testing.expectEqualStrings(signature, selected_signature);
+    try std.testing.expectEqual(@as(usize, 1), selected.hmac_calls);
 }
 
 test "connection strings support explicit endpoints and harmless trailing semicolons" {

--- a/examples/administration.zig
+++ b/examples/administration.zig
@@ -21,10 +21,12 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(transport.asTransport(), crypto.asProvider());
     var service = try tables.TableServiceClient.initFromConnectionString(
         allocator,
         connection_string,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer service.deinit();
@@ -52,7 +54,7 @@ pub fn main(init: std.process.Init) !void {
             var secondary = try tables.TableServiceClient.initFromConnectionString(
                 allocator,
                 secondary_connection_string,
-                transport.asTransport(),
+                runtime,
                 .{},
             );
             defer secondary.deinit();

--- a/examples/authentication.zig
+++ b/examples/authentication.zig
@@ -12,6 +12,8 @@ pub fn main(init: std.process.Init) !void {
     const env = init.environ_map;
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(transport.asTransport(), crypto.asProvider());
 
     const endpoint = env.get("AZURE_DATA_TABLES_ENDPOINT");
     if (endpoint) |service_endpoint| {
@@ -21,7 +23,7 @@ pub fn main(init: std.process.Init) !void {
                 allocator,
                 service_endpoint,
                 credential.asCredential(),
-                transport.asTransport(),
+                runtime,
                 .{},
             );
             defer client.deinit();
@@ -39,7 +41,7 @@ pub fn main(init: std.process.Init) !void {
                 allocator,
                 service_endpoint,
                 &credential,
-                transport.asTransport(),
+                runtime,
                 .{},
             );
             defer client.deinit();
@@ -50,7 +52,7 @@ pub fn main(init: std.process.Init) !void {
         var client = try tables.TableServiceClient.initWithSasUrl(
             allocator,
             sas_url,
-            transport.asTransport(),
+            runtime,
             .{},
         );
         defer client.deinit();
@@ -60,7 +62,7 @@ pub fn main(init: std.process.Init) !void {
         var client = try tables.TableServiceClient.initFromConnectionString(
             allocator,
             connection_string,
-            transport.asTransport(),
+            runtime,
             .{},
         );
         defer client.deinit();
@@ -70,7 +72,7 @@ pub fn main(init: std.process.Init) !void {
         var client = try tables.TableServiceClient.initFromConnectionString(
             allocator,
             "UseDevelopmentStorage=true",
-            transport.asTransport(),
+            runtime,
             .{},
         );
         defer client.deinit();

--- a/examples/entities.zig
+++ b/examples/entities.zig
@@ -20,11 +20,13 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(transport.asTransport(), crypto.asProvider());
     var client = try tables.TableClient.initFromConnectionString(
         allocator,
         connection_string,
         table_name,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer client.deinit();

--- a/examples/transactions.zig
+++ b/examples/transactions.zig
@@ -17,11 +17,13 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(transport.asTransport(), crypto.asProvider());
     var client = try tables.TableClient.initFromConnectionString(
         allocator,
         connection_string,
         table_name,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer client.deinit();

--- a/integration_tests/azurite.zig
+++ b/integration_tests/azurite.zig
@@ -52,10 +52,12 @@ test "Azurite table lifecycle, CRUD, query paging, ETag, and batch" {
 
     var transport = core.http.StdHttpTransport.init(allocator, std.testing.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(transport.asTransport(), crypto.asProvider());
     var service = try tables.TableServiceClient.initFromConnectionString(
         allocator,
         config.connection_string,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer service.deinit();

--- a/live_tests/main.zig
+++ b/live_tests/main.zig
@@ -67,7 +67,9 @@ test "live Entra, Shared Key, SAS, ACL, properties, and statistics" {
 
     var transport = core.http.StdHttpTransport.init(allocator, std.testing.io);
     defer transport.deinit();
-    try entraSmoke(allocator, config, &transport);
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(transport.asTransport(), crypto.asProvider());
+    try entraSmoke(allocator, config, runtime);
 
     var shared_key = try tables.SharedKeyCredential.init(
         allocator,
@@ -79,7 +81,7 @@ test "live Entra, Shared Key, SAS, ACL, properties, and statistics" {
         allocator,
         config.endpoint,
         &shared_key,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer service.deinit();
@@ -94,13 +96,13 @@ test "live Entra, Shared Key, SAS, ACL, properties, and statistics" {
         defer table.deinit();
         try aclSmoke(&table, allocator);
     }
-    try sasSmoke(&service, allocator, &transport);
+    try sasSmoke(&service, allocator, runtime);
     try serviceAdministrationSmoke(
         allocator,
         &service,
         config.secondary_endpoint,
         &shared_key,
-        &transport,
+        runtime,
     );
     var deleted = try service.deleteTable(allocator, table_name, .{});
     defer deleted.deinit();
@@ -111,14 +113,14 @@ test "live Entra, Shared Key, SAS, ACL, properties, and statistics" {
 fn entraSmoke(
     allocator: std.mem.Allocator,
     config: Config,
-    transport: *core.http.StdHttpTransport,
+    runtime: core.http.HttpRuntime,
 ) !void {
     var credential = core.env_token.EnvTokenCredential.init(allocator, config.bearer);
     var service = try tables.TableServiceClient.initWithToken(
         allocator,
         config.endpoint,
         credential.asCredential(),
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer service.deinit();
@@ -149,7 +151,7 @@ fn aclSmoke(client: *tables.TableClient, allocator: std.mem.Allocator) !void {
 fn sasSmoke(
     service: *tables.TableServiceClient,
     allocator: std.mem.Allocator,
-    transport: *core.http.StdHttpTransport,
+    runtime: core.http.HttpRuntime,
 ) !void {
     var threaded: std.Io.Threaded = .init_single_threaded;
     const now: i64 = @intCast(@divTrunc(
@@ -165,7 +167,7 @@ fn sasSmoke(
     var sas = try tables.TableServiceClient.initWithSasUrl(
         allocator,
         sas_url,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer sas.deinit();
@@ -179,13 +181,13 @@ fn serviceAdministrationSmoke(
     primary: *tables.TableServiceClient,
     secondary_endpoint: []const u8,
     shared_key: *tables.SharedKeyCredential,
-    transport: *core.http.StdHttpTransport,
+    runtime: core.http.HttpRuntime,
 ) !void {
     var statistics_client = try tables.TableServiceClient.initWithSharedKey(
         allocator,
         secondary_endpoint,
         shared_key,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer statistics_client.deinit();

--- a/options.zig
+++ b/options.zig
@@ -13,7 +13,7 @@ pub const ProtocolOptions = struct {
     /// End-to-end client budget. A blocking in-flight send may exceed it.
     operation_timeout_ms: ?u64 = null,
     /// Per-call policies run before the client's configured pipeline.
-    policies: []const *core.pipeline.HttpPolicy = &.{},
+    policies: []const *core.http.HttpPolicy = &.{},
 };
 
 pub const QueryEntitiesOptions = struct {
@@ -138,7 +138,7 @@ pub const TableClientOptions = struct {
     operation_timeout_ms: ?u64 = null,
     /// Policies run once per retry. SAS query authentication is appended only
     /// after these policies, immediately before the transport.
-    policies: []const *core.pipeline.HttpPolicy = &.{},
+    policies: []const *core.http.HttpPolicy = &.{},
 };
 
 pub const TableServiceClientOptions = TableClientOptions;

--- a/options.zig
+++ b/options.zig
@@ -91,8 +91,6 @@ pub const UpsertEntityOptions = struct {
     mode: UpdateMode = .merge,
 };
 
-/// Explicit boundaries are primarily useful for deterministic wire tests.
-/// Normal transaction submissions generate unpredictable MIME boundaries.
 pub const SetServicePropertiesOptions = struct {
     protocol: ProtocolOptions = .{},
 };
@@ -103,6 +101,9 @@ pub const GetStatisticsOptions = struct {
     protocol: ProtocolOptions = .{},
 };
 
+/// Explicit boundaries are primarily useful for deterministic wire tests.
+/// Normal transaction submissions generate unpredictable MIME boundaries
+/// through the client's borrowed runtime crypto provider.
 pub const TransactionBoundaries = struct {
     batch: []const u8,
     changeset: []const u8,
@@ -110,6 +111,8 @@ pub const TransactionBoundaries = struct {
 
 pub const TransactionOptions = struct {
     protocol: ProtocolOptions = .{},
+    /// Explicit boundaries bypass runtime randomness for deterministic
+    /// fixtures. Both values are borrowed for the submission call.
     boundaries: ?TransactionBoundaries = null,
 };
 

--- a/pager.zig
+++ b/pager.zig
@@ -5,6 +5,12 @@
 
 const std = @import("std");
 const core = @import("azure_sdk_core");
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 const entity = @import("entity.zig");
 const entity_codec = @import("entity_codec.zig");
 const options = @import("options.zig");
@@ -131,7 +137,7 @@ fn copyListOptions(
     }
     if (source.protocol.policies.len > 0)
         result.protocol.policies = try allocator.dupe(
-            *core.pipeline.HttpPolicy,
+            *core.http.HttpPolicy,
             source.protocol.policies,
         );
     return result;
@@ -419,7 +425,7 @@ fn copyQueryEntitiesOptions(
     };
     if (source.protocol.policies.len > 0)
         result.protocol.policies = try allocator.dupe(
-            *core.pipeline.HttpPolicy,
+            *core.http.HttpPolicy,
             source.protocol.policies,
         );
     return result;
@@ -444,13 +450,13 @@ fn deinitQueryEntitiesOptions(
 const OptionPolicy = struct {
     calls: usize = 0,
     expected_request_id: []const u8,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         request: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *OptionPolicy = @alignCast(@fieldParentPtr("policy", policy));
         if (!std.mem.eql(
@@ -459,8 +465,8 @@ const OptionPolicy = struct {
             request.getHeader("x-ms-client-request-id") orelse return error.MissingRequestId,
         )) return error.UnexpectedRequestId;
         self.calls += 1;
-        if (next.len == 0) return transport.send(request);
-        return next[0].process(request, next[1..], transport);
+        if (next.len == 0) return runtime.transport.send(request);
+        return next[0].process(request, next[1..], runtime);
     }
 };
 
@@ -488,10 +494,7 @@ test "table pager carries options and exact continuation bytes across pages" {
         },
     };
     var transport = core.http.SequenceMockTransport.init(allocator, &responses_for_pages);
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var protocol = try protocol_client.ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",
@@ -562,10 +565,7 @@ test "table pager represents each OData metadata format" {
             .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
             .{ .name = "Content-Type", .value = "application/json" },
         };
-        const base_pipeline: core.pipeline.HttpPipeline = .{
-            .policies = &.{},
-            .transport_impl = transport.asTransport(),
-        };
+        const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
         var protocol = try protocol_client.ProtocolClient.init(
             allocator,
             "https://account.table.core.windows.net",
@@ -607,10 +607,7 @@ test "table pager owns list option bytes and policy pointer storage" {
         },
     };
     var transport = core.http.SequenceMockTransport.init(allocator, &pages);
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var protocol = try protocol_client.ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",
@@ -625,7 +622,7 @@ test "table pager owns list option bytes and policy pointer storage" {
     var metadata = [_]u8{ 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n', '/', 'j', 's', 'o', 'n', ';', 'o', 'd', 'a', 't', 'a', '=', 'c', 'u', 's', 't', 'o', 'm' };
     var applied = OptionPolicy{ .expected_request_id = "orig-id" };
     var replacement = OptionPolicy{ .expected_request_id = "orig-id" };
-    var policy_ptrs = [_]*core.pipeline.HttpPolicy{&applied.policy};
+    var policy_ptrs = [_]*core.http.HttpPolicy{&applied.policy};
     var table_pager = try TablePager.init(allocator, &protocol, .{
         .select = &select,
         .filter = &filter,
@@ -670,10 +667,7 @@ fn testPagerAllocationFailures(allocator: std.mem.Allocator) !void {
         .{ .name = "Content-Type", .value = "application/json" },
         .{ .name = "x-ms-continuation-NextTableName", .value = "Continuation" },
     };
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var protocol = try protocol_client.ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",
@@ -686,7 +680,7 @@ fn testPagerAllocationFailures(allocator: std.mem.Allocator) !void {
     var request_id = [_]u8{ 'a', 'l', 'l', 'o', 'c' };
     var metadata = [_]u8{ 'c', 'u', 's', 't', 'o', 'm' };
     var option_policy = OptionPolicy{ .expected_request_id = "alloc" };
-    var policy_ptrs = [_]*core.pipeline.HttpPolicy{&option_policy.policy};
+    var policy_ptrs = [_]*core.http.HttpPolicy{&option_policy.policy};
     var table_pager = try TablePager.init(allocator, &protocol, .{
         .select = &select,
         .filter = &filter,
@@ -759,10 +753,7 @@ test "entity pager preserves all continuation combinations and decodes typed pag
         },
     };
     var transport = core.http.SequenceMockTransport.init(allocator, &page_headers);
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var protocol = try protocol_client.ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",
@@ -850,10 +841,7 @@ test "entity pager owns mutable options and decodes dynamic EDM values" {
         },
     };
     var transport = core.http.SequenceMockTransport.init(allocator, &pages);
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var protocol = try protocol_client.ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",
@@ -869,7 +857,7 @@ test "entity pager owns mutable options and decodes dynamic EDM values" {
     var initial_partition = [_]u8{ 'i', 'n', 'i', 't', ' ', '/', '%', '?' };
     var applied = OptionPolicy{ .expected_request_id = "orig-id" };
     var replacement = OptionPolicy{ .expected_request_id = "orig-id" };
-    var policy_ptrs = [_]*core.pipeline.HttpPolicy{&applied.policy};
+    var policy_ptrs = [_]*core.http.HttpPolicy{&applied.policy};
     var entity_pager = try EntityPager(entity.DynamicEntity).init(allocator, &protocol, "Table123", .{
         .select = &select,
         .filter = &filter,
@@ -944,10 +932,7 @@ test "entity pager preserves continuation after a structured service failure" {
         },
     };
     var transport = core.http.SequenceMockTransport.init(allocator, &pages);
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var protocol = try protocol_client.ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",
@@ -1004,10 +989,7 @@ fn testEntityPagerAllocationFailures(allocator: std.mem.Allocator) !void {
         .{ .name = "x-ms-continuation-NextPartitionKey", .value = "next" },
         .{ .name = "x-ms-continuation-NextRowKey", .value = "row" },
     };
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var protocol = try protocol_client.ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -5,12 +5,18 @@
 
 const std = @import("std");
 const core = @import("azure_sdk_core");
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 const auth = @import("auth.zig");
 const options = @import("options.zig");
 const responses = @import("responses.zig");
 
-const HttpPolicy = core.pipeline.HttpPolicy;
-const HttpTransport = core.http.HttpTransport;
+const HttpPolicy = core.http.HttpPolicy;
+const HttpRuntime = core.http.HttpRuntime;
 const Request = core.http.Request;
 const Response = core.http.Response;
 
@@ -30,10 +36,11 @@ fn sleepMs(ms: u64) void {
     threaded.io().sleep(.fromNanoseconds(nanoseconds), .awake) catch {};
 }
 
-pub const user_agent = "azsdk-zig-data-tables/0.1.0";
+pub const user_agent = "azsdk-zig-data-tables/0.2.0";
 
 /// Heap-owned policy storage shared by an owning client and its derived
-/// clients. The credential, transport, and caller policy objects are borrowed.
+/// clients. The credential, runtime backend contexts, and caller policy
+/// objects are borrowed and must outlive all clients and in-flight calls.
 ///
 /// The mutable bearer-token cache and the standard transport are not
 /// thread-safe. Calls sharing this state, including calls from derived clients,
@@ -41,11 +48,11 @@ pub const user_agent = "azsdk-zig-data-tables/0.1.0";
 pub const PipelineState = struct {
     allocator: std.mem.Allocator,
     request_options: RequestOptionsPolicy,
-    telemetry: core.pipeline.TelemetryPolicy,
-    retry: core.pipeline.RetryPolicy,
+    telemetry: core.http.TelemetryPolicy,
+    retry: core.http.RetryPolicy,
     authentication: Authentication,
     policy_ptrs: []*HttpPolicy,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
     owned_user_agent: []u8,
     owned_client_request_id: ?[]u8,
     owned_api_version: []u8,
@@ -53,7 +60,7 @@ pub const PipelineState = struct {
     pub fn create(
         allocator: std.mem.Allocator,
         credential: *core.credentials.TokenCredential,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         init_options: options.TableClientOptions,
     ) !*PipelineState {
         try validateHeaderValue(init_options.client_request_id, error.InvalidClientRequestId);
@@ -64,9 +71,9 @@ pub const PipelineState = struct {
 
         return createWithAuthentication(
             allocator,
-            transport,
+            runtime,
             init_options,
-            .{ .bearer = core.pipeline.BearerTokenAuthPolicy.init(
+            .{ .bearer = core.http.BearerTokenAuthPolicy.init(
                 allocator,
                 credential,
                 &.{auth.storage_scope},
@@ -77,12 +84,12 @@ pub const PipelineState = struct {
     pub fn createSharedKey(
         allocator: std.mem.Allocator,
         credential: *auth.SharedKeyCredential,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         init_options: options.TableClientOptions,
     ) !*PipelineState {
         return createWithAuthentication(
             allocator,
-            transport,
+            runtime,
             init_options,
             .{ .shared_key = auth.SharedKeyLitePolicy.init(credential, init_options.api_version) },
         );
@@ -91,15 +98,15 @@ pub const PipelineState = struct {
     /// Used by SAS clients. It deliberately has no authorization policy.
     pub fn createNoAuth(
         allocator: std.mem.Allocator,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         init_options: options.TableClientOptions,
     ) !*PipelineState {
-        return createWithAuthentication(allocator, transport, init_options, .{ .none = .{} });
+        return createWithAuthentication(allocator, runtime, init_options, .{ .none = .{} });
     }
 
     fn createWithAuthentication(
         allocator: std.mem.Allocator,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
         init_options: options.TableClientOptions,
         authentication: Authentication,
     ) !*PipelineState {
@@ -138,8 +145,8 @@ pub const PipelineState = struct {
                 request_id,
                 init_options.operation_timeout_ms,
             ),
-            .telemetry = core.pipeline.TelemetryPolicy.init(agent),
-            .retry = core.pipeline.RetryPolicy.init(),
+            .telemetry = core.http.TelemetryPolicy.init(agent),
+            .retry = core.http.RetryPolicy.init(),
             .authentication = authentication,
             .policy_ptrs = policy_ptrs,
             .pipeline = undefined,
@@ -159,10 +166,7 @@ pub const PipelineState = struct {
         policy_ptrs[2] = state.retry.asPolicy();
         policy_ptrs[3] = state.authentication.asPolicy();
         @memcpy(policy_ptrs[4..], init_options.policies);
-        state.pipeline = .{
-            .policies = policy_ptrs,
-            .transport_impl = transport,
-        };
+        state.pipeline = .init(runtime, policy_ptrs);
         return state;
     }
 
@@ -211,17 +215,16 @@ const NoAuthenticationPolicy = struct {
         _: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response {
         // A SAS URL's signature is in the query. The SDK never synthesizes
         // Authorization for this mode.
-        if (next.len == 0) return transport.send(request);
-        return next[0].process(request, next[1..], transport);
+        return callNext(request, next, runtime);
     }
 };
 
 const Authentication = union(enum) {
-    bearer: core.pipeline.BearerTokenAuthPolicy,
+    bearer: core.http.BearerTokenAuthPolicy,
     shared_key: auth.SharedKeyLitePolicy,
     none: NoAuthenticationPolicy,
 
@@ -272,18 +275,18 @@ const RequestOptionsPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response {
         const self: *RequestOptionsPolicy = @alignCast(@fieldParentPtr("policy", policy));
         if (request.getHeader("x-ms-client-request-id") == null) {
             if (self.client_request_id) |request_id|
                 try request.setHeader("x-ms-client-request-id", request_id)
             else
-                try core.pipeline.ensureRequestId(request);
+                try core.http.ensureRequestId(request, runtime);
         }
         if (request.operation_timeout_ms == null)
             request.operation_timeout_ms = self.operation_timeout_ms;
-        return callNext(request, next, transport);
+        return callNext(request, next, runtime);
     }
 };
 
@@ -302,11 +305,11 @@ pub const CallContext = struct {
     capture_policy: ?*CapturePolicy,
     sas_policy: *SasAuthPolicy,
     policy_ptrs: []*HttpPolicy,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn init(
         allocator: std.mem.Allocator,
-        base: core.pipeline.HttpPipeline,
+        base: core.http.HttpPipeline,
         raw_endpoint_query: ?[]const u8,
         endpoint_query_is_sas: bool,
         operation_timeout_ms: ?u64,
@@ -328,7 +331,7 @@ pub const CallContext = struct {
 
     pub fn initWithResponseBody(
         allocator: std.mem.Allocator,
-        base: core.pipeline.HttpPipeline,
+        base: core.http.HttpPipeline,
         raw_endpoint_query: ?[]const u8,
         endpoint_query_is_sas: bool,
         operation_timeout_ms: ?u64,
@@ -350,7 +353,7 @@ pub const CallContext = struct {
 
     pub fn initNoCapture(
         allocator: std.mem.Allocator,
-        base: core.pipeline.HttpPipeline,
+        base: core.http.HttpPipeline,
         raw_endpoint_query: ?[]const u8,
         endpoint_query_is_sas: bool,
         operation_timeout_ms: ?u64,
@@ -375,7 +378,7 @@ pub const CallContext = struct {
     /// the standard retry policy because repeating their payload is safe.
     pub fn initMutation(
         allocator: std.mem.Allocator,
-        base: core.pipeline.HttpPipeline,
+        base: core.http.HttpPipeline,
         raw_endpoint_query: ?[]const u8,
         endpoint_query_is_sas: bool,
         operation_timeout_ms: ?u64,
@@ -405,7 +408,7 @@ pub const CallContext = struct {
     /// entry. Retry only failures known to precede transport dispatch.
     pub fn initTransaction(
         allocator: std.mem.Allocator,
-        base: core.pipeline.HttpPipeline,
+        base: core.http.HttpPipeline,
         raw_endpoint_query: ?[]const u8,
         endpoint_query_is_sas: bool,
         operation_timeout_ms: ?u64,
@@ -432,7 +435,7 @@ pub const CallContext = struct {
 
     fn initInternal(
         allocator: std.mem.Allocator,
-        base: core.pipeline.HttpPipeline,
+        base: core.http.HttpPipeline,
         raw_endpoint_query: ?[]const u8,
         endpoint_query_is_sas: bool,
         operation_timeout_ms: ?u64,
@@ -481,7 +484,7 @@ pub const CallContext = struct {
             .capture_policy = capture,
             .sas_policy = sas,
             .policy_ptrs = policies,
-            .pipeline = .{ .policies = policies, .transport_impl = base.transport_impl },
+            .pipeline = .init(base.runtime, policies),
         };
     }
 
@@ -543,7 +546,7 @@ const ConfigPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response {
         const self: *ConfigPolicy = @alignCast(@fieldParentPtr("policy", policy));
         const old_timeout = request.operation_timeout_ms;
@@ -564,7 +567,7 @@ const ConfigPolicy = struct {
             owned_url = timeout_url;
             url = timeout_url;
         }
-        if (owned_url == null) return self.send(request, next, transport);
+        if (owned_url == null) return self.send(request, next, runtime);
         const final_url = owned_url.?;
         owned_url = null;
         request.url = final_url;
@@ -572,20 +575,20 @@ const ConfigPolicy = struct {
             request.url = old_url;
             request.allocator.free(final_url);
         }
-        return self.send(request, next, transport);
+        return self.send(request, next, runtime);
     }
 
     fn send(
         self: *ConfigPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
         const mutation = self.mutation_retry orelse
-            return callNext(request, next, transport);
+            return callNext(request, next, runtime);
 
         if (!mutation.conditional) {
-            return callNext(request, next, transport) catch |err| {
+            return callNext(request, next, runtime) catch |err| {
                 if (request.transport_started) return outcomeUnknown(mutation.outcome);
                 return err;
             };
@@ -609,7 +612,7 @@ const ConfigPolicy = struct {
         while (true) {
             if (deadlineExpired(deadline_ns)) return error.OperationTimedOut;
             request.transport_started = false;
-            const result = callNext(request, next, transport);
+            const result = callNext(request, next, runtime);
             if (result) |response| return response else |err| {
                 if (request.transport_started) return outcomeUnknown(mutation.outcome);
                 if (!isRetryablePreTransportError(err) or
@@ -723,10 +726,10 @@ const SasAuthPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response {
         const self: *SasAuthPolicy = @alignCast(@fieldParentPtr("policy", policy));
-        const raw_query = self.raw_query orelse return callNext(request, next, transport);
+        const raw_query = self.raw_query orelse return callNext(request, next, runtime);
         if (next.len != 0) return error.InvalidSasPolicyOrder;
 
         const signed_url = try appendEndpointQuery(request.allocator, request.url, raw_query);
@@ -740,7 +743,7 @@ const SasAuthPolicy = struct {
             request.redirect_policy = old_redirect_policy;
             request.allocator.free(signed_url);
         }
-        return transport.send(request);
+        return runtime.transport.send(request);
     }
 };
 
@@ -801,10 +804,10 @@ const CapturePolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response {
         const self: *CapturePolicy = @alignCast(@fieldParentPtr("policy", policy));
-        var response = try callNext(request, next, transport);
+        var response = try callNext(request, next, runtime);
         errdefer response.deinit();
         if (self.metadata) |*old| old.deinit();
         self.metadata = try responses.ResponseMetadata.fromResponse(self.allocator, &response);
@@ -827,10 +830,7 @@ fn testLargeSuccessCapture(allocator: std.mem.Allocator) !void {
     @memset(&body, 'x');
     var transport = core.http.MockTransport.init(allocator, 200, &body);
     defer transport.deinit();
-    const base: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var call = try CallContext.init(allocator, base, null, false, null, null, &.{});
     defer call.deinit();
     var request = Request.init(allocator, .GET, "https://example.test/Tables");
@@ -854,10 +854,7 @@ test "capture retains a non-success body for structured error adaptation" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 409, "failure body");
     defer transport.deinit();
-    const base: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var call = try CallContext.init(allocator, base, null, false, null, null, &.{});
     defer call.deinit();
     var request = Request.init(allocator, .GET, "https://example.test/Tables");
@@ -872,10 +869,10 @@ test "capture retains a non-success body for structured error adaptation" {
 fn callNext(
     request: *Request,
     next: []*HttpPolicy,
-    transport: *HttpTransport,
+    runtime: HttpRuntime,
 ) !Response {
-    if (next.len == 0) return transport.send(request);
-    return next[0].process(request, next[1..], transport);
+    if (next.len == 0) return runtime.transport.send(request);
+    return next[0].process(request, next[1..], runtime);
 }
 
 const ExpiringCredential = struct {
@@ -890,6 +887,7 @@ const ExpiringCredential = struct {
         credential: *core.credentials.TokenCredential,
         context: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         const self: *ExpiringCredential = @alignCast(
             @fieldParentPtr("credential", credential),
@@ -912,7 +910,7 @@ const InspectPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response {
         const self: *InspectPolicy = @alignCast(@fieldParentPtr("policy", policy));
         if (request.getHeader("Authorization") == null or
@@ -922,7 +920,7 @@ const InspectPolicy = struct {
             return error.IncorrectPolicyOrder;
         }
         self.calls += 1;
-        return callNext(request, next, transport);
+        return callNext(request, next, runtime);
     }
 };
 
@@ -934,7 +932,7 @@ const RetryOncePolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) anyerror!Response {
         const self: *RetryOncePolicy = @alignCast(@fieldParentPtr("policy", policy));
         if (request.getHeader("Authorization") == null)
@@ -948,22 +946,23 @@ const RetryOncePolicy = struct {
                 .allocator = request.allocator,
             };
         }
-        return callNext(request, next, transport);
+        return callNext(request, next, runtime);
     }
 };
 
 const FailingTransport = struct {
-    transport: HttpTransport = .{ .sendFn = &send },
     captured_url: [512]u8 = undefined,
     captured_url_len: usize = 0,
     saw_redirects_disabled: bool = false,
 
-    fn asTransport(self: *FailingTransport) *HttpTransport {
-        return &self.transport;
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
+
+    fn asTransport(self: *FailingTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
-    fn send(transport: *HttpTransport, request: *Request) anyerror!Response {
-        const self: *FailingTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn send(context: *anyopaque, request: *Request) anyerror!Response {
+        const self: *FailingTransport = @ptrCast(@alignCast(context));
         if (request.url.len > self.captured_url.len) return error.TestUrlTooLong;
         @memcpy(self.captured_url[0..request.url.len], request.url);
         self.captured_url_len = request.url.len;
@@ -986,7 +985,7 @@ test "stable policy order authenticates every retry and runs caller policies" {
     const state = try PipelineState.create(
         allocator,
         credential.asCredential(),
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{
             .retry = .{
                 .max_retries = 1,
@@ -1034,14 +1033,14 @@ test "core logging and tracing never observe SAS while retries send exact opaque
     });
     var recording_tracer = core.tracing.RecordingTracer.init(allocator);
     defer recording_tracer.deinit();
-    var logging = core.pipeline.LoggingPolicy.init();
-    var tracing = core.pipeline.TracingPolicy.init(
+    var logging = core.http.LoggingPolicy.init();
+    var tracing = core.http.TracingPolicy.init(
         recording_tracer.asTracer(),
         "Microsoft.Storage",
     );
     const state = try PipelineState.createNoAuth(
         allocator,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{
             .retry = .{
                 .max_retries = 1,
@@ -1080,14 +1079,14 @@ test "SAS transport errors restore the credential-free URL and redirect policy" 
     var transport = FailingTransport{};
     var recording_tracer = core.tracing.RecordingTracer.init(allocator);
     defer recording_tracer.deinit();
-    var logging = core.pipeline.LoggingPolicy.init();
-    var tracing = core.pipeline.TracingPolicy.init(
+    var logging = core.http.LoggingPolicy.init();
+    var tracing = core.http.TracingPolicy.init(
         recording_tracer.asTracer(),
         "Microsoft.Storage",
     );
     const state = try PipelineState.createNoAuth(
         allocator,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{
             .retry = .{ .max_retries = 0 },
             .policies = &.{ logging.asPolicy(), tracing.asPolicy() },
@@ -1127,10 +1126,7 @@ test "SAS URL allocation errors leave the request untouched" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    const base: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = transport.asTransport(),
-    };
+    const base = core.http.HttpPipeline.init(testingRuntime(transport.asTransport()), &.{});
     var call = try CallContext.init(
         allocator,
         base,
@@ -1165,15 +1161,15 @@ test "Shared Key core observability records no credential material in URLs" {
     defer credential.deinit();
     var recording_tracer = core.tracing.RecordingTracer.init(allocator);
     defer recording_tracer.deinit();
-    var logging = core.pipeline.LoggingPolicy.init();
-    var tracing = core.pipeline.TracingPolicy.init(
+    var logging = core.http.LoggingPolicy.init();
+    var tracing = core.http.TracingPolicy.init(
         recording_tracer.asTracer(),
         "Microsoft.Storage",
     );
     const state = try PipelineState.createSharedKey(
         allocator,
         &credential,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{ .policies = &.{ logging.asPolicy(), tracing.asPolicy() } },
     );
     defer state.deinit();
@@ -1203,7 +1199,7 @@ test "Shared Key policy retains an owned API version across caller mutation and 
     var state = try PipelineState.createSharedKey(
         allocator,
         &credential,
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{ .api_version = supplied_api_version },
     );
     defer state.deinit();

--- a/protocol_client.zig
+++ b/protocol_client.zig
@@ -1,5 +1,11 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 const errors = @import("errors.zig");
 const protocol = @import("azure_rest_data_tables");
 const serde = @import("serde");
@@ -30,7 +36,7 @@ pub const ProtocolClient = struct {
     api_version: []u8,
     mutation_retry: options.RetryOptions,
     default_operation_timeout_ms: ?u64,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub const InitOptions = struct {
         api_version: []const u8 = options.latest_api_version,
@@ -42,7 +48,7 @@ pub const ProtocolClient = struct {
     pub fn init(
         allocator: std.mem.Allocator,
         endpoint: []const u8,
-        http_pipeline: core.pipeline.HttpPipeline,
+        http_pipeline: core.http.HttpPipeline,
         init_options: InitOptions,
     ) !ProtocolClient {
         try request.validateApiVersion(init_options.api_version);
@@ -112,8 +118,7 @@ pub const ProtocolClient = struct {
 
         var call = try self.beginCall(arena_allocator, query_options.protocol, null);
         defer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(
-            arena_allocator,
+        var generated = protocol.TablesClient.init(
             call.pipeline,
             .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
         );
@@ -159,8 +164,7 @@ pub const ProtocolClient = struct {
 
         var call = try self.beginCall(arena_allocator, query_options.protocol, null);
         defer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(
-            arena_allocator,
+        var generated = protocol.TablesClient.init(
             call.pipeline,
             .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
         );
@@ -209,8 +213,7 @@ pub const ProtocolClient = struct {
 
         var call = try self.beginEntityCall(arena_allocator, query_options.protocol);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(
-            arena_allocator,
+        var generated = protocol.TablesClient.init(
             call.pipeline,
             .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
         );
@@ -262,7 +265,7 @@ pub const ProtocolClient = struct {
             query_options.protocol.timeout,
         );
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
         const value = table.query(arena_allocator, query_options.protocol.client_request_id, query_options.protocol.metadata, query_options.top, query_options.select, query_options.filter, query_options.continuation_token) catch |err| {
             const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
@@ -286,7 +289,7 @@ pub const ProtocolClient = struct {
         const arena_allocator = arena.allocator();
         var call = try self.beginCall(arena_allocator, create_options.protocol, create_options.protocol.timeout);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
         const value = table.create(arena_allocator, create_options.protocol.client_request_id, create_options.protocol.metadata, .{ .table_name = table_name }, create_options.prefer) catch |err| {
             const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
@@ -310,7 +313,7 @@ pub const ProtocolClient = struct {
         const arena_allocator = arena.allocator();
         var call = try self.beginCall(arena_allocator, delete_options.protocol, delete_options.protocol.timeout);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
         const value = table.delete(arena_allocator, delete_options.protocol.client_request_id, table_name) catch |err| {
             const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
@@ -347,7 +350,7 @@ pub const ProtocolClient = struct {
             get_options.protocol.policies,
         );
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
         const generated_value = table.getAccessPolicy(
             arena_allocator,
@@ -414,7 +417,7 @@ pub const ProtocolClient = struct {
         const table_acl = try service_models.toWire(arena_allocator, identifiers);
         var call = try self.beginCall(arena_allocator, set_options.protocol, null);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var table = generated.table();
         const value = table.setAccessPolicy(
             arena_allocator,
@@ -469,7 +472,7 @@ pub const ProtocolClient = struct {
         const body_policy = try arena_allocator.create(BodyOverridePolicy);
         body_policy.* = .{ .body = entity_json };
         const call_policies = try arena_allocator.alloc(
-            *core.pipeline.HttpPolicy,
+            *core.http.HttpPolicy,
             add_options.protocol.policies.len + 1,
         );
         @memcpy(call_policies[0..add_options.protocol.policies.len], add_options.protocol.policies);
@@ -478,8 +481,7 @@ pub const ProtocolClient = struct {
         protocol_options.policies = call_policies;
         var call = try self.beginEntityCall(arena_allocator, protocol_options);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(
-            arena_allocator,
+        var generated = protocol.TablesClient.init(
             call.pipeline,
             .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
         );
@@ -537,8 +539,7 @@ pub const ProtocolClient = struct {
 
         var call = try self.beginEntityCall(arena_allocator, query_options.protocol);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(
-            arena_allocator,
+        var generated = protocol.TablesClient.init(
             call.pipeline,
             .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
         );
@@ -598,8 +599,7 @@ pub const ProtocolClient = struct {
 
         var call = try self.beginEntityCall(arena_allocator, delete_options.protocol);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(
-            arena_allocator,
+        var generated = protocol.TablesClient.init(
             call.pipeline,
             .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
         );
@@ -670,7 +670,7 @@ pub const ProtocolClient = struct {
         const body_policy = try arena_allocator.create(BodyOverridePolicy);
         body_policy.* = .{ .body = entity_json };
         const call_policies = try arena_allocator.alloc(
-            *core.pipeline.HttpPolicy,
+            *core.http.HttpPolicy,
             protocol_options_input.policies.len + 1,
         );
         @memcpy(
@@ -686,8 +686,7 @@ pub const ProtocolClient = struct {
             if_match != null and !std.mem.eql(u8, if_match.?, "*"),
         );
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(
-            arena_allocator,
+        var generated = protocol.TablesClient.init(
             call.pipeline,
             .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version },
         );
@@ -805,7 +804,7 @@ pub const ProtocolClient = struct {
         const body_policy = try arena_allocator.create(BodyOverridePolicy);
         body_policy.* = .{ .body = body_xml };
         const call_policies = try arena_allocator.alloc(
-            *core.pipeline.HttpPolicy,
+            *core.http.HttpPolicy,
             call_options.policies.len + 1,
         );
         @memcpy(call_policies[0..call_options.policies.len], call_options.policies);
@@ -814,7 +813,7 @@ pub const ProtocolClient = struct {
         body_options.policies = call_policies;
         var call = try self.beginCall(arena_allocator, body_options, null);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var service = generated.service();
         const value = service.setProperties(arena_allocator, call_options.client_request_id, call_options.timeout, properties) catch |err| {
             // The generated XML serializer maps its allocation failure to
@@ -844,7 +843,7 @@ pub const ProtocolClient = struct {
         const arena_allocator = arena.allocator();
         var call = try self.beginCall(arena_allocator, call_options, null);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var service = generated.service();
         const value = service.getProperties(arena_allocator, call_options.client_request_id, call_options.timeout) catch |err| {
             const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
@@ -873,7 +872,7 @@ pub const ProtocolClient = struct {
         const arena_allocator = arena.allocator();
         var call = try self.beginCall(arena_allocator, call_options, null);
         errdefer call.deinit();
-        var generated = protocol.TablesClient.initWithPipeline(arena_allocator, call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
+        var generated = protocol.TablesClient.init(call.pipeline, .{ .endpoint = self.endpoint.base_url, .api_version = self.api_version });
         var service = generated.service();
         const value = service.getStatistics(arena_allocator, call_options.client_request_id, call_options.timeout) catch |err| {
             const table_error = try self.tableErrorFromGeneratedFailure(allocator, &call, err);
@@ -944,20 +943,20 @@ pub const ProtocolClient = struct {
 
 const BodyOverridePolicy = struct {
     body: []const u8,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     // Generated serializers cannot represent all SDK wire adaptations, such
     // as validated JSON annotations and omission-aware XML optionals.
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         req: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *BodyOverridePolicy = @alignCast(@fieldParentPtr("policy", policy));
         req.body = self.body;
-        if (next.len == 0) return transport.send(req);
-        return next[0].process(req, next[1..], transport);
+        if (next.len == 0) return runtime.transport.send(req);
+        return next[0].process(req, next[1..], runtime);
     }
 };
 
@@ -978,18 +977,18 @@ fn errorsFromMetadata(
 }
 
 const HeaderPolicy = struct {
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         req: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         _ = policy;
         try req.setHeader("x-test-policy", "applied");
-        if (next.len == 0) return transport.send(req);
-        return next[0].process(req, next[1..], transport);
+        if (next.len == 0) return runtime.transport.send(req);
+        return next[0].process(req, next[1..], runtime);
     }
 };
 
@@ -1005,10 +1004,7 @@ test "generated query receives SDK options and preserves SAS bytes" {
         .{ .name = "x-extra", .value = "first" },
         .{ .name = "x-extra", .value = "second" },
     };
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = mock.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(mock.asTransport()), &.{});
     var client = try ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net/?sv=1%2F2&sig=a+b%3D&sp=r",
@@ -1052,10 +1048,7 @@ test "invalid generated call inputs fail before transport" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, "{}");
     defer mock.deinit();
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = mock.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(mock.asTransport()), &.{});
     var client = try ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",
@@ -1094,10 +1087,7 @@ test "queryEntities retains its source-compatible raw response signature" {
         .{ .name = "Date", .value = "Sun, 26 Jul 2026 00:00:00 GMT" },
         .{ .name = "Content-Type", .value = "application/json" },
     };
-    const base_pipeline: core.pipeline.HttpPipeline = .{
-        .policies = &.{},
-        .transport_impl = mock.asTransport(),
-    };
+    const base_pipeline = core.http.HttpPipeline.init(testingRuntime(mock.asTransport()), &.{});
     var client = try ProtocolClient.init(
         allocator,
         "https://account.table.core.windows.net",

--- a/sas.zig
+++ b/sas.zig
@@ -1,7 +1,24 @@
 //! Account and table SAS values, validation, canonical signing, and encoding.
 const std = @import("std");
+const core = @import("azure_sdk_core");
 const auth = @import("auth.zig");
 const request = @import("request.zig");
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingCrypto() core.crypto.CryptoProvider {
+    return testing_crypto_provider.asProvider();
+}
+
+fn wipe(bytes: []u8) void {
+    const volatile_bytes: []volatile u8 = bytes;
+    @memset(volatile_bytes, 0);
+}
+
+fn wipeAndFree(allocator: std.mem.Allocator, bytes: []u8) void {
+    wipe(bytes);
+    allocator.free(bytes);
+}
 
 /// The newest stable Azure Tables contract version. A newer general Storage
 /// version is not a newer Tables data-plane contract.
@@ -179,6 +196,7 @@ pub const AccountSignatureValues = struct {
         self: AccountSignatureValues,
         allocator: std.mem.Allocator,
         credential: *const auth.SharedKeyCredential,
+        crypto_provider: core.crypto.CryptoProvider,
     ) !QueryParameters {
         try self.validate();
 
@@ -211,8 +229,8 @@ pub const AccountSignatureValues = struct {
             },
         );
         defer allocator.free(string_to_sign);
-        const signature = try credential.sign(allocator, string_to_sign);
-        defer allocator.free(signature);
+        const signature = try credential.sign(allocator, crypto_provider, string_to_sign);
+        defer wipeAndFree(allocator, signature);
 
         var query: std.ArrayList(u8) = .empty;
         errdefer query.deinit(allocator);
@@ -279,6 +297,7 @@ pub const TableSignatureValues = struct {
         self: TableSignatureValues,
         allocator: std.mem.Allocator,
         credential: *const auth.SharedKeyCredential,
+        crypto_provider: core.crypto.CryptoProvider,
     ) !QueryParameters {
         try self.validate();
 
@@ -339,8 +358,8 @@ pub const TableSignatureValues = struct {
             },
         );
         defer allocator.free(string_to_sign);
-        const signature = try credential.sign(allocator, string_to_sign);
-        defer allocator.free(signature);
+        const signature = try credential.sign(allocator, crypto_provider, string_to_sign);
+        defer wipeAndFree(allocator, signature);
 
         var query: std.ArrayList(u8) = .empty;
         errdefer query.deinit(allocator);
@@ -419,7 +438,7 @@ pub const QueryParameters = struct {
     encoded_query: []u8,
 
     pub fn deinit(self: *QueryParameters) void {
-        self.allocator.free(self.encoded_query);
+        wipeAndFree(self.allocator, self.encoded_query);
         self.* = undefined;
     }
 
@@ -619,12 +638,12 @@ test "stored SAS identifiers count Unicode scalar values" {
     var ascii = try (TableSignatureValues{
         .tableName = "People",
         .accessPolicy = .{ .stored = "a" ** 64 },
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     ascii.deinit();
     var multibyte = try (TableSignatureValues{
         .tableName = "People",
         .accessPolicy = .{ .stored = "雪" ** 64 },
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     multibyte.deinit();
 
     const invalid = [_][]const u8{ "a" ** 65, "雪" ** 65, "\xff" };
@@ -634,7 +653,7 @@ test "stored SAS identifiers count Unicode scalar values" {
             (TableSignatureValues{
                 .tableName = "People",
                 .accessPolicy = .{ .stored = identifier },
-            }).sign(allocator, &credential),
+            }).sign(allocator, &credential, testingCrypto()),
         );
     }
 }
@@ -660,7 +679,7 @@ test "Azure Go SDK table SAS vector adapted to a valid table name" {
             .startTime = .fromUnixSeconds(1_699_455_845),
             .expiryTime = .fromUnixSeconds(1_699_459_445),
         } },
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     defer parameters.deinit();
     const encoded = try parameters.encode(allocator);
     defer allocator.free(encoded);
@@ -687,7 +706,7 @@ test "official account SAS canonical form and SDK ordering" {
         .resourceTypes = .{ .service = true, .container = true, .object = true },
         .startTime = .fromUnixSeconds(1_699_455_845),
         .expiryTime = .fromUnixSeconds(1_699_459_445),
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     defer parameters.deinit();
     const encoded = try parameters.encode(allocator);
     defer allocator.free(encoded);
@@ -710,7 +729,7 @@ test "stored policy omits inline access fields and signs exact canonical values"
         .startRowKey = "00",
         .endPartitionKey = "Z",
         .endRowKey = "99",
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     defer parameters.deinit();
     const encoded = try parameters.encode(allocator);
     defer allocator.free(encoded);
@@ -729,7 +748,7 @@ test "partition-only bounds have exact canonical signature" {
         .accessPolicy = .{ .stored = "policy" },
         .startPartitionKey = "A",
         .endPartitionKey = "Z",
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     defer parameters.deinit();
     const encoded = try parameters.encode(allocator);
     defer allocator.free(encoded);
@@ -766,7 +785,7 @@ test "all absent partition-only and partition-row bound combinations are valid" 
                 .startRowKey = start.row,
                 .endPartitionKey = end.partition,
                 .endRowKey = end.row,
-            }).sign(allocator, &credential);
+            }).sign(allocator, &credential, testingCrypto());
             parameters.deinit();
         }
     }
@@ -782,7 +801,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .permissions = .{},
             .resourceTypes = .{ .service = true },
             .expiryTime = .fromUnixSeconds(2),
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasPermissionResourceCombination,
@@ -790,7 +809,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .permissions = .{ .add = true },
             .resourceTypes = .{ .service = true },
             .expiryTime = .fromUnixSeconds(2),
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.MissingSasServices,
@@ -799,7 +818,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .services = .{},
             .resourceTypes = .{ .service = true },
             .expiryTime = .fromUnixSeconds(2),
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.MissingSasResourceTypes,
@@ -807,7 +826,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .permissions = .{ .read = true },
             .resourceTypes = .{},
             .expiryTime = .fromUnixSeconds(2),
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.MissingSasExpiry,
@@ -815,7 +834,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .permissions = .{ .read = true },
             .resourceTypes = .{ .service = true },
             .expiryTime = null,
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasPermissionResourceCombination,
@@ -823,7 +842,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .permissions = .{ .read = true },
             .resourceTypes = .{ .container = true },
             .expiryTime = .fromUnixSeconds(2),
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasTimeRange,
@@ -834,14 +853,14 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
                 .startTime = .fromUnixSeconds(2),
                 .expiryTime = .fromUnixSeconds(2),
             } },
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasIdentifier,
         (TableSignatureValues{
             .tableName = "People",
             .accessPolicy = .{ .stored = "" },
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasKeyRange,
@@ -852,7 +871,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .startRowKey = "0",
             .endPartitionKey = "a",
             .endRowKey = "0",
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasKeyRange,
@@ -860,7 +879,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .tableName = "People",
             .accessPolicy = .{ .stored = "policy" },
             .endRowKey = "z",
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasKeyRange,
@@ -871,7 +890,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .startRowKey = "z",
             .endPartitionKey = "a",
             .endRowKey = "a",
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasKeyRange,
@@ -879,7 +898,7 @@ test "SAS validation rejects missing fields combinations and reversed ranges" {
             .tableName = "People",
             .accessPolicy = .{ .stored = "policy" },
             .startRowKey = "a",
-        }).sign(allocator, &credential),
+        }).sign(allocator, &credential, testingCrypto()),
     );
     try std.testing.expectError(
         error.InvalidSasIPRange,
@@ -918,7 +937,7 @@ test "SAS value and query formatting redact all sensitive values" {
             .expiryTime = .fromUnixSeconds(1_699_459_445),
         } },
     };
-    var parameters = try values.sign(allocator, &credential);
+    var parameters = try values.sign(allocator, &credential, testingCrypto());
     defer parameters.deinit();
     var output: std.Io.Writer.Allocating = .init(allocator);
     defer output.deinit();
@@ -942,7 +961,7 @@ fn testSasSigningAllocationFailures(allocator: std.mem.Allocator) !void {
         .startTime = .fromUnixSeconds(1_699_455_845),
         .expiryTime = .fromUnixSeconds(1_699_459_445),
         .ipRange = try IPRange.parse("192.0.2.1", "192.0.2.20"),
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     defer account_parameters.deinit();
     const account_url = try account_parameters.appendToUrl(
         allocator,
@@ -961,7 +980,7 @@ fn testSasSigningAllocationFailures(allocator: std.mem.Allocator) !void {
         .startRowKey = "0",
         .endPartitionKey = "Z",
         .endRowKey = "9",
-    }).sign(allocator, &credential);
+    }).sign(allocator, &credential, testingCrypto());
     defer parameters.deinit();
     const url = try parameters.appendToUrl(
         allocator,

--- a/scripts/verify-rest-regeneration.sh
+++ b/scripts/verify-rest-regeneration.sh
@@ -10,9 +10,9 @@ fi
 
 codegen_worktree=$1
 rest_worktree=$2
-generator_commit=f5dde2c7aa95e7a5ac496793b5527c9a212d642c
-core_commit=da55987aa3c90393a726fc1fa5e86ccd69d72271
-core_hash=azure_sdk_core-0.1.2-eFY0EtO6BQARBvYkxdhibifztfqTgJKEN1fe14sMUIYs
+generator_commit=c83a1cbef5f728d7530fdec4a724cc453233cfa4
+core_commit=bc77bcacbb64af935ca53d60bf8a351c9592bc41
+core_hash=azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV
 output="$codegen_worktree/.release/data_tables-regeneration-check"
 
 if [ "$(git -C "$codegen_worktree" rev-parse HEAD)" != "$generator_commit" ]; then

--- a/scripts/verify-typespec-version.sh
+++ b/scripts/verify-typespec-version.sh
@@ -9,7 +9,7 @@ source_commit=0744f52a86919d243ba2225e55bdb9c87bf521a5
 source_path=specification/cosmos-db/data-plane/Tables
 expected_version=2019-02-02
 
-latest_commit=$(git ls-remote "$source_repository" refs/heads/main | awk '{print $1}')
+latest_commit=$(git ls-remote "$source_repository" refs/heads/main | cut -f1)
 if [ "$latest_commit" != "$source_commit" ]; then
     echo "Azure Tables TypeSpec changed: pinned $source_commit, upstream $latest_commit" >&2
     exit 1
@@ -24,7 +24,7 @@ routes=$(curl --fail --silent --show-error --location \
 
 printf '%s\n' "$config" | grep -Fq 'service-dir'
 versions=$(printf '%s\n' "$main" |
-    awk -F'"' '/^[[:space:]]*v[0-9][0-9][0-9][0-9]_[0-9][0-9]_[0-9][0-9]:/ { print $2 }' |
+    sed -n 's/^[[:space:]]*v[0-9][0-9][0-9][0-9]_[0-9][0-9]_[0-9][0-9]:[[:space:]]*"\([^"]*\)".*/\1/p' |
     sort -u)
 if [ "$versions" != "$expected_version" ]; then
     echo "expected only stable Tables version $expected_version; found: $versions" >&2
@@ -36,7 +36,7 @@ if printf '%s\n' "$routes" | grep -Fq '$batch'; then
 fi
 grep -Fq "pub const latest_api_version = \"$expected_version\";" \
     "$repository_root/options.zig"
-grep -Fq "#67d001426e73385a944a1bacde8d482b81dbf5ae" \
+grep -Fq "#799b35f81a0478045ec8faca7eb0e1b41c5fafe0" \
     "$repository_root/build.zig.zon"
 
 printf '%s\n' "Azure Tables TypeSpec is current at $source_commit ($expected_version; \$batch absent)."

--- a/service_client.zig
+++ b/service_client.zig
@@ -1,5 +1,11 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 const auth = @import("auth.zig");
 const connection_string = @import("connection_string.zig");
 const client = @import("client.zig");
@@ -14,10 +20,11 @@ const service_models = @import("service_models.zig");
 
 /// Client for Azure Table Service operations (list/create/delete tables).
 ///
-/// The credential, transport, and configured policy objects are borrowed and
-/// must outlive the client. The client owns its endpoint, API version, policy
-/// pointer list, and bearer-token cache. Calls must be serialized because the
-/// token cache and standard transport are mutable and not thread-safe.
+/// The credential, configured policy objects, and runtime backend contexts are
+/// borrowed and must outlive the client and in-flight calls. The client owns
+/// its endpoint, API version, policy pointer list, and bearer-token cache.
+/// Calls must be serialized because the token cache and standard transport are
+/// mutable and not thread-safe.
 pub const TableServiceClient = struct {
     allocator: std.mem.Allocator,
     protocol: protocol_client.ProtocolClient,
@@ -30,14 +37,14 @@ pub const TableServiceClient = struct {
         allocator: std.mem.Allocator,
         endpoint: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableServiceClient {
         try request.validateTokenEndpoint(endpoint);
         const state = try pipeline.PipelineState.create(
             allocator,
             credential,
-            transport,
+            runtime,
             init_options,
         );
         errdefer state.deinit();
@@ -63,11 +70,11 @@ pub const TableServiceClient = struct {
         allocator: std.mem.Allocator,
         endpoint: []const u8,
         credential: *auth.SharedKeyCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableServiceClient {
         try request.validateSharedKeyEndpoint(endpoint);
-        const state = try pipeline.PipelineState.createSharedKey(allocator, credential, transport, init_options);
+        const state = try pipeline.PipelineState.createSharedKey(allocator, credential, runtime, init_options);
         errdefer state.deinit();
         const protocol = try protocol_client.ProtocolClient.init(
             allocator,
@@ -85,11 +92,11 @@ pub const TableServiceClient = struct {
     pub fn initWithSasUrl(
         allocator: std.mem.Allocator,
         complete_sas_url: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableServiceClient {
         try request.validateSasEndpoint(complete_sas_url);
-        const state = try pipeline.PipelineState.createNoAuth(allocator, transport, init_options);
+        const state = try pipeline.PipelineState.createNoAuth(allocator, runtime, init_options);
         errdefer state.deinit();
         const protocol = try protocol_client.ProtocolClient.init(
             allocator,
@@ -108,7 +115,7 @@ pub const TableServiceClient = struct {
     pub fn initFromConnectionString(
         allocator: std.mem.Allocator,
         value: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         init_options: Options,
     ) !TableServiceClient {
         var parsed = try connection_string.parse(allocator, value);
@@ -118,11 +125,11 @@ pub const TableServiceClient = struct {
             errdefer allocator.destroy(credential);
             credential.* = try auth.SharedKeyCredential.init(allocator, parsed.account_name, key);
             errdefer credential.deinit();
-            var result = try initWithSharedKey(allocator, parsed.endpoint, credential, transport, init_options);
+            var result = try initWithSharedKey(allocator, parsed.endpoint, credential, runtime, init_options);
             result.owned_credential = credential;
             return result;
         }
-        return initWithSasUrl(allocator, parsed.endpoint, transport, init_options);
+        return initWithSasUrl(allocator, parsed.endpoint, runtime, init_options);
     }
 
     /// Creates a table client that shares this service client's pipeline,
@@ -183,7 +190,11 @@ pub const TableServiceClient = struct {
     ) ![]u8 {
         const credential = self.pipeline_state.sharedKeyCredential() orelse
             return error.SasRequiresSharedKeyCredential;
-        var parameters = try signature_values.sign(allocator, credential);
+        var parameters = try signature_values.sign(
+            allocator,
+            credential,
+            self.pipeline_state.pipeline.runtime.crypto,
+        );
         defer parameters.deinit();
         const service_url = try std.fmt.allocPrint(
             allocator,
@@ -344,7 +355,7 @@ pub const TableServiceClient = struct {
 const BodyCapturePolicy = struct {
     allocator: std.mem.Allocator,
     body: ?[]u8 = null,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     fn deinit(self: *BodyCapturePolicy) void {
         if (self.body) |body| self.allocator.free(body);
@@ -352,13 +363,13 @@ const BodyCapturePolicy = struct {
     }
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         req: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *BodyCapturePolicy = @alignCast(@fieldParentPtr("policy", policy));
-        const response = if (next.len == 0) try transport.send(req) else try next[0].process(req, next[1..], transport);
+        const response = if (next.len == 0) try runtime.transport.send(req) else try next[0].process(req, next[1..], runtime);
         if (self.body) |body| self.allocator.free(body);
         self.body = if (req.body) |body| try self.allocator.dupe(u8, body) else null;
         return response;
@@ -377,6 +388,7 @@ const CountingCredential = struct {
         credential: *core.credentials.TokenCredential,
         context: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         const self: *CountingCredential = @alignCast(
             @fieldParentPtr("credential", credential),
@@ -388,6 +400,65 @@ const CountingCredential = struct {
         }
         self.calls += 1;
         return .{ .token = "shared-token", .expires_on = std.math.maxInt(i64) };
+    }
+};
+
+const CountingCryptoProvider = struct {
+    inner: core.crypto.CryptoProvider,
+    hmac_calls: usize = 0,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn provider(self: *@This()) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn fromContext(context: *anyopaque) *@This() {
+        return @ptrCast(@alignCast(context));
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        return fromContext(context).inner.randomBytes(out);
+    }
+
+    fn md5(
+        context: *anyopaque,
+        data: []const u8,
+        out: *core.crypto.Md5Digest,
+    ) !void {
+        out.* = try fromContext(context).inner.md5(data);
+    }
+
+    fn sha256(
+        context: *anyopaque,
+        data: []const u8,
+        out: *core.crypto.Sha256Digest,
+    ) !void {
+        out.* = try fromContext(context).inner.sha256(data);
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const counting = fromContext(context);
+        counting.hmac_calls += 1;
+        out.* = try counting.inner.hmacSha256(key, message);
+    }
+
+    fn sha256Init(
+        context: *anyopaque,
+        allocator: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return fromContext(context).inner.sha256Init(allocator);
     }
 };
 
@@ -415,7 +486,7 @@ test "derived clients share token cache and transport and borrow pipeline state"
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer service.deinit();
@@ -465,7 +536,7 @@ test "table pager survives a service client move across continuation pages" {
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     var moved = try moveServiceWithPager(source, allocator);
@@ -499,7 +570,7 @@ test "token service client rejects HTTP before credential and transport use" {
             allocator,
             "http://tables.private.example:10002/account",
             credential.asCredential(),
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
     );
@@ -517,7 +588,7 @@ test "token service client accepts HTTPS custom private endpoint" {
         allocator,
         "https://tables.private.example:8443/account/path/",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer service.deinit();
@@ -530,21 +601,23 @@ test "token service client accepts HTTPS custom private endpoint" {
     try std.testing.expectEqual(@as(usize, 0), transport.call_count);
 }
 
-test "account SAS URL is exact and works with a credential-free service client" {
+test "connection-string account SAS uses selected runtime crypto provider" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var credential = try auth.SharedKeyCredential.init(
-        allocator,
-        "fakeaccount",
-        "ZmFrZS1rZXk=",
-    );
-    defer credential.deinit();
-    var shared = try TableServiceClient.initWithSharedKey(
-        allocator,
-        "https://fakeaccount.table.core.windows.net",
-        &credential,
+    var standard_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var counting_crypto = CountingCryptoProvider{
+        .inner = standard_crypto.asProvider(),
+    };
+    const runtime = core.http.HttpRuntime.init(
         transport.asTransport(),
+        counting_crypto.provider(),
+    );
+    var shared = try TableServiceClient.initFromConnectionString(
+        allocator,
+        "DefaultEndpointsProtocol=https;AccountName=fakeaccount;" ++
+            "AccountKey=ZmFrZS1rZXk=;EndpointSuffix=core.windows.net",
+        runtime,
         .{},
     );
     defer shared.deinit();
@@ -560,11 +633,12 @@ test "account SAS URL is exact and works with a credential-free service client" 
         "https://fakeaccount.table.core.windows.net/?se=2023-11-08T16%3A04%3A05Z&sig=%2BUBePkRnknhwbw%2FT4HuUIu0YAlJlq7mt6Lrfwpestjo%3D&sp=rl&spr=https&srt=sc&ss=t&st=2023-11-08T15%3A04%3A05Z&sv=2019-02-02",
         sas_url,
     );
+    try std.testing.expectEqual(@as(usize, 1), counting_crypto.hmac_calls);
 
     var anonymous = try TableServiceClient.initWithSasUrl(
         allocator,
         sas_url,
-        transport.asTransport(),
+        runtime,
         .{},
     );
     defer anonymous.deinit();
@@ -600,7 +674,7 @@ test "table lifecycle result variants preserve generated responses and service e
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{ .client_request_id = "lifecycle-request" },
     );
     defer service.deinit();
@@ -650,7 +724,7 @@ test "table lifecycle validates names before transport and table clients are con
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer service.deinit();
@@ -692,7 +766,7 @@ test "table lifecycle uses Shared Key and SAS pipeline authentication" {
         allocator,
         "https://account.table.core.windows.net",
         &shared_credential,
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer shared.deinit();
@@ -707,7 +781,7 @@ test "table lifecycle uses Shared Key and SAS pipeline authentication" {
     var sas_client = try TableServiceClient.initWithSasUrl(
         allocator,
         "https://account.table.core.windows.net?sv=1%2F2&sig=secret%3D&sp=r",
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer sas_client.deinit();
@@ -750,7 +824,7 @@ test "table lifecycle retains all documented table service failure codes" {
             allocator,
             "https://account.table.core.windows.net",
             credential.asCredential(),
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         );
         defer service.deinit();
@@ -780,7 +854,7 @@ fn testLifecycleAllocationFailures(allocator: std.mem.Allocator) !void {
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{ .retry = .{ .max_retries = 0 } },
     );
     defer service.deinit();
@@ -811,7 +885,7 @@ test "service properties use generated XML and preserve response metadata" {
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{ .policies = &.{&capture.policy} },
     );
     defer service.deinit();
@@ -900,7 +974,7 @@ test "service administration validates before transport and returns structured f
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer service.deinit();
@@ -960,7 +1034,7 @@ test "secondary statistics preserve unknown replication status and UTC time" {
         allocator,
         "https://account-secondary.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer service.deinit();
@@ -1003,7 +1077,7 @@ test "malformed service properties XML is released on decode failure" {
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{},
     );
     defer service.deinit();
@@ -1026,7 +1100,7 @@ fn testServiceAdminAllocationFailures(allocator: std.mem.Allocator) !void {
         allocator,
         "https://account.table.core.windows.net",
         credential.asCredential(),
-        transport.asTransport(),
+        testingRuntime(transport.asTransport()),
         .{ .retry = .{ .max_retries = 0 } },
     );
     defer service.deinit();

--- a/transaction.zig
+++ b/transaction.zig
@@ -5,6 +5,12 @@
 
 const std = @import("std");
 const core = @import("azure_sdk_core");
+
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testingRuntime(http_transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(http_transport, testing_crypto_provider.asProvider());
+}
 const entity = @import("entity.zig");
 const entity_codec = @import("entity_codec.zig");
 const errors = @import("errors.zig");
@@ -1141,7 +1147,7 @@ fn expectIndeterminateTransactionResponse(
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
         "People",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1204,7 +1210,7 @@ test "submitted transaction inner failure remains a precise indexed TableError" 
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
         "People",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1234,6 +1240,7 @@ const TestCredential = struct {
         _: *core.credentials.TokenCredential,
         _: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         return .{ .token = "transaction-token", .expires_on = std.math.maxInt(i64) };
     }
@@ -1282,7 +1289,7 @@ fn expectTransactionRedirectRejected(
             "https://account.table.core.windows.net",
             "People",
             &test_credential.credential,
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
         .shared_key => try client_mod.TableClient.initWithSharedKey(
@@ -1290,14 +1297,14 @@ fn expectTransactionRedirectRejected(
             "https://account.table.core.windows.net",
             "People",
             &shared_credential,
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
         .sas => try client_mod.TableClient.initWithSasUrl(
             allocator,
             "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
             "People",
-            transport.asTransport(),
+            testingRuntime(transport.asTransport()),
             .{},
         ),
     };
@@ -1347,31 +1354,31 @@ test "transaction 307 and 308 redirects are rejected without replay for every au
 
 const PreTransportOncePolicy = struct {
     calls: usize = 0,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         req: *core.http.Request,
-        next: []*core.pipeline.HttpPolicy,
-        transport: *core.http.HttpTransport,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *PreTransportOncePolicy = @alignCast(@fieldParentPtr("policy", policy));
         self.calls += 1;
         if (self.calls == 1) return error.InjectedPreTransportFailure;
-        if (next.len == 0) return transport.send(req);
-        return next[0].process(req, next[1..], transport);
+        if (next.len == 0) return runtime.transport.send(req);
+        return next[0].process(req, next[1..], runtime);
     }
 };
 
 const AlwaysFailPreTransportPolicy = struct {
     calls: usize = 0,
-    policy: core.pipeline.HttpPolicy = .{ .processFn = &process },
+    policy: core.http.HttpPolicy = .{ .processFn = &process },
 
     fn process(
-        policy: *core.pipeline.HttpPolicy,
+        policy: *core.http.HttpPolicy,
         _: *core.http.Request,
-        _: []*core.pipeline.HttpPolicy,
-        _: *core.http.HttpTransport,
+        _: []*core.http.HttpPolicy,
+        _: core.http.HttpRuntime,
     ) anyerror!core.http.Response {
         const self: *AlwaysFailPreTransportPolicy = @alignCast(
             @fieldParentPtr("policy", policy),
@@ -1384,19 +1391,18 @@ const AlwaysFailPreTransportPolicy = struct {
 const FailingTransactionTransport = struct {
     calls: usize = 0,
     failure: anyerror = error.InjectedTransportFailure,
-    transport: core.http.HttpTransport = .{ .sendFn = &send },
 
-    fn asTransport(self: *FailingTransactionTransport) *core.http.HttpTransport {
-        return &self.transport;
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
+
+    fn asTransport(self: *FailingTransactionTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn send(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         _: *core.http.Request,
     ) anyerror!core.http.Response {
-        const self: *FailingTransactionTransport = @alignCast(
-            @fieldParentPtr("transport", transport),
-        );
+        const self: *FailingTransactionTransport = @ptrCast(@alignCast(context));
         self.calls += 1;
         return self.failure;
     }
@@ -1417,7 +1423,7 @@ test "transaction POST retries pretransport failure but not ambiguous transport 
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
         "People",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{ .retry = .{ .max_retries = 1, .initial_delay_ms = 0, .max_delay_ms = 0 } },
     );
     defer client.deinit();
@@ -1438,7 +1444,7 @@ test "transaction POST retries pretransport failure but not ambiguous transport 
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
         "People",
-        failing.asTransport(),
+        testingRuntime(failing.asTransport()),
         .{ .retry = .{ .max_retries = 5, .initial_delay_ms = 0, .max_delay_ms = 0 } },
     );
     defer failing_client.deinit();
@@ -1455,7 +1461,7 @@ test "transaction POST retries pretransport failure but not ambiguous transport 
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
         "People",
-        timed_out.asTransport(),
+        testingRuntime(timed_out.asTransport()),
         .{},
     );
     defer timeout_client.deinit();
@@ -1479,7 +1485,7 @@ test "transaction pretransport retries honor operation time budget" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
         "People",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{ .retry = .{ .max_retries = 5, .initial_delay_ms = 50, .max_delay_ms = 50 } },
     );
     defer client.deinit();
@@ -1516,7 +1522,7 @@ test "transaction submission uses bearer and SharedKey authentication" {
         "https://account.table.core.windows.net",
         "People",
         &test_credential.credential,
-        bearer_mock.asTransport(),
+        testingRuntime(bearer_mock.asTransport()),
         .{},
     );
     defer bearer.deinit();
@@ -1543,7 +1549,7 @@ test "transaction submission uses bearer and SharedKey authentication" {
         "https://account.table.core.windows.net",
         "People",
         &credential,
-        shared_mock.asTransport(),
+        testingRuntime(shared_mock.asTransport()),
         .{},
     );
     defer shared.deinit();
@@ -1567,7 +1573,7 @@ test "transaction validation occurs before transport" {
         allocator,
         "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
         "People",
-        mock.asTransport(),
+        testingRuntime(mock.asTransport()),
         .{},
     );
     defer client.deinit();

--- a/transaction.zig
+++ b/transaction.zig
@@ -485,7 +485,11 @@ pub fn submitResult(
     var batch_boundary: [38]u8 = undefined;
     var changeset_boundary: [42]u8 = undefined;
     const boundaries = transaction_options.boundaries orelse
-        try randomBoundaries(&batch_boundary, &changeset_boundary);
+        try randomBoundaries(
+            protocol.pipeline.runtime.crypto,
+            &batch_boundary,
+            &changeset_boundary,
+        );
     var serialized = try serializeWithEndpoint(
         builder,
         allocator,
@@ -555,10 +559,13 @@ pub fn submitResult(
     ) catch return error.TransactionOutcomeUnknown;
 }
 
-fn randomBoundaries(batch: *[38]u8, changeset: *[42]u8) !Boundaries {
+fn randomBoundaries(
+    crypto_provider: core.crypto.CryptoProvider,
+    batch: *[38]u8,
+    changeset: *[42]u8,
+) !Boundaries {
     var bytes: [32]u8 = undefined;
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    try threaded.io().randomSecure(&bytes);
+    try crypto_provider.randomBytes(&bytes);
     const batch_slice = std.fmt.bufPrint(batch, "batch_{x}", .{bytes[0..16]}) catch unreachable;
     const changeset_slice = std.fmt.bufPrint(
         changeset,
@@ -568,10 +575,64 @@ fn randomBoundaries(batch: *[38]u8, changeset: *[42]u8) !Boundaries {
     return .{ .batch = batch_slice, .changeset = changeset_slice };
 }
 
+const BoundaryCryptoProvider = struct {
+    random_calls: usize = 0,
+    fail: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn provider(self: *@This()) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.random_calls += 1;
+        if (self.fail) return error.ProviderFailure;
+        for (out, 0..) |*byte, index| byte.* = @truncate(index);
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.Unused;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.Unused;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.Unused;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.Unused;
+    }
+};
+
 test "generated multipart boundaries are valid and distinct" {
     var batch: [38]u8 = undefined;
     var changeset: [42]u8 = undefined;
-    const boundaries = try randomBoundaries(&batch, &changeset);
+    var provider = BoundaryCryptoProvider{};
+    const boundaries = try randomBoundaries(
+        provider.provider(),
+        &batch,
+        &changeset,
+    );
+    try std.testing.expectEqual(@as(usize, 1), provider.random_calls);
     try std.testing.expectEqual(@as(usize, 38), boundaries.batch.len);
     try std.testing.expectEqual(@as(usize, 42), boundaries.changeset.len);
     try std.testing.expect(!std.mem.eql(u8, boundaries.batch, boundaries.changeset));
@@ -1131,6 +1192,94 @@ const transaction_response_headers = &[_]core.http.MockTransport.HeaderPair{
     .{ .name = "Content-Type", .value = "multipart/mixed; boundary=batchresponse" },
     .{ .name = "x-ms-request-id", .value = "outer-request" },
 };
+
+test "automatic transaction boundaries use the selected runtime provider" {
+    const client_mod = @import("client.zig");
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 202, one_success_body);
+    defer mock.deinit();
+    mock.response_headers_list = transaction_response_headers;
+    var crypto = BoundaryCryptoProvider{};
+    const runtime = core.http.HttpRuntime.init(
+        mock.asTransport(),
+        crypto.provider(),
+    );
+    var client = try client_mod.TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
+        "People",
+        runtime,
+        .{},
+    );
+    defer client.deinit();
+    var builder = TransactionBuilder.init(allocator);
+    defer builder.deinit();
+    try builder.delete("p", "r", "*");
+
+    var result = try client.submitTransactionResult(allocator, &builder, .{
+        .protocol = .{ .client_request_id = "automatic-boundary-test" },
+    });
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), crypto.random_calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        mock.last_body.?,
+        "batch_000102030405060708090a0b0c0d0e0f",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        mock.last_body.?,
+        "changeset_101112131415161718191a1b1c1d1e1f",
+    ) != null);
+}
+
+test "boundary provider failure prevents send and explicit boundaries bypass it" {
+    const client_mod = @import("client.zig");
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 202, one_success_body);
+    defer mock.deinit();
+    mock.response_headers_list = transaction_response_headers;
+    var crypto = BoundaryCryptoProvider{ .fail = true };
+    const runtime = core.http.HttpRuntime.init(
+        mock.asTransport(),
+        crypto.provider(),
+    );
+    var client = try client_mod.TableClient.initWithSasUrl(
+        allocator,
+        "https://account.table.core.windows.net?sv=1&sig=SECRET&sp=a",
+        "People",
+        runtime,
+        .{},
+    );
+    defer client.deinit();
+    var builder = TransactionBuilder.init(allocator);
+    defer builder.deinit();
+    try builder.delete("p", "r", "*");
+
+    try std.testing.expectError(
+        error.ProviderFailure,
+        client.submitTransactionResult(allocator, &builder, .{
+            .protocol = .{ .client_request_id = "boundary-failure-test" },
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), crypto.random_calls);
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+
+    var result = try client.submitTransactionResult(allocator, &builder, .{
+        .protocol = .{ .client_request_id = "explicit-boundary-test" },
+        .boundaries = .{ .batch = "batch", .changeset = "changeset" },
+    });
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), crypto.random_calls);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        mock.last_body.?,
+        "--batch\r\nContent-Type: multipart/mixed; boundary=changeset\r\n",
+    ));
+}
 
 fn expectIndeterminateTransactionResponse(
     status: u16,


### PR DESCRIPTION
## Summary

- migrate all Data Tables constructors, pipeline state, protocol calls, pagers, examples, and tests to `core.http.HttpRuntime` and the current `HttpPipeline`
- route SharedKeyLite, connection-string, account SAS, and table SAS HMAC through `runtime.crypto`, with selected-provider and provider-failure atomicity coverage
- preserve borrowed runtime contexts, request/auth canonicalization, retry behavior, and service-derived client state
- bump `azure_sdk_data_tables` to `0.2.0` and refresh release verification metadata

Part of #412
Part of #414

## Exact pins

- `azure_sdk_core` `0.3.0`: `git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41`
  - `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- `azure_rest_data_tables` `0.1.0`: `git+https://github.com/cataggar/azure-sdk-for-zig.git#799b35f81a0478045ec8faca7eb0e1b41c5fafe0`
  - `azure_rest_data_tables-0.1.0-CqXnR-ZzAQD4MTM5hBpINSq2sdV70SMD2lKjSN1-9loh`

## Validation

- `git ls-files -z -- '*.zig' 'build.zig.zon' | xargs -0 zig fmt --check`
- `zig build --summary all`
- `zig build test --summary all` — 142/142 passed
- `zig build examples --summary all`
- `zig build azurite-test --summary all` — compiled; skipped because Azurite opt-in environment was not configured (Docker is unavailable locally)
- `zig build live-test --summary all` — compiled; skipped because live credentials/opt-in were not configured
- `git diff --check`

The package branch defines no `package-check` or `package-history-check` build steps. `./scripts/verify-typespec-version.sh` reports that upstream `Azure/azure-rest-api-specs` `main` moved from pinned source `0744f52a86919d243ba2225e55bdb9c87bf521a5` to `df78633c3e09ab1455f524ed5917268668bc60fb`; the released REST package remains pinned to the requested immutable commit and provenance.