### PR TITLE
eventhubs: adopt HTTP runtime and crypto provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ retry schedule, CBS authorisation, and a connection that rebuilds itself. It
 is what turns a client into one that reaches the network.
 
 ```zig
+var http = core.http.StdHttpTransport.init(allocator, io);
+defer http.deinit();
+var crypto = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    http.asTransport(),
+    crypto.asProvider(),
+);
+
 var hub: HubConnection = undefined;
 hub.open(.{
     .allocator = allocator,
@@ -24,6 +32,7 @@ defer hub.deinit();
 
 var producer = try ProducerClient.fromConnectionString(
     allocator,
+    runtime,
     connection_string,
     "my-hub",
     hub.asTransport(),
@@ -34,7 +43,7 @@ defer producer.close();
 // parses, and that credential does not exist until the client is built.
 const audience = try producer.entityAudience(allocator);
 defer allocator.free(audience);
-try hub.bind(&producer.credential, audience);
+try hub.bind(&producer.credential, audience, producer.options.runtime);
 ```
 
 Initialise it in place. It holds interior pointers — the authorizer points at
@@ -53,11 +62,15 @@ holding it across a rebuild would leave it pointing at a dead session.
 ## Authentication
 
 Both clients hold a `Credential`, which is either an AAD `TokenCredential` or
-a shared access signature parsed out of a connection string:
+a shared access signature parsed out of a connection string. Their required
+`HttpRuntime` is copied by value; its HTTP transport and SDK crypto provider
+borrow their backend contexts, which must outlive the client, credential
+calls, and open HTTP operations:
 
 ```zig
 // AAD. The credential must outlive the client.
 var producer = ProducerClient.init(.{
+    .runtime = runtime,
     .fully_qualified_namespace = "ns.servicebus.windows.net",
     .event_hub_name = "hub",
 }, cred.asCredential(), transport);
@@ -65,12 +78,20 @@ defer producer.close();
 
 // Connection string. The string must outlive the client, because the
 // namespace, hub name, and key are all borrowed from it.
-var producer = try ProducerClient.fromConnectionString(allocator, cs, null, transport);
+var producer = try ProducerClient.fromConnectionString(
+    allocator,
+    runtime,
+    cs,
+    null,
+    transport,
+);
 defer producer.close();
 ```
 
 AAD tokens are requested for `https://eventhubs.azure.net/.default` and put to
 CBS as `jwt`; connection-string tokens are put as `servicebus.windows.net:sastoken`.
+Shared-key SAS signatures use `runtime.crypto`; provider failures propagate
+without falling back to the standard provider.
 
 A token authorises an audience rather than the whole namespace.
 `entityAudience` returns `amqps://{namespace}/{hub}` for management operations

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,20 +1,20 @@
 .{
     .name = .azure_sdk_eventhubs,
-    .version = "0.5.0",
+    .version = "0.6.0",
     .fingerprint = 0xcb7772a1125a8d42,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .azure_sdk_messaging_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#2dd41660a706db7bbaa2ef2fe76b67e92568a8e6",
-            .hash = "azure_sdk_messaging_common-0.2.0-YklmSkWIAACgiNHymgq5TSnhW6t9nULx2U8H4kxUgGWN",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#6326815bfacb61c7484d93f969f959082f406dcc",
+            .hash = "azure_sdk_messaging_common-0.3.0-YklmSimrAABYnVM-KFESp7QVjZSRzJXVpQl3CJ8a_ZeO",
         },
         .azure_sdk_storage_blobs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#4a21c5e1d85e9da22fa9481b7ffde8920bf53fae",
-            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgAxYhvh6lYm59jMOZ_-NaWDqKDvXheMlGoU",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#2bd2b47df464e2bd548d6aad6f5d8d425f2e74a9",
+            .hash = "azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d",
         },
         .azure_sdk_amqp = .{
             .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bd5330d983ca75a56771a085659ec1136c9a81f6",

--- a/checkpoint_store.zig
+++ b/checkpoint_store.zig
@@ -376,14 +376,46 @@ test {
     _ = @import("checkpoint.zig");
 }
 
-fn testContainer(transport: *core.http.HttpTransport) blobs.BlobContainerClient {
-    return blobs.BlobContainerClient.initWithPipeline(
-        .{ .policies = &.{}, .transport_impl = transport },
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testContainer(transport: core.http.HttpTransport) blobs.BlobContainerClient {
+    return testContainerWithProvider(
+        transport,
+        testing_crypto_provider.asProvider(),
+    );
+}
+
+fn testContainerWithProvider(
+    transport: core.http.HttpTransport,
+    provider: core.crypto.CryptoProvider,
+) blobs.BlobContainerClient {
+    const runtime = core.http.HttpRuntime.init(
+        transport,
+        provider,
+    );
+    return blobs.BlobContainerClient.init(
+        core.http.HttpPipeline.init(runtime, &.{}),
         .{
             .endpoint = "https://myaccount.blob.core.windows.net",
             .container_name = "checkpoints",
         },
     );
+}
+
+test "checkpoint blob clients preserve the selected runtime crypto provider" {
+    var mock = core.http.MockTransport.init(testing.allocator, 200, "");
+    defer mock.deinit();
+    var selected_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const provider = selected_provider.asProvider();
+
+    var container = testContainerWithProvider(mock.asTransport(), provider);
+    const blob = container.getBlobClient("ns/hub/$Default/checkpoint/0");
+
+    try testing.expectEqual(
+        provider.context,
+        blob.pipeline.runtime.crypto.context,
+    );
+    try testing.expectEqual(provider.vtable, blob.pipeline.runtime.crypto.vtable);
 }
 
 test "buildCheckpointPath" {
@@ -764,7 +796,10 @@ const ScriptedTransport = struct {
     replies: []const Reply,
     index: usize = 0,
     requests: std.ArrayList(Captured) = .empty,
-    transport: core.http.HttpTransport = .{ .sendFn = &sendImpl },
+
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &sendImpl,
+    };
 
     fn init(allocator: std.mem.Allocator, replies: []const Reply) ScriptedTransport {
         return .{ .allocator = allocator, .replies = replies };
@@ -775,15 +810,15 @@ const ScriptedTransport = struct {
         self.requests.deinit(self.allocator);
     }
 
-    fn asTransport(self: *ScriptedTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *ScriptedTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn sendImpl(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
     ) anyerror!core.http.Response {
-        const self: *ScriptedTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *ScriptedTransport = @ptrCast(@alignCast(context));
 
         var captured = Captured{
             .url = try self.allocator.dupe(u8, request.url),

--- a/checkpoint_store_blob/README.md
+++ b/checkpoint_store_blob/README.md
@@ -35,3 +35,9 @@ Ownership additionally uses the blob's own `ETag` and `Last-Modified`:
 
 Slices returned by the store are allocator-owned; free them with
 `freeCheckpoints` or `freeOwnerships`.
+
+Construct `BlobContainerClient` with an `HttpPipeline` built from the
+application's `HttpRuntime`. Derived checkpoint blob clients preserve that
+runtime, including its SDK crypto provider. The pipeline's borrowed transport,
+crypto, policy, and credential contexts must outlive the checkpoint store and
+all of its operations.

--- a/connection_options.zig
+++ b/connection_options.zig
@@ -40,7 +40,8 @@ pub const CustomEndpoint = struct {
     port: u16 = amqp.tls_port,
 };
 
-/// TLS knobs.
+/// AMQP TLS trust knobs. This certificate bundle is unrelated to the SDK
+/// `CryptoProvider` carried by `core.http.HttpRuntime`.
 pub const TlsSettings = struct {
     /// Certificate bundle to validate against. Null rescans the system trust
     /// store on every dial, which is slow enough that a long-lived client

--- a/examples/batch_producer.zig
+++ b/examples/batch_producer.zig
@@ -9,6 +9,7 @@
 //! `createBatch` is a client method rather than a free function.
 
 const std = @import("std");
+const core = @import("azure_sdk_core");
 const eh = @import("azure_sdk_eventhubs");
 
 pub fn main(init: std.process.Init) !void {
@@ -25,6 +26,14 @@ pub fn main(init: std.process.Init) !void {
         return error.MissingConnectionString;
     const properties = try eh.ConnectionStringProperties.parse(connection_string);
 
+    var http = core.http.StdHttpTransport.init(allocator, init.io);
+    defer http.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        http.asTransport(),
+        crypto_provider.asProvider(),
+    );
+
     var hub: eh.HubConnection = undefined;
     hub.open(.{
         .allocator = allocator,
@@ -36,6 +45,7 @@ pub fn main(init: std.process.Init) !void {
 
     var producer = try eh.ProducerClient.fromConnectionString(
         allocator,
+        runtime,
         connection_string,
         hub_name,
         hub.asTransport(),
@@ -44,7 +54,7 @@ pub fn main(init: std.process.Init) !void {
 
     const audience = try producer.entityAudience(allocator);
     defer allocator.free(audience);
-    try hub.bind(&producer.credential, audience);
+    try hub.bind(&producer.credential, audience, producer.options.runtime);
 
     var stdout_file = std.Io.File.stdout();
     var buffer: [256]u8 = undefined;

--- a/examples/connection_string_auth.zig
+++ b/examples/connection_string_auth.zig
@@ -8,6 +8,7 @@
 //! `EntityPath`.
 
 const std = @import("std");
+const core = @import("azure_sdk_core");
 const eh = @import("azure_sdk_eventhubs");
 
 pub fn main(init: std.process.Init) !void {
@@ -25,6 +26,14 @@ pub fn main(init: std.process.Init) !void {
 
     const properties = try eh.ConnectionStringProperties.parse(connection_string);
 
+    var http = core.http.StdHttpTransport.init(allocator, init.io);
+    defer http.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        http.asTransport(),
+        crypto_provider.asProvider(),
+    );
+
     var hub: eh.HubConnection = undefined;
     hub.open(.{
         .allocator = allocator,
@@ -36,6 +45,7 @@ pub fn main(init: std.process.Init) !void {
 
     var producer = try eh.ProducerClient.fromConnectionString(
         allocator,
+        runtime,
         connection_string,
         hub_name,
         hub.asTransport(),
@@ -44,7 +54,7 @@ pub fn main(init: std.process.Init) !void {
 
     const audience = try producer.entityAudience(allocator);
     defer allocator.free(audience);
-    try hub.bind(&producer.credential, audience);
+    try hub.bind(&producer.credential, audience, producer.options.runtime);
 
     var batch = try producer.createBatch(allocator, .{});
     defer batch.deinit(allocator);

--- a/examples/consume_partition.zig
+++ b/examples/consume_partition.zig
@@ -8,6 +8,7 @@
 //! `examples/processor.zig`.
 
 const std = @import("std");
+const core = @import("azure_sdk_core");
 const eh = @import("azure_sdk_eventhubs");
 
 pub fn main(init: std.process.Init) !void {
@@ -23,6 +24,14 @@ pub fn main(init: std.process.Init) !void {
         return error.MissingConnectionString;
     const properties = try eh.ConnectionStringProperties.parse(connection_string);
 
+    var http = core.http.StdHttpTransport.init(allocator, init.io);
+    defer http.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        http.asTransport(),
+        crypto_provider.asProvider(),
+    );
+
     var hub: eh.HubConnection = undefined;
     hub.open(.{
         .allocator = allocator,
@@ -35,6 +44,7 @@ pub fn main(init: std.process.Init) !void {
 
     var consumer = try eh.ConsumerClient.fromConnectionString(
         allocator,
+        runtime,
         connection_string,
         hub_name,
         hub.asTransport(),
@@ -43,7 +53,7 @@ pub fn main(init: std.process.Init) !void {
 
     const audience = try consumer.entityAudience(allocator);
     defer allocator.free(audience);
-    try hub.bind(&consumer.credential, audience);
+    try hub.bind(&consumer.credential, audience, consumer.options.runtime);
 
     var stdout_file = std.Io.File.stdout();
     var buffer: [4096]u8 = undefined;

--- a/examples/hub_properties.zig
+++ b/examples/hub_properties.zig
@@ -7,6 +7,7 @@
 //! so neither sends nor receives events.
 
 const std = @import("std");
+const core = @import("azure_sdk_core");
 const eh = @import("azure_sdk_eventhubs");
 
 pub fn main(init: std.process.Init) !void {
@@ -21,6 +22,14 @@ pub fn main(init: std.process.Init) !void {
         return error.MissingConnectionString;
     const properties = try eh.ConnectionStringProperties.parse(connection_string);
 
+    var http = core.http.StdHttpTransport.init(allocator, init.io);
+    defer http.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        http.asTransport(),
+        crypto_provider.asProvider(),
+    );
+
     var hub: eh.HubConnection = undefined;
     hub.open(.{
         .allocator = allocator,
@@ -32,6 +41,7 @@ pub fn main(init: std.process.Init) !void {
 
     var consumer = try eh.ConsumerClient.fromConnectionString(
         allocator,
+        runtime,
         connection_string,
         hub_name,
         hub.asTransport(),
@@ -40,7 +50,7 @@ pub fn main(init: std.process.Init) !void {
 
     const audience = try consumer.entityAudience(allocator);
     defer allocator.free(audience);
-    try hub.bind(&consumer.credential, audience);
+    try hub.bind(&consumer.credential, audience, consumer.options.runtime);
 
     var stdout_file = std.Io.File.stdout();
     var buffer: [4096]u8 = undefined;

--- a/examples/processor.zig
+++ b/examples/processor.zig
@@ -31,19 +31,29 @@ pub fn main(init: std.process.Init) !void {
     // ── Checkpoint store ──────────────────────────────────────────────
     var http = core.http.StdHttpTransport.init(allocator, init.io);
     defer http.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        http.asTransport(),
+        crypto_provider.asProvider(),
+    );
 
     var storage_credential = core.env_token.EnvTokenCredential.init(
         allocator,
         init.environ_map.get("AZURE_TOKEN") orelse return error.MissingAzureToken,
     );
 
-    var container = try blobs.BlobContainerClient.init(allocator, .{
-        .credential = storage_credential.asCredential(),
-        .transport = http.asTransport(),
+    var auth_policy = core.http.BearerTokenAuthPolicy.init(
+        allocator,
+        storage_credential.asCredential(),
+        blobs.auth_scopes,
+    );
+    defer auth_policy.deinit();
+    var storage_policies = [_]*core.http.HttpPolicy{auth_policy.asPolicy()};
+    const storage_pipeline = core.http.HttpPipeline.init(runtime, &storage_policies);
+    var container = blobs.BlobContainerClient.init(storage_pipeline, .{
         .endpoint = storage_endpoint,
         .container_name = container_name,
     });
-    defer container.deinit();
 
     var store = eh.checkpoint_store_blob.BlobCheckpointStore.init(&container);
 
@@ -59,6 +69,7 @@ pub fn main(init: std.process.Init) !void {
 
     var consumer = try eh.ConsumerClient.fromConnectionString(
         allocator,
+        runtime,
         connection_string,
         hub_name,
         hub.asTransport(),
@@ -67,7 +78,7 @@ pub fn main(init: std.process.Init) !void {
 
     const audience = try consumer.entityAudience(allocator);
     defer allocator.free(audience);
-    try hub.bind(&consumer.credential, audience);
+    try hub.bind(&consumer.credential, audience, consumer.options.runtime);
 
     var opener = consumer.partitionOpener(&hub.connection, 60_000);
     var clock = eh.load_balancing.SystemClock{ .io = init.io };

--- a/examples/send_events.zig
+++ b/examples/send_events.zig
@@ -27,11 +27,15 @@ pub fn main(init: std.process.Init) !void {
 
     var transport = core.http.StdHttpTransport.init(allocator, init.io);
     defer transport.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(init.io);
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_provider.asProvider(),
+    );
 
     var credential = try core.identity.DefaultAzureCredential.init(
         allocator,
         init.io,
-        transport.asTransport(),
         init.environ_map,
     );
     defer credential.deinit();
@@ -48,6 +52,7 @@ pub fn main(init: std.process.Init) !void {
     defer hub.deinit();
 
     var producer = eh.ProducerClient.init(.{
+        .runtime = runtime,
         .fully_qualified_namespace = namespace,
         .event_hub_name = hub_name,
     }, credential.asCredential(), hub.asTransport());
@@ -57,7 +62,7 @@ pub fn main(init: std.process.Init) !void {
     // the transport, so binding is the last step rather than part of `open`.
     const audience = try producer.entityAudience(allocator);
     defer allocator.free(audience);
-    try hub.bind(&producer.credential, audience);
+    try hub.bind(&producer.credential, audience, producer.options.runtime);
 
     var batch = try producer.createBatch(allocator, .{});
     defer batch.deinit(allocator);

--- a/live_tests/main.zig
+++ b/live_tests/main.zig
@@ -97,6 +97,9 @@ fn nonEmpty(value: ?[]const u8) ?[]const u8 {
 /// transport at the connection. Copying it by value would leave both dangling.
 const LiveSession = struct {
     allocator: std.mem.Allocator,
+    http: core.http.StdHttpTransport,
+    crypto: core.crypto.StdCryptoProvider,
+    runtime: core.http.HttpRuntime,
     hub: eh.HubConnection,
     producer: eh.ProducerClient,
     audience: []u8,
@@ -109,6 +112,13 @@ const LiveSession = struct {
         const self = try allocator.create(LiveSession);
         errdefer allocator.destroy(self);
         self.allocator = allocator;
+        self.http = core.http.StdHttpTransport.init(allocator, io);
+        errdefer self.http.deinit();
+        self.crypto = core.crypto.StdCryptoProvider.init(io);
+        self.runtime = core.http.HttpRuntime.init(
+            self.http.asTransport(),
+            self.crypto.asProvider(),
+        );
 
         self.hub.open(.{
             .allocator = allocator,
@@ -120,6 +130,7 @@ const LiveSession = struct {
 
         self.producer = try eh.ProducerClient.fromConnectionString(
             allocator,
+            self.runtime,
             config.connection_string,
             config.hub_name,
             self.hub.asTransport(),
@@ -128,7 +139,11 @@ const LiveSession = struct {
 
         self.audience = try self.producer.entityAudience(allocator);
         errdefer allocator.free(self.audience);
-        try self.hub.bind(&self.producer.credential, self.audience);
+        try self.hub.bind(
+            &self.producer.credential,
+            self.audience,
+            self.producer.options.runtime,
+        );
         return self;
     }
 
@@ -139,6 +154,7 @@ const LiveSession = struct {
     fn consumer(self: *LiveSession, config: Config) !eh.ConsumerClient {
         var client = try eh.ConsumerClient.fromConnectionString(
             self.allocator,
+            self.runtime,
             config.connection_string,
             config.hub_name,
             self.hub.asTransport(),
@@ -151,6 +167,7 @@ const LiveSession = struct {
         self.allocator.free(self.audience);
         self.producer.deinit();
         self.hub.deinit();
+        self.http.deinit();
         self.allocator.destroy(self);
     }
 };
@@ -253,15 +270,25 @@ test "live: a checkpoint written to blob storage is listed back" {
 
     var http = core.http.StdHttpTransport.init(allocator, std.testing.io);
     defer http.deinit();
+    var crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+    const runtime = core.http.HttpRuntime.init(
+        http.asTransport(),
+        crypto_provider.asProvider(),
+    );
 
     var credential = core.env_token.EnvTokenCredential.init(allocator, storage.token);
-    var container = try blobs.BlobContainerClient.init(allocator, .{
-        .credential = credential.asCredential(),
-        .transport = http.asTransport(),
+    var auth_policy = core.http.BearerTokenAuthPolicy.init(
+        allocator,
+        credential.asCredential(),
+        blobs.auth_scopes,
+    );
+    defer auth_policy.deinit();
+    var policies = [_]*core.http.HttpPolicy{auth_policy.asPolicy()};
+    const pipeline = core.http.HttpPipeline.init(runtime, &policies);
+    var container = blobs.BlobContainerClient.init(pipeline, .{
         .endpoint = storage.endpoint,
         .container_name = storage.container,
     });
-    defer container.deinit();
 
     var blob_store = eh.checkpoint_store_blob.BlobCheckpointStore.init(&container);
     const store = blob_store.asCheckpointStore();

--- a/root.zig
+++ b/root.zig
@@ -655,14 +655,22 @@ pub const Credential = union(enum) {
     pub fn getToken(
         self: *Credential,
         ctx: core.context.Context,
+        runtime: core.http.HttpRuntime,
     ) !core.credentials.AccessToken {
-        return self.tokenCredential().getToken(.{ .scopes = &.{token_scope} }, ctx);
+        return self.tokenCredential().getToken(
+            .{ .scopes = &.{token_scope} },
+            ctx,
+            runtime,
+        );
     }
 };
 
 // ─────────────────────── Clients ───────────────────────
 
 pub const ProducerClientOptions = struct {
+    /// Copied runtime whose transport and crypto descriptors borrow backend
+    /// contexts that must outlive this client and its credential calls.
+    runtime: core.http.HttpRuntime,
     fully_qualified_namespace: []const u8,
     event_hub_name: []const u8,
     /// Application id, custom endpoint, retry schedule, TLS, and WebSockets.
@@ -704,6 +712,7 @@ pub const ProducerClient = struct {
     /// hub name, and key all borrow from it.
     pub fn fromConnectionString(
         allocator: std.mem.Allocator,
+        runtime: core.http.HttpRuntime,
         connection_string: []const u8,
         event_hub_name: ?[]const u8,
         amqp_transport: *AmqpTransport,
@@ -716,6 +725,7 @@ pub const ProducerClient = struct {
 
         return .{
             .options = .{
+                .runtime = runtime,
                 .fully_qualified_namespace = cs.fully_qualified_namespace,
                 .event_hub_name = hub,
             },
@@ -745,7 +755,7 @@ pub const ProducerClient = struct {
     /// Acquire a token for this hub, for putting to CBS before a link
     /// attaches.
     pub fn getToken(self: *ProducerClient, ctx: core.context.Context) !core.credentials.AccessToken {
-        return self.credential.getToken(ctx);
+        return self.credential.getToken(ctx, self.options.runtime);
     }
 
     /// Scratch space for an entity path that is only needed long enough to
@@ -888,6 +898,9 @@ pub const ProducerClient = struct {
 };
 
 pub const ConsumerClientOptions = struct {
+    /// Copied runtime whose transport and crypto descriptors borrow backend
+    /// contexts that must outlive this client and its credential calls.
+    runtime: core.http.HttpRuntime,
     fully_qualified_namespace: []const u8,
     event_hub_name: []const u8,
     consumer_group: []const u8 = "$Default",
@@ -930,6 +943,7 @@ pub const ConsumerClient = struct {
     /// hub name, and key all borrow from it.
     pub fn fromConnectionString(
         allocator: std.mem.Allocator,
+        runtime: core.http.HttpRuntime,
         connection_string: []const u8,
         event_hub_name: ?[]const u8,
         amqp_transport: *AmqpTransport,
@@ -942,6 +956,7 @@ pub const ConsumerClient = struct {
 
         return .{
             .options = .{
+                .runtime = runtime,
                 .fully_qualified_namespace = cs.fully_qualified_namespace,
                 .event_hub_name = hub,
             },
@@ -987,7 +1002,7 @@ pub const ConsumerClient = struct {
     /// Acquire a token for this hub, for putting to CBS before a link
     /// attaches.
     pub fn getToken(self: *ConsumerClient, ctx: core.context.Context) !core.credentials.AccessToken {
-        return self.credential.getToken(ctx);
+        return self.credential.getToken(ctx, self.options.runtime);
     }
 
     /// The AMQP address a partition is read from. Caller owns the result.
@@ -1210,15 +1225,23 @@ pub const CbsAuthorizer = struct {
     credential: ?*Credential = null,
     /// `amqps://{fqns}/{hub}`. Owned when `bind` copied it.
     audience: ?[]u8 = null,
+    /// Copied descriptor whose backend contexts remain caller-owned.
+    runtime: ?core.http.HttpRuntime = null,
     link_id: []const u8 = "eventhubs",
     ctx: core.context.Context = .none,
     authorizer: recovery.Authorizer = .{ .authorizeFn = authorize },
 
-    pub fn bind(self: *CbsAuthorizer, credential: *Credential, audience: []const u8) !void {
+    pub fn bind(
+        self: *CbsAuthorizer,
+        credential: *Credential,
+        audience: []const u8,
+        runtime: core.http.HttpRuntime,
+    ) !void {
         const owned = try self.allocator.dupe(u8, audience);
         if (self.audience) |old| self.allocator.free(old);
         self.audience = owned;
         self.credential = credential;
+        self.runtime = runtime;
     }
 
     pub fn deinit(self: *CbsAuthorizer) void {
@@ -1234,8 +1257,9 @@ pub const CbsAuthorizer = struct {
         const self: *CbsAuthorizer = @fieldParentPtr("authorizer", a);
         const credential = self.credential orelse return error.CredentialNotBound;
         const audience = self.audience orelse return error.CredentialNotBound;
+        const runtime = self.runtime orelse return error.CredentialNotBound;
 
-        var token = try credential.getToken(self.ctx);
+        var token = try credential.getToken(self.ctx, runtime);
         defer token.deinit();
 
         const client = try amqp.Cbs.open(session, .{ .link_id = self.link_id }, deadline_ms);
@@ -1330,8 +1354,13 @@ pub const HubConnection = struct {
     /// Separate from `open` because a connection-string client owns the
     /// credential it parses, so the credential does not exist until after the
     /// client is built, and the client needs this transport to be built.
-    pub fn bind(self: *HubConnection, credential: *Credential, audience: []const u8) !void {
-        return self.authorizer.bind(credential, audience);
+    pub fn bind(
+        self: *HubConnection,
+        credential: *Credential,
+        audience: []const u8,
+        runtime: core.http.HttpRuntime,
+    ) !void {
+        return self.authorizer.bind(credential, audience, runtime);
     }
 
     pub fn asTransport(self: *HubConnection) *AmqpTransport {
@@ -1354,6 +1383,77 @@ test {
     _ = ConsumerPartitionOpener;
 }
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+var unused_http_context: u8 = 0;
+const unused_http_vtable: core.http.HttpTransport.VTable = .{
+    .send = struct {
+        fn send(_: *anyopaque, _: *core.http.Request) anyerror!core.http.Response {
+            return error.UnexpectedHttpRequest;
+        }
+    }.send,
+};
+
+fn testRuntime() core.http.HttpRuntime {
+    return testRuntimeWithCrypto(testing_crypto_provider.asProvider());
+}
+
+fn testRuntimeWithCrypto(
+    provider: core.crypto.CryptoProvider,
+) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(
+        .{ .context = &unused_http_context, .vtable = &unused_http_vtable },
+        provider,
+    );
+}
+
+const TestCryptoProvider = struct {
+    hmac_calls: usize = 0,
+    fail: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &unusedRandomBytes,
+        .md5 = &unusedMd5,
+        .sha256 = &unusedSha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &unusedSha256Init,
+    };
+
+    fn provider(self: *TestCryptoProvider) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn unusedRandomBytes(_: *anyopaque, _: []u8) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn unusedMd5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn unusedSha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self: *TestCryptoProvider = @ptrCast(@alignCast(context));
+        self.hmac_calls += 1;
+        if (self.fail) return error.ProviderFailure;
+        @memset(out, 0xa5);
+    }
+
+    fn unusedSha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.UnexpectedCryptoOperation;
+    }
+};
+
 test "a hub connection wires itself up without dialling" {
     const allocator = std.testing.allocator;
     var threaded: std.Io.Threaded = .init_single_threaded;
@@ -1373,7 +1473,11 @@ test "a hub connection wires itself up without dialling" {
     try std.testing.expect(hub.authorizer.credential == null);
 
     var credential = Credential{ .sas = undefined };
-    try hub.bind(&credential, "amqps://ns.servicebus.windows.net/hub");
+    try hub.bind(
+        &credential,
+        "amqps://ns.servicebus.windows.net/hub",
+        testRuntime(),
+    );
     try std.testing.expectEqualStrings(
         "amqps://ns.servicebus.windows.net/hub",
         hub.authorizer.audience.?,
@@ -1381,7 +1485,11 @@ test "a hub connection wires itself up without dialling" {
 
     // Binding twice replaces rather than leaks: recovery rebinds after a
     // credential is swapped.
-    try hub.bind(&credential, "amqps://ns.servicebus.windows.net/other");
+    try hub.bind(
+        &credential,
+        "amqps://ns.servicebus.windows.net/other",
+        testRuntime(),
+    );
     try std.testing.expectEqualStrings(
         "amqps://ns.servicebus.windows.net/other",
         hub.authorizer.audience.?,
@@ -1568,9 +1676,10 @@ test "ProducerClient createBatch" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer mock.deinit();
-    var cred = cred_mod.ClientSecretCredential.init(allocator, mock.asTransport(), "t", "c", "s");
+    var cred = cred_mod.ClientSecretCredential.init(allocator, "t", "c", "s");
     var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
@@ -1586,9 +1695,10 @@ test "ProducerClient sendBatch" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer mock_http.deinit();
-    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var cred = cred_mod.ClientSecretCredential.init(allocator, "t", "c", "s");
     var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
@@ -1611,9 +1721,10 @@ test "ProducerClient sendBatch targets the hub, or one partition when pinned" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer mock_http.deinit();
-    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var cred = cred_mod.ClientSecretCredential.init(allocator, "t", "c", "s");
     var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
@@ -1643,9 +1754,10 @@ test "createBatch adopts the sender link's max-message-size" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer mock_http.deinit();
-    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var cred = cred_mod.ClientSecretCredential.init(allocator, "t", "c", "s");
     var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
@@ -1697,9 +1809,10 @@ test "ProducerClient sendBatch empty returns error" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer mock_http.deinit();
-    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var cred = cred_mod.ClientSecretCredential.init(allocator, "t", "c", "s");
     var mock_amqp = MockAmqpTransport.init();
     var producer = ProducerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
@@ -1718,10 +1831,11 @@ test "ProducerClient getEventHubProperties" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer mock_http.deinit();
-    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var cred = cred_mod.ClientSecretCredential.init(allocator, "t", "c", "s");
     var mock_amqp = MockAmqpTransport.init();
     mock_amqp.hub_properties = .{ .name = "my-hub", .partition_ids = &.{ "0", "1", "2" } };
     var producer = ProducerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
@@ -1738,9 +1852,10 @@ test "ConsumerClient receiveEvents" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer mock_http.deinit();
-    var cred = cred_mod.ClientSecretCredential.init(allocator, mock_http.asTransport(), "t", "c", "s");
+    var cred = cred_mod.ClientSecretCredential.init(allocator, "t", "c", "s");
     var mock_amqp = MockAmqpTransport.init();
     var consumer = ConsumerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "my-hub",
     }, cred.asCredential(), mock_amqp.asTransport());
@@ -1992,7 +2107,7 @@ test "sendBatches groups batches by the link each one addresses" {
     const allocator = std.testing.allocator;
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     defer producer.deinit();
 
     const partitions = [_]?[]const u8{ "0", "0", "1", null, null };
@@ -2031,7 +2146,7 @@ test "sendBatches keeps one run whole when every batch shares a partition" {
     const allocator = std.testing.allocator;
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     defer producer.deinit();
 
     var batches: [4]EventDataBatch = undefined;
@@ -2057,7 +2172,7 @@ test "sendBatches refuses an empty batch before sending anything" {
     const allocator = std.testing.allocator;
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     defer producer.deinit();
 
     var full = try EventDataBatch.init(.{});
@@ -2130,7 +2245,7 @@ test "ProducerClient fromConnectionString" {
     const allocator = std.testing.allocator;
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=mykey;SharedAccessKey=abc123=;EntityPath=myhub";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     defer producer.deinit();
     try std.testing.expectEqualStrings("mynamespace.servicebus.windows.net", producer.options.fully_qualified_namespace);
     try std.testing.expectEqualStrings("myhub", producer.options.event_hub_name);
@@ -2145,7 +2260,7 @@ test "ProducerClient fromConnectionString with override" {
     const allocator = std.testing.allocator;
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub1";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, "hub2", mock_amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, testRuntime(), cs, "hub2", mock_amqp.asTransport());
     defer producer.deinit();
     try std.testing.expectEqualStrings("hub2", producer.options.event_hub_name);
     try std.testing.expectEqualStrings("amqps://ns.servicebus.windows.net/hub2", producer.owned_audience.?);
@@ -2154,7 +2269,7 @@ test "ProducerClient fromConnectionString with override" {
 test "ProducerClient fromConnectionString missing hub" {
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v";
-    const result = ProducerClient.fromConnectionString(std.testing.allocator, cs, null, mock_amqp.asTransport());
+    const result = ProducerClient.fromConnectionString(std.testing.allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     try std.testing.expectError(error.MissingEventHubName, result);
 }
 
@@ -2162,7 +2277,7 @@ test "ConsumerClient fromConnectionString" {
     const allocator = std.testing.allocator;
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=hub";
-    var consumer = try ConsumerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    var consumer = try ConsumerClient.fromConnectionString(allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     defer consumer.deinit();
     try std.testing.expectEqualStrings("ns.servicebus.windows.net", consumer.options.fully_qualified_namespace);
     try std.testing.expectEqualStrings("hub", consumer.options.event_hub_name);
@@ -2188,6 +2303,7 @@ const ScopeRecordingCredential = struct {
         credential: *core.credentials.TokenCredential,
         request_context: core.credentials.TokenRequestContext,
         ctx: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         _ = ctx;
         const self: *ScopeRecordingCredential = @fieldParentPtr("credential", credential);
@@ -2217,7 +2333,7 @@ test "connection string credential signs the parsed entity" {
     const allocator = std.testing.allocator;
     var mock_amqp = MockAmqpTransport.init();
     const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=policy;SharedAccessKey=c2VjcmV0;EntityPath=hub";
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     defer producer.deinit();
 
     try std.testing.expect(producer.credential == .sas);
@@ -2239,10 +2355,48 @@ test "connection string credential signs the parsed entity" {
     try std.testing.expect(token.expires_on > 0);
 }
 
+test "connection string credential uses the selected runtime crypto provider" {
+    const allocator = std.testing.allocator;
+    var provider = TestCryptoProvider{};
+    var mock_amqp = MockAmqpTransport.init();
+    const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=policy;SharedAccessKey=c2VjcmV0;EntityPath=hub";
+    var producer = try ProducerClient.fromConnectionString(
+        allocator,
+        testRuntimeWithCrypto(provider.provider()),
+        cs,
+        null,
+        mock_amqp.asTransport(),
+    );
+    defer producer.deinit();
+
+    var token = try producer.getToken(.none);
+    defer token.deinit();
+    try std.testing.expectEqual(@as(usize, 1), provider.hmac_calls);
+}
+
+test "connection string credential propagates runtime crypto provider failure" {
+    const allocator = std.testing.allocator;
+    var provider = TestCryptoProvider{ .fail = true };
+    var mock_amqp = MockAmqpTransport.init();
+    const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=policy;SharedAccessKey=c2VjcmV0;EntityPath=hub";
+    var producer = try ProducerClient.fromConnectionString(
+        allocator,
+        testRuntimeWithCrypto(provider.provider()),
+        cs,
+        null,
+        mock_amqp.asTransport(),
+    );
+    defer producer.deinit();
+
+    try std.testing.expectError(error.ProviderFailure, producer.getToken(.none));
+    try std.testing.expectEqual(@as(usize, 1), provider.hmac_calls);
+}
+
 test "AAD credential is asked for the Event Hubs scope" {
     var mock_amqp = MockAmqpTransport.init();
     var recorder = ScopeRecordingCredential.init();
     var producer = ProducerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "hub",
     }, recorder.asCredential(), mock_amqp.asTransport());
@@ -2268,6 +2422,7 @@ test "entityAudience matches the hub, partitionAudience the consumer group path"
     var mock_amqp = MockAmqpTransport.init();
     var recorder = ScopeRecordingCredential.init();
     var consumer = ConsumerClient.init(.{
+        .runtime = testRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .event_hub_name = "hub",
         .consumer_group = "cg",
@@ -2294,7 +2449,7 @@ test "a SAS credential survives being returned by value" {
     // `SasCredential` recovers itself with `@fieldParentPtr`, so a pointer
     // taken before the client was moved would dangle. Resolving lazily
     // through the moved client must still produce a usable token.
-    var producer = try ProducerClient.fromConnectionString(allocator, cs, null, mock_amqp.asTransport());
+    var producer = try ProducerClient.fromConnectionString(allocator, testRuntime(), cs, null, mock_amqp.asTransport());
     defer producer.deinit();
     var moved = producer;
     producer.owned_audience = null;


### PR DESCRIPTION
## Summary

- migrate Event Hubs credentials, examples, live tests, and Blob checkpoint storage to `HttpRuntime` and the current `HttpPipeline`
- preserve the selected runtime crypto provider through Messaging SAS signing and derived Blob checkpoint clients, with provider-spy/failure coverage
- keep AMQP TLS certificate bundles separate from SDK cryptography and document borrowed runtime/context lifetimes
- bump `azure_sdk_eventhubs` to 0.6.0

## Released dependency pins

- Core 0.3.0: `bc77bcacbb64af935ca53d60bf8a351c9592bc41` / `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- Messaging Common 0.3.0: `6326815bfacb61c7484d93f969f959082f406dcc` / `azure_sdk_messaging_common-0.3.0-YklmSimrAABYnVM-KFESp7QVjZSRzJXVpQl3CJ8a_ZeO`
- Storage Blobs 0.3.0: `2bd2b47df464e2bd548d6aad6f5d8d425f2e74a9` / `azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d`
- retains the existing valid AMQP 0.4.0 pin

Part of #412
Part of #414

## Validation

- `zig fmt --check root.zig checkpoint_store.zig connection_options.zig examples/ live_tests/ build.zig`
- `zig build`
- `zig build test --summary all` (216 passed)
- `zig build examples`
- `zig build live-test --summary all` (compiled; 4 skipped while unconfigured)
- `zig build bench -Doptimize=ReleaseFast --summary all`
