### PR TITLE
Migrate DevOps SDK to HttpRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,16 @@ const devops = @import("azure_sdk_devops");
 pub fn main(init: std.process.Init) !void {
     var transport = core.http.StdHttpTransport.init(init.gpa, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try devops.DevOpsClient.init(init.gpa, .{
         .organization = "contoso",
         .credential = .fromPat(pat),
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 
@@ -85,7 +90,7 @@ var client = try devops.DevOpsClient.init(allocator, .{
     .organization = "DefaultCollection",
     .endpoint = "https://tfs.contoso.com/tfs",
     .credential = .fromPat(pat),
-    .transport = transport.asTransport(),
+    .runtime = runtime,
 });
 ```
 
@@ -155,6 +160,27 @@ const Repository = models.GitRepository;
 
 `DevOpsClient.areaClient` builds any generated root client on the shared
 pipeline, so an area without a named accessor is still one call away.
+
+## Runtime and ownership
+
+`DevOpsClient` has one canonical dependency path: callers supply a
+`core.http.HttpRuntime`, and the client builds its telemetry, retry, and
+credential policies around that runtime. Runtime, transport, and crypto
+provider descriptors are copied by value. Their backend contexts are borrowed
+and must outlive the client, every derived area/sub-client or pager fetcher,
+every token-credential call, and every open operation.
+
+The selected HTTP transport and SDK crypto provider remain independent and are
+preserved through all generated derived clients. Entra ID token credentials
+receive that same runtime for each token acquisition. This package performs no
+MD5, SHA-256, HMAC-SHA256, or random-byte operation itself; it has no direct
+`std.crypto` use or standard-provider fallback. PAT Base64 is wire encoding,
+not hashing or signing.
+
+The client borrows `organization`, `endpoint`, `scope`, credential, and runtime
+backend contexts. Deinitialize the client before releasing them. A
+`ContinuationPager` borrows its fetcher; fetchers normally contain a generated
+sub-client whose copied pipeline still borrows the original runtime contexts.
 
 ## Examples
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,12 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .azure_rest_devops = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bb73526b43837f609df2b63fb8b08caa659f1c57",
-            .hash = "azure_rest_devops-0.1.0-anpXMs5vQwC3S97m6Uv4b8l38Vp3fZ16GnuOLE0268sA",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#d2aff59967ad422b0f29c65622019925ce5aa87d",
+            .hash = "azure_rest_devops-0.1.0-anpXMvM1QgAVQ0IBR1LtJlzrJapFjyEIhE9lAIELuaBK",
         },
     },
     .paths = .{

--- a/examples/list_builds.zig
+++ b/examples/list_builds.zig
@@ -109,11 +109,16 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     const settings = try support.loadSettings(init.environ_map);
     const project = try support.requireProject(settings);
 
-    var client = try support.client(allocator, settings, transport.asTransport());
+    var client = try support.client(allocator, settings, runtime);
     defer client.deinit();
 
     var build_client = client.build();

--- a/examples/list_projects.zig
+++ b/examples/list_projects.zig
@@ -19,10 +19,15 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     const settings = try support.loadSettings(init.environ_map);
 
-    var client = try support.client(allocator, settings, transport.asTransport());
+    var client = try support.client(allocator, settings, runtime);
     defer client.deinit();
 
     // `core` is an Azure DevOps API area as well as the name of the Zig

--- a/examples/list_repositories.zig
+++ b/examples/list_repositories.zig
@@ -20,11 +20,16 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     const settings = try support.loadSettings(init.environ_map);
     const project = try support.requireProject(settings);
 
-    var client = try support.client(allocator, settings, transport.asTransport());
+    var client = try support.client(allocator, settings, runtime);
     defer client.deinit();
 
     var git = client.git();

--- a/examples/page_audit_log.zig
+++ b/examples/page_audit_log.zig
@@ -82,10 +82,15 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     const settings = try support.loadSettings(init.environ_map);
 
-    var client = try support.client(allocator, settings, transport.asTransport());
+    var client = try support.client(allocator, settings, runtime);
     defer client.deinit();
 
     var audit = client.audit();

--- a/examples/query_work_items.zig
+++ b/examples/query_work_items.zig
@@ -28,11 +28,16 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     const settings = try support.loadSettings(init.environ_map);
     const project = try support.requireProject(settings);
 
-    var client = try support.client(allocator, settings, transport.asTransport());
+    var client = try support.client(allocator, settings, runtime);
     defer client.deinit();
 
     var wit = client.workItemTracking();

--- a/examples/support.zig
+++ b/examples/support.zig
@@ -1,7 +1,7 @@
 //! Shared setup for the Azure DevOps examples.
 //!
 //! Every example needs the same three things — an organization, a
-//! credential and a transport — so they are resolved here from the
+//! credential and an HTTP runtime — so they are resolved here from the
 //! environment rather than repeated four times.
 //!
 //! Environment:
@@ -60,11 +60,11 @@ pub fn requireProject(settings: Settings) ![]const u8 {
 pub fn client(
     allocator: std.mem.Allocator,
     settings: Settings,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 ) !devops.DevOpsClient {
     return devops.DevOpsClient.init(allocator, .{
         .organization = settings.organization,
         .credential = .fromPat(settings.pat),
-        .transport = transport,
+        .runtime = runtime,
     });
 }

--- a/live_tests/main.zig
+++ b/live_tests/main.zig
@@ -42,11 +42,16 @@ test "live: the organization's projects can be listed with a PAT" {
 
     var transport = core.http.StdHttpTransport.init(allocator, std.testing.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try devops.DevOpsClient.init(allocator, .{
         .organization = settings.organization,
         .credential = .fromPat(settings.pat),
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 
@@ -77,11 +82,16 @@ test "live: a project's Git repositories can be listed" {
 
     var transport = core.http.StdHttpTransport.init(allocator, std.testing.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try devops.DevOpsClient.init(allocator, .{
         .organization = settings.organization,
         .credential = .fromPat(settings.pat),
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 
@@ -111,11 +121,16 @@ test "live: an invalid PAT is rejected rather than silently succeeding" {
 
     var transport = core.http.StdHttpTransport.init(allocator, std.testing.io);
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try devops.DevOpsClient.init(allocator, .{
         .organization = settings.organization,
         .credential = .fromPat("this-is-not-a-valid-pat"),
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -17,10 +17,10 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
-const HttpPolicy = core.pipeline.HttpPolicy;
+const HttpPolicy = core.http.HttpPolicy;
 const Request = core.http.Request;
 const Response = core.http.Response;
-const HttpTransport = core.http.HttpTransport;
+const HttpRuntime = core.http.HttpRuntime;
 
 /// The first-party application ID Azure DevOps registers in Entra ID.
 /// Every organization authenticates against this same resource, so the
@@ -51,7 +51,10 @@ pub const Credential = union(enum) {
 /// Applies a `Credential` to every request travelling through a pipeline.
 ///
 /// Bearer tokens are cached until they approach expiry; PAT headers are
-/// encoded once at `init` because they never change.
+/// encoded once at `init` because they never change. Entra ID acquisition
+/// receives the request's `HttpRuntime`, preserving the selected transport and
+/// crypto provider. Runtime backend contexts and credentials are borrowed and
+/// must outlive the policy and in-flight requests.
 pub const CredentialPolicy = struct {
     allocator: std.mem.Allocator,
     credential: Credential,
@@ -101,8 +104,10 @@ pub const CredentialPolicy = struct {
 
     /// The `Authorization` value for the current credential, refreshing a
     /// bearer token when the cached one is missing or near expiry.
-    /// Returns null when unauthenticated. The policy owns the slice.
-    pub fn authorizationHeader(self: *CredentialPolicy) !?[]const u8 {
+    /// Returns null when unauthenticated. The policy owns the slice. The
+    /// runtime descriptor is copied and its backend contexts are borrowed for
+    /// the duration of token acquisition.
+    pub fn authorizationHeader(self: *CredentialPolicy, runtime: HttpRuntime) !?[]const u8 {
         return switch (self.credential) {
             .unauthenticated => null,
             .pat => self.basic_value,
@@ -118,6 +123,7 @@ pub const CredentialPolicy = struct {
                 var token = try credential.getToken(
                     .{ .scopes = &scopes },
                     core.context.Context.none,
+                    runtime,
                 );
                 defer token.deinit();
                 const value = try std.fmt.allocPrint(
@@ -132,9 +138,9 @@ pub const CredentialPolicy = struct {
         };
     }
 
-    fn prepareImpl(policy: *HttpPolicy, request: *Request) !void {
+    fn prepareImpl(policy: *HttpPolicy, request: *Request, runtime: HttpRuntime) !void {
         const self: *CredentialPolicy = @alignCast(@fieldParentPtr("policy", policy));
-        if (try self.authorizationHeader()) |value| {
+        if (try self.authorizationHeader(runtime)) |value| {
             try request.setHeader("Authorization", value);
         }
     }
@@ -143,11 +149,11 @@ pub const CredentialPolicy = struct {
         policy: *HttpPolicy,
         request: *Request,
         next: []*HttpPolicy,
-        final_transport: *HttpTransport,
+        runtime: HttpRuntime,
     ) !Response {
-        try prepareImpl(policy, request);
-        if (next.len == 0) return final_transport.send(request);
-        return next[0].process(request, next[1..], final_transport);
+        try prepareImpl(policy, request, runtime);
+        if (next.len == 0) return runtime.transport.send(request);
+        return next[0].process(request, next[1..], runtime);
     }
 };
 
@@ -163,12 +169,98 @@ fn encodeBasic(allocator: std.mem.Allocator, pat: []const u8) ![]u8 {
     return std.fmt.allocPrint(allocator, "Basic {s}", .{encoded});
 }
 
+const TestCryptoProvider = struct {
+    random_calls: usize = 0,
+    fail_random: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn asProvider(self: *TestCryptoProvider) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *TestCryptoProvider = @ptrCast(@alignCast(context));
+        self.random_calls += 1;
+        if (self.fail_random) return error.InjectedProviderFailure;
+        @memset(out, 0x5a);
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.UnexpectedCryptoOperation;
+    }
+};
+
+const RuntimeTokenCredential = struct {
+    credential: core.credentials.TokenCredential,
+    seen_transport_context: ?*anyopaque = null,
+    seen_crypto_context: ?*anyopaque = null,
+
+    fn init() RuntimeTokenCredential {
+        return .{
+            .credential = .{ .getTokenFn = &getToken },
+        };
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        _: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+        runtime: HttpRuntime,
+    ) !core.credentials.AccessToken {
+        const self: *RuntimeTokenCredential = @alignCast(
+            @fieldParentPtr("credential", credential),
+        );
+        self.seen_transport_context = runtime.transport.context;
+        self.seen_crypto_context = runtime.crypto.context;
+        var probe: [1]u8 = undefined;
+        try runtime.crypto.randomBytes(&probe);
+        return .{
+            .token = "runtime-token",
+            .expires_on = std.math.maxInt(i64),
+        };
+    }
+};
+
 test "PAT credentials are sent as Basic auth with an empty user name" {
     const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "");
+    defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
     var policy = try CredentialPolicy.init(allocator, .fromPat("secret-pat"), .{});
     defer policy.deinit();
 
-    const header = (try policy.authorizationHeader()).?;
+    const header = (try policy.authorizationHeader(runtime)).?;
     try std.testing.expectStringStartsWith(header, "Basic ");
 
     const encoded = header["Basic ".len..];
@@ -180,9 +272,16 @@ test "PAT credentials are sent as Basic auth with an empty user name" {
 }
 
 test "unauthenticated credentials send no Authorization header" {
+    var transport = core.http.MockTransport.init(std.testing.allocator, 200, "");
+    defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
     var policy = try CredentialPolicy.init(std.testing.allocator, .unauthenticated, .{});
     defer policy.deinit();
-    try std.testing.expect((try policy.authorizationHeader()) == null);
+    try std.testing.expect((try policy.authorizationHeader(runtime)) == null);
 }
 
 test "the Azure DevOps scope is the first-party resource, not the endpoint" {
@@ -193,4 +292,62 @@ test "the Azure DevOps scope is the first-party resource, not the endpoint" {
         "499b84ac-1321-427f-aa17-267ca6975798/.default",
         devops_scope,
     );
+}
+
+test "token credentials receive the selected runtime" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
+    defer transport.deinit();
+    var crypto = TestCryptoProvider{};
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
+    var credential = RuntimeTokenCredential.init();
+    var policy = try CredentialPolicy.init(
+        allocator,
+        .fromTokenCredential(&credential.credential),
+        .{},
+    );
+    defer policy.deinit();
+
+    const header = (try policy.authorizationHeader(runtime)).?;
+    try std.testing.expectStringEndsWith(header, "runtime-token");
+    try std.testing.expectEqual(@as(usize, 1), crypto.random_calls);
+    try std.testing.expectEqual(
+        runtime.transport.context,
+        credential.seen_transport_context.?,
+    );
+    try std.testing.expectEqual(
+        runtime.crypto.context,
+        credential.seen_crypto_context.?,
+    );
+}
+
+test "provider failure propagates before transport dispatch" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
+    defer transport.deinit();
+    var crypto = TestCryptoProvider{ .fail_random = true };
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
+    var credential = RuntimeTokenCredential.init();
+    var policy = try CredentialPolicy.init(
+        allocator,
+        .fromTokenCredential(&credential.credential),
+        .{},
+    );
+    defer policy.deinit();
+    var request = Request.init(allocator, .GET, "https://dev.azure.com");
+    defer request.deinit();
+
+    try std.testing.expectError(
+        error.InjectedProviderFailure,
+        policy.asPolicy().process(&request, &.{}, runtime),
+    );
+    try std.testing.expectEqual(@as(usize, 1), crypto.random_calls);
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+    try std.testing.expect(request.getHeader("Authorization") == null);
 }

--- a/src/client.zig
+++ b/src/client.zig
@@ -6,10 +6,18 @@
 //! and authenticate 44 clients separately:
 //!
 //! ```zig
+//! var transport = core.http.StdHttpTransport.init(allocator, io);
+//! defer transport.deinit();
+//! var crypto = core.crypto.StdCryptoProvider.init(io);
+//! const runtime = core.http.HttpRuntime.init(
+//!     transport.asTransport(),
+//!     crypto.asProvider(),
+//! );
+//!
 //! var client = try DevOpsClient.init(allocator, .{
 //!     .organization = "contoso",
 //!     .credential = .fromPat(pat),
-//!     .transport = &transport,
+//!     .runtime = runtime,
 //! });
 //! defer client.deinit();
 //!
@@ -31,7 +39,7 @@ const auth = @import("auth.zig");
 
 const Credential = auth.Credential;
 const CredentialPolicy = auth.CredentialPolicy;
-const HttpPolicy = core.pipeline.HttpPolicy;
+const HttpPolicy = core.http.HttpPolicy;
 
 pub const user_agent = "azsdk-zig-devops/" ++ "0.1.0";
 
@@ -42,25 +50,32 @@ pub const ClientOptions = struct {
     /// instead of threading it through every call site.
     organization: []const u8,
     credential: Credential = .unauthenticated,
-    transport: *core.http.HttpTransport,
-    /// Overrides every area's own default host. Azure DevOps Server
+    /// HTTP and SDK crypto dependencies. The descriptor is copied by value
+    /// while its transport and crypto contexts remain borrowed.
+    runtime: core.http.HttpRuntime,
+    /// Borrowed override for every area's own default host. Azure DevOps Server
     /// serves all areas from one collection URL, e.g.
     /// `https://tfs.contoso.com/tfs/DefaultCollection`; Azure DevOps
     /// Services should leave this null.
     endpoint: ?[]const u8 = null,
-    /// Entra ID scope requested from a `TokenCredential`.
+    /// Borrowed Entra ID scope requested from a `TokenCredential`.
     scope: []const u8 = auth.devops_scope,
 };
 
+/// One authenticated pipeline shared by every generated Azure DevOps area.
+///
+/// Runtime and provider descriptors are copied by value. The transport and
+/// crypto backend contexts, credential, organization, endpoint, and scope are
+/// borrowed and must outlive this client and every derived area or operation.
 pub const DevOpsClient = struct {
     allocator: std.mem.Allocator,
     organization: []const u8,
     endpoint: ?[]const u8,
     credential_policy: *CredentialPolicy,
-    telemetry_policy: *core.pipeline.TelemetryPolicy,
-    retry_policy: *core.pipeline.RetryPolicy,
+    telemetry_policy: *core.http.TelemetryPolicy,
+    retry_policy: *core.http.RetryPolicy,
     policy_ptrs: []*HttpPolicy,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline: core.http.HttpPipeline,
 
     pub fn init(allocator: std.mem.Allocator, options: ClientOptions) !DevOpsClient {
         const credential_policy = try allocator.create(CredentialPolicy);
@@ -72,13 +87,13 @@ pub const DevOpsClient = struct {
         );
         errdefer credential_policy.deinit();
 
-        const telemetry_policy = try allocator.create(core.pipeline.TelemetryPolicy);
+        const telemetry_policy = try allocator.create(core.http.TelemetryPolicy);
         errdefer allocator.destroy(telemetry_policy);
-        telemetry_policy.* = core.pipeline.TelemetryPolicy.init(user_agent);
+        telemetry_policy.* = core.http.TelemetryPolicy.init(user_agent);
 
-        const retry_policy = try allocator.create(core.pipeline.RetryPolicy);
+        const retry_policy = try allocator.create(core.http.RetryPolicy);
         errdefer allocator.destroy(retry_policy);
-        retry_policy.* = core.pipeline.RetryPolicy.init();
+        retry_policy.* = core.http.RetryPolicy.init();
 
         const policy_ptrs = try allocator.alloc(*HttpPolicy, 3);
         errdefer allocator.free(policy_ptrs);
@@ -94,10 +109,7 @@ pub const DevOpsClient = struct {
             .telemetry_policy = telemetry_policy,
             .retry_policy = retry_policy,
             .policy_ptrs = policy_ptrs,
-            .pipeline = .{
-                .policies = policy_ptrs,
-                .transport_impl = options.transport,
-            },
+            .pipeline = core.http.HttpPipeline.init(options.runtime, policy_ptrs),
         };
     }
 
@@ -117,11 +129,11 @@ pub const DevOpsClient = struct {
     /// itself generic over the area.
     pub fn areaClient(self: *DevOpsClient, comptime Client: type) Client {
         if (self.endpoint) |endpoint| {
-            return Client.initWithPipeline(self.allocator, self.pipeline, .{
+            return Client.init(self.pipeline, .{
                 .endpoint = endpoint,
             });
         }
-        return Client.initWithPipeline(self.allocator, self.pipeline, .{});
+        return Client.init(self.pipeline, .{});
     }
 
     pub fn account(self: *DevOpsClient) protocol.account.AccountClient {

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -7,67 +7,20 @@ const root = @import("root.zig");
 
 const DevOpsClient = root.DevOpsClient;
 
-/// Records the last request it saw and replays a canned response.
-const StubTransport = struct {
-    allocator: std.mem.Allocator,
-    transport: core.http.HttpTransport,
-    status_code: u16 = 200,
-    body: []const u8 = "{}",
-    last_url: ?[]u8 = null,
-    last_authorization: ?[]u8 = null,
-    last_user_agent: ?[]u8 = null,
-
-    fn init(allocator: std.mem.Allocator) StubTransport {
-        return .{
-            .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl },
-        };
-    }
-
-    fn deinit(self: *StubTransport) void {
-        if (self.last_url) |value| self.allocator.free(value);
-        if (self.last_authorization) |value| self.allocator.free(value);
-        if (self.last_user_agent) |value| self.allocator.free(value);
-    }
-
-    fn asTransport(self: *StubTransport) *core.http.HttpTransport {
-        return &self.transport;
-    }
-
-    fn sendImpl(
-        transport: *core.http.HttpTransport,
-        request: *core.http.Request,
-    ) anyerror!core.http.Response {
-        const self: *StubTransport = @alignCast(@fieldParentPtr("transport", transport));
-        if (self.last_url) |value| self.allocator.free(value);
-        self.last_url = try self.allocator.dupe(u8, request.url);
-        if (request.getHeader("Authorization")) |value| {
-            if (self.last_authorization) |old| self.allocator.free(old);
-            self.last_authorization = try self.allocator.dupe(u8, value);
-        }
-        if (request.getHeader("User-Agent")) |value| {
-            if (self.last_user_agent) |old| self.allocator.free(old);
-            self.last_user_agent = try self.allocator.dupe(u8, value);
-        }
-        return .{
-            .status_code = self.status_code,
-            .body = try self.allocator.dupe(u8, self.body),
-            .headers = .init(self.allocator),
-            .allocator = self.allocator,
-            .response_headers = .{},
-        };
-    }
-};
-
 test "every area is reachable from one authenticated client" {
     const allocator = std.testing.allocator;
-    var transport = StubTransport.init(allocator);
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try DevOpsClient.init(allocator, .{
         .organization = "contoso",
         .credential = .fromPat("secret-pat"),
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 
@@ -84,12 +37,17 @@ test "every area is reachable from one authenticated client" {
 
 test "areas keep their own hosts unless the caller overrides the endpoint" {
     const allocator = std.testing.allocator;
-    var transport = StubTransport.init(allocator);
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try DevOpsClient.init(allocator, .{
         .organization = "contoso",
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 
@@ -101,7 +59,7 @@ test "areas keep their own hosts unless the caller overrides the endpoint" {
     // Azure DevOps Server serves every area from one collection URL.
     var server = try DevOpsClient.init(allocator, .{
         .organization = "DefaultCollection",
-        .transport = transport.asTransport(),
+        .runtime = runtime,
         .endpoint = "https://tfs.contoso.com/tfs",
     });
     defer server.deinit();
@@ -113,14 +71,22 @@ test "areas keep their own hosts unless the caller overrides the endpoint" {
 
 test "requests carry the PAT and the SDK user agent" {
     const allocator = std.testing.allocator;
-    var transport = StubTransport.init(allocator);
+    var transport = core.http.MockTransport.init(
+        allocator,
+        200,
+        "{\"count\":0,\"value\":[]}",
+    );
     defer transport.deinit();
-    transport.body = "{\"count\":0,\"value\":[]}";
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try DevOpsClient.init(allocator, .{
         .organization = "contoso",
         .credential = .fromPat("secret-pat"),
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 
@@ -132,21 +98,68 @@ test "requests carry the PAT and the SDK user agent" {
     };
     _ = result;
 
-    try std.testing.expectStringStartsWith(transport.last_authorization.?, "Basic ");
-    try std.testing.expectEqualStrings(root.user_agent, transport.last_user_agent.?);
+    try std.testing.expectStringStartsWith(
+        transport.last_headers.get("Authorization").?,
+        "Basic ",
+    );
+    try std.testing.expectEqualStrings(
+        root.user_agent,
+        transport.last_headers.get("User-Agent").?,
+    );
 }
 
 test "the api-version is pinned to the generated 7.2 contract" {
     const allocator = std.testing.allocator;
-    var transport = StubTransport.init(allocator);
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
 
     var client = try DevOpsClient.init(allocator, .{
         .organization = "contoso",
-        .transport = transport.asTransport(),
+        .runtime = runtime,
     });
     defer client.deinit();
 
     const git = client.git();
     try std.testing.expectStringStartsWith(git.api_version, "7.2");
+}
+
+test "derived operation clients preserve the selected runtime" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
+    defer transport.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto.asProvider(),
+    );
+
+    var client = try DevOpsClient.init(allocator, .{
+        .organization = "contoso",
+        .runtime = runtime,
+    });
+    defer client.deinit();
+
+    var git = client.git();
+    const repositories = git.repositories();
+    try std.testing.expectEqual(
+        runtime.transport.context,
+        repositories.pipeline.runtime.transport.context,
+    );
+    try std.testing.expectEqual(
+        runtime.transport.vtable,
+        repositories.pipeline.runtime.transport.vtable,
+    );
+    try std.testing.expectEqual(
+        runtime.crypto.context,
+        repositories.pipeline.runtime.crypto.context,
+    );
+    try std.testing.expectEqual(
+        runtime.crypto.vtable,
+        repositories.pipeline.runtime.crypto.vtable,
+    );
 }

--- a/src/continuation.zig
+++ b/src/continuation.zig
@@ -47,7 +47,9 @@ pub fn Page(comptime T: type) type {
 /// ```
 ///
 /// which is normally a small struct capturing the area sub-client and
-/// the operation's fixed parameters.
+/// the operation's fixed parameters. The pager borrows that fetcher. When the
+/// fetcher contains a generated client, its copied pipeline still borrows the
+/// original runtime's transport and crypto contexts, which must outlive paging.
 pub fn ContinuationPager(comptime T: type, comptime Fetcher: type) type {
     return struct {
         fetcher: *Fetcher,


### PR DESCRIPTION
## Summary

- replace the legacy transport-pointer client path with canonical `core.http.HttpRuntime` and current `core.http.HttpPipeline` construction
- migrate the custom credential policy, generated area clients, examples, live tests, and unit tests to the runtime-aware APIs
- preserve copied transport and crypto descriptors through area/sub-client and token-credential paths while documenting all borrowed context and pager lifetimes
- add selected-runtime and provider-failure coverage proving provider errors propagate before transport dispatch, with no partial authorization header or fallback
- audit SDK hashing, HMAC, and random use: production DevOps code performs none; PAT Base64 is wire encoding, while token credentials receive `runtime.crypto`

Part of #412
Part of #414

## Exact pins

- `azure_sdk_core` 0.3.0: `git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41`
  - `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- `azure_rest_devops` 0.1.0: `git+https://github.com/cataggar/azure-sdk-for-zig.git#d2aff59967ad422b0f29c65622019925ce5aa87d`
  - `azure_rest_devops-0.1.0-anpXMvM1QgAVQ0IBR1LtJlzrJapFjyEIhE9lAIELuaBK`

No `azure_sdk_devops` release tag exists, so 0.1.0 remains the next valid first package version; the user agent remains aligned with it.

## Validation

- `git ls-files -z -- '*.zig' 'build.zig.zon' | xargs -0 zig fmt --check`
- `zig build --summary all`
- `zig build test --summary all` — 17/17 passed; all five examples also compile through the test graph
- `zig build examples --summary all` — 12/12 steps succeeded
- `zig build live-test --summary all` — compiled; 3/3 skipped because live credentials were not configured
- `git diff --check`
- verified the Core and REST release tags resolve to the exact pinned commits
- verified `HEAD...origin/sdk/devops` was `0 0` before the migration commit

This package branch defines no separate `package-check` or `package-history-check` build steps; its package CI checks formatting, unit tests, examples, and live-test compilation as run above.

Auto-merge is intentionally disabled.