### PR TITLE
Migrate Attestation SDK to HttpRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,41 @@
 Azure Attestation client exposing `AttestationClient`.
 
 Release branch: `sdk/attestation`. The package depends on
-`azure_sdk_core` and `serde` and starts at `0.1.0`.
+`azure_sdk_core` and `serde`. The current breaking runtime release is `0.2.0`.
+
+Construct clients with Core's canonical HTTP runtime:
+
+```zig
+var transport = core.http.StdHttpTransport.init(allocator, io);
+defer transport.deinit();
+var crypto = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    transport.asTransport(),
+    crypto.asProvider(),
+);
+var client = try attestation.AttestationClient.init(
+    allocator,
+    endpoint,
+    credential,
+    .{ .runtime = runtime },
+);
+defer client.deinit();
+```
+
+The client copies the runtime, transport, and crypto descriptors by value.
+Their backend contexts and the credential are borrowed and must outlive the
+client and every operation on it. Transport and crypto providers remain
+independently selectable. Attestation request IDs use `runtime.crypto`;
+provider failures propagate without falling back to `std.crypto` or sending a
+request.
+
+Core is pinned to commit
+`bc77bcacbb64af935ca53d60bf8a351c9592bc41` with package hash
+`azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`.
 
 ## Development
 
 ```bash
+zig build
 zig build test --summary all
 ```

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .azure_sdk_attestation,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0x124c751563a36975,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",

--- a/root.zig
+++ b/root.zig
@@ -16,26 +16,81 @@ pub const AttestationResult = struct {
 // ──────────────────── AttestationClient ───────────────────────
 
 pub const AttestationClientOptions = struct {
+    runtime: core.http.HttpRuntime,
     api_version: []const u8 = "2022-08-01",
 };
 
-pub const AttestationClient = struct {
-    endpoint: []const u8,
-    api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+pub const attestation_scopes: []const []const u8 = &.{
+    "https://attest.azure.net/.default",
+};
 
+pub const AttestationClient = struct {
+    allocator: std.mem.Allocator,
+    endpoint: []u8,
+    api_version: []u8,
+    auth_policy: *core.http.BearerTokenAuthPolicy,
+    request_id_policy: *core.http.RequestIdPolicy,
+    policy_ptrs: []*core.http.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
+
+    /// Constructs a client with the canonical HTTP runtime.
+    ///
+    /// Runtime descriptors are copied by value. Their transport and crypto
+    /// backend contexts, and `credential`, remain borrowed and must outlive
+    /// this client and every operation on it. The selected crypto provider is
+    /// used for request IDs without falling back to the standard provider.
     pub fn init(
+        allocator: std.mem.Allocator,
         endpoint: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
         options: AttestationClientOptions,
-    ) AttestationClient {
-        _ = credential;
+    ) !AttestationClient {
+        const owned_endpoint = try allocator.dupe(u8, endpoint);
+        errdefer allocator.free(owned_endpoint);
+        const owned_api_version = try allocator.dupe(u8, options.api_version);
+        errdefer allocator.free(owned_api_version);
+
+        const request_id_policy = try allocator.create(core.http.RequestIdPolicy);
+        errdefer allocator.destroy(request_id_policy);
+        request_id_policy.* = .init();
+
+        const auth_policy = try allocator.create(core.http.BearerTokenAuthPolicy);
+        errdefer allocator.destroy(auth_policy);
+        auth_policy.* = .init(allocator, credential, attestation_scopes);
+        errdefer auth_policy.deinit();
+
+        const policy_ptrs = try allocator.alloc(*core.http.HttpPolicy, 2);
+        errdefer allocator.free(policy_ptrs);
+        policy_ptrs[0] = request_id_policy.asPolicy();
+        policy_ptrs[1] = auth_policy.asPolicy();
+
         return .{
-            .endpoint = endpoint,
-            .api_version = options.api_version,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .allocator = allocator,
+            .endpoint = owned_endpoint,
+            .api_version = owned_api_version,
+            .auth_policy = auth_policy,
+            .request_id_policy = request_id_policy,
+            .policy_ptrs = policy_ptrs,
+            .pipeline = .init(options.runtime, policy_ptrs),
         };
+    }
+
+    pub fn deinit(self: *AttestationClient) void {
+        self.allocator.free(self.policy_ptrs);
+        self.auth_policy.deinit();
+        self.allocator.destroy(self.auth_policy);
+        self.allocator.destroy(self.request_id_policy);
+        self.allocator.free(self.api_version);
+        self.allocator.free(self.endpoint);
+        self.* = undefined;
+    }
+
+    /// Returns a copy of the runtime descriptor used by every operation.
+    ///
+    /// The returned descriptor borrows the same backend contexts as the
+    /// client.
+    pub fn runtime(self: *const AttestationClient) core.http.HttpRuntime {
+        return self.pipeline.runtime;
     }
 
     /// POST /attest/SgxEnclave?api-version=...
@@ -66,6 +121,7 @@ pub const AttestationClient = struct {
     ) !core.errors.Result(AttestationResult) {
         return self.attestResult(allocator, "SgxEnclave", quote);
     }
+
     pub fn attestOpenEnclaveResult(
         self: *AttestationClient,
         allocator: std.mem.Allocator,
@@ -80,8 +136,8 @@ pub const AttestationClient = struct {
         enclave_type: []const u8,
         evidence: []const u8,
     ) !AttestationResult {
-        var r = try self.attestResult(allocator, enclave_type, evidence);
-        return r.unwrap(error.AttestationFailed);
+        var result = try self.attestResult(allocator, enclave_type, evidence);
+        return result.unwrap(error.AttestationFailed);
     }
 
     fn attestResult(
@@ -104,23 +160,23 @@ pub const AttestationClient = struct {
         );
         defer allocator.free(body);
 
-        var req = core.http.Request.init(allocator, .POST, url);
-        defer req.deinit();
-        try req.setHeader("Content-Type", "application/json");
-        try req.setHeader("Accept", "application/json");
-        req.body = body;
+        var request = core.http.Request.init(allocator, .POST, url);
+        defer request.deinit();
+        try request.setHeader("Content-Type", "application/json");
+        try request.setHeader("Accept", "application/json");
+        request.body = body;
 
-        var resp = try self.pipeline.send(&req);
-        defer resp.deinit();
+        var response = try self.pipeline.send(&request);
+        defer response.deinit();
 
-        if (!resp.isSuccess()) {
-            if (core.errors.errorFromResponse(allocator, resp)) |az_err| {
-                return .{ .err = az_err };
+        if (!response.isSuccess()) {
+            if (core.errors.errorFromResponse(allocator, response)) |azure_error| {
+                return .{ .err = azure_error };
             }
             return error.AzureRequestFailed;
         }
 
-        return .{ .ok = try parseAttestationResult(allocator, resp.body) };
+        return .{ .ok = try parseAttestationResult(allocator, response.body) };
     }
 };
 
@@ -135,43 +191,190 @@ fn parseAttestationResult(allocator: std.mem.Allocator, body: []const u8) !Attes
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    const parsed = serde.json.fromSlice(Schema, arena.allocator(), body) catch
-        return .{};
+    const parsed = serde.json.fromSlice(Schema, arena.allocator(), body) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return .{},
+    };
 
     var result = AttestationResult{};
-    if (parsed.token) |v| result.token = try allocator.dupe(u8, v);
+    if (parsed.token) |value| result.token = try allocator.dupe(u8, value);
     result.is_debuggable = parsed.isDebuggable;
     return result;
 }
 
 // ─────────────────────────── Tests ────────────────────────────
 
-test "AttestationClient attestSgxEnclave" {
-    const allocator = std.testing.allocator;
+const TestCredential = struct {
+    credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
+    calls: usize = 0,
+    transport_context: ?*anyopaque = null,
+    crypto_context: ?*anyopaque = null,
+    scope: ?[]const u8 = null,
+
+    fn asCredential(self: *@This()) *core.credentials.TokenCredential {
+        return &self.credential;
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        request_context: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+        runtime_value: core.http.HttpRuntime,
+    ) anyerror!core.credentials.AccessToken {
+        const self: *@This() = @alignCast(@fieldParentPtr("credential", credential));
+        self.calls += 1;
+        self.transport_context = runtime_value.transport.context;
+        self.crypto_context = runtime_value.crypto.context;
+        self.scope = request_context.scopes[0];
+        return .{
+            .token = "test-token",
+            .expires_on = std.math.maxInt(i64),
+        };
+    }
+};
+
+const TestCryptoProvider = struct {
+    random_calls: usize = 0,
+    fail_random: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn asProvider(self: *@This()) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        self.random_calls += 1;
+        if (self.fail_random) return error.ProviderFailure;
+        for (out, 0..) |*byte, index| byte.* = @truncate(index);
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.Unused;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.Unused;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.Unused;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.Unused;
+    }
+};
+
+fn attestationAllocationFixture(allocator: std.mem.Allocator) !void {
     var mock = core.http.MockTransport.init(allocator, 200,
-        \\{"token":"eyJhbGciOiJSUzI1NiJ9.attestation-token","isDebuggable":false}
+        \\{"token":"attestation-token","isDebuggable":false}
     );
     defer mock.deinit();
-
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-
-    var client = AttestationClient.init(
+    var provider = TestCryptoProvider{};
+    var credential = TestCredential{};
+    var client = try AttestationClient.init(
+        allocator,
         "https://myattestation.attest.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
-        .{},
+        credential.asCredential(),
+        .{ .runtime = .init(mock.asTransport(), provider.asProvider()) },
     );
+    defer client.deinit();
 
     const result = try client.attestSgxEnclave(allocator, "base64-encoded-quote");
-    defer allocator.free(result.token.?);
+    defer result.deinit(allocator);
+}
 
-    try std.testing.expectEqualStrings("eyJhbGciOiJSUzI1NiJ9.attestation-token", result.token.?);
+test "AttestationClient preserves runtime providers across operations" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200,
+        \\{"token":"attestation-token","isDebuggable":false}
+    );
+    defer mock.deinit();
+    var provider = TestCryptoProvider{};
+    var credential = TestCredential{};
+    const runtime_value = core.http.HttpRuntime.init(
+        mock.asTransport(),
+        provider.asProvider(),
+    );
+    var client = try AttestationClient.init(
+        allocator,
+        "https://myattestation.attest.azure.net",
+        credential.asCredential(),
+        .{ .runtime = runtime_value },
+    );
+    defer client.deinit();
+
+    const result = try client.attestSgxEnclave(allocator, "base64-encoded-quote");
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqualStrings("attestation-token", result.token.?);
     try std.testing.expectEqual(false, result.is_debuggable.?);
     try std.testing.expectEqual(core.http.Method.POST, mock.last_method.?);
-    try std.testing.expect(std.mem.find(u8, mock.last_url.?, "attest/SgxEnclave?api-version=") != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        mock.last_url.?,
+        "attest/SgxEnclave?api-version=",
+    ) != null);
+    try std.testing.expectEqualStrings(
+        "Bearer test-token",
+        mock.last_headers.get("Authorization").?,
+    );
+    try std.testing.expectEqualStrings(
+        "00010203-0405-4607-8809-0a0b0c0d0e0f",
+        mock.last_headers.get("x-ms-client-request-id").?,
+    );
+    try std.testing.expectEqual(@as(usize, 1), provider.random_calls);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
+    try std.testing.expectEqual(runtime_value.transport.context, credential.transport_context.?);
+    try std.testing.expectEqual(runtime_value.crypto.context, credential.crypto_context.?);
+    try std.testing.expectEqualStrings(attestation_scopes[0], credential.scope.?);
+    try std.testing.expectEqual(runtime_value.transport.context, client.runtime().transport.context);
+    try std.testing.expectEqual(runtime_value.crypto.context, client.runtime().crypto.context);
+}
+
+test "AttestationClient propagates selected provider failure before transport" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "{}");
+    defer mock.deinit();
+    var provider = TestCryptoProvider{ .fail_random = true };
+    var credential = TestCredential{};
+    var client = try AttestationClient.init(
+        allocator,
+        "https://myattestation.attest.azure.net",
+        credential.asCredential(),
+        .{ .runtime = .init(mock.asTransport(), provider.asProvider()) },
+    );
+    defer client.deinit();
+
+    try std.testing.expectError(
+        error.ProviderFailure,
+        client.attestSgxEnclave(allocator, "base64-encoded-quote"),
+    );
+    try std.testing.expectEqual(@as(usize, 1), provider.random_calls);
+    try std.testing.expectEqual(@as(usize, 0), credential.calls);
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+}
+
+test "AttestationClient releases every allocation failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        attestationAllocationFixture,
+        .{},
+    );
 }


### PR DESCRIPTION
Part of #412
Part of #414

## Summary

- replace the legacy credential/transport constructor with the canonical `core.http.HttpRuntime` and current `core.http.HttpPipeline`
- add stable bearer-token and request-ID policies so every operation preserves the complete runtime and uses the selected crypto provider for request randomness
- document copied runtime descriptors and borrowed credential, transport-context, and crypto-context lifetimes
- remove the old pipeline/transport API, propagate provider failures without fallback or transport dispatch, and preserve allocation failures during response parsing
- add runtime/provider preservation, provider-failure, and exhaustive allocation-failure coverage
- bump `azure_sdk_attestation` from 0.1.0 to the unreleased breaking version 0.2.0

## Core pin

- `azure_sdk_core` 0.3.0: `git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41`
- hash: `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`

## Validation

- `zig fmt --check root.zig build.zig`
- `zig build --summary all`
- `zig build test --summary all` — 3/3 passed
- `git diff --check`
- audited package Zig sources: no direct `std.crypto`, `randomSecure`, legacy `core.pipeline`, or legacy transport construction remains
- this package branch defines no `package-check` or `package-history-check` build steps
