### PR TITLE
Migrate Key Vault SDK to HttpRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ contexts are borrowed. Credentials and policy contexts are borrowed too. They
 must outlive every client, derived cryptography client, pager, and in-flight
 operation that uses them. Keep a parent `KeyClient` alive until clients
 returned by `getCryptographyClient` and all of its pagers are deinitialized.
-The package installs no fallback crypto provider.
+Core's bearer-token cache is mutable and unsynchronized, so callers must
+serialize every operation sharing a client's pipeline state, including pager
+operations and calls through derived cryptography clients, even when the
+selected transport and crypto backends are independently synchronized. The
+package installs no fallback crypto provider.
+
+Authenticated pagers accept continuation URLs only when they are absolute
+HTTPS URLs on the original vault's effective host and port. Cross-origin,
+userinfo-bearing, fragmented, malformed, and non-HTTPS continuations fail
+before the URL can be retained for another authenticated request.
 
 `keys.CryptographyClient` performs Key Vault service-side cryptography: its
 `sign` operation sends a caller-provided digest as a REST payload. It does not

--- a/README.md
+++ b/README.md
@@ -11,8 +11,45 @@ One independently versioned Key Vault package with four namespaces:
 
 - Source: `sdk/keyvault`
 - Release branch: `sdk/keyvault`
-- Initial version: `0.1.0`
+- Current version: `0.2.0`
 - Dependencies: `azure_sdk_core` and `serde`
+
+All clients require an explicit `core.http.HttpRuntime`, so applications select
+the HTTP transport and SDK crypto provider independently:
+
+```zig
+const core = @import("azure_sdk_core");
+const keyvault = @import("azure_sdk_keyvault");
+
+var transport = core.http.StdHttpTransport.init(allocator, io);
+defer transport.deinit();
+var crypto = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    transport.asTransport(),
+    crypto.asProvider(),
+);
+
+var client = try keyvault.secrets.SecretClient.init(
+    allocator,
+    "https://my-vault.vault.azure.net",
+    credential,
+    runtime,
+    .{},
+);
+defer client.deinit();
+```
+
+Runtime descriptors are copied by value while their transport and crypto
+contexts are borrowed. Credentials and policy contexts are borrowed too. They
+must outlive every client, derived cryptography client, pager, and in-flight
+operation that uses them. Keep a parent `KeyClient` alive until clients
+returned by `getCryptographyClient` and all of its pagers are deinitialized.
+The package installs no fallback crypto provider.
+
+`keys.CryptographyClient` performs Key Vault service-side cryptography: its
+`sign` operation sends a caller-provided digest as a REST payload. It does not
+hash that payload locally and is separate from both SDK runtime cryptography
+and the transport's TLS implementation.
 
 The handwritten Secrets namespace is separate from the generated
 [`azure_rest_keyvault_secrets`](https://github.com/cataggar/azure-sdk-for-zig/tree/main/rest/keyvault_secrets)

--- a/administration/README.md
+++ b/administration/README.md
@@ -8,3 +8,7 @@ Azure Key Vault administration clients:
 These clients are exposed through `azure_sdk_keyvault.administration` and
 version with the [`azure_sdk_keyvault`](../README.md) package. The old
 `azure_sdk_keyvault` module receives no alias.
+
+Both clients require a caller-selected `core.http.HttpRuntime`. Its backend
+contexts and the credential are borrowed and must outlive the client, pagers,
+and polling operations.

--- a/administration/README.md
+++ b/administration/README.md
@@ -11,4 +11,5 @@ version with the [`azure_sdk_keyvault`](../README.md) package. The old
 
 Both clients require a caller-selected `core.http.HttpRuntime`. Its backend
 contexts and the credential are borrowed and must outlive the client, pagers,
-and polling operations.
+and polling operations. Callers must serialize all operations sharing a
+client's pipeline state.

--- a/administration/root.zig
+++ b/administration/root.zig
@@ -25,7 +25,8 @@ pub const BackupClientOptions = struct {
 
 /// Runtime descriptors are copied by value. Their borrowed transport and
 /// crypto contexts and the credential must outlive this client and every
-/// in-flight operation.
+/// in-flight operation. The caller must serialize every operation sharing
+/// this client's pipeline state.
 pub const BackupClient = struct {
     vault_url: []const u8,
     api_version: []const u8,
@@ -199,7 +200,8 @@ pub const SettingsClientOptions = struct {
 
 /// Runtime descriptors are copied by value. Their borrowed transport and
 /// crypto contexts and the credential must outlive this client and every
-/// pager returned by it.
+/// pager returned by it. The caller must serialize every operation sharing
+/// this client's pipeline state, including pager operations.
 pub const SettingsClient = struct {
     vault_url: []const u8,
     api_version: []const u8,

--- a/administration/root.zig
+++ b/administration/root.zig
@@ -1,6 +1,11 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 const serde = @import("serde");
+const pipeline_mod = @import("azure_sdk_keyvault_pipeline");
+const test_support = if (@import("builtin").is_test)
+    @import("azure_sdk_keyvault_test_support")
+else
+    struct {};
 
 /// Pager type returned by `listSettings`.
 pub const AdminSettingPager = core.pager.PipelinePager(AdminSetting);
@@ -14,25 +19,41 @@ pub const AdminSetting = struct {
 
 pub const BackupClientOptions = struct {
     api_version: []const u8 = "7.6-preview.2",
+    retry: pipeline_mod.RetryOptions = .{},
+    scope: []const u8 = pipeline_mod.default_scope,
 };
 
+/// Runtime descriptors are copied by value. Their borrowed transport and
+/// crypto contexts and the credential must outlive this client and every
+/// in-flight operation.
 pub const BackupClient = struct {
     vault_url: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline_state: *pipeline_mod.PipelineState,
 
     pub fn init(
+        allocator: std.mem.Allocator,
         vault_url: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         options: BackupClientOptions,
-    ) BackupClient {
-        _ = credential;
+    ) !BackupClient {
         return .{
             .vault_url = vault_url,
             .api_version = options.api_version,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .pipeline_state = try pipeline_mod.PipelineState.create(
+                allocator,
+                credential,
+                runtime,
+                options.retry,
+                options.scope,
+            ),
         };
+    }
+
+    pub fn deinit(self: *BackupClient) void {
+        self.pipeline_state.deinit();
+        self.* = undefined;
     }
 
     /// POST /backup?api-version=... — begins a full backup (LRO stub returning operation ID).
@@ -73,7 +94,7 @@ pub const BackupClient = struct {
         try req.setHeader("Accept", "application/json");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -124,7 +145,7 @@ pub const BackupClient = struct {
         try req.setHeader("Accept", "application/json");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -143,7 +164,13 @@ pub const BackupClient = struct {
         allocator: std.mem.Allocator,
         operation_url: []const u8,
     ) !core.lro.PollResult {
-        return core.lro.pollUntilDone(allocator, &self.pipeline, operation_url, 2000, 60);
+        return core.lro.pollUntilDone(
+            allocator,
+            &self.pipeline_state.pipeline,
+            operation_url,
+            2000,
+            60,
+        );
     }
 
     /// Wait for a restore operation to complete by polling the operation URL.
@@ -152,28 +179,55 @@ pub const BackupClient = struct {
         allocator: std.mem.Allocator,
         operation_url: []const u8,
     ) !core.lro.PollResult {
-        return core.lro.pollUntilDone(allocator, &self.pipeline, operation_url, 2000, 60);
+        return core.lro.pollUntilDone(
+            allocator,
+            &self.pipeline_state.pipeline,
+            operation_url,
+            2000,
+            60,
+        );
     }
 };
 
 // ──────────────────────── SettingsClient ──────────────────────
 
+pub const SettingsClientOptions = struct {
+    api_version: []const u8 = "7.6-preview.2",
+    retry: pipeline_mod.RetryOptions = .{},
+    scope: []const u8 = pipeline_mod.default_scope,
+};
+
+/// Runtime descriptors are copied by value. Their borrowed transport and
+/// crypto contexts and the credential must outlive this client and every
+/// pager returned by it.
 pub const SettingsClient = struct {
     vault_url: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline_state: *pipeline_mod.PipelineState,
 
     pub fn init(
+        allocator: std.mem.Allocator,
         vault_url: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
-    ) SettingsClient {
-        _ = credential;
+        runtime: core.http.HttpRuntime,
+        options: SettingsClientOptions,
+    ) !SettingsClient {
         return .{
             .vault_url = vault_url,
-            .api_version = "7.6-preview.2",
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .api_version = options.api_version,
+            .pipeline_state = try pipeline_mod.PipelineState.create(
+                allocator,
+                credential,
+                runtime,
+                options.retry,
+                options.scope,
+            ),
         };
+    }
+
+    pub fn deinit(self: *SettingsClient) void {
+        self.pipeline_state.deinit();
+        self.* = undefined;
     }
 
     /// GET /settings/{name}?api-version=...
@@ -203,7 +257,7 @@ pub const SettingsClient = struct {
         defer req.deinit();
         try req.setHeader("Accept", "application/json");
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -250,7 +304,7 @@ pub const SettingsClient = struct {
         try req.setHeader("Accept", "application/json");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -273,7 +327,7 @@ pub const SettingsClient = struct {
         defer allocator.free(url);
 
         return AdminSettingPager.init(
-            self.pipeline,
+            self.pipeline_state.pipeline,
             url,
             allocator,
             &parseAdminSettingListPage,
@@ -343,19 +397,15 @@ test "BackupClient beginBackup" {
     );
     defer mock.deinit();
 
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-
-    var client = BackupClient.init(
+    var credential = test_support.StaticCredential{};
+    var client = try BackupClient.init(
+        allocator,
         "https://vault.managedhsm.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     const op_id = try client.beginBackup(allocator, "https://storage.blob.core.windows.net/backup", "sas-token");
     defer allocator.free(op_id);
@@ -372,18 +422,15 @@ test "SettingsClient getSetting" {
     );
     defer mock.deinit();
 
-    const identity2 = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity2.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-
-    var client = SettingsClient.init(
+    var credential = test_support.StaticCredential{};
+    var client = try SettingsClient.init(
+        allocator,
         "https://vault.managedhsm.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
+        .{},
     );
+    defer client.deinit();
 
     const value = try client.getSetting(allocator, "AllowKeyManagementOperationsThroughARM");
     defer allocator.free(value);

--- a/build.zig
+++ b/build.zig
@@ -16,12 +16,29 @@ pub fn build(b: *std.Build) void {
     });
     const serde_mod = serde_dep.module("serde");
 
+    const pipeline_mod = b.createModule(.{
+        .root_source_file = b.path("pipeline.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "azure_sdk_core", .module = core_mod },
+        },
+    });
+    const test_support_mod = b.createModule(.{
+        .root_source_file = b.path("test_support.zig"),
+        .target = target,
+        .imports = &.{
+            .{ .name = "azure_sdk_core", .module = core_mod },
+        },
+    });
+
     _ = b.addModule("azure_sdk_keyvault", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .imports = &.{
             .{ .name = "azure_sdk_core", .module = core_mod },
             .{ .name = "serde", .module = serde_mod },
+            .{ .name = "azure_sdk_keyvault_pipeline", .module = pipeline_mod },
+            .{ .name = "azure_sdk_keyvault_test_support", .module = test_support_mod },
         },
     });
 
@@ -41,6 +58,8 @@ pub fn build(b: *std.Build) void {
                 .imports = &.{
                     .{ .name = "azure_sdk_core", .module = core_mod },
                     .{ .name = "serde", .module = serde_mod },
+                    .{ .name = "azure_sdk_keyvault_pipeline", .module = pipeline_mod },
+                    .{ .name = "azure_sdk_keyvault_test_support", .module = test_support_mod },
                 },
             }),
         });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .azure_sdk_keyvault,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0x627e5ce0e9b1cf05,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",
@@ -18,6 +18,8 @@
         "build.zig",
         "build.zig.zon",
         "root.zig",
+        "pipeline.zig",
+        "test_support.zig",
         "secrets",
         "keys",
         "certificates",

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -7,4 +7,5 @@ with the [`azure_sdk_keyvault`](../README.md) package.
 
 Construction requires a caller-selected `core.http.HttpRuntime`. Its backend
 contexts and the credential are borrowed and must outlive the client and its
-pagers.
+pagers. Callers must serialize all operations sharing the client's pipeline
+state. Continuation URLs are restricted to the original HTTPS vault origin.

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -4,3 +4,7 @@ Azure Key Vault Certificates client exposing `CertificateClient`.
 
 The client is exposed through `azure_sdk_keyvault.certificates` and versions
 with the [`azure_sdk_keyvault`](../README.md) package.
+
+Construction requires a caller-selected `core.http.HttpRuntime`. Its backend
+contexts and the credential are borrowed and must outlive the client and its
+pagers.

--- a/certificates/root.zig
+++ b/certificates/root.zig
@@ -1,6 +1,11 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 const serde = @import("serde");
+const pipeline_mod = @import("azure_sdk_keyvault_pipeline");
+const test_support = if (@import("builtin").is_test)
+    @import("azure_sdk_keyvault_test_support")
+else
+    struct {};
 
 // ─────────────────────────── Models ───────────────────────────
 
@@ -29,25 +34,41 @@ pub const KeyVaultCertificate = struct {
 
 pub const CertificateClientOptions = struct {
     api_version: []const u8 = "7.6-preview.2",
+    retry: pipeline_mod.RetryOptions = .{},
+    scope: []const u8 = pipeline_mod.default_scope,
 };
 
+/// Runtime descriptors are copied by value. Their borrowed transport and
+/// crypto contexts and the credential must outlive this client and every
+/// pager returned by it.
 pub const CertificateClient = struct {
     vault_url: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline_state: *pipeline_mod.PipelineState,
 
     pub fn init(
+        allocator: std.mem.Allocator,
         vault_url: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         options: CertificateClientOptions,
-    ) CertificateClient {
-        _ = credential;
+    ) !CertificateClient {
         return .{
             .vault_url = vault_url,
             .api_version = options.api_version,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .pipeline_state = try pipeline_mod.PipelineState.create(
+                allocator,
+                credential,
+                runtime,
+                options.retry,
+                options.scope,
+            ),
         };
+    }
+
+    pub fn deinit(self: *CertificateClient) void {
+        self.pipeline_state.deinit();
+        self.* = undefined;
     }
 
     /// GET /certificates/{name}?api-version=...
@@ -73,7 +94,7 @@ pub const CertificateClient = struct {
         defer req.deinit();
         try req.setHeader("Accept", "application/json");
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -122,7 +143,7 @@ pub const CertificateClient = struct {
         try req.setHeader("Accept", "application/json");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -157,7 +178,7 @@ pub const CertificateClient = struct {
         var req = core.http.Request.init(allocator, .DELETE, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.isSuccess()) return .{ .ok = {} };
@@ -176,7 +197,7 @@ pub const CertificateClient = struct {
         defer allocator.free(url);
 
         return CertificatePager.init(
-            self.pipeline,
+            self.pipeline_state.pipeline,
             url,
             allocator,
             &parseCertificateListPage,
@@ -285,19 +306,15 @@ test "CertificateClient getCertificate" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
-
-    var client = CertificateClient.init(
+    var credential = test_support.StaticCredential{};
+    var client = try CertificateClient.init(
+        allocator,
         "https://vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     const cert = try client.getCertificate(allocator, "mycert");
     defer allocator.free(cert.id.?);

--- a/certificates/root.zig
+++ b/certificates/root.zig
@@ -10,7 +10,7 @@ else
 // ─────────────────────────── Models ───────────────────────────
 
 /// Pager type returned by `listCertificates`.
-pub const CertificatePager = core.pager.PipelinePager(KeyVaultCertificate);
+pub const CertificatePager = pipeline_mod.ValidatedPipelinePager(KeyVaultCertificate);
 
 pub const CertificateProperties = struct {
     enabled: ?bool = null,
@@ -40,7 +40,8 @@ pub const CertificateClientOptions = struct {
 
 /// Runtime descriptors are copied by value. Their borrowed transport and
 /// crypto contexts and the credential must outlive this client and every
-/// pager returned by it.
+/// pager returned by it. The caller must serialize all operations sharing
+/// this client's pipeline state, including pager operations.
 pub const CertificateClient = struct {
     vault_url: []const u8,
     api_version: []const u8,
@@ -199,8 +200,10 @@ pub const CertificateClient = struct {
         return CertificatePager.init(
             self.pipeline_state.pipeline,
             url,
+            self.vault_url,
             allocator,
             &parseCertificateListPage,
+            &deinitCertificates,
             "application/json",
         );
     }
@@ -272,7 +275,11 @@ const CertListSchema = struct {
     nextLink: ?[]const u8 = null,
 };
 
-fn parseCertificateListPage(allocator: std.mem.Allocator, body: []const u8) !core.pager.PageResult(KeyVaultCertificate) {
+fn parseCertificateListPage(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    origin: []const u8,
+) !core.pager.PageResult(KeyVaultCertificate) {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
@@ -281,7 +288,10 @@ fn parseCertificateListPage(allocator: std.mem.Allocator, body: []const u8) !cor
 
     var next_link: ?[]u8 = null;
     if (parsed.nextLink) |nl| {
-        if (nl.len > 0) next_link = try allocator.dupe(u8, nl);
+        if (nl.len > 0) {
+            try pipeline_mod.validateHttpsOrigin(origin, nl);
+            next_link = try allocator.dupe(u8, nl);
+        }
     }
 
     const entries = parsed.value orelse
@@ -294,6 +304,14 @@ fn parseCertificateListPage(allocator: std.mem.Allocator, body: []const u8) !cor
         result[i] = cert;
     }
     return .{ .items = result, .next_link = next_link };
+}
+
+fn deinitCertificates(
+    allocator: std.mem.Allocator,
+    certificates: []KeyVaultCertificate,
+) void {
+    for (certificates) |certificate| certificate.deinit(allocator);
+    allocator.free(certificates);
 }
 
 // ─────────────────────────── Tests ────────────────────────────
@@ -323,4 +341,32 @@ test "CertificateClient getCertificate" {
     try std.testing.expectEqual(true, cert.properties.enabled.?);
     try std.testing.expectEqual(@as(i64, 1800000000), cert.properties.expires_on.?);
     try std.testing.expect(std.mem.find(u8, mock.last_url.?, "certificates/mycert?api-version=") != null);
+}
+
+test "CertificateClient pager rejects cross-origin continuation before dispatch" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"value":[{"id":"https://vault.azure.net/certificates/mycert/v1"}],"nextLink":"https://attacker.example/steal"}
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+    var credential = test_support.StaticCredential{};
+    var client = try CertificateClient.init(
+        allocator,
+        "https://vault.azure.net",
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
+        .{ .retry = .{ .max_retries = 0 } },
+    );
+    defer client.deinit();
+
+    var pager = try client.listCertificates(allocator);
+    defer pager.deinit();
+    try std.testing.expectError(error.InvalidContinuationUrl, pager.next());
+    try std.testing.expect(pager.next_url == null);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try std.testing.expectEqualStrings(
+        "https://vault.azure.net/certificates?api-version=7.6-preview.2",
+        mock.last_url.?,
+    );
 }

--- a/keys/README.md
+++ b/keys/README.md
@@ -10,6 +10,7 @@ the [`azure_sdk_keyvault`](../README.md) package.
 
 `KeyClient.getCryptographyClient` returns a derived client that borrows the
 parent's authenticated pipeline and selected transport/crypto providers. The
-derived client must be deinitialized before its parent. `CryptographyClient`
-sends digests to the Key Vault service; it does not replace runtime
-cryptography or transport TLS.
+derived client must be deinitialized before its parent, and callers must
+serialize all parent, derived-client, and pager operations sharing that
+pipeline state. `CryptographyClient` sends digests to the Key Vault service;
+it does not replace runtime cryptography or transport TLS.

--- a/keys/README.md
+++ b/keys/README.md
@@ -7,3 +7,9 @@ Azure Key Vault Keys clients:
 
 These clients are exposed through `azure_sdk_keyvault.keys` and version with
 the [`azure_sdk_keyvault`](../README.md) package.
+
+`KeyClient.getCryptographyClient` returns a derived client that borrows the
+parent's authenticated pipeline and selected transport/crypto providers. The
+derived client must be deinitialized before its parent. `CryptographyClient`
+sends digests to the Key Vault service; it does not replace runtime
+cryptography or transport TLS.

--- a/keys/root.zig
+++ b/keys/root.zig
@@ -6,13 +6,14 @@
 const std = @import("std");
 const serde = @import("serde");
 const core = @import("azure_sdk_core");
+const pipeline_mod = @import("azure_sdk_keyvault_pipeline");
+const test_support = if (@import("builtin").is_test)
+    @import("azure_sdk_keyvault_test_support")
+else
+    struct {};
 
-const HttpPipeline = core.pipeline.HttpPipeline;
-const HttpPolicy = core.pipeline.HttpPolicy;
-const RetryPolicy = core.pipeline.RetryPolicy;
-const BearerTokenAuthPolicy = core.pipeline.BearerTokenAuthPolicy;
+const HttpPipeline = core.http.HttpPipeline;
 const Request = core.http.Request;
-const HttpTransport = core.http.HttpTransport;
 const TokenCredential = core.credentials.TokenCredential;
 const Result = core.errors.Result;
 
@@ -118,11 +119,7 @@ pub const Tag = struct {
     value: []const u8,
 };
 
-pub const RetryOptions = struct {
-    max_retries: u32 = 3,
-    initial_delay_ms: u64 = 800,
-    max_delay_ms: u64 = 60_000,
-};
+pub const RetryOptions = pipeline_mod.RetryOptions;
 
 pub const KeyClientOptions = struct {
     retry: RetryOptions = .{},
@@ -249,75 +246,37 @@ pub const Signature = struct {
     }
 };
 
-const PipelineState = struct {
-    allocator: std.mem.Allocator,
-    scope: []u8,
-    scopes: [1][]const u8,
-    retry: RetryPolicy,
-    auth: BearerTokenAuthPolicy,
-    policies: [2]*HttpPolicy,
-
-    fn create(
-        allocator: std.mem.Allocator,
-        credential: *TokenCredential,
-        retry_options: RetryOptions,
-        scope: []const u8,
-    ) !*PipelineState {
-        const self = try allocator.create(PipelineState);
-        errdefer allocator.destroy(self);
-        const owned_scope = try allocator.dupe(u8, scope);
-        errdefer allocator.free(owned_scope);
-        var retry = RetryPolicy.init();
-        retry.max_retries = retry_options.max_retries;
-        retry.initial_delay_ms = retry_options.initial_delay_ms;
-        retry.max_delay_ms = retry_options.max_delay_ms;
-        self.allocator = allocator;
-        self.scope = owned_scope;
-        self.scopes = .{self.scope};
-        self.retry = retry;
-        self.auth = BearerTokenAuthPolicy.init(allocator, credential, &self.scopes);
-        self.policies = .{ self.retry.asPolicy(), self.auth.asPolicy() };
-        return self;
-    }
-
-    fn pipeline(self: *PipelineState, transport: *HttpTransport) HttpPipeline {
-        return .{ .transport_impl = transport, .policies = &self.policies };
-    }
-
-    fn deinit(self: *PipelineState) void {
-        const allocator = self.allocator;
-        self.auth.deinit();
-        allocator.free(self.scope);
-        allocator.destroy(self);
-    }
-};
-
+/// Client for Key Vault key management operations.
+///
+/// Runtime descriptors are copied by value. Their borrowed transport and
+/// crypto contexts and the credential must outlive this client, all derived
+/// cryptography clients and pagers, and every in-flight call. Derived clients
+/// and pagers must be deinitialized before this client.
 pub const KeyClient = struct {
     vault_url: []u8,
-    transport: *HttpTransport,
-    pipeline_state: *PipelineState,
+    pipeline_state: *pipeline_mod.PipelineState,
     allocator: std.mem.Allocator,
 
     pub fn init(
         allocator: std.mem.Allocator,
         vault_url: []const u8,
         credential: *TokenCredential,
-        transport: *HttpTransport,
+        runtime: core.http.HttpRuntime,
         options: KeyClientOptions,
     ) !KeyClient {
         const normalized_url = std.mem.trimEnd(u8, vault_url, "/");
         try validateVaultUrl(normalized_url);
         const owned_url = try allocator.dupe(u8, normalized_url);
         errdefer allocator.free(owned_url);
-        const pipeline_state = try PipelineState.create(
+        const pipeline_state = try pipeline_mod.PipelineState.create(
             allocator,
             credential,
+            runtime,
             options.retry,
             options.scope,
         );
         return .{
             .vault_url = owned_url,
-            .transport = transport,
             .pipeline_state = pipeline_state,
             .allocator = allocator,
         };
@@ -330,7 +289,22 @@ pub const KeyClient = struct {
     }
 
     fn pipeline(self: *KeyClient) HttpPipeline {
-        return self.pipeline_state.pipeline(self.transport);
+        return self.pipeline_state.pipeline;
+    }
+
+    /// Creates a cryptography client that borrows this client's authenticated
+    /// pipeline state. The returned client must not outlive this `KeyClient`.
+    pub fn getCryptographyClient(
+        self: *KeyClient,
+        allocator: std.mem.Allocator,
+        key_id: []const u8,
+    ) !CryptographyClient {
+        try validateContinuationUrl(self.vault_url, key_id);
+        return CryptographyClient.initBorrowed(
+            allocator,
+            key_id,
+            self.pipeline_state,
+        );
     }
 
     pub fn createRsaKey(
@@ -557,45 +531,69 @@ pub const KeyClient = struct {
     }
 };
 
+/// Client for Key Vault service-side cryptography payload operations.
+///
+/// These operations send caller-provided digests to Key Vault; they do not
+/// perform local hashing and are independent of transport TLS. The selected
+/// runtime crypto provider remains available to pipeline policies and
+/// credentials. A directly initialized client owns its pipeline state; a
+/// client returned by `KeyClient.getCryptographyClient` borrows that state and
+/// must be deinitialized before its parent.
 pub const CryptographyClient = struct {
     key_id: []u8,
-    transport: *HttpTransport,
-    pipeline_state: *PipelineState,
+    pipeline_state: *pipeline_mod.PipelineState,
+    owns_pipeline_state: bool,
     allocator: std.mem.Allocator,
 
     pub fn init(
         allocator: std.mem.Allocator,
         key_id: []const u8,
         credential: *TokenCredential,
-        transport: *HttpTransport,
+        runtime: core.http.HttpRuntime,
         options: CryptographyClientOptions,
     ) !CryptographyClient {
         const parsed_key_id = try parseKeyId(key_id);
         if (parsed_key_id.version == null) return error.VersionedKeyIdRequired;
         const owned_key_id = try allocator.dupe(u8, key_id);
         errdefer allocator.free(owned_key_id);
-        const pipeline_state = try PipelineState.create(
+        const pipeline_state = try pipeline_mod.PipelineState.create(
             allocator,
             credential,
+            runtime,
             options.retry,
             options.scope,
         );
         return .{
             .key_id = owned_key_id,
-            .transport = transport,
             .pipeline_state = pipeline_state,
+            .owns_pipeline_state = true,
+            .allocator = allocator,
+        };
+    }
+
+    fn initBorrowed(
+        allocator: std.mem.Allocator,
+        key_id: []const u8,
+        pipeline_state: *pipeline_mod.PipelineState,
+    ) !CryptographyClient {
+        const parsed_key_id = try parseKeyId(key_id);
+        if (parsed_key_id.version == null) return error.VersionedKeyIdRequired;
+        return .{
+            .key_id = try allocator.dupe(u8, key_id),
+            .pipeline_state = pipeline_state,
+            .owns_pipeline_state = false,
             .allocator = allocator,
         };
     }
 
     pub fn deinit(self: *CryptographyClient) void {
         self.allocator.free(self.key_id);
-        self.pipeline_state.deinit();
+        if (self.owns_pipeline_state) self.pipeline_state.deinit();
         self.* = undefined;
     }
 
     fn pipeline(self: *CryptographyClient) HttpPipeline {
-        return self.pipeline_state.pipeline(self.transport);
+        return self.pipeline_state.pipeline;
     }
 
     pub fn sign(
@@ -663,6 +661,8 @@ pub const KeyPager = struct {
     vault_url: []u8,
     allocator: std.mem.Allocator,
 
+    /// Copies the pipeline runtime descriptors and borrows their backend and
+    /// policy contexts. The originating client must outlive this pager.
     fn init(
         pipeline: HttpPipeline,
         initial_url: []const u8,
@@ -1079,22 +1079,14 @@ test "typed key values map to Key Vault wire values" {
 
 test "create RSA key authenticates, escapes JSON, and disables retries" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(allocator, 200, key_response);
     defer service_mock.deinit();
     var client = try KeyClient.init(
         allocator,
         "https://vault.example/",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{ .scope = "https://vault.usgovcloudapi.net/.default" },
     );
     defer client.deinit();
@@ -1108,11 +1100,10 @@ test "create RSA key authenticates, escapes JSON, and disables retries" {
         "https://vault.example/keys/ssh-ca/create?api-version=2025-07-01",
         service_mock.last_url.?,
     );
-    try std.testing.expect(std.mem.indexOf(
-        u8,
-        credential_mock.last_body.?,
-        "scope=https%3A%2F%2Fvault.usgovcloudapi.net%2F.default",
-    ) != null);
+    try std.testing.expectEqualStrings(
+        "https://vault.usgovcloudapi.net/.default",
+        credential.last_scope.?,
+    );
     try std.testing.expectEqualStrings("Bearer test-token", service_mock.last_headers.get("Authorization").?);
     try std.testing.expectEqualStrings(
         "{\"kty\":\"RSA\",\"key_size\":3072,\"key_ops\":[\"sign\",\"verify\"],\"attributes\":{\"enabled\":true,\"exportable\":false},\"tags\":{\"operation-id\":\"quoted \\\"value\\\"\"}}",
@@ -1134,22 +1125,14 @@ test "create RSA key authenticates, escapes JSON, and disables retries" {
 
 test "version-aware get and version listing preserve tags" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(allocator, 200, key_response);
     defer service_mock.deinit();
     var client = try KeyClient.init(
         allocator,
         "https://vault.example",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1180,15 +1163,7 @@ test "version-aware get and version listing preserve tags" {
 
 test "RS512 signing uses exact digest and returns decoded signature bytes" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(
         allocator,
         200,
@@ -1199,7 +1174,7 @@ test "RS512 signing uses exact digest and returns decoded signature bytes" {
         allocator,
         "https://vault.example/keys/ssh-ca/version1",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1220,15 +1195,7 @@ test "RS512 signing uses exact digest and returns decoded signature bytes" {
 
 test "Key Vault service errors remain structured" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(
         allocator,
         403,
@@ -1239,7 +1206,7 @@ test "Key Vault service errors remain structured" {
         allocator,
         "https://vault.example/keys/ssh-ca/version1",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{ .retry = .{ .max_retries = 0 } },
     );
     defer client.deinit();
@@ -1288,15 +1255,7 @@ test "Key Vault service errors remain structured" {
 
 test "get retries transient responses but create does not" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.SequenceMockTransport.init(allocator, &.{
         .{ .status = 500, .body = "{}" },
         .{ .status = 200, .body = key_response },
@@ -1305,7 +1264,7 @@ test "get retries transient responses but create does not" {
         allocator,
         "https://vault.example",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{ .retry = .{ .initial_delay_ms = 0 } },
     );
     defer client.deinit();
@@ -1332,22 +1291,14 @@ test "SSH CA validation rejects release policies and exportability" {
 
 test "unsafe SSH CA create options fail before the network call" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(allocator, 200, key_response);
     defer service_mock.deinit();
     var client = try KeyClient.init(
         allocator,
         "https://vault.example",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1371,20 +1322,12 @@ test "unsafe SSH CA create options fail before the network call" {
         }),
     );
     try std.testing.expect(service_mock.last_url == null);
-    try std.testing.expect(credential_mock.last_url == null);
+    try std.testing.expectEqual(@as(usize, 0), credential.calls);
 }
 
 test "KeyClient requires an HTTPS vault origin" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(allocator, 200, key_response);
     defer service_mock.deinit();
 
@@ -1394,7 +1337,7 @@ test "KeyClient requires an HTTPS vault origin" {
             allocator,
             "http://vault.example",
             credential.asCredential(),
-            service_mock.asTransport(),
+            test_support.runtime(service_mock.asTransport()),
             .{},
         ),
     );
@@ -1404,7 +1347,7 @@ test "KeyClient requires an HTTPS vault origin" {
             allocator,
             "https://user@vault.example",
             credential.asCredential(),
-            service_mock.asTransport(),
+            test_support.runtime(service_mock.asTransport()),
             .{},
         ),
     );
@@ -1412,15 +1355,7 @@ test "KeyClient requires an HTTPS vault origin" {
 
 test "cryptography requires a version and verifies the response key id" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(
         allocator,
         200,
@@ -1434,7 +1369,7 @@ test "cryptography requires a version and verifies the response key id" {
             allocator,
             "https://vault.example/keys/ssh-ca",
             credential.asCredential(),
-            service_mock.asTransport(),
+            test_support.runtime(service_mock.asTransport()),
             .{},
         ),
     );
@@ -1443,7 +1378,7 @@ test "cryptography requires a version and verifies the response key id" {
         allocator,
         "https://vault.example/keys/ssh-ca/version1",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1456,15 +1391,7 @@ test "cryptography requires a version and verifies the response key id" {
 
 test "sign retries throttling responses" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.SequenceMockTransport.init(allocator, &.{
         .{ .status = 429, .body = "{\"error\":{\"code\":\"Throttled\"}}" },
         .{
@@ -1476,7 +1403,7 @@ test "sign retries throttling responses" {
         allocator,
         "https://vault.example/keys/ssh-ca/version1",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{ .retry = .{ .initial_delay_ms = 0 } },
     );
     defer client.deinit();
@@ -1489,15 +1416,7 @@ test "sign retries throttling responses" {
 
 test "key pager rejects cross-origin continuation URLs" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(
         allocator,
         200,
@@ -1508,7 +1427,7 @@ test "key pager rejects cross-origin continuation URLs" {
         allocator,
         "https://vault.example",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1524,15 +1443,7 @@ test "key pager rejects cross-origin continuation URLs" {
 
 test "delete preserves structured Azure errors" {
     const allocator = std.testing.allocator;
-    var credential_mock = core.http.MockTransport.init(allocator, 200, credential_response);
-    defer credential_mock.deinit();
-    var credential = core.identity.ClientSecretCredential.init(
-        allocator,
-        credential_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = test_support.StaticCredential{};
     var service_mock = core.http.MockTransport.init(
         allocator,
         404,
@@ -1543,7 +1454,7 @@ test "delete preserves structured Azure errors" {
         allocator,
         "https://vault.example",
         credential.asCredential(),
-        service_mock.asTransport(),
+        test_support.runtime(service_mock.asTransport()),
         .{},
     );
     defer client.deinit();
@@ -1559,9 +1470,165 @@ test "delete preserves structured Azure errors" {
     }
 }
 
-const credential_response =
-    \\{"access_token":"test-token","expires_in":3600,"token_type":"Bearer"}
-;
+const CryptoSpy = struct {
+    random_calls: usize = 0,
+    fail_random: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn asProvider(self: *CryptoSpy) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *CryptoSpy = @ptrCast(@alignCast(context));
+        self.random_calls += 1;
+        if (self.fail_random) return error.SelectedCryptoFailure;
+        @memset(out, 0xa5);
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.UnexpectedLocalCryptography;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.UnexpectedLocalCryptography;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.UnexpectedLocalCryptography;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.UnexpectedLocalCryptography;
+    }
+};
+
+test "derived cryptography client and pager preserve runtime providers" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(
+        allocator,
+        200,
+        "{\"kid\":\"https://vault.example/keys/ssh-ca/version1\",\"value\":\"-__-\"}",
+    );
+    defer transport.deinit();
+    var crypto_spy = CryptoSpy{};
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_spy.asProvider(),
+    );
+    var credential = test_support.StaticCredential{};
+    var client = try KeyClient.init(
+        allocator,
+        "https://vault.example",
+        credential.asCredential(),
+        runtime,
+        .{ .retry = .{ .max_retries = 0 } },
+    );
+    defer client.deinit();
+
+    var cryptography = try client.getCryptographyClient(
+        allocator,
+        "https://vault.example/keys/ssh-ca/version1",
+    );
+    defer cryptography.deinit();
+    try std.testing.expect(!cryptography.owns_pipeline_state);
+    try std.testing.expectEqual(client.pipeline_state, cryptography.pipeline_state);
+    try std.testing.expectEqual(
+        runtime.transport.context,
+        cryptography.pipeline().runtime.transport.context,
+    );
+    try std.testing.expectEqual(
+        runtime.crypto.context,
+        cryptography.pipeline().runtime.crypto.context,
+    );
+
+    const digest = [_]u8{0} ** 64;
+    var signature = try cryptography.sign(allocator, .rs512, &digest);
+    defer signature.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), crypto_spy.random_calls);
+
+    transport.response_body = key_list_response;
+    var pager = try client.listKeys(allocator, null);
+    defer pager.deinit();
+    try std.testing.expectEqual(
+        runtime.transport.context,
+        pager.inner.pipeline.runtime.transport.context,
+    );
+    try std.testing.expectEqual(
+        runtime.crypto.context,
+        pager.inner.pipeline.runtime.crypto.context,
+    );
+}
+
+test "selected crypto failure prevents derived cryptography transport dispatch" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(
+        allocator,
+        200,
+        "{\"kid\":\"https://vault.example/keys/ssh-ca/version1\",\"value\":\"-__-\"}",
+    );
+    defer transport.deinit();
+    var crypto_spy = CryptoSpy{ .fail_random = true };
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_spy.asProvider(),
+    );
+    var credential = test_support.StaticCredential{};
+    var client = try KeyClient.init(
+        allocator,
+        "https://vault.example",
+        credential.asCredential(),
+        runtime,
+        .{ .retry = .{ .max_retries = 0 } },
+    );
+    defer client.deinit();
+    var cryptography = try client.getCryptographyClient(
+        allocator,
+        "https://vault.example/keys/ssh-ca/version1",
+    );
+    defer cryptography.deinit();
+
+    var request = Request.init(
+        allocator,
+        .POST,
+        "https://vault.example/keys/ssh-ca/version1/sign?api-version=2025-07-01",
+    );
+    defer request.deinit();
+    try request.setHeader("Authorization", "unchanged");
+    var derived_pipeline = cryptography.pipeline();
+    try std.testing.expectError(
+        error.SelectedCryptoFailure,
+        derived_pipeline.send(&request),
+    );
+    try std.testing.expectEqualStrings(
+        "unchanged",
+        request.getHeader("Authorization").?,
+    );
+
+    const digest = [_]u8{0} ** 64;
+    try std.testing.expectError(
+        error.SelectedCryptoFailure,
+        cryptography.sign(allocator, .rs512, &digest),
+    );
+    try std.testing.expectEqual(@as(usize, 2), crypto_spy.random_calls);
+    try std.testing.expectEqual(@as(usize, 0), credential.calls);
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
 
 const key_response =
     \\{"key":{"kid":"https://vault.example/keys/ssh-ca/version1","kty":"RSA","key_ops":["sign","verify"],"n":"gAE","e":"AQAB"},"attributes":{"enabled":true,"exportable":false,"recoveryLevel":"Recoverable+Purgeable"},"tags":{"operation-id":"quoted \"value\""},"managed":false}

--- a/keys/root.zig
+++ b/keys/root.zig
@@ -251,7 +251,9 @@ pub const Signature = struct {
 /// Runtime descriptors are copied by value. Their borrowed transport and
 /// crypto contexts and the credential must outlive this client, all derived
 /// cryptography clients and pagers, and every in-flight call. Derived clients
-/// and pagers must be deinitialized before this client.
+/// and pagers must be deinitialized before this client. The caller must
+/// serialize every operation sharing this client's pipeline state, including
+/// operations from derived clients and pagers.
 pub const KeyClient = struct {
     vault_url: []u8,
     pipeline_state: *pipeline_mod.PipelineState,
@@ -538,7 +540,8 @@ pub const KeyClient = struct {
 /// runtime crypto provider remains available to pipeline policies and
 /// credentials. A directly initialized client owns its pipeline state; a
 /// client returned by `KeyClient.getCryptographyClient` borrows that state and
-/// must be deinitialized before its parent.
+/// must be deinitialized before its parent. The caller must serialize its
+/// operations with every other operation sharing the same pipeline state.
 pub const CryptographyClient = struct {
     key_id: []u8,
     pipeline_state: *pipeline_mod.PipelineState,
@@ -1030,27 +1033,7 @@ fn validateVaultUrl(vault_url: []const u8) !void {
 }
 
 fn validateContinuationUrl(vault_url: []const u8, next_url: []const u8) !void {
-    const expected = std.Uri.parse(vault_url) catch return error.InvalidContinuationUrl;
-    const candidate = std.Uri.parse(next_url) catch return error.InvalidContinuationUrl;
-    if (!std.ascii.eqlIgnoreCase(candidate.scheme, "https") or
-        candidate.host == null or
-        candidate.user != null or
-        candidate.password != null or
-        candidate.fragment != null)
-    {
-        return error.InvalidContinuationUrl;
-    }
-
-    var expected_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
-    var candidate_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
-    const expected_host = expected.getHost(&expected_host_buffer) catch
-        return error.InvalidContinuationUrl;
-    const candidate_host = candidate.getHost(&candidate_host_buffer) catch
-        return error.InvalidContinuationUrl;
-    if (!std.ascii.eqlIgnoreCase(expected_host.bytes, candidate_host.bytes))
-        return error.InvalidContinuationUrl;
-    if ((expected.port orelse 443) != (candidate.port orelse 443))
-        return error.InvalidContinuationUrl;
+    return pipeline_mod.validateHttpsOrigin(vault_url, next_url);
 }
 
 fn validatePathSegment(value: []const u8) !void {

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -16,8 +16,10 @@ pub const RetryOptions = struct {
 /// Runtime descriptors are copied by value. Their transport and crypto
 /// contexts, the credential, and all policy backend state are borrowed and
 /// must outlive the owning client, every derived client and pager, and all
-/// in-flight calls. Calls sharing this state must be serialized unless the
-/// borrowed implementations provide equivalent synchronization.
+/// in-flight calls. Because Core's bearer-token cache is mutable and
+/// unsynchronized, the caller must serialize every operation sharing this
+/// state, including operations from derived clients and pagers, regardless of
+/// whether the borrowed transport and crypto implementations are synchronized.
 pub const PipelineState = struct {
     allocator: std.mem.Allocator,
     scope: []u8,
@@ -74,3 +76,149 @@ pub const PipelineState = struct {
         allocator.destroy(self);
     }
 };
+
+/// Require an absolute HTTPS continuation URL on the original effective
+/// scheme, host, and port. Userinfo and fragments are never accepted.
+pub fn validateHttpsOrigin(expected_origin: []const u8, candidate_url: []const u8) !void {
+    const expected = std.Uri.parse(expected_origin) catch
+        return error.InvalidContinuationUrl;
+    const candidate = std.Uri.parse(candidate_url) catch
+        return error.InvalidContinuationUrl;
+    if (!std.ascii.eqlIgnoreCase(expected.scheme, "https") or
+        expected.host == null or
+        expected.user != null or
+        expected.password != null or
+        expected.fragment != null or
+        !std.ascii.eqlIgnoreCase(candidate.scheme, "https") or
+        candidate.host == null or
+        candidate.user != null or
+        candidate.password != null or
+        candidate.fragment != null)
+    {
+        return error.InvalidContinuationUrl;
+    }
+
+    var expected_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    var candidate_host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const expected_host = expected.getHost(&expected_host_buffer) catch
+        return error.InvalidContinuationUrl;
+    const candidate_host = candidate.getHost(&candidate_host_buffer) catch
+        return error.InvalidContinuationUrl;
+    if (!std.ascii.eqlIgnoreCase(expected_host.bytes, candidate_host.bytes))
+        return error.InvalidContinuationUrl;
+    if ((expected.port orelse 443) != (candidate.port orelse 443))
+        return error.InvalidContinuationUrl;
+}
+
+/// Authenticated pager that validates every continuation before retaining it.
+pub fn ValidatedPipelinePager(comptime T: type) type {
+    return struct {
+        pipeline: core.http.HttpPipeline,
+        next_url: ?[]u8,
+        origin: []u8,
+        allocator: std.mem.Allocator,
+        accept_header: []const u8,
+        pager: core.pager.Pager(T),
+        parseFn: *const fn (
+            allocator: std.mem.Allocator,
+            body: []const u8,
+            origin: []const u8,
+        ) anyerror!core.pager.PageResult(T),
+        deinitItemsFn: *const fn (allocator: std.mem.Allocator, items: []T) void,
+
+        const Self = @This();
+
+        pub fn init(
+            pipeline: core.http.HttpPipeline,
+            initial_url: []const u8,
+            origin: []const u8,
+            allocator: std.mem.Allocator,
+            parseFn: *const fn (
+                std.mem.Allocator,
+                []const u8,
+                []const u8,
+            ) anyerror!core.pager.PageResult(T),
+            deinitItemsFn: *const fn (std.mem.Allocator, []T) void,
+            accept_header: []const u8,
+        ) !Self {
+            try validateHttpsOrigin(origin, initial_url);
+            const owned_url = try allocator.dupe(u8, initial_url);
+            errdefer allocator.free(owned_url);
+            return .{
+                .pipeline = pipeline,
+                .next_url = owned_url,
+                .origin = try allocator.dupe(u8, origin),
+                .allocator = allocator,
+                .accept_header = accept_header,
+                .pager = .{ .nextFn = &nextImpl, .deinitFn = &deinitImpl },
+                .parseFn = parseFn,
+                .deinitItemsFn = deinitItemsFn,
+            };
+        }
+
+        pub fn asPager(self: *Self) *core.pager.Pager(T) {
+            return &self.pager;
+        }
+
+        pub fn next(self: *Self) !?[]T {
+            return self.asPager().next();
+        }
+
+        pub fn deinit(self: *Self) void {
+            if (self.next_url) |url| self.allocator.free(url);
+            self.next_url = null;
+            self.allocator.free(self.origin);
+        }
+
+        fn nextImpl(pager_ptr: *core.pager.Pager(T)) anyerror!?[]T {
+            const self: *Self = @alignCast(@fieldParentPtr("pager", pager_ptr));
+            const url = self.next_url orelse return null;
+
+            var request = core.http.Request.init(self.allocator, .GET, url);
+            defer request.deinit();
+            try request.setHeader("Accept", self.accept_header);
+
+            var response = try self.pipeline.send(&request);
+            defer response.deinit();
+
+            self.allocator.free(url);
+            self.next_url = null;
+
+            if (!response.isSuccess()) {
+                core.pager.logHttpError(
+                    "ValidatedPipelinePager.next",
+                    response.status_code,
+                    response.body,
+                );
+                return error.PageFetchFailed;
+            }
+
+            const result = self.parseFn(
+                self.allocator,
+                response.body,
+                self.origin,
+            ) catch |err| {
+                core.pager.logHttpError(
+                    "ValidatedPipelinePager.next parse failed",
+                    response.status_code,
+                    response.body,
+                );
+                return err;
+            };
+            if (result.next_link) |next_link| {
+                validateHttpsOrigin(self.origin, next_link) catch |err| {
+                    self.allocator.free(next_link);
+                    self.deinitItemsFn(self.allocator, result.items);
+                    return err;
+                };
+                self.next_url = next_link;
+            }
+            return result.items;
+        }
+
+        fn deinitImpl(pager_ptr: *core.pager.Pager(T)) void {
+            const self: *Self = @alignCast(@fieldParentPtr("pager", pager_ptr));
+            self.deinit();
+        }
+    };
+}

--- a/pipeline.zig
+++ b/pipeline.zig
@@ -1,0 +1,76 @@
+//! Stable authenticated pipeline state shared by Key Vault clients.
+
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+pub const default_scope = "https://vault.azure.net/.default";
+
+pub const RetryOptions = struct {
+    max_retries: u32 = 3,
+    initial_delay_ms: u64 = 800,
+    max_delay_ms: u64 = 60_000,
+};
+
+/// Heap-owned policy state for a Key Vault client and its derived clients.
+///
+/// Runtime descriptors are copied by value. Their transport and crypto
+/// contexts, the credential, and all policy backend state are borrowed and
+/// must outlive the owning client, every derived client and pager, and all
+/// in-flight calls. Calls sharing this state must be serialized unless the
+/// borrowed implementations provide equivalent synchronization.
+pub const PipelineState = struct {
+    allocator: std.mem.Allocator,
+    scope: []u8,
+    scopes: [1][]const u8,
+    retry: core.http.RetryPolicy,
+    request_id: core.http.RequestIdPolicy,
+    auth: core.http.BearerTokenAuthPolicy,
+    policies: [3]*core.http.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
+
+    pub fn create(
+        allocator: std.mem.Allocator,
+        credential: *core.credentials.TokenCredential,
+        runtime: core.http.HttpRuntime,
+        retry_options: RetryOptions,
+        scope: []const u8,
+    ) !*PipelineState {
+        const state = try allocator.create(PipelineState);
+        errdefer allocator.destroy(state);
+        const owned_scope = try allocator.dupe(u8, scope);
+        errdefer allocator.free(owned_scope);
+
+        state.* = .{
+            .allocator = allocator,
+            .scope = owned_scope,
+            .scopes = .{owned_scope},
+            .retry = core.http.RetryPolicy.init(),
+            .request_id = core.http.RequestIdPolicy.init(),
+            .auth = undefined,
+            .policies = undefined,
+            .pipeline = undefined,
+        };
+        state.retry.max_retries = retry_options.max_retries;
+        state.retry.initial_delay_ms = retry_options.initial_delay_ms;
+        state.retry.max_delay_ms = retry_options.max_delay_ms;
+        state.auth = core.http.BearerTokenAuthPolicy.init(
+            allocator,
+            credential,
+            &state.scopes,
+        );
+        state.policies = .{
+            state.retry.asPolicy(),
+            state.request_id.asPolicy(),
+            state.auth.asPolicy(),
+        };
+        state.pipeline = core.http.HttpPipeline.init(runtime, &state.policies);
+        return state;
+    }
+
+    pub fn deinit(self: *PipelineState) void {
+        const allocator = self.allocator;
+        self.auth.deinit();
+        allocator.free(self.scope);
+        allocator.destroy(self);
+    }
+};

--- a/root.zig
+++ b/root.zig
@@ -4,3 +4,4 @@ pub const secrets = @import("secrets/root.zig");
 pub const keys = @import("keys/root.zig");
 pub const certificates = @import("certificates/root.zig");
 pub const administration = @import("administration/root.zig");
+pub const pipeline = @import("azure_sdk_keyvault_pipeline");

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -7,3 +7,7 @@ The namespace is part of the versioned
 [`azure_sdk_keyvault`](../README.md) package and is distinct from the generated
 [`azure_rest_keyvault_secrets`](https://github.com/cataggar/azure-sdk-for-zig/tree/main/rest/keyvault_secrets)
 package.
+
+Construction requires a caller-selected `core.http.HttpRuntime`. Its backend
+contexts and the credential are borrowed and must outlive the client and its
+pagers.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -10,4 +10,5 @@ package.
 
 Construction requires a caller-selected `core.http.HttpRuntime`. Its backend
 contexts and the credential are borrowed and must outlive the client and its
-pagers.
+pagers. Callers must serialize all operations sharing the client's pipeline
+state. Continuation URLs are restricted to the original HTTPS vault origin.

--- a/secrets/root.zig
+++ b/secrets/root.zig
@@ -8,7 +8,7 @@ else
     struct {};
 
 /// Pager type returned by `listSecrets`.
-pub const SecretNamePager = core.pager.PipelinePager([]const u8);
+pub const SecretNamePager = pipeline_mod.ValidatedPipelinePager([]const u8);
 
 // ─────────────────────────── Models ───────────────────────────
 
@@ -60,7 +60,8 @@ pub const SecretClientOptions = struct {
 /// Runtime descriptors are copied by value. Their borrowed transport and
 /// crypto contexts and the credential must outlive this client and every
 /// pager returned by it. Keep the client alive until its pagers are
-/// deinitialized.
+/// deinitialized. The caller must serialize all operations sharing this
+/// client's pipeline state, including pager operations.
 pub const SecretClient = struct {
     vault_url: []const u8,
     api_version: []const u8,
@@ -168,6 +169,7 @@ pub const SecretClient = struct {
 
         var req = core.http.Request.init(allocator, .PUT, url);
         defer req.deinit();
+        req.retryable = false;
         try req.setHeader("Content-Type", "application/json");
         try req.setHeader("Accept", "application/json");
         req.body = body;
@@ -344,8 +346,10 @@ pub const SecretClient = struct {
         return SecretNamePager.init(
             self.pipeline_state.pipeline,
             url,
+            self.vault_url,
             allocator,
             &parseSecretListPage,
+            &deinitSecretNames,
             "application/json",
         );
     }
@@ -402,7 +406,11 @@ const SecretListSchema = struct {
 
 /// Parse a JSON list-secrets response into a PageResult.
 /// Format: {"value":[{"id":"https://.../secrets/name1"}, ...], "nextLink":"https://..."}
-fn parseSecretListPage(allocator: std.mem.Allocator, body: []const u8) !core.pager.PageResult([]const u8) {
+fn parseSecretListPage(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    origin: []const u8,
+) !core.pager.PageResult([]const u8) {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
@@ -411,7 +419,10 @@ fn parseSecretListPage(allocator: std.mem.Allocator, body: []const u8) !core.pag
 
     var next_link: ?[]u8 = null;
     if (parsed.nextLink) |nl| {
-        if (nl.len > 0) next_link = try allocator.dupe(u8, nl);
+        if (nl.len > 0) {
+            try pipeline_mod.validateHttpsOrigin(origin, nl);
+            next_link = try allocator.dupe(u8, nl);
+        }
     }
 
     const entries = parsed.value orelse
@@ -429,6 +440,11 @@ fn parseSecretListPage(allocator: std.mem.Allocator, body: []const u8) !core.pag
     }
 
     return .{ .items = names, .next_link = next_link };
+}
+
+fn deinitSecretNames(allocator: std.mem.Allocator, names: [][]const u8) void {
+    for (names) |name| allocator.free(name);
+    allocator.free(names);
 }
 
 test "SecretClient getSecretResult: ok path" {
@@ -567,6 +583,7 @@ test "SecretClient setSecret" {
 
     try std.testing.expectEqualStrings("new-val", secret.value.?);
     try std.testing.expectEqual(core.http.Method.PUT, mock.last_method.?);
+    try std.testing.expect(!mock.last_retryable.?);
 }
 
 test "SecretClient getSecret 404" {
@@ -614,6 +631,34 @@ test "SecretClient setSecret failure" {
     try std.testing.expectError(error.SetSecretFailed, result);
 }
 
+test "SecretClient setSecret does not retry ambiguous transient failure" {
+    const allocator = std.testing.allocator;
+    var mock = core.http.SequenceMockTransport.init(allocator, &.{
+        .{
+            .status = 500,
+            .body = "{\"error\":{\"code\":\"InternalServerError\"}}",
+        },
+        .{
+            .status = 200,
+            .body = "{\"value\":\"duplicate\",\"id\":\"https://v.vault.azure.net/secrets/s/v2\"}",
+        },
+    });
+    var credential = test_support.StaticCredential{};
+    var client = try SecretClient.init(
+        allocator,
+        "https://v.vault.azure.net",
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
+        .{ .retry = .{ .initial_delay_ms = 0 } },
+    );
+    defer client.deinit();
+
+    var result = try client.setSecretResult(allocator, "s", "value");
+    defer result.deinit(allocator);
+    try std.testing.expect(!result.isOk());
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
 test "SecretClient listSecrets" {
     const allocator = std.testing.allocator;
     const body =
@@ -649,4 +694,32 @@ test "SecretClient listSecrets" {
     // Pager should have a next_url set from nextLink (but we'd need a
     // SequenceMockTransport to actually fetch the second page).
     try std.testing.expect(pager.next_url != null);
+}
+
+test "SecretClient pager rejects cross-origin continuation before dispatch" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"value":[{"id":"https://v.vault.azure.net/secrets/secret1"}],"nextLink":"https://attacker.example/steal"}
+    ;
+    var mock = core.http.MockTransport.init(allocator, 200, body);
+    defer mock.deinit();
+    var credential = test_support.StaticCredential{};
+    var client = try SecretClient.init(
+        allocator,
+        "https://v.vault.azure.net",
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
+        .{ .retry = .{ .max_retries = 0 } },
+    );
+    defer client.deinit();
+
+    var pager = try client.listSecrets(allocator);
+    defer pager.deinit();
+    try std.testing.expectError(error.InvalidContinuationUrl, pager.next());
+    try std.testing.expect(pager.next_url == null);
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+    try std.testing.expectEqualStrings(
+        "https://v.vault.azure.net/secrets?api-version=7.6-preview.2",
+        mock.last_url.?,
+    );
 }

--- a/secrets/root.zig
+++ b/secrets/root.zig
@@ -1,8 +1,11 @@
 const std = @import("std");
 const core = @import("azure_sdk_core");
 const serde = @import("serde");
-
-const Context = core.context.Context;
+const pipeline_mod = @import("azure_sdk_keyvault_pipeline");
+const test_support = if (@import("builtin").is_test)
+    @import("azure_sdk_keyvault_test_support")
+else
+    struct {};
 
 /// Pager type returned by `listSecrets`.
 pub const SecretNamePager = core.pager.PipelinePager([]const u8);
@@ -48,28 +51,44 @@ pub const DeletedSecret = struct {
 
 pub const SecretClientOptions = struct {
     api_version: []const u8 = "7.6-preview.2",
+    retry: pipeline_mod.RetryOptions = .{},
+    scope: []const u8 = pipeline_mod.default_scope,
 };
 
 /// Client for Azure Key Vault Secrets.
 ///
-/// All REST calls go through the HTTP pipeline with bearer-token auth.
+/// Runtime descriptors are copied by value. Their borrowed transport and
+/// crypto contexts and the credential must outlive this client and every
+/// pager returned by it. Keep the client alive until its pagers are
+/// deinitialized.
 pub const SecretClient = struct {
     vault_url: []const u8,
     api_version: []const u8,
-    pipeline: core.pipeline.HttpPipeline,
+    pipeline_state: *pipeline_mod.PipelineState,
 
     pub fn init(
+        allocator: std.mem.Allocator,
         vault_url: []const u8,
         credential: *core.credentials.TokenCredential,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         options: SecretClientOptions,
-    ) SecretClient {
-        _ = credential;
+    ) !SecretClient {
         return .{
             .vault_url = vault_url,
             .api_version = options.api_version,
-            .pipeline = .{ .policies = &.{}, .transport_impl = transport },
+            .pipeline_state = try pipeline_mod.PipelineState.create(
+                allocator,
+                credential,
+                runtime,
+                options.retry,
+                options.scope,
+            ),
         };
+    }
+
+    pub fn deinit(self: *SecretClient) void {
+        self.pipeline_state.deinit();
+        self.* = undefined;
     }
 
     /// GET /secrets/{name}?api-version=...
@@ -109,7 +128,7 @@ pub const SecretClient = struct {
         defer req.deinit();
         try req.setHeader("Accept", "application/json");
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -153,7 +172,7 @@ pub const SecretClient = struct {
         try req.setHeader("Accept", "application/json");
         req.body = body;
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -189,7 +208,7 @@ pub const SecretClient = struct {
         defer req.deinit();
         try req.setHeader("Accept", "application/json");
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -224,7 +243,7 @@ pub const SecretClient = struct {
         var req = core.http.Request.init(allocator, .DELETE, url);
         defer req.deinit();
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (resp.status_code == 204 or resp.isSuccess()) {
@@ -259,7 +278,7 @@ pub const SecretClient = struct {
         defer req.deinit();
         try req.setHeader("Accept", "application/json");
 
-        var resp = try self.pipeline.send(&req);
+        var resp = try self.pipeline_state.pipeline.send(&req);
         defer resp.deinit();
 
         if (!resp.isSuccess()) {
@@ -323,7 +342,7 @@ pub const SecretClient = struct {
         defer allocator.free(url);
 
         return SecretNamePager.init(
-            self.pipeline,
+            self.pipeline_state.pipeline,
             url,
             allocator,
             &parseSecretListPage,
@@ -420,19 +439,16 @@ test "SecretClient getSecretResult: ok path" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://myvault.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     var r = try client.getSecretResult(allocator, "mysecret");
     defer r.deinit(allocator);
@@ -449,19 +465,16 @@ test "SecretClient getSecretResult: err path surfaces SecretNotFound code" {
     var mock = core.http.MockTransport.init(allocator, 404, body);
     defer mock.deinit();
 
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://myvault.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     var r = try client.getSecretResult(allocator, "missing");
     defer r.deinit(allocator);
@@ -477,19 +490,16 @@ test "SecretClient getSecretResult: err path with no parseable body" {
     var mock = core.http.MockTransport.init(allocator, 500, "Internal Server Error");
     defer mock.deinit();
 
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://myvault.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     var r = try client.getSecretResult(allocator, "boom");
     defer r.deinit(allocator);
@@ -512,19 +522,16 @@ test "SecretClient getSecret" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://myvault.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     const secret = try client.getSecret(allocator, "mysecret");
     defer allocator.free(secret.value.?);
@@ -543,19 +550,16 @@ test "SecretClient setSecret" {
     );
     defer mock.deinit();
 
-    const identity2 = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity2.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://v.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     const secret = try client.setSecret(allocator, "s", "new-val");
     defer allocator.free(secret.value.?);
@@ -573,19 +577,16 @@ test "SecretClient getSecret 404" {
     var mock = core.http.MockTransport.init(allocator, 404, body);
     defer mock.deinit();
 
-    const identity3 = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity3.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://myvault.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     const result = client.getSecret(allocator, "nonexistent");
     try std.testing.expectError(error.SecretNotFound, result);
@@ -598,19 +599,16 @@ test "SecretClient setSecret failure" {
     );
     defer mock.deinit();
 
-    const identity4 = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity4.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://myvault.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     const result = client.setSecret(allocator, "s", "val");
     try std.testing.expectError(error.SetSecretFailed, result);
@@ -624,19 +622,16 @@ test "SecretClient listSecrets" {
     var mock = core.http.MockTransport.init(allocator, 200, body);
     defer mock.deinit();
 
-    const identity5 = @import("azure_sdk_core").identity;
-    var cred_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"t","expires_in":3600}
-    );
-    defer cred_mock.deinit();
-    var cred = identity5.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var credential = test_support.StaticCredential{};
 
-    var client = SecretClient.init(
+    var client = try SecretClient.init(
+        allocator,
         "https://v.vault.azure.net",
-        cred.asCredential(),
-        mock.asTransport(),
+        credential.asCredential(),
+        test_support.runtime(mock.asTransport()),
         .{},
     );
+    defer client.deinit();
 
     var pager = try client.listSecrets(allocator);
     defer pager.deinit();

--- a/test_support.zig
+++ b/test_support.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+
+var standard_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+pub fn runtime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return .init(transport, standard_crypto.asProvider());
+}
+
+pub const StaticCredential = struct {
+    credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
+    calls: usize = 0,
+    last_scope: ?[]const u8 = null,
+
+    pub fn asCredential(self: *StaticCredential) *core.credentials.TokenCredential {
+        return &self.credential;
+    }
+
+    fn getToken(
+        credential: *core.credentials.TokenCredential,
+        request_context: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+        _: core.http.HttpRuntime,
+    ) !core.credentials.AccessToken {
+        const self: *StaticCredential = @alignCast(
+            @fieldParentPtr("credential", credential),
+        );
+        self.calls += 1;
+        self.last_scope = if (request_context.scopes.len == 0)
+            null
+        else
+            request_context.scopes[0];
+        return .{
+            .token = "test-token",
+            .expires_on = 7_258_118_400,
+        };
+    }
+};


### PR DESCRIPTION
Part of #412
Part of #414

## Summary

- replace legacy `HttpTransport` pointer constructors and pipeline literals across Secrets, Keys, Certificates, and Administration with the canonical caller-selected `core.http.HttpRuntime` / current `core.http.HttpPipeline`
- add stable shared authenticated pipeline state that copies runtime descriptors while borrowing transport, crypto, credential, and policy contexts
- preserve the selected transport and crypto provider in pagers and `KeyClient`-derived `CryptographyClient` instances, with explicit parent/borrowed lifetime documentation
- route Key Vault SDK request randomness through `runtime.crypto` via `RequestIdPolicy`; the package has no production `std.crypto`, hash, HMAC, or random fallback
- keep Key Vault service-side signing as a REST payload operation over caller-provided digests, separate from SDK runtime cryptography and transport TLS
- add provider preservation/failure coverage, including prevention of transport dispatch and partial authorization mutation
- bump `azure_sdk_keyvault` from 0.1.0 to the next unused version, 0.2.0

## Review fixes

- reject Secrets and Certificates `nextLink` values unless they are absolute HTTPS URLs on the original vault host and effective port; validation happens before the continuation is copied or retained, and malicious-origin tests prove no second dispatch
- mark Set Secret requests non-retryable so ambiguous transient/transport outcomes cannot create duplicate secret versions
- require unconditional caller serialization for all operations sharing `PipelineState` because Core bearer-token cache mutation is unsynchronized, including pagers and derived cryptography clients

## Dependency pin

- `azure_sdk_core` 0.3.0
  - URL: `git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41`
  - hash: `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`

## Validation

- target `sdk/keyvault` refreshed at `c1f900b13f10ae2c8ac5aa0cd6abfbe5431d2b39` before commit
- `git ls-files -z -- '*.zig' 'build.zig.zon' | xargs -0 zig fmt --check`
- `zig fmt --check pipeline.zig test_support.zig`
- `zig build`
- `zig build test --summary all` — 29/29 passed
- `git diff --check`
- `zig build -l` exposes only `install`, `uninstall`, and `test`; no package-check/history-check step exists on this package branch
- audited package Zig sources: no production direct `std.crypto`, MD5, SHA-256, HMAC-SHA256, secure-random, legacy pipeline, or transport-pointer client path remains

No merge or auto-merge requested.

