### PR TITLE
Migrate Service Bus to HttpRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ either.
 Administration runs over the `azure_sdk_core` HTTP pipeline against the
 management REST API and is unrelated to the AMQP path.
 
+```zig
+var http_transport = core.http.StdHttpTransport.init(allocator, io);
+defer http_transport.deinit();
+var crypto = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    http_transport.asTransport(),
+    crypto.asProvider(),
+);
+var credential = core.identity.ClientSecretCredential.init(
+    allocator,
+    tenant_id,
+    client_id,
+    client_secret,
+);
+var admin = try sb.ServiceBusAdministrationClient.init(
+    allocator,
+    "contoso.servicebus.windows.net",
+    credential.asCredential(),
+    runtime,
+    .{},
+);
+defer admin.deinit();
+```
+
+The administration client copies the runtime descriptors into its pipeline.
+The credential and both runtime backend contexts are borrowed and must outlive
+the client and all in-flight operations.
+
 ## Layout
 
 | file | what |
@@ -69,7 +97,13 @@ one encode buffer. Nothing dials until the first operation needs the wire.
 ```zig
 var transport: sb.AmqpTransport = undefined;
 // The entity path the string named, if it named one.
-const entity = try transport.initFromConnectionString(allocator, io, connection_string, .{});
+const entity = try transport.initFromConnectionString(
+    allocator,
+    io,
+    connection_string,
+    runtime,
+    .{},
+);
 defer transport.deinit();
 
 var client = sb.ServiceBusSenderClient.init(
@@ -81,6 +115,11 @@ var client = sb.ServiceBusSenderClient.init(
 
 The connection string is parsed once, here, and the transport borrows from it
 — so it has to outlive the transport.
+
+`runtime` is a `core.http.HttpRuntime`. The transport copies both descriptors
+by value and borrows their backend contexts. Those contexts must outlive the
+transport and every operation. AMQP TLS certificate validation remains
+configured separately through `ConnectionOptions.tls.bundle`.
 
 Authentication is the transport's, not the client's: a client carries no
 credential, because the claim that authorises a link is put by `$cbs` and

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ defer admin.deinit();
 
 The administration client copies the runtime descriptors into its pipeline.
 The credential and both runtime backend contexts are borrowed and must outlive
-the client and all in-flight operations.
+the client and all in-flight operations. Its bearer-token cache is synchronized
+for concurrent operations and for any pager or derived client sharing that
+pipeline. Credential and transport callbacks run outside the cache lock, so
+they may re-enter the same client. Call `deinit` only after all such operations
+and callbacks have completed.
 
 ## Layout
 

--- a/admin.zig
+++ b/admin.zig
@@ -135,37 +135,29 @@ const SynchronizedBearerAuthPolicy = struct {
             runtime,
         );
         defer fresh.deinit();
+
+        self.cache_lock.lock();
+        defer self.cache_lock.unlock();
+        if (self.cached_auth_value) |auth_value| {
+            if (unixTimestampSeconds() < self.cached_expires_on - refresh_buffer_secs) {
+                return request.setHeader("Authorization", auth_value);
+            }
+        }
+
         const replacement = try std.fmt.allocPrint(
             self.allocator,
             "Bearer {s}",
             .{fresh.token},
         );
-        var replacement_owned = true;
-        errdefer if (replacement_owned) self.allocator.free(replacement);
+        errdefer self.allocator.free(replacement);
+        try request.setHeader("Authorization", replacement);
 
-        var old_auth_value: ?[]u8 = null;
-        self.cache_lock.lock();
-        if (self.cached_auth_value) |auth_value| {
-            if (unixTimestampSeconds() < self.cached_expires_on - refresh_buffer_secs) {
-                const result = request.setHeader("Authorization", auth_value);
-                self.cache_lock.unlock();
-                replacement_owned = false;
-                self.allocator.free(replacement);
-                return result;
-            }
-        }
-
-        request.setHeader("Authorization", replacement) catch |err| {
-            self.cache_lock.unlock();
-            return err;
-        };
-        old_auth_value = self.cached_auth_value;
+        const old_auth_value = self.cached_auth_value;
         self.cached_auth_value = replacement;
         self.cached_expires_on = fresh.expires_on;
-        replacement_owned = false;
-        self.cache_lock.unlock();
         // Request headers own their copies, and no cache reader can retain this
-        // slice after releasing the lock.
+        // slice after releasing the lock. Free under the same lock as the swap
+        // because the cache allocator need not be thread-safe.
         if (old_auth_value) |value| self.allocator.free(value);
     }
 };
@@ -744,6 +736,84 @@ const ConcurrentWorker = struct {
     }
 };
 
+const GuardedAllocator = struct {
+    parent: std.mem.Allocator,
+    active: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    overlapped: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn allocator(self: *GuardedAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn enter(self: *GuardedAllocator) void {
+        if (self.active.fetchAdd(1, .acq_rel) != 0) {
+            self.overlapped.store(true, .release);
+        }
+        for (0..128) |_| std.Thread.yield() catch {};
+    }
+
+    fn leave(self: *GuardedAllocator) void {
+        _ = self.active.fetchSub(1, .acq_rel);
+    }
+
+    fn alloc(
+        context: *anyopaque,
+        len: usize,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        return self.parent.rawAlloc(len, alignment, return_address);
+    }
+
+    fn resize(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) bool {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        return self.parent.rawResize(memory, alignment, new_len, return_address);
+    }
+
+    fn remap(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        return self.parent.rawRemap(memory, alignment, new_len, return_address);
+    }
+
+    fn free(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) void {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        self.parent.rawFree(memory, alignment, return_address);
+    }
+};
+
 test "AdministrationClient preserves runtime and provider failures are atomic" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, "");
@@ -949,5 +1019,50 @@ test "AdministrationClient synchronizes shared authentication cache" {
     try std.testing.expect(!failed.load(.acquire));
     try std.testing.expect(!transport.missing_auth.load(.acquire));
     try std.testing.expectEqual(worker_count, transport.calls.load(.acquire));
+    try std.testing.expectEqual(worker_count, credential.entered.load(.acquire));
+}
+
+test "AdministrationClient serializes cache allocator operations during concurrent refresh" {
+    const worker_allocator = std.testing.allocator;
+    const worker_count = 8;
+    var guarded = GuardedAllocator{ .parent = std.heap.page_allocator };
+    const cache_allocator = guarded.allocator();
+    var transport = ConcurrentTransport{};
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = BarrierCredential{
+        .allocator = worker_allocator,
+        .expected_calls = worker_count,
+    };
+    var admin = try ServiceBusAdministrationClient.init(
+        cache_allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(transport.asTransport(), crypto.asProvider()),
+        .{},
+    );
+    defer admin.deinit();
+
+    admin.pipeline_state.auth_policy.cached_auth_value =
+        try cache_allocator.dupe(u8, "expired");
+    admin.pipeline_state.auth_policy.cached_expires_on = 0;
+
+    var start = std.atomic.Value(bool).init(false);
+    var failed = std.atomic.Value(bool).init(false);
+    var threads: [worker_count]std.Thread = undefined;
+    for (&threads, 0..) |*thread, index| {
+        thread.* = try std.Thread.spawn(.{}, ConcurrentWorker.run, .{ConcurrentWorker{
+            .client = &admin,
+            .allocator = worker_allocator,
+            .index = index,
+            .start = &start,
+            .failed = &failed,
+        }});
+    }
+    start.store(true, .release);
+    for (threads) |thread| thread.join();
+
+    try std.testing.expect(!failed.load(.acquire));
+    try std.testing.expect(!guarded.overlapped.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 0), guarded.active.load(.acquire));
     try std.testing.expectEqual(worker_count, credential.entered.load(.acquire));
 }

--- a/admin.zig
+++ b/admin.zig
@@ -45,24 +45,69 @@ pub const AdministrationClientOptions = struct {
     api_version: []const u8 = "2021-05",
 };
 
+const token_scope = "https://servicebus.azure.net/.default";
+
+const PipelineState = struct {
+    allocator: std.mem.Allocator,
+    auth_policy: core.http.BearerTokenAuthPolicy,
+    policies: [1]*core.http.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
+
+    fn create(
+        allocator: std.mem.Allocator,
+        credential: *core.credentials.TokenCredential,
+        runtime: core.http.HttpRuntime,
+    ) !*PipelineState {
+        const state = try allocator.create(PipelineState);
+        state.allocator = allocator;
+        state.auth_policy = core.http.BearerTokenAuthPolicy.init(
+            allocator,
+            credential,
+            &.{token_scope},
+        );
+        state.policies[0] = state.auth_policy.asPolicy();
+        state.pipeline = core.http.HttpPipeline.init(runtime, &state.policies);
+        return state;
+    }
+
+    fn deinit(self: *PipelineState) void {
+        const allocator = self.allocator;
+        self.auth_policy.deinit();
+        allocator.destroy(self);
+    }
+};
+
 /// Manages Service Bus queues, topics, and subscriptions via REST API.
+///
+/// The credential and runtime backend contexts are borrowed and must outlive
+/// the client and every in-flight operation. The runtime descriptors are
+/// copied by value into the pipeline state.
 pub const ServiceBusAdministrationClient = struct {
     fully_qualified_namespace: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline_state: *PipelineState,
 
     pub fn init(
+        allocator: std.mem.Allocator,
         fully_qualified_namespace: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         options: AdministrationClientOptions,
-    ) ServiceBusAdministrationClient {
-        _ = credential;
+    ) !ServiceBusAdministrationClient {
         return .{
             .fully_qualified_namespace = fully_qualified_namespace,
             .api_version = options.api_version,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .pipeline_state = try PipelineState.create(
+                allocator,
+                credential,
+                runtime,
+            ),
         };
+    }
+
+    pub fn deinit(self: *ServiceBusAdministrationClient) void {
+        self.pipeline_state.deinit();
+        self.* = undefined;
     }
 
     // ── Queue operations ──
@@ -91,7 +136,7 @@ pub const ServiceBusAdministrationClient = struct {
         try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -114,7 +159,7 @@ pub const ServiceBusAdministrationClient = struct {
         var req = core.http.Request.init(allocator, .DELETE, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -137,7 +182,7 @@ pub const ServiceBusAdministrationClient = struct {
         var req = core.http.Request.init(allocator, .GET, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -176,7 +221,7 @@ pub const ServiceBusAdministrationClient = struct {
         try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -199,7 +244,7 @@ pub const ServiceBusAdministrationClient = struct {
         var req = core.http.Request.init(allocator, .DELETE, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -222,7 +267,7 @@ pub const ServiceBusAdministrationClient = struct {
         var req = core.http.Request.init(allocator, .GET, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -261,7 +306,7 @@ pub const ServiceBusAdministrationClient = struct {
         try req.setHeader("Content-Type", "application/atom+xml;type=entry;charset=utf-8");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -389,33 +434,159 @@ fn parseSubscriptionNames(allocator: std.mem.Allocator, body: []const u8, topic_
 
 // ───────────────────── Tests ─────────────────────
 
+const StubCredential = struct {
+    credential: core.credentials.TokenCredential = .{ .getTokenFn = getToken },
+    calls: usize = 0,
+    use_runtime_crypto: bool = false,
+
+    fn asCredential(self: *StubCredential) *core.credentials.TokenCredential {
+        return &self.credential;
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        _: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+        runtime: core.http.HttpRuntime,
+    ) !core.credentials.AccessToken {
+        const self: *StubCredential = @alignCast(
+            @fieldParentPtr("credential", credential),
+        );
+        self.calls += 1;
+        if (self.use_runtime_crypto) {
+            var byte: [1]u8 = undefined;
+            try runtime.crypto.randomBytes(&byte);
+        }
+        return .{
+            .token = "test-token",
+            .expires_on = 7_258_118_400,
+        };
+    }
+};
+
+fn testRuntime(
+    transport: core.http.HttpTransport,
+    crypto: core.crypto.CryptoProvider,
+) core.http.HttpRuntime {
+    return .init(transport, crypto);
+}
+
+const FailingCryptoProvider = struct {
+    random_calls: usize = 0,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn asProvider(self: *FailingCryptoProvider) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *FailingCryptoProvider = @ptrCast(@alignCast(context));
+        self.random_calls += 1;
+        @memset(out, 0xa5);
+        return error.SelectedCryptoFailure;
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.UnexpectedCryptoOperation;
+    }
+};
+
+test "AdministrationClient preserves runtime and provider failures are atomic" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "");
+    defer mock.deinit();
+    var crypto = FailingCryptoProvider{};
+    const runtime = testRuntime(mock.asTransport(), crypto.asProvider());
+    var credential = StubCredential{ .use_runtime_crypto = true };
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        runtime,
+        .{},
+    );
+    defer admin.deinit();
+
+    try std.testing.expectEqual(
+        runtime.transport.context,
+        admin.pipeline_state.pipeline.runtime.transport.context,
+    );
+    try std.testing.expectEqual(
+        runtime.crypto.context,
+        admin.pipeline_state.pipeline.runtime.crypto.context,
+    );
+    try std.testing.expectError(
+        error.SelectedCryptoFailure,
+        admin.createQueue(allocator, "testqueue"),
+    );
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
+    try std.testing.expectEqual(@as(usize, 1), crypto.random_calls);
+    try std.testing.expectEqual(@as(usize, 0), mock.call_count);
+    try std.testing.expect(mock.last_headers.get("Authorization") == null);
+}
+
 test "AdministrationClient createQueue" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
     defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = StubCredential{};
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(mock.asTransport(), crypto.asProvider()),
+        .{},
     );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    defer admin.deinit();
     try admin.createQueue(allocator, "testqueue");
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "testqueue") != null);
     try std.testing.expectEqual(core.http.Method.PUT, mock.last_method.?);
+    try std.testing.expect(mock.last_headers.get("Authorization") != null);
+    try std.testing.expectEqual(@as(usize, 1), credential.calls);
 }
 
 test "AdministrationClient deleteQueue" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, "");
     defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = StubCredential{};
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(mock.asTransport(), crypto.asProvider()),
+        .{},
     );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    defer admin.deinit();
     try admin.deleteQueue(allocator, "testqueue");
     try std.testing.expectEqual(core.http.Method.DELETE, mock.last_method.?);
 }
@@ -427,13 +598,16 @@ test "AdministrationClient listQueues" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = StubCredential{};
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(mock.asTransport(), crypto.asProvider()),
+        .{},
     );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    defer admin.deinit();
     const queues = try admin.listQueues(allocator);
     defer {
         for (queues) |q| allocator.free(q.name);
@@ -448,13 +622,16 @@ test "AdministrationClient createSubscription" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 201, "<entry/>");
     defer mock.deinit();
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = StubCredential{};
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(mock.asTransport(), crypto.asProvider()),
+        .{},
     );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-    var admin = ServiceBusAdministrationClient.init("ns.servicebus.windows.net", cred.asCredential(), mock.asTransport(), .{});
+    defer admin.deinit();
     try admin.createSubscription(allocator, "mytopic", "mysub");
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mytopic/subscriptions/mysub") != null);
 }

--- a/admin.zig
+++ b/admin.zig
@@ -47,9 +47,137 @@ pub const AdministrationClientOptions = struct {
 
 const token_scope = "https://servicebus.azure.net/.default";
 
+const SpinLock = struct {
+    held: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn lock(self: *SpinLock) void {
+        while (self.held.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
+            while (self.held.load(.monotonic)) {
+                std.Thread.yield() catch {};
+            }
+        }
+    }
+
+    fn unlock(self: *SpinLock) void {
+        self.held.store(false, .release);
+    }
+};
+
+/// A bearer policy whose shared cache is safe for every pipeline use,
+/// including pagers or derived clients that retain a copy of the pipeline.
+///
+/// Credential acquisition and transport dispatch happen outside the cache
+/// lock, so callbacks may re-enter the same client without deadlocking.
+const SynchronizedBearerAuthPolicy = struct {
+    allocator: std.mem.Allocator,
+    credential: *core.credentials.TokenCredential,
+    cached_auth_value: ?[]u8 = null,
+    cached_expires_on: i64 = 0,
+    cache_lock: SpinLock = .{},
+    policy: core.http.HttpPolicy,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        credential: *core.credentials.TokenCredential,
+    ) SynchronizedBearerAuthPolicy {
+        return .{
+            .allocator = allocator,
+            .credential = credential,
+            .policy = .{
+                .processFn = &processImpl,
+                .prepareFn = &prepareImpl,
+            },
+        };
+    }
+
+    fn asPolicy(self: *SynchronizedBearerAuthPolicy) *core.http.HttpPolicy {
+        return &self.policy;
+    }
+
+    fn deinit(self: *SynchronizedBearerAuthPolicy) void {
+        if (self.cached_auth_value) |value| self.allocator.free(value);
+    }
+
+    fn processImpl(
+        policy: *core.http.HttpPolicy,
+        request: *core.http.Request,
+        next: []*core.http.HttpPolicy,
+        runtime: core.http.HttpRuntime,
+    ) !core.http.Response {
+        try prepareImpl(policy, request, runtime);
+        if (next.len == 0) return runtime.transport.send(request);
+        return next[0].process(request, next[1..], runtime);
+    }
+
+    fn prepareImpl(
+        policy: *core.http.HttpPolicy,
+        request: *core.http.Request,
+        runtime: core.http.HttpRuntime,
+    ) !void {
+        const self: *SynchronizedBearerAuthPolicy = @alignCast(
+            @fieldParentPtr("policy", policy),
+        );
+        const refresh_buffer_secs: i64 = 300;
+
+        self.cache_lock.lock();
+        if (self.cached_auth_value) |auth_value| {
+            if (unixTimestampSeconds() < self.cached_expires_on - refresh_buffer_secs) {
+                const result = request.setHeader("Authorization", auth_value);
+                self.cache_lock.unlock();
+                return result;
+            }
+        }
+        self.cache_lock.unlock();
+
+        var fresh = try self.credential.getToken(
+            .{ .scopes = &.{token_scope} },
+            .none,
+            runtime,
+        );
+        defer fresh.deinit();
+        const replacement = try std.fmt.allocPrint(
+            self.allocator,
+            "Bearer {s}",
+            .{fresh.token},
+        );
+        var replacement_owned = true;
+        errdefer if (replacement_owned) self.allocator.free(replacement);
+
+        var old_auth_value: ?[]u8 = null;
+        self.cache_lock.lock();
+        if (self.cached_auth_value) |auth_value| {
+            if (unixTimestampSeconds() < self.cached_expires_on - refresh_buffer_secs) {
+                const result = request.setHeader("Authorization", auth_value);
+                self.cache_lock.unlock();
+                replacement_owned = false;
+                self.allocator.free(replacement);
+                return result;
+            }
+        }
+
+        request.setHeader("Authorization", replacement) catch |err| {
+            self.cache_lock.unlock();
+            return err;
+        };
+        old_auth_value = self.cached_auth_value;
+        self.cached_auth_value = replacement;
+        self.cached_expires_on = fresh.expires_on;
+        replacement_owned = false;
+        self.cache_lock.unlock();
+        // Request headers own their copies, and no cache reader can retain this
+        // slice after releasing the lock.
+        if (old_auth_value) |value| self.allocator.free(value);
+    }
+};
+
+fn unixTimestampSeconds() i64 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    return std.Io.Timestamp.now(threaded.io(), .real).toSeconds();
+}
+
 const PipelineState = struct {
     allocator: std.mem.Allocator,
-    auth_policy: core.http.BearerTokenAuthPolicy,
+    auth_policy: SynchronizedBearerAuthPolicy,
     policies: [1]*core.http.HttpPolicy,
     pipeline: core.http.HttpPipeline,
 
@@ -60,11 +188,7 @@ const PipelineState = struct {
     ) !*PipelineState {
         const state = try allocator.create(PipelineState);
         state.allocator = allocator;
-        state.auth_policy = core.http.BearerTokenAuthPolicy.init(
-            allocator,
-            credential,
-            &.{token_scope},
-        );
+        state.auth_policy = SynchronizedBearerAuthPolicy.init(allocator, credential);
         state.policies[0] = state.auth_policy.asPolicy();
         state.pipeline = core.http.HttpPipeline.init(runtime, &state.policies);
         return state;
@@ -81,7 +205,11 @@ const PipelineState = struct {
 ///
 /// The credential and runtime backend contexts are borrowed and must outlive
 /// the client and every in-flight operation. The runtime descriptors are
-/// copied by value into the pipeline state.
+/// copied by value into the pipeline state. Administration calls may run
+/// concurrently when the selected runtime backends and credential allow it;
+/// the shared bearer-token cache is synchronized by the pipeline policy.
+/// Credential and transport callbacks run without that cache lock and may
+/// re-enter the client. Call `deinit` only after all operations have finished.
 pub const ServiceBusAdministrationClient = struct {
     fully_qualified_namespace: []const u8,
     api_version: []const u8,
@@ -329,7 +457,7 @@ pub const ServiceBusAdministrationClient = struct {
         var req = core.http.Request.init(allocator, .DELETE, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -352,7 +480,7 @@ pub const ServiceBusAdministrationClient = struct {
         var req = core.http.Request.init(allocator, .GET, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -518,6 +646,104 @@ const FailingCryptoProvider = struct {
     }
 };
 
+const BarrierCredential = struct {
+    allocator: std.mem.Allocator,
+    expected_calls: usize,
+    entered: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    credential: core.credentials.TokenCredential = .{ .getTokenFn = getToken },
+
+    fn asCredential(self: *BarrierCredential) *core.credentials.TokenCredential {
+        return &self.credential;
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        _: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+        _: core.http.HttpRuntime,
+    ) !core.credentials.AccessToken {
+        const self: *BarrierCredential = @alignCast(
+            @fieldParentPtr("credential", credential),
+        );
+        const call_index = self.entered.fetchAdd(1, .acq_rel);
+        while (self.entered.load(.acquire) < self.expected_calls) {
+            std.Thread.yield() catch {};
+        }
+        return .{
+            .token = try std.fmt.allocPrint(
+                self.allocator,
+                "concurrent-token-{d}",
+                .{call_index},
+            ),
+            .expires_on = 7_258_118_400,
+            .allocator = self.allocator,
+        };
+    }
+};
+
+const ConcurrentTransport = struct {
+    calls: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    missing_auth: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
+
+    fn asTransport(self: *ConcurrentTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn send(context: *anyopaque, request: *core.http.Request) !core.http.Response {
+        const self: *ConcurrentTransport = @ptrCast(@alignCast(context));
+        const auth = request.getHeader("Authorization");
+        if (auth == null or !std.mem.startsWith(u8, auth.?, "Bearer concurrent-token-")) {
+            self.missing_auth.store(true, .release);
+        }
+        _ = self.calls.fetchAdd(1, .acq_rel);
+        return .{
+            .status_code = 200,
+            .headers = std.StringHashMap([]const u8).init(request.allocator),
+            .body = try request.allocator.dupe(
+                u8,
+                "<feed xmlns=\"http://www.w3.org/2005/Atom\"></feed>",
+            ),
+            .allocator = request.allocator,
+        };
+    }
+};
+
+const ConcurrentWorker = struct {
+    client: *ServiceBusAdministrationClient,
+    allocator: std.mem.Allocator,
+    index: usize,
+    start: *std.atomic.Value(bool),
+    failed: *std.atomic.Value(bool),
+
+    fn run(self: ConcurrentWorker) void {
+        while (!self.start.load(.acquire)) {
+            std.Thread.yield() catch {};
+        }
+
+        if (self.index % 2 == 0) {
+            self.client.deleteSubscription(
+                self.allocator,
+                "topic",
+                "subscription",
+            ) catch {
+                self.failed.store(true, .release);
+            };
+        } else {
+            const subscriptions = self.client.listSubscriptions(
+                self.allocator,
+                "topic",
+            ) catch {
+                self.failed.store(true, .release);
+                return;
+            };
+            for (subscriptions) |subscription| self.allocator.free(subscription.name);
+            self.allocator.free(subscriptions);
+        }
+    }
+};
+
 test "AdministrationClient preserves runtime and provider failures are atomic" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, "");
@@ -634,4 +860,94 @@ test "AdministrationClient createSubscription" {
     defer admin.deinit();
     try admin.createSubscription(allocator, "mytopic", "mysub");
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "mytopic/subscriptions/mysub") != null);
+}
+
+test "AdministrationClient deleteSubscription" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.MockTransport.init(allocator, 200, "");
+    defer mock.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = StubCredential{};
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(mock.asTransport(), crypto.asProvider()),
+        .{},
+    );
+    defer admin.deinit();
+
+    try admin.deleteSubscription(allocator, "mytopic", "mysub");
+    try std.testing.expectEqual(core.http.Method.DELETE, mock.last_method.?);
+    try std.testing.expect(
+        std.mem.find(u8, mock.last_url.?, "mytopic/subscriptions/mysub") != null,
+    );
+}
+
+test "AdministrationClient listSubscriptions" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>sub1</title></entry><entry><title>sub2</title></entry></feed>
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = StubCredential{};
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(mock.asTransport(), crypto.asProvider()),
+        .{},
+    );
+    defer admin.deinit();
+
+    const subscriptions = try admin.listSubscriptions(allocator, "mytopic");
+    defer {
+        for (subscriptions) |subscription| allocator.free(subscription.name);
+        allocator.free(subscriptions);
+    }
+    try std.testing.expectEqual(@as(usize, 2), subscriptions.len);
+    try std.testing.expectEqualStrings("sub1", subscriptions[0].name);
+    try std.testing.expectEqualStrings("sub2", subscriptions[1].name);
+    try std.testing.expectEqualStrings("mytopic", subscriptions[0].topic_name);
+}
+
+test "AdministrationClient synchronizes shared authentication cache" {
+    const allocator = std.testing.allocator;
+    const worker_count = 8;
+    var transport = ConcurrentTransport{};
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var credential = BarrierCredential{
+        .allocator = allocator,
+        .expected_calls = worker_count,
+    };
+    var admin = try ServiceBusAdministrationClient.init(
+        allocator,
+        "ns.servicebus.windows.net",
+        credential.asCredential(),
+        testRuntime(transport.asTransport(), crypto.asProvider()),
+        .{},
+    );
+    defer admin.deinit();
+
+    var start = std.atomic.Value(bool).init(false);
+    var failed = std.atomic.Value(bool).init(false);
+    var threads: [worker_count]std.Thread = undefined;
+    for (&threads, 0..) |*thread, index| {
+        thread.* = try std.Thread.spawn(.{}, ConcurrentWorker.run, .{ConcurrentWorker{
+            .client = &admin,
+            .allocator = allocator,
+            .index = index,
+            .start = &start,
+            .failed = &failed,
+        }});
+    }
+    start.store(true, .release);
+    for (threads) |thread| thread.join();
+
+    try std.testing.expect(!failed.load(.acquire));
+    try std.testing.expect(!transport.missing_auth.load(.acquire));
+    try std.testing.expectEqual(worker_count, transport.calls.load(.acquire));
+    try std.testing.expectEqual(worker_count, credential.entered.load(.acquire));
 }

--- a/amqp_transport.zig
+++ b/amqp_transport.zig
@@ -170,6 +170,8 @@ pub const TlsSettings = struct {
 const receiver_prefetch_limit: u32 = 8;
 const receiver_max_message_size: u64 = 128 * 1024 * 1024;
 const receiver_max_buffered_bytes: u64 = 1024 * 1024 * 1024;
+const receive_and_delete_settlement_batch: u32 =
+    amqp.default_max_unsettled_deliveries;
 
 pub const ConnectionOptions = struct {
     /// Prefixed to the user agent so the service can attribute traffic to the
@@ -328,7 +330,9 @@ const dead_letter_condition = "com.microsoft:dead-letter";
 ///
 /// The same ceiling `azure_sdk_eventhubs` puts on a receive, and for the same
 /// reason: the count becomes both a credit grant and a precise reservation, so
-/// it has to be the caller's intent rather than whatever number arrived.
+/// it has to be the caller's intent rather than whatever number arrived. The
+/// receiver retains at most this many unsettled ids; payload buffering remains
+/// independently bounded by the eight-credit, one-GiB window above.
 pub const max_receive_count: u32 = 5000;
 
 /// How much of a management call's remaining deadline is kept back from the
@@ -744,6 +748,7 @@ pub const AmqpTransport = struct {
             .prefetch = @min(self.options.prefetch, receiver_prefetch_limit),
             .max_message_size = receiver_max_message_size,
             .max_buffered_bytes = receiver_max_buffered_bytes,
+            .max_unsettled_deliveries = max_receive_count,
         }, deadline_ms);
         errdefer current.closeReceiver(receiver, 0);
 
@@ -855,10 +860,18 @@ pub const AmqpTransport = struct {
         const deadline_ms = self.deadlineFrom(current);
         const receiver = try self.receiverFor(current, entity, mode, deadline_ms);
 
-        // Without a prefetch window the link holds no credit at all, so ask
-        // for exactly what this call needs on top of anything outstanding.
-        if (self.options.prefetch == 0 and receiver.credit < max_count) {
-            try receiver.issueCredit(max_count - receiver.credit);
+        // Manual credit may be partly live and partly deferred behind the
+        // receiver's byte or settlement bounds. Both are still outstanding
+        // demand; asking from live credit alone duplicates the deferred part
+        // on every short receive. Charged deliveries, including aborted ones,
+        // reduce these public AMQP counters, and a replacement link starts
+        // them at zero.
+        if (self.options.prefetch == 0) {
+            const outstanding =
+                (receiver.credit +| receiver.deferred_credit) -| receiver.overrun;
+            if (outstanding < max_count) {
+                try receiver.issueCredit(max_count - outstanding);
+            }
         }
 
         // Nothing is allocated until a message actually arrives. A consumer on
@@ -879,6 +892,7 @@ pub const AmqpTransport = struct {
         // where the broker's own mode is at-most-once: a disposition lost in
         // flight means redelivery rather than a silently dropped message.
         var settling = amqp.SettleBatch.init(receiver, .accepted);
+        var settlements_since_flush: u32 = 0;
 
         while (messages.items.len < max_count) {
             const delivery = receiver.receive(deadline_ms) catch |err| {
@@ -908,7 +922,12 @@ pub const AmqpTransport = struct {
                 // Settling is advisory: a message that could not be settled
                 // is redelivered, and failing here would throw away messages
                 // the caller has already been given.
-                settling.add(delivery) catch {};
+                settling.add(delivery) catch continue;
+                settlements_since_flush += 1;
+                if (settlements_since_flush >= receive_and_delete_settlement_batch) {
+                    settling.flush() catch {};
+                    settlements_since_flush = 0;
+                }
             }
         }
 
@@ -2668,6 +2687,19 @@ fn pushMessage(
     }, payload);
 }
 
+/// Consume one delivery and its credit without producing a message.
+fn pushAborted(peer: Peer, handle: u32, delivery_id: u32) !void {
+    try peer.pushTransfer(0, .{
+        .handle = handle,
+        .delivery_id = delivery_id,
+        .delivery_tag = "aborted",
+        .message_format = 0,
+        .settled = false,
+        .more = false,
+        .aborted = true,
+    }, "");
+}
+
 /// Every disposition body the client emitted.
 fn emittedDispositions(allocator: Allocator, written: []const u8) ![]const []const u8 {
     var frames = try harness.EmittedFrames.parse(allocator, written);
@@ -3232,6 +3264,216 @@ test "max_count is honoured and leaves the rest for the next call" {
     try testing.expectEqual(@as(i64, 2), rest.messages[0].sequence_number.?);
 }
 
+test "manual credit does not duplicate deferred demand across short maximum batches" {
+    const allocator = testing.allocator;
+    var h = try Harness.init(allocator);
+    defer h.deinit();
+
+    try scriptEntityReceiver(&h, allocator, "orders");
+    h.mem.starve = true;
+    try h.start(.{ .prefetch = 0, .deadline_ms = 1_000 });
+    h.clock.auto_advance_ms = 5;
+
+    for (0..3) |i| {
+        try pushMessage(
+            h.peer(),
+            allocator,
+            2,
+            first_incoming_id + @as(u32, @intCast(i)),
+            "t",
+            "m",
+            @intCast(i),
+        );
+        var batch = try h.transport.receiveMessages(
+            allocator,
+            "orders",
+            max_receive_count,
+            .peek_lock,
+        );
+        defer batch.deinit();
+        try testing.expectEqual(@as(usize, 1), batch.count());
+
+        const receiver = h.transport.receivers.get("orders").?.receiver;
+        try testing.expectEqual(
+            max_receive_count - 1,
+            receiver.credit + receiver.deferred_credit,
+        );
+    }
+}
+
+test "manual demand accounts for an aborted delivery before the next call" {
+    const allocator = testing.allocator;
+    var h = try Harness.init(allocator);
+    defer h.deinit();
+
+    try scriptEntityReceiver(&h, allocator, "orders");
+    h.mem.starve = true;
+    try h.start(.{ .prefetch = 0, .deadline_ms = 1_000 });
+    h.clock.auto_advance_ms = 5;
+
+    try pushAborted(h.peer(), 2, first_incoming_id);
+    try pushMessage(h.peer(), allocator, 2, first_incoming_id + 1, "t", "first", 1);
+    var first = try h.transport.receiveMessages(
+        allocator,
+        "orders",
+        max_receive_count,
+        .peek_lock,
+    );
+    defer first.deinit();
+    try testing.expectEqual(@as(usize, 1), first.count());
+
+    const receiver = h.transport.receivers.get("orders").?.receiver;
+    try testing.expectEqual(
+        max_receive_count - 2,
+        receiver.credit + receiver.deferred_credit,
+    );
+
+    try pushMessage(h.peer(), allocator, 2, first_incoming_id + 2, "t", "second", 2);
+    var second = try h.transport.receiveMessages(
+        allocator,
+        "orders",
+        max_receive_count,
+        .peek_lock,
+    );
+    defer second.deinit();
+    try testing.expectEqual(@as(usize, 1), second.count());
+    try testing.expectEqual(
+        max_receive_count - 1,
+        receiver.credit + receiver.deferred_credit,
+    );
+}
+
+test "manual deferred demand is discarded with a replaced receiver link" {
+    const allocator = testing.allocator;
+    var h = try Harness.init(allocator);
+    defer h.deinit();
+
+    try scriptEntityReceiver(&h, allocator, "orders");
+    try pushMessage(h.peer(), allocator, 2, first_incoming_id, "t", "first", 1);
+    try h.peer().push(0, .{ .detach = .{ .handle = 2, .closed = true } });
+    try scriptReceiverAttach(h.peer(), 3, "servicebus-receiver-orders");
+    try pushMessage(h.peer(), allocator, 3, first_incoming_id + 1, "t", "second", 2);
+    try h.start(.{ .prefetch = 0 });
+
+    var first = try h.transport.receiveMessages(
+        allocator,
+        "orders",
+        max_receive_count,
+        .peek_lock,
+    );
+    defer first.deinit();
+    try testing.expectEqual(@as(usize, 1), first.count());
+    try testing.expect(!h.transport.receivers.get("orders").?.receiver.attached);
+    try testing.expect(
+        h.transport.receivers.get("orders").?.receiver.deferred_credit > 0,
+    );
+
+    h.mem.clearWritten();
+    var second = try h.transport.receiveMessages(allocator, "orders", 1, .peek_lock);
+    defer second.deinit();
+    try testing.expectEqualStrings("second", second.messages[0].body);
+    try testing.expectEqual(
+        @as(?u32, 1),
+        try creditFor(allocator, h.mem.written(), 3),
+    );
+}
+
+test "peek lock receives beyond AMQP's default unsettled limit" {
+    const allocator = testing.allocator;
+    const count: u32 = amqp.default_max_unsettled_deliveries + 1;
+    var h = try Harness.init(allocator);
+    defer h.deinit();
+
+    try scriptEntityReceiver(&h, allocator, "orders");
+    for (0..count) |i| {
+        try pushMessage(
+            h.peer(),
+            allocator,
+            2,
+            first_incoming_id + @as(u32, @intCast(i)),
+            "t",
+            "m",
+            @intCast(i),
+        );
+    }
+    try h.start(.{});
+
+    var batch = try h.transport.receiveMessages(allocator, "orders", count, .peek_lock);
+    defer batch.deinit();
+    try testing.expectEqual(@as(usize, count), batch.count());
+
+    const receiver = h.transport.receivers.get("orders").?.receiver;
+    try testing.expectEqual(max_receive_count, receiver.max_unsettled_deliveries);
+    try testing.expectEqual(@as(usize, count), receiver.unsettled_ids.items.len);
+}
+
+test "receive and delete periodically settles beyond the default unsettled limit" {
+    const allocator = testing.allocator;
+    const count: u32 = amqp.default_max_unsettled_deliveries + 1;
+    var h = try Harness.init(allocator);
+    defer h.deinit();
+
+    try scriptEntityReceiver(&h, allocator, "orders");
+    for (0..count) |i| {
+        try pushMessage(
+            h.peer(),
+            allocator,
+            2,
+            first_incoming_id + @as(u32, @intCast(i)),
+            "t",
+            "m",
+            @intCast(i),
+        );
+    }
+    try h.start(.{});
+    _ = try h.transport.receiverFor(
+        h.session,
+        "orders",
+        .receive_and_delete,
+        10_000,
+    );
+    h.mem.clearWritten();
+
+    var batch = try h.transport.receiveMessages(
+        allocator,
+        "orders",
+        count,
+        .receive_and_delete,
+    );
+    defer batch.deinit();
+    try testing.expectEqual(@as(usize, count), batch.count());
+    try testing.expectEqual(
+        @as(usize, 0),
+        h.transport.receivers.get("orders").?.receiver.unsettled_ids.items.len,
+    );
+
+    const dispositions = try emittedDispositions(allocator, h.mem.written());
+    defer allocator.free(dispositions);
+    try testing.expectEqual(@as(usize, 2), dispositions.len);
+
+    var first = try amqp.performative.decode(allocator, dispositions[0]);
+    defer first.deinit();
+    try testing.expectEqual(
+        first_incoming_id,
+        first.performative.disposition.first,
+    );
+    try testing.expectEqual(
+        first_incoming_id + receive_and_delete_settlement_batch - 1,
+        first.performative.disposition.last.?,
+    );
+
+    var last = try amqp.performative.decode(allocator, dispositions[1]);
+    defer last.deinit();
+    try testing.expectEqual(
+        first_incoming_id + receive_and_delete_settlement_batch,
+        last.performative.disposition.first,
+    );
+    try testing.expectEqual(
+        first_incoming_id + receive_and_delete_settlement_batch,
+        last.performative.disposition.last.?,
+    );
+}
+
 test "a prefetch window grants credit up front, and no window grants exactly what is asked" {
     const allocator = testing.allocator;
 
@@ -3252,6 +3494,7 @@ test "a prefetch window grants credit up front, and no window grants exactly wha
         const receiver = h.transport.receivers.get("orders").?.receiver;
         try testing.expectEqual(@as(?u64, receiver_max_message_size), receiver.max_message_size);
         try testing.expectEqual(@as(?u64, receiver_max_buffered_bytes), receiver.max_buffered_bytes);
+        try testing.expectEqual(max_receive_count, receiver.max_unsettled_deliveries);
     }
 
     {

--- a/amqp_transport.zig
+++ b/amqp_transport.zig
@@ -3305,10 +3305,6 @@ const amqp_receive_allocs_per_delivery = 2;
 /// Encoding a replenishment Flow currently needs two temporary allocations.
 const amqp_allocs_per_refill = 2;
 
-/// AMQP 0.5 tracks each unsettled id both on the receiver and session-wide.
-/// Across the batch sizes below their backing storage moves at most twice.
-const max_receive_tracking_growth_allocs = 2;
-
 /// What a batch costs beyond those per-delivery copies: the arena struct, its
 /// first page, and the one copy of the entity name every message shares. The
 /// message list and the delivery tags come out of the arena page.
@@ -3354,6 +3350,17 @@ test "a received message costs a bounded number of allocations, whatever the bat
     var warm = try h.transport.receiveMessages(allocator, "orders", 1, .peek_lock);
     warm.deinit();
 
+    // AMQP 0.5 tracks unsettled ids both on the receiver and session-wide.
+    // Reserve those dependency-owned tables up front so allocator-specific
+    // growth policy is not mistaken for Service Bus's per-message cost.
+    const tracked: usize = 1 + small + large;
+    const receiver = h.transport.receivers.get("orders").?.receiver;
+    try receiver.unsettled_ids.ensureTotalCapacityPrecise(allocator, tracked);
+    try h.session.incoming_deliveries.ensureUnusedCapacity(
+        allocator,
+        @intCast(tracked - h.session.incoming_deliveries.count()),
+    );
+
     h.mem.clearWritten();
     counting.reset();
     var first = try h.transport.receiveMessages(allocator, "orders", small, .peek_lock);
@@ -3387,8 +3394,7 @@ test "a received message costs a bounded number of allocations, whatever the bat
         (large_refills - small_refills) * amqp_allocs_per_refill;
     try testing.expect(marginal <=
         (large - small) * amqp_receive_allocs_per_delivery +
-            refill_growth +
-            max_receive_tracking_growth_allocs);
+            refill_growth);
 
     // The other half of the claim, and the discriminating half: what is left
     // once the dependency's per-delivery copies and replenishment Flows are

--- a/amqp_transport.zig
+++ b/amqp_transport.zig
@@ -167,6 +167,10 @@ pub const TlsSettings = struct {
     bundle: ?*std.crypto.Certificate.Bundle = null,
 };
 
+const receiver_prefetch_limit: u32 = 8;
+const receiver_max_message_size: u64 = 128 * 1024 * 1024;
+const receiver_max_buffered_bytes: u64 = 1024 * 1024 * 1024;
+
 pub const ConnectionOptions = struct {
     /// Prefixed to the user agent so the service can attribute traffic to the
     /// calling application. Borrowed; must outlive the transport.
@@ -193,10 +197,12 @@ pub const ConnectionOptions = struct {
     ///
     /// A receiver holding credit lets the broker stream messages ahead of the
     /// call that asks for them, so a batch is one round trip rather than one
-    /// per message. Zero disables the window and makes each `receiveMessages`
-    /// ask for exactly the count it was given, which is the right shape for a
-    /// consumer that must not hold locks it is not about to work through.
-    prefetch: u32 = 300,
+    /// per message. Service Bus caps this at eight deliveries to keep every
+    /// grant within the receiver's one-GiB aggregate byte budget. Zero
+    /// disables the window and makes each `receiveMessages` ask for exactly
+    /// the count it was given, which is the right shape for a consumer that
+    /// must not hold locks it is not about to work through.
+    prefetch: u32 = receiver_prefetch_limit,
     session: amqp.SessionOptions = .{},
     /// Service Bus expects an anonymous SASL layer and then CBS. Cleared for
     /// a peer that negotiates no SASL layer at all.
@@ -735,7 +741,9 @@ pub const AmqpTransport = struct {
         const receiver = try amqp.openReceiver(current, .{
             .name = name,
             .source_address = entity,
-            .prefetch = self.options.prefetch,
+            .prefetch = @min(self.options.prefetch, receiver_prefetch_limit),
+            .max_message_size = receiver_max_message_size,
+            .max_buffered_bytes = receiver_max_buffered_bytes,
         }, deadline_ms);
         errdefer current.closeReceiver(receiver, 0);
 
@@ -3238,9 +3246,12 @@ test "a prefetch window grants credit up front, and no window grants exactly wha
         var batch = try h.transport.receiveMessages(allocator, "orders", 1, .peek_lock);
         defer batch.deinit();
 
-        // The default window is granted on attach, so the broker may stream
-        // ahead of the call that asks for the messages.
-        try testing.expectEqual(@as(u32, 300), (try creditFor(allocator, h.mem.written(), 2)).?);
+        // The bounded default window is granted on attach, so the broker may
+        // stream ahead of the call that asks for the messages.
+        try testing.expectEqual(receiver_prefetch_limit, (try creditFor(allocator, h.mem.written(), 2)).?);
+        const receiver = h.transport.receivers.get("orders").?.receiver;
+        try testing.expectEqual(@as(?u64, receiver_max_message_size), receiver.max_message_size);
+        try testing.expectEqual(@as(?u64, receiver_max_buffered_bytes), receiver.max_buffered_bytes);
     }
 
     {
@@ -3291,6 +3302,13 @@ test "settling a message with no entity is refused rather than guessed at" {
 /// this package hands to the caller.
 const amqp_receive_allocs_per_delivery = 2;
 
+/// Encoding a replenishment Flow currently needs two temporary allocations.
+const amqp_allocs_per_refill = 2;
+
+/// AMQP 0.5 tracks each unsettled id both on the receiver and session-wide.
+/// Across the batch sizes below their backing storage moves at most twice.
+const max_receive_tracking_growth_allocs = 2;
+
 /// What a batch costs beyond those per-delivery copies: the arena struct, its
 /// first page, and the one copy of the entity name every message shares. The
 /// message list and the delivery tags come out of the arena page.
@@ -3336,40 +3354,55 @@ test "a received message costs a bounded number of allocations, whatever the bat
     var warm = try h.transport.receiveMessages(allocator, "orders", 1, .peek_lock);
     warm.deinit();
 
+    h.mem.clearWritten();
     counting.reset();
     var first = try h.transport.receiveMessages(allocator, "orders", small, .peek_lock);
     const cost_small = counting.count;
+    const small_refills = blk: {
+        const flows = try emittedFlows(testing.allocator, h.mem.written());
+        defer testing.allocator.free(flows);
+        break :blk flows.len;
+    };
     try testing.expectEqual(@as(usize, small), first.count());
     first.deinit();
 
+    h.mem.clearWritten();
     counting.reset();
     var rest = try h.transport.receiveMessages(allocator, "orders", large, .peek_lock);
     const cost_large = counting.count;
+    const large_refills = blk: {
+        const flows = try emittedFlows(testing.allocator, h.mem.written());
+        defer testing.allocator.free(flows);
+        break :blk flows.len;
+    };
     try testing.expectEqual(@as(usize, large), rest.count());
     rest.deinit();
 
-    // Never more than the dependency's own two copies per message, so this
-    // package adds no backing allocation that scales with the batch: the
-    // arena, the message list and the entity copy are all paid for once.
-    // It comes in a little under, because the receiver's ready queue has
-    // finished growing by the time the larger batch runs.
-    // Both bounds below sit at zero or one allocation of slack, which is what
-    // makes them worth having — but it also means a std growth-policy change
-    // or a different arena page split will trip them while nothing here has
-    // regressed. Check what moved before assuming it was this package.
+    // AMQP 0.5's bounded eight-delivery window is replenished as it drains.
+    // Account for those emitted Flows explicitly rather than weakening the
+    // per-delivery bound: this package still adds no backing allocation that
+    // scales with the batch.
     const marginal = cost_large - cost_small;
-    try testing.expect(marginal <= (large - small) * amqp_receive_allocs_per_delivery);
+    const refill_growth =
+        (large_refills - small_refills) * amqp_allocs_per_refill;
+    try testing.expect(marginal <=
+        (large - small) * amqp_receive_allocs_per_delivery +
+            refill_growth +
+            max_receive_tracking_growth_allocs);
 
     // The other half of the claim, and the discriminating half: what is left
-    // once the dependency's per-delivery copies are taken out is the batch's
-    // own overhead, and it is paid once rather than per message. A second
-    // arena, a second reservation or a per-message entity copy all land here.
+    // once the dependency's per-delivery copies and replenishment Flows are
+    // taken out is the batch's own overhead, paid once rather than per
+    // message. A second arena, reservation, or per-message entity copy lands
+    // here.
     //
     // No matching lower bound on `marginal`: `azure_sdk_amqp` dupes the
     // payload and the tag itself, so a lower bound of one per message would
     // be satisfied by the dependency alone whatever this code did. That the
     // messages really are copied is the lifetime test's job, not this one's.
-    const fixed = cost_small - small * amqp_receive_allocs_per_delivery;
+    const fixed = cost_small -
+        small * amqp_receive_allocs_per_delivery -
+        small_refills * amqp_allocs_per_refill;
     try testing.expect(fixed <= max_receive_fixed_allocs);
 }
 
@@ -3438,7 +3471,7 @@ test "a settle run stops at the entity boundary, whichever entity comes first" {
     try pushMessage(h.peer(), allocator, 2, first_incoming_id, "t", "o", 1);
     // A second audience means a second claim, but the connection and the
     // `$cbs` link pair are already up.
-    try scriptCbsReply(h.peer(), allocator, 2);
+    try scriptCbsReplyAt(h.peer(), allocator, 2, 1, 2);
     try scriptReceiverAttach(h.peer(), 3, "servicebus-receiver-audit");
     try pushMessage(h.peer(), allocator, 3, first_incoming_id + 2, "t", "a", 2);
 

--- a/amqp_transport.zig
+++ b/amqp_transport.zig
@@ -27,8 +27,26 @@ const management = @import("management.zig");
 
 const Allocator = std.mem.Allocator;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+var testing_http_context: u8 = 0;
+
+const testing_http_vtable: core.http.HttpTransport.VTable = .{
+    .send = struct {
+        fn send(_: *anyopaque, _: *core.http.Request) !core.http.Response {
+            return error.UnexpectedHttpRequest;
+        }
+    }.send,
+};
+
+fn testingRuntime() core.http.HttpRuntime {
+    return .init(
+        .{ .context = &testing_http_context, .vtable = &testing_http_vtable },
+        testing_crypto_provider.asProvider(),
+    );
+}
+
 /// Version reported to the service in the `open` properties.
-pub const sdk_version = "0.1.0";
+pub const sdk_version = "0.2.0";
 
 /// The product half of the user agent, matching the other SDKs' shape.
 pub const user_agent_product = "azsdk-zig-servicebus";
@@ -75,8 +93,16 @@ pub const Credential = union(enum) {
         };
     }
 
-    pub fn getToken(self: *Credential, ctx: core.context.Context) !core.credentials.AccessToken {
-        return self.tokenCredential().getToken(.{ .scopes = &.{token_scope} }, ctx);
+    pub fn getToken(
+        self: *Credential,
+        ctx: core.context.Context,
+        runtime: core.http.HttpRuntime,
+    ) !core.credentials.AccessToken {
+        return self.tokenCredential().getToken(
+            .{ .scopes = &.{token_scope} },
+            ctx,
+            runtime,
+        );
     }
 };
 
@@ -89,6 +115,7 @@ pub const Credential = union(enum) {
 /// still outlives the borrow.
 const TokenSource = struct {
     credential: *Credential,
+    runtime: core.http.HttpRuntime,
     ctx: core.context.Context = .none,
     held: ?core.credentials.AccessToken = null,
 
@@ -103,7 +130,7 @@ const TokenSource = struct {
         _ = audience;
 
         self.release();
-        var token = try self.credential.getToken(self.ctx);
+        var token = try self.credential.getToken(self.ctx, self.runtime);
         errdefer token.deinit();
         self.held = token;
 
@@ -309,6 +336,9 @@ const server_timeout_buffer_ms: i64 = 1000;
 /// so initialise it in place and never copy it afterwards.
 pub const AmqpTransport = struct {
     allocator: Allocator,
+    /// Copied by value. Its HTTP and crypto backend contexts are borrowed and
+    /// must outlive this transport and every operation.
+    runtime: core.http.HttpRuntime,
     /// Required to dial. Unused when a session is supplied instead.
     io: ?std.Io = null,
     fully_qualified_namespace: []const u8,
@@ -357,6 +387,7 @@ pub const AmqpTransport = struct {
 
     pub const Options = struct {
         allocator: Allocator,
+        runtime: core.http.HttpRuntime,
         io: ?std.Io = null,
         fully_qualified_namespace: []const u8,
         credential: Credential,
@@ -369,6 +400,7 @@ pub const AmqpTransport = struct {
     pub fn init(self: *AmqpTransport, options: Options) void {
         self.* = .{
             .allocator = options.allocator,
+            .runtime = options.runtime,
             .io = options.io,
             .fully_qualified_namespace = options.fully_qualified_namespace,
             .credential = options.credential,
@@ -377,7 +409,10 @@ pub const AmqpTransport = struct {
         };
         self.encode_buf = amqp.encoder.Buffer.initDynamic(options.allocator);
         self.scratch = .init(options.allocator);
-        self.token_source = .{ .credential = &self.credential };
+        self.token_source = .{
+            .credential = &self.credential,
+            .runtime = options.runtime,
+        };
     }
 
     /// Initialise from a connection string, parsing it exactly once.
@@ -393,6 +428,7 @@ pub const AmqpTransport = struct {
         allocator: Allocator,
         io: ?std.Io,
         connection_string: []const u8,
+        runtime: core.http.HttpRuntime,
         options: ConnectionOptions,
     ) !?[]const u8 {
         const properties = try sb.ConnectionStringProperties.parse(connection_string);
@@ -423,6 +459,7 @@ pub const AmqpTransport = struct {
 
         self.init(.{
             .allocator = allocator,
+            .runtime = runtime,
             .io = io,
             .fully_qualified_namespace = properties.fully_qualified_namespace,
             .credential = .{ .sas = sas },
@@ -1507,8 +1544,9 @@ const StubCredential = struct {
         c: *core.credentials.TokenCredential,
         request_context: core.credentials.TokenRequestContext,
         ctx: core.context.Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
-        _ = .{ request_context, ctx };
+        _ = .{ request_context, ctx, runtime };
         const self: *StubCredential = @alignCast(@fieldParentPtr("credential", c));
         self.calls += 1;
         // Borrowed, so `deinit` frees nothing — the transport must not assume
@@ -1533,8 +1571,9 @@ const OwningStubCredential = struct {
         c: *core.credentials.TokenCredential,
         request_context: core.credentials.TokenRequestContext,
         ctx: core.context.Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
-        _ = .{ request_context, ctx };
+        _ = .{ request_context, ctx, runtime };
         const self: *OwningStubCredential = @alignCast(@fieldParentPtr("credential", c));
         self.calls += 1;
         return .{
@@ -1542,6 +1581,54 @@ const OwningStubCredential = struct {
             .expires_on = stub_token_expires_on,
             .allocator = self.allocator,
         };
+    }
+};
+
+const CryptoSpy = struct {
+    hmac_calls: usize = 0,
+    fail_hmac: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn asProvider(self: *CryptoSpy) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(_: *anyopaque, _: []u8) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.UnexpectedCryptoOperation;
+    }
+
+    fn hmacSha256(
+        context: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        out: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self: *CryptoSpy = @ptrCast(@alignCast(context));
+        self.hmac_calls += 1;
+        @memset(out, 0xa5);
+        if (self.fail_hmac) return error.SelectedCryptoFailure;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.UnexpectedCryptoOperation;
     }
 };
 
@@ -1749,6 +1836,7 @@ const Harness = struct {
         }, 10_000);
         self.transport.init(.{
             .allocator = self.allocator,
+            .runtime = testingRuntime(),
             .fully_qualified_namespace = "ns.servicebus.windows.net",
             .credential = .{ .token = &self.credential.credential },
             .connection = options,
@@ -2059,7 +2147,13 @@ test "a connection string is parsed once and yields its entity path" {
         "SharedAccessKey=c2VjcmV0;EntityPath=orders";
 
     var t: AmqpTransport = undefined;
-    const entity = try t.initFromConnectionString(allocator, null, cs, .{});
+    const entity = try t.initFromConnectionString(
+        allocator,
+        null,
+        cs,
+        testingRuntime(),
+        .{},
+    );
     defer t.deinit();
 
     try testing.expectEqualStrings("orders", entity.?);
@@ -2068,13 +2162,58 @@ test "a connection string is parsed once and yields its entity path" {
     try testing.expect(t.options.use_tls);
 }
 
+test "connection string SAS preserves the runtime and provider failures are atomic" {
+    const allocator = testing.allocator;
+    const cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=root;" ++
+        "SharedAccessKey=c2VjcmV0;EntityPath=orders";
+    var crypto = CryptoSpy{};
+    const runtime = core.http.HttpRuntime.init(
+        .{ .context = &testing_http_context, .vtable = &testing_http_vtable },
+        crypto.asProvider(),
+    );
+
+    var transport: AmqpTransport = undefined;
+    _ = try transport.initFromConnectionString(
+        allocator,
+        null,
+        cs,
+        runtime,
+        .{},
+    );
+    defer transport.deinit();
+
+    try testing.expectEqual(runtime.transport.context, transport.runtime.transport.context);
+    try testing.expectEqual(runtime.transport.vtable, transport.runtime.transport.vtable);
+    try testing.expectEqual(runtime.crypto.context, transport.runtime.crypto.context);
+    try testing.expectEqual(runtime.crypto.vtable, transport.runtime.crypto.vtable);
+
+    const provider = transport.token_source.provider();
+    _ = try provider.getToken(transport.owned_audience.?);
+    try testing.expectEqual(@as(usize, 1), crypto.hmac_calls);
+    try testing.expect(transport.token_source.held != null);
+
+    crypto.fail_hmac = true;
+    try testing.expectError(
+        error.SelectedCryptoFailure,
+        provider.getToken(transport.owned_audience.?),
+    );
+    try testing.expectEqual(@as(usize, 2), crypto.hmac_calls);
+    try testing.expect(transport.token_source.held == null);
+}
+
 test "the emulator's connection string turns TLS off" {
     const allocator = testing.allocator;
     const cs = "Endpoint=sb://localhost;SharedAccessKeyName=root;" ++
         "SharedAccessKey=c2VjcmV0;UseDevelopmentEmulator=true";
 
     var t: AmqpTransport = undefined;
-    _ = try t.initFromConnectionString(allocator, null, cs, .{});
+    _ = try t.initFromConnectionString(
+        allocator,
+        null,
+        cs,
+        testingRuntime(),
+        .{},
+    );
     defer t.deinit();
 
     try testing.expect(!t.options.use_tls);
@@ -2087,6 +2226,7 @@ test "dialling without an io implementation is refused, not crashed" {
     var t: AmqpTransport = undefined;
     t.init(.{
         .allocator = allocator,
+        .runtime = testingRuntime(),
         .fully_qualified_namespace = "ns.servicebus.windows.net",
         .credential = .{ .token = &credential.credential },
     });
@@ -2428,6 +2568,7 @@ test "the emulator's audience names plaintext AMQP" {
         allocator,
         null,
         "Endpoint=sb://localhost;SharedAccessKeyName=root;SharedAccessKey=c2VjcmV0;UseDevelopmentEmulator=true;EntityPath=orders",
+        testingRuntime(),
         .{},
     );
     defer transport.deinit();

--- a/amqp_transport.zig
+++ b/amqp_transport.zig
@@ -860,15 +860,12 @@ pub const AmqpTransport = struct {
         const deadline_ms = self.deadlineFrom(current);
         const receiver = try self.receiverFor(current, entity, mode, deadline_ms);
 
-        // Manual credit may be partly live and partly deferred behind the
-        // receiver's byte or settlement bounds. Both are still outstanding
-        // demand; asking from live credit alone duplicates the deferred part
-        // on every short receive. Charged deliveries, including aborted ones,
-        // reduce these public AMQP counters, and a replacement link starts
-        // them at zero.
+        // AMQP owns manual demand, including restoring a request consumed by
+        // a hidden aborted delivery. Live plus deferred credit is therefore
+        // the authoritative outstanding count: top up only its delta across
+        // short receives, while a replacement link naturally starts at zero.
         if (self.options.prefetch == 0) {
-            const outstanding =
-                (receiver.credit +| receiver.deferred_credit) -| receiver.overrun;
+            const outstanding = receiver.credit +| receiver.deferred_credit;
             if (outstanding < max_count) {
                 try receiver.issueCredit(max_count - outstanding);
             }
@@ -3301,46 +3298,59 @@ test "manual credit does not duplicate deferred demand across short maximum batc
     }
 }
 
-test "manual demand accounts for an aborted delivery before the next call" {
+test "manual receive replaces an aborted delivery before returning" {
     const allocator = testing.allocator;
     var h = try Harness.init(allocator);
     defer h.deinit();
 
     try scriptEntityReceiver(&h, allocator, "orders");
-    h.mem.starve = true;
-    try h.start(.{ .prefetch = 0, .deadline_ms = 1_000 });
-    h.clock.auto_advance_ms = 5;
-
     try pushAborted(h.peer(), 2, first_incoming_id);
-    try pushMessage(h.peer(), allocator, 2, first_incoming_id + 1, "t", "first", 1);
-    var first = try h.transport.receiveMessages(
+    try pushMessage(
+        h.peer(),
         allocator,
-        "orders",
-        max_receive_count,
-        .peek_lock,
+        2,
+        first_incoming_id + 1,
+        "t",
+        "replacement",
+        1,
     );
-    defer first.deinit();
-    try testing.expectEqual(@as(usize, 1), first.count());
+    try h.start(.{ .prefetch = 0 });
+    _ = try h.transport.receiverFor(
+        h.session,
+        "orders",
+        .peek_lock,
+        10_000,
+    );
+    h.mem.clearWritten();
+
+    var batch = try h.transport.receiveMessages(allocator, "orders", 1, .peek_lock);
+    defer batch.deinit();
+    try testing.expectEqual(@as(usize, 1), batch.count());
+    try testing.expectEqualStrings("replacement", batch.messages[0].body);
+
+    // The peer's valid delivery follows an aborted one. AMQP must replace the
+    // consumed manual request with a second Flow before reading that delivery;
+    // its delivery-count proves the abort was charged first.
+    const flows = try emittedFlows(allocator, h.mem.written());
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 2), flows.len);
+
+    var initial = try amqp.performative.decode(allocator, flows[0]);
+    defer initial.deinit();
+    try testing.expectEqual(@as(?u32, 0), initial.performative.flow.delivery_count);
+    try testing.expectEqual(@as(?u32, 1), initial.performative.flow.link_credit);
+
+    var replacement = try amqp.performative.decode(allocator, flows[1]);
+    defer replacement.deinit();
+    try testing.expectEqual(@as(?u32, 1), replacement.performative.flow.delivery_count);
+    try testing.expectEqual(@as(?u32, 1), replacement.performative.flow.link_credit);
 
     const receiver = h.transport.receivers.get("orders").?.receiver;
     try testing.expectEqual(
-        max_receive_count - 2,
+        @as(u32, 0),
         receiver.credit + receiver.deferred_credit,
     );
-
-    try pushMessage(h.peer(), allocator, 2, first_incoming_id + 2, "t", "second", 2);
-    var second = try h.transport.receiveMessages(
-        allocator,
-        "orders",
-        max_receive_count,
-        .peek_lock,
-    );
-    defer second.deinit();
-    try testing.expectEqual(@as(usize, 1), second.count());
-    try testing.expectEqual(
-        max_receive_count - 1,
-        receiver.credit + receiver.deferred_credit,
-    );
+    try testing.expectEqual(@as(usize, 0), h.mem.reads_with_pending_writes);
 }
 
 test "manual deferred demand is discarded with a replaced receiver link" {

--- a/benchmarks/main.zig
+++ b/benchmarks/main.zig
@@ -22,6 +22,17 @@ const amqp = @import("azure_sdk_amqp");
 
 const perf = core.perf;
 
+var runtime_io: std.Io = undefined;
+var unused_http_context: u8 = 0;
+
+const unused_http_vtable: core.http.HttpTransport.VTable = .{
+    .send = struct {
+        fn send(_: *anyopaque, _: *core.http.Request) !core.http.Response {
+            return error.UnexpectedHttpRequest;
+        }
+    }.send,
+};
+
 /// Representative Service Bus payload: a small JSON order.
 const small_body = "{\"order\":\"SO-4821\",\"total\":19.95,\"currency\":\"USD\"}";
 
@@ -221,8 +232,9 @@ const BenchCredential = struct {
         c: *core.credentials.TokenCredential,
         request_context: core.credentials.TokenRequestContext,
         ctx: core.context.Context,
+        runtime: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
-        _ = .{ c, request_context, ctx };
+        _ = .{ c, request_context, ctx, runtime };
         return .{ .token = "bench-jwt", .expires_on = bench_token_expires_on };
     }
 };
@@ -358,9 +370,15 @@ fn receiveScripted(allocator: std.mem.Allocator, script: []const u8, count: u32)
     defer session.deinit();
 
     var credential: BenchCredential = .{};
+    var crypto_provider = core.crypto.StdCryptoProvider.init(runtime_io);
+    const runtime = core.http.HttpRuntime.init(
+        .{ .context = &unused_http_context, .vtable = &unused_http_vtable },
+        crypto_provider.asProvider(),
+    );
     var transport: sb.AmqpTransport = undefined;
     transport.init(.{
         .allocator = allocator,
+        .runtime = runtime,
         .fully_qualified_namespace = bench_options.hostname.?,
         .credential = .{ .token = &credential.credential },
         // No prefetch window, so the link is granted exactly what is asked
@@ -411,6 +429,7 @@ fn benchScriptPush(allocator: std.mem.Allocator) !void {
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const io = init.io;
+    runtime_io = io;
 
     const annotations = [_]amqp.MapEntry{.{
         .key = .{ .symbol = sb.annotation.sequence_number },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "azure_sdk_messaging_common-0.3.0-YklmSimrAABYnVM-KFESp7QVjZSRzJXVpQl3CJ8a_ZeO",
         },
         .azure_sdk_amqp = .{
-            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/1c5ba890ad9c2fcb366c8a18b24eb8d90976a4cc.tar.gz",
-            .hash = "azure_sdk_amqp-0.5.0-fUByf5TFCgBKs3NyXoM79xpHDwp7NExRKKj-YyZupvR8",
+            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b.tar.gz",
+            .hash = "azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,16 +1,16 @@
 .{
     .name = .azure_sdk_servicebus,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xe97d9ecab3df6bbd,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .azure_sdk_messaging_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#2dd41660a706db7bbaa2ef2fe76b67e92568a8e6",
-            .hash = "azure_sdk_messaging_common-0.2.0-YklmSkWIAACgiNHymgq5TSnhW6t9nULx2U8H4kxUgGWN",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#6326815bfacb61c7484d93f969f959082f406dcc",
+            .hash = "azure_sdk_messaging_common-0.3.0-YklmSimrAABYnVM-KFESp7QVjZSRzJXVpQl3CJ8a_ZeO",
         },
         .azure_sdk_amqp = .{
             .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bd5330d983ca75a56771a085659ec1136c9a81f6",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .hash = "azure_sdk_messaging_common-0.3.0-YklmSimrAABYnVM-KFESp7QVjZSRzJXVpQl3CJ8a_ZeO",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bd5330d983ca75a56771a085659ec1136c9a81f6",
-            .hash = "azure_sdk_amqp-0.4.0-fUByfyWRBwDU9pQlQL3AnageJI-noNZtH_5PxOJAk90U",
+            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/1c5ba890ad9c2fcb366c8a18b24eb8d90976a4cc.tar.gz",
+            .hash = "azure_sdk_amqp-0.5.0-fUByf5TFCgBKs3NyXoM79xpHDwp7NExRKKj-YyZupvR8",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",


### PR DESCRIPTION
## Summary
- migrate the administration client to `HttpRuntime` and the current `HttpPipeline`, including bearer authentication and explicit lifetime ownership
- keep credential and transport callbacks outside the auth cache lock while serializing cache double-check, authorization allocation, swap, and old-value free for non-thread-safe allocators
- carry the complete runtime through AMQP token acquisition so Messaging Common SAS signing uses `runtime.crypto` and provider failures remain atomic
- retain `azure_sdk_servicebus` 0.2.0 and pin the released Azure AMQP 0.5.1 package
- bound production receiver links to 8 credits, 128 MiB per message, and 1 GiB buffered while preserving zero-prefetch/manual credit
- use AMQP's live-plus-deferred demand as authoritative across short receives and link replacement; hidden aborted deliveries receive replacement credit inside the same receive pump
- retain the public 5000-message receive contract with 5000 unsettled-ID slots; receive-and-delete flushes settlement every 1024 messages while peek-lock may retain the requested batch
- correct the multi-audience CBS fixture to use session-unique incoming delivery IDs and account precisely for AMQP refill/tracking allocations

## Dependency pins
- Core 0.3.0: `git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41` (`azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`)
- Messaging Common 0.3.0: `git+https://github.com/cataggar/azure-sdk-for-zig.git#6326815bfacb61c7484d93f969f959082f406dcc` (`azure_sdk_messaging_common-0.3.0-YklmSimrAABYnVM-KFESp7QVjZSRzJXVpQl3CJ8a_ZeO`)
- Azure AMQP 0.5.1: `https://github.com/cataggar/azure-sdk-for-zig/archive/86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b.tar.gz` (`azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam`)

## Validation
- `zig fmt --check build.zig admin.zig amqp_transport.zig benchmarks/main.zig build.zig.zon management.zig message.zig root.zig`
- `zig build test --summary all` (Debug, 126/126; includes guarded allocator, manual/deferred credit, hidden-abort replacement Flow, allocation, delivery-ID, and >1024 receive conformance coverage)
- `zig build test -Doptimize=ReleaseSafe --summary all` (126/126; benchmark executable compiled)
- `zig build --summary all` (manifest/dependency validation)

Part of #412
Part of #414