### PR TITLE
kusto: adopt HttpRuntime and CryptoProvider

### DIFF
--- a/.migration/dependencies.tsv
+++ b/.migration/dependencies.tsv
@@ -1,4 +1,4 @@
-azure_sdk_core	git+https://github.com/cataggar/azure-sdk-for-zig.git#5c37f2997b0a9dcc2db91f83baf0a492342621a2	azure_sdk_core-0.1.0-eFY0EtlTBQDltjWjN0xVytGGsv4kqwm1JP_PY18iWFb3
-azure_sdk_storage_common	git+https://github.com/cataggar/azure-sdk-for-zig.git#93be9fdd48cefa1f30023c5b852f89193671988c	azure_sdk_storage_common-0.1.0-JzoreP9kAAAHmHB4xxMQDJ2Gc4wMxrevGjreIYUMiU9O
-azure_sdk_storage_blobs	git+https://github.com/cataggar/azure-sdk-for-zig.git#4f1e3c0e3ed14df68956af442cd401ac2974b362	azure_sdk_storage_blobs-0.1.0-I5lGdgoKAQCviVvGY2BIs_0Guj5BQj1OpWy_m3VLkKpH
-azure_sdk_storage_queues	git+https://github.com/cataggar/azure-sdk-for-zig.git#fa33ee1b6a02f6dc3f6064e3563d292fd3320f2d	azure_sdk_storage_queues-0.1.0-LKTiC7hzAACesUmmsuRTQOhm4jz_vbwPWdE2d0pGCE6X
+azure_sdk_core	git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41	azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV
+azure_sdk_storage_common	git+https://github.com/cataggar/azure-sdk-for-zig.git#5291e5d7224b4d69989d403f605345d949c41db7	azure_sdk_storage_common-0.3.0-JzoreF0KAQDsbNtEXsub-0AZ1oiyzWJ-CGf1S5XSmQK4
+azure_sdk_storage_blobs	git+https://github.com/cataggar/azure-sdk-for-zig.git#2bd2b47df464e2bd548d6aad6f5d8d425f2e74a9	azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d
+azure_sdk_storage_queues	git+https://github.com/cataggar/azure-sdk-for-zig.git#fc0cd875afed13f246390143a83610525d3cb96d	azure_sdk_storage_queues-0.2.0-LKTiC_-GAADCn39zCwbaY707DVIVlEa-C-kcPSl1JWgI

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ independently versioned package:
 | [`data`](data/README.md) | Query, management, progressive results, KQL, and typed rows |
 | [`ingest`](ingest/README.md) | Streaming, managed, and queued ingestion |
 
-The package begins at `0.1.0`. All namespaces release together. Ingest uses
+The current package version is `0.2.0`. All namespaces release together. Ingest uses
 the Storage packages required for complete-SAS queued ingestion.
 
 ## Feature matrix
@@ -35,9 +35,17 @@ cells, and preserve dynamic or unknown cells as raw JSON.
 Create authenticated clients from one owned `KustoConnection`:
 
 ```zig
+const core = @import("azure_sdk_core");
 const kusto = @import("azure_sdk_kusto");
 const common = kusto.common;
 const data = kusto.data;
+
+var std_transport = core.http.StdHttpTransport.init(allocator, io);
+var crypto_provider = core.crypto.StdCryptoProvider.init(io);
+const runtime = core.http.HttpRuntime.init(
+    std_transport.asTransport(),
+    crypto_provider.asProvider(),
+);
 
 var builder = common.KustoConnectionStringBuilder.init(
     "https://mycluster.kusto.windows.net",
@@ -47,27 +55,28 @@ _ = builder.withTokenCredential(credential);
 const connection = try common.KustoConnection.init(
     allocator,
     builder.build(),
-    transport,
+    runtime,
     .{},
 );
 defer connection.deinit();
 
-var client = data.KustoClient.initWithConnection(connection, .{});
+var client = data.KustoClient.init(connection, .{});
 ```
 
 `KustoConnection` owns copies of its endpoint, scope, user-agent, policy, and
-token-cache state. It borrows the credential and transport; both must outlive
-the connection. Derived clients borrow the connection, require no `deinit`,
-and must not outlive it.
+token-cache state. It copies `HttpRuntime` by value while borrowing the
+credential plus the runtime's transport and crypto contexts. Those contexts
+must outlive the connection, every derived client, and every open operation.
+Derived clients borrow the connection, require no `deinit`, and must not
+outlive it. Provider failures propagate directly; Kusto never falls back to
+`std.crypto` or another transport.
 
 Connections and derived clients are not safe for concurrent use. Externally
 serialize all calls, including calls through separate clients sharing one
 connection.
 
-The existing client constructors remain unauthenticated compatibility APIs.
-Authentication configuration passed to them returns
-`AuthenticatedConnectionRequired`; authenticated code must use
-`initWithConnection`. `withAadAppKey` is deprecated and rejected with
+Every Data and Ingest client is derived from this shared connection.
+`withAadAppKey` is deprecated and rejected with
 `AadAppKeyAuthenticationUnsupported`; use an
 `azure_sdk_core.credentials.TokenCredential`.
 
@@ -101,7 +110,7 @@ credential authority themselves.
 
 | Previous entry point or assumption | Migration |
 | --- | --- |
-| Client `init` methods with authentication fields | Create one `KustoConnection`, then use `initWithConnection` |
+| Transport-only or `initWithConnection` client constructors | Create one `KustoConnection` with `HttpRuntime`, then call the client's `init` |
 | `withAadAppKey` | Supply a `TokenCredential` |
 | Generic `executeQuery`, `executeMgmt`, or `execute` failures | Prefer `*Result` APIs retaining `.ok`, `.partial`, and `.err` |
 | Slice/Blob ingestion compatibility wrappers | Prefer runtime-source `ingestResult`/`ingest` |

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,24 +1,24 @@
 .{
     .name = .azure_sdk_kusto,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0x897430dd7c19e528,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
         .azure_sdk_storage_common = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#17d6f1550c53cda7245f07bc487de1dd7a00f265",
-            .hash = "azure_sdk_storage_common-0.2.0-JzoreP9kAAB71S4mgwDVPdCfjSL0auVfrlU8hhaD4O-q",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#5291e5d7224b4d69989d403f605345d949c41db7",
+            .hash = "azure_sdk_storage_common-0.3.0-JzoreF0KAQDsbNtEXsub-0AZ1oiyzWJ-CGf1S5XSmQK4",
         },
         .azure_sdk_storage_blobs = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#4a21c5e1d85e9da22fa9481b7ffde8920bf53fae",
-            .hash = "azure_sdk_storage_blobs-0.2.0-I5lGdlJ7CgAxYhvh6lYm59jMOZ_-NaWDqKDvXheMlGoU",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#2bd2b47df464e2bd548d6aad6f5d8d425f2e74a9",
+            .hash = "azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d",
         },
         .azure_sdk_storage_queues = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#e02a5870bc9594fd487060dcdaf7538b79753370",
-            .hash = "azure_sdk_storage_queues-0.1.0-LKTiC7hzAAAsObDHKG7ERKNGJ8TaVHiICq-S0c1wPm0V",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#fc0cd875afed13f246390143a83610525d3cb96d",
+            .hash = "azure_sdk_storage_queues-0.2.0-LKTiC_-GAADCn39zCwbaY707DVIVlEa-C-kcPSl1JWgI",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#7012f58c7ddf490125852e1d22006b552a1693c7",

--- a/common/root.zig
+++ b/common/root.zig
@@ -319,17 +319,18 @@ pub const KustoConnectionOptions = struct {
     additional_trusted_hosts: []const []const u8 = &.{},
     /// The connection never changes or inspects the credential's authority;
     /// configure any credential authority when constructing that credential.
-    user_agent: []const u8 = "azsdk-zig-kusto/0.1.0",
+    user_agent: []const u8 = "azsdk-zig-kusto/0.2.0",
     retry: KustoRetryOptions = .{},
 };
 
 /// Allocator-owned, stable HTTP connection shared by Kusto service clients.
 ///
-/// The credential and transport are borrowed and must outlive this connection.
-/// This connection must outlive all derived clients and their in-flight
-/// requests. `HttpTransport` and the authentication cache are not thread-safe,
-/// so callers must externally serialize use of this connection and its derived
-/// clients.
+/// The credential is borrowed and must outlive this connection. This
+/// connection must outlive all derived clients and their in-flight requests.
+/// The runtime is copied by value and borrows its transport and
+/// crypto contexts; both contexts, the credential, and any open operations
+/// must outlive this connection. Callers must externally serialize use when
+/// any borrowed backend context is not concurrent-safe.
 pub const KustoConnection = struct {
     allocator: std.mem.Allocator,
     /// Engine endpoint retained under its #46 field name for source compatibility.
@@ -339,15 +340,15 @@ pub const KustoConnection = struct {
     user_agent: []u8,
     cloud_info: ?KustoCloudInfo,
     credential: *core.credentials.TokenCredential,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
     scopes: [1][]const u8,
-    request_id: core.pipeline.RequestIdPolicy,
-    telemetry: core.pipeline.TelemetryPolicy,
-    retry: core.pipeline.RetryPolicy,
-    auth: core.pipeline.BearerTokenAuthPolicy,
-    decompression: core.decompression.DecompressionPolicy,
-    policies: [5]*core.pipeline.HttpPolicy,
-    pipeline: core.pipeline.HttpPipeline,
+    request_id: core.http.RequestIdPolicy,
+    telemetry: core.http.TelemetryPolicy,
+    retry: core.http.RetryPolicy,
+    auth: core.http.BearerTokenAuthPolicy,
+    decompression: core.http.DecompressionPolicy,
+    policies: [5]*core.http.HttpPolicy,
+    pipeline: core.http.HttpPipeline,
 
     /// This type has mutable policy state and requires external serialization.
     pub const supports_concurrent_use = false;
@@ -355,7 +356,7 @@ pub const KustoConnection = struct {
     pub fn init(
         allocator: std.mem.Allocator,
         properties: ConnectionProperties,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         options: KustoConnectionOptions,
     ) !*KustoConnection {
         if (properties.application_key != null or
@@ -385,7 +386,7 @@ pub const KustoConnection = struct {
                 }
             }
             if (resolved_cloud_info == null) {
-                var fetched = try discoverCloudInfo(allocator, transport, normalized_engine);
+                var fetched = try discoverCloudInfo(allocator, runtime, normalized_engine);
                 errdefer fetched.deinit(allocator);
                 try validateCloudInfo(&fetched);
                 resolved_cloud_info = fetched;
@@ -447,20 +448,20 @@ pub const KustoConnection = struct {
         self.cloud_info = resolved_cloud_info;
         resolved_cloud_info = null;
         self.credential = credential;
-        self.transport = transport;
+        self.runtime = runtime;
         self.scopes = .{self.token_scope};
-        self.request_id = core.pipeline.RequestIdPolicy.init();
-        self.telemetry = core.pipeline.TelemetryPolicy.init(self.user_agent);
-        self.retry = core.pipeline.RetryPolicy.init();
+        self.request_id = core.http.RequestIdPolicy.init();
+        self.telemetry = core.http.TelemetryPolicy.init(self.user_agent);
+        self.retry = core.http.RetryPolicy.init();
         self.retry.max_retries = options.retry.max_retries;
         self.retry.initial_delay_ms = options.retry.initial_delay_ms;
         self.retry.max_delay_ms = options.retry.max_delay_ms;
-        self.auth = core.pipeline.BearerTokenAuthPolicy.init(
+        self.auth = core.http.BearerTokenAuthPolicy.init(
             allocator,
             credential,
             &self.scopes,
         );
-        self.decompression = core.decompression.DecompressionPolicy.init();
+        self.decompression = core.http.DecompressionPolicy.init();
         self.policies = .{
             self.request_id.asPolicy(),
             self.telemetry.asPolicy(),
@@ -468,10 +469,7 @@ pub const KustoConnection = struct {
             self.auth.asPolicy(),
             self.decompression.asPolicy(),
         };
-        self.pipeline = .{
-            .policies = &self.policies,
-            .transport_impl = transport,
-        };
+        self.pipeline = core.http.HttpPipeline.init(runtime, &self.policies);
         return self;
     }
 
@@ -677,7 +675,11 @@ fn isAdditionalHost(host: []const u8, additional_hosts: []const []const u8) bool
     return false;
 }
 
-fn discoverCloudInfo(allocator: std.mem.Allocator, transport: *core.http.HttpTransport, engine_url: []const u8) !KustoCloudInfo {
+fn discoverCloudInfo(
+    allocator: std.mem.Allocator,
+    runtime: core.http.HttpRuntime,
+    engine_url: []const u8,
+) !KustoCloudInfo {
     const metadata_url = try std.fmt.allocPrint(allocator, "{s}/v1/rest/auth/metadata", .{engine_url});
     defer allocator.free(metadata_url);
     var request = core.http.Request.init(allocator, .GET, metadata_url);
@@ -686,7 +688,8 @@ fn discoverCloudInfo(allocator: std.mem.Allocator, transport: *core.http.HttpTra
     request.redirect_policy = .not_allowed;
     try request.setHeader("Accept", "application/json");
     try request.setHeader("Accept-Encoding", "gzip, deflate");
-    var response = try transport.send(&request);
+    var pipeline = core.http.HttpPipeline.init(runtime, &.{});
+    var response = try pipeline.send(&request);
     defer response.deinit();
 
     const body = std.mem.trim(u8, response.body, " \t\r\n");
@@ -1487,6 +1490,7 @@ const TestTokenCredential = struct {
         credential: *core.credentials.TokenCredential,
         request_context: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         const self: *TestTokenCredential = @alignCast(@fieldParentPtr("credential", credential));
         self.call_count += 1;
@@ -1500,10 +1504,10 @@ const TestTokenCredential = struct {
 
 const DiscoveryTestTransport = struct {
     const CannedResponse = struct { status: u16, body: []const u8 };
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
 
     allocator: std.mem.Allocator,
     responses: []const CannedResponse,
-    transport: core.http.HttpTransport,
     call_count: usize = 0,
     bootstrap_has_authorization: ?bool = null,
     bootstrap_retryable: ?bool = null,
@@ -1515,16 +1519,15 @@ const DiscoveryTestTransport = struct {
         return .{
             .allocator = allocator,
             .responses = responses,
-            .transport = .{ .sendFn = &send },
         };
     }
 
-    fn asTransport(self: *DiscoveryTestTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *DiscoveryTestTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
-    fn send(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *DiscoveryTestTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn send(context: *anyopaque, request: *core.http.Request) !core.http.Response {
+        const self: *DiscoveryTestTransport = @ptrCast(@alignCast(context));
         if (self.call_count == 0) {
             self.bootstrap_has_authorization = request.getHeader("Authorization") != null;
             self.bootstrap_retryable = request.retryable;
@@ -1548,6 +1551,12 @@ const public_metadata =
     \\{"AzureAD":{"LoginEndpoint":"https://login.microsoftonline.com","LoginMfaRequired":false,"KustoClientAppId":"app","KustoClientRedirectUri":"https://redirect","KustoServiceResourceId":"https://cluster.kusto.windows.net","FirstPartyAuthorityUrl":"https://authority"}}
 ;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
 test "KustoConnection discovers metadata and bootstraps without authentication" {
     const allocator = std.testing.allocator;
     var transport = DiscoveryTestTransport.init(allocator, &.{
@@ -1558,7 +1567,7 @@ test "KustoConnection discovers metadata and bootstraps without authentication" 
     const connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
         .{},
     );
     defer connection.deinit();
@@ -1590,7 +1599,7 @@ test "KustoConnection derives MFA scope from metadata" {
     const connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
         .{},
     );
     defer connection.deinit();
@@ -1604,7 +1613,7 @@ test "KustoConnection uses public defaults for 404 and empty metadata" {
     const from_404 = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        missing.asTransport(),
+        testRuntime(missing.asTransport()),
         .{},
     );
     defer from_404.deinit();
@@ -1614,7 +1623,7 @@ test "KustoConnection uses public defaults for 404 and empty metadata" {
     const from_empty = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        empty.asTransport(),
+        testRuntime(empty.asTransport()),
         .{},
     );
     defer from_empty.deinit();
@@ -1628,28 +1637,28 @@ test "KustoConnection rejects malformed metadata and metadata failures" {
     try std.testing.expectError(error.MalformedKustoMetadata, KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        malformed.asTransport(),
+        testRuntime(malformed.asTransport()),
         .{},
     ));
     var empty_object = DiscoveryTestTransport.init(allocator, &.{.{ .status = 200, .body = "{}" }});
     try std.testing.expectError(error.MalformedKustoMetadata, KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        empty_object.asTransport(),
+        testRuntime(empty_object.asTransport()),
         .{},
     ));
     var failed = DiscoveryTestTransport.init(allocator, &.{.{ .status = 500, .body = "no" }});
     try std.testing.expectError(error.KustoMetadataRequestFailed, KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        failed.asTransport(),
+        testRuntime(failed.asTransport()),
         .{},
     ));
     var redirected = DiscoveryTestTransport.init(allocator, &.{.{ .status = 302, .body = "" }});
     try std.testing.expectError(error.KustoMetadataRequestFailed, KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        redirected.asTransport(),
+        testRuntime(redirected.asTransport()),
         .{},
     ));
 }
@@ -1663,7 +1672,7 @@ test "KustoConnection enforces authority keyed and custom endpoint trust" {
     const sovereign_connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.usgovcloudapi.net", .credential = credential.asCredential() },
-        sovereign.asTransport(),
+        testRuntime(sovereign.asTransport()),
         .{},
     );
     defer sovereign_connection.deinit();
@@ -1674,7 +1683,7 @@ test "KustoConnection enforces authority keyed and custom endpoint trust" {
     try std.testing.expectError(error.UntrustedKustoEndpoint, KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        mismatch.asTransport(),
+        testRuntime(mismatch.asTransport()),
         .{},
     ));
 
@@ -1684,7 +1693,7 @@ test "KustoConnection enforces authority keyed and custom endpoint trust" {
     const custom_connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://custom.example", .credential = credential.asCredential() },
-        custom.asTransport(),
+        testRuntime(custom.asTransport()),
         .{ .additional_trusted_hosts = &.{"custom.example"} },
     );
     defer custom_connection.deinit();
@@ -1695,7 +1704,7 @@ test "KustoConnection enforces authority keyed and custom endpoint trust" {
     const explicit_custom_dm = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://custom.example", .credential = credential.asCredential() },
-        custom_dm_mock.asTransport(),
+        testRuntime(custom_dm_mock.asTransport()),
         .{
             .metadata_mode = .disabled,
             .data_management_endpoint = "https://custom-ingest.example",
@@ -1714,7 +1723,7 @@ test "KustoConnection honors explicit endpoints and derives ingest endpoint" {
     const explicit = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://ignored.kusto.windows.net", .credential = credential.asCredential() },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{
             .metadata_mode = .disabled,
             .engine_endpoint = "https://query.kusto.windows.net/",
@@ -1730,7 +1739,7 @@ test "KustoConnection honors explicit endpoints and derives ingest endpoint" {
     const derived = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://query.kusto.windows.net", .credential = credential.asCredential() },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer derived.deinit();
@@ -1746,14 +1755,14 @@ test "KustoConnection caches successful metadata but retries failed discovery" {
     const first = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        cached_transport.asTransport(),
+        testRuntime(cached_transport.asTransport()),
         .{ .cloud_info_cache = &cache },
     );
     defer first.deinit();
     const second = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        cached_transport.asTransport(),
+        testRuntime(cached_transport.asTransport()),
         .{ .cloud_info_cache = &cache },
     );
     defer second.deinit();
@@ -1768,13 +1777,13 @@ test "KustoConnection caches successful metadata but retries failed discovery" {
     try std.testing.expectError(error.KustoMetadataRequestFailed, KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://retry.kusto.windows.net", .credential = credential.asCredential() },
-        retry_transport.asTransport(),
+        testRuntime(retry_transport.asTransport()),
         .{ .cloud_info_cache = &retry_cache },
     ));
     const retried = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://retry.kusto.windows.net", .credential = credential.asCredential() },
-        retry_transport.asTransport(),
+        testRuntime(retry_transport.asTransport()),
         .{ .cloud_info_cache = &retry_cache },
     );
     defer retried.deinit();
@@ -1791,13 +1800,13 @@ test "KustoConnection caches successful metadata but retries failed discovery" {
     try std.testing.expectError(error.UntrustedKustoEndpoint, KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        untrusted_then_valid.asTransport(),
+        testRuntime(untrusted_then_valid.asTransport()),
         .{ .cloud_info_cache = &trust_cache },
     ));
     const trusted_retry = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        untrusted_then_valid.asTransport(),
+        testRuntime(untrusted_then_valid.asTransport()),
         .{ .cloud_info_cache = &trust_cache },
     );
     defer trusted_retry.deinit();
@@ -1812,7 +1821,7 @@ test "KustoConnection authenticates only validated service origins" {
     const connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
@@ -1849,7 +1858,7 @@ test "KustoConnection owns normalized configuration" {
             .cluster_url = cluster_url[0..],
             .credential = credential.asCredential(),
         },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{
             .token_scope = token_scope[0..],
             .user_agent = user_agent[0..],
@@ -1876,7 +1885,7 @@ test "KustoConnection rejects unsupported and missing authentication" {
         KustoConnection.init(
             allocator,
             .{ .cluster_url = "https://cluster.kusto.windows.net", .application_key = "secret" },
-            mock.asTransport(),
+            testRuntime(mock.asTransport()),
             .{ .metadata_mode = .disabled },
         ),
     );
@@ -1885,7 +1894,7 @@ test "KustoConnection rejects unsupported and missing authentication" {
         KustoConnection.init(
             allocator,
             .{ .cluster_url = "https://cluster.kusto.windows.net", .application_client_id = "client-id" },
-            mock.asTransport(),
+            testRuntime(mock.asTransport()),
             .{ .metadata_mode = .disabled },
         ),
     );
@@ -1894,7 +1903,7 @@ test "KustoConnection rejects unsupported and missing authentication" {
         KustoConnection.init(
             allocator,
             .{ .cluster_url = "https://cluster.kusto.windows.net", .authority_id = "tenant-id" },
-            mock.asTransport(),
+            testRuntime(mock.asTransport()),
             .{},
         ),
     );
@@ -1903,7 +1912,7 @@ test "KustoConnection rejects unsupported and missing authentication" {
         KustoConnection.init(
             allocator,
             .{ .cluster_url = "https://cluster.kusto.windows.net" },
-            mock.asTransport(),
+            testRuntime(mock.asTransport()),
             .{},
         ),
     );
@@ -1930,7 +1939,7 @@ test "Kusto connection formatting omits authentication material" {
     const connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = properties.cluster_url, .credential = credential.asCredential() },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
@@ -1949,7 +1958,7 @@ test "KustoConnection sends authenticated request with default and override scop
     const connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
@@ -1962,7 +1971,7 @@ test "KustoConnection sends authenticated request with default and override scop
     try std.testing.expectEqual(@as(u32, 1), credential.call_count);
     try std.testing.expectEqualStrings("https://kusto.kusto.windows.net/.default", credential.last_scope.?);
     try std.testing.expect(std.mem.endsWith(u8, mock.last_headers.get("Authorization").?, "connection-test-token"));
-    try std.testing.expectEqualStrings("azsdk-zig-kusto/0.1.0", mock.last_headers.get("User-Agent").?);
+    try std.testing.expectEqualStrings("azsdk-zig-kusto/0.2.0", mock.last_headers.get("User-Agent").?);
     try std.testing.expectEqualStrings("gzip, deflate", mock.last_headers.get("Accept-Encoding").?);
     const request_id = mock.last_headers.get("x-ms-client-request-id").?;
     try std.testing.expectEqual(@as(usize, 36), request_id.len);
@@ -1974,7 +1983,7 @@ test "KustoConnection sends authenticated request with default and override scop
     const override_connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        override_mock.asTransport(),
+        testRuntime(override_mock.asTransport()),
         .{
             .token_scope = "https://custom.kusto.windows.net/.default",
             .metadata_mode = .disabled,
@@ -2001,7 +2010,7 @@ test "KustoConnection applies retry options" {
     const connection = try KustoConnection.init(
         allocator,
         .{ .cluster_url = "https://cluster.kusto.windows.net", .credential = credential.asCredential() },
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
         .{
             .metadata_mode = .disabled,
             .retry = .{ .max_retries = 1, .initial_delay_ms = 0 },
@@ -2020,7 +2029,7 @@ test "KustoConnection applies retry options" {
 fn initializeConnection(
     allocator: std.mem.Allocator,
     credential: *core.credentials.TokenCredential,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 ) !void {
     const connection = try KustoConnection.init(
         allocator,
@@ -2028,7 +2037,7 @@ fn initializeConnection(
             .cluster_url = "https://cluster.kusto.windows.net/",
             .credential = credential,
         },
-        transport,
+        runtime,
         .{ .metadata_mode = .disabled },
     );
     connection.deinit();
@@ -2037,7 +2046,7 @@ fn initializeConnection(
 fn initializeDiscoveredConnection(
     allocator: std.mem.Allocator,
     credential: *core.credentials.TokenCredential,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 ) !void {
     const connection = try KustoConnection.init(
         allocator,
@@ -2045,7 +2054,7 @@ fn initializeDiscoveredConnection(
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = credential,
         },
-        transport,
+        runtime,
         .{},
     );
     connection.deinit();
@@ -2060,7 +2069,7 @@ test "KustoConnection handles every initialization allocation failure" {
     try std.testing.checkAllAllocationFailures(
         allocator,
         initializeConnection,
-        .{ credential.asCredential(), mock.asTransport() },
+        .{ credential.asCredential(), testRuntime(mock.asTransport()) },
     );
 }
 
@@ -2072,7 +2081,7 @@ test "KustoConnection cleans up discovery initialization allocation failures" {
     try std.testing.checkAllAllocationFailures(
         allocator,
         initializeDiscoveredConnection,
-        .{ credential.asCredential(), transport.asTransport() },
+        .{ credential.asCredential(), testRuntime(transport.asTransport()) },
     );
 }
 
@@ -2083,7 +2092,7 @@ test "KustoConnectionStringBuilder withTokenCredential" {
         \\{"access_token":"t","expires_in":3600}
     );
     defer cred_mock.deinit();
-    var cred = identity.ClientSecretCredential.init(allocator, cred_mock.asTransport(), "t", "c", "s");
+    var cred = identity.ClientSecretCredential.init(allocator, "t", "c", "s");
 
     var kcsb = KustoConnectionStringBuilder.init("https://cluster.kusto.windows.net");
     _ = kcsb.withTokenCredential(cred.asCredential());

--- a/data/root.zig
+++ b/data/root.zig
@@ -78,47 +78,26 @@ pub const dynamic = kql.dynamic;
 
 pub const KustoClientOptions = struct {
     application_name: []const u8 = "azure-sdk-zig",
-    client_version: []const u8 = "azsdk-zig-kusto/0.1.0",
+    client_version: []const u8 = "azsdk-zig-kusto/0.2.0",
 };
 
 /// Client for executing KQL queries and management commands against a Kusto cluster.
 ///
-/// Clients created with `initWithConnection` borrow their `KustoConnection` and
-/// may be copied or moved. The connection must outlive every client copy. Since
+/// Clients borrow their `KustoConnection` and may be copied or moved. The
+/// connection and its borrowed runtime contexts must outlive every client copy. Since
 /// `KustoConnection.supports_concurrent_use` is false, callers must serialize
 /// requests that share one connection.
 pub const KustoClient = struct {
-    runtime: Runtime,
+    connection: *KustoConnection,
     application_name: []const u8,
     client_version: []const u8,
 
-    const Runtime = union(enum) {
-        legacy: struct {
-            connection: ConnectionProperties,
-            pipeline: core.pipeline.HttpPipeline,
-        },
-        shared: *KustoConnection,
-    };
-
     pub fn init(
-        connection: ConnectionProperties,
-        transport: *core.http.HttpTransport,
+        connection: *KustoConnection,
         options: KustoClientOptions,
     ) KustoClient {
         return .{
-            .runtime = .{ .legacy = .{
-                .connection = connection,
-                .pipeline = .{ .policies = &.{}, .transport_impl = transport },
-            } },
-            .application_name = options.application_name,
-            .client_version = options.client_version,
-        };
-    }
-
-    /// Create a client that borrows `connection`; this client has no deinit.
-    pub fn initWithConnection(connection: *KustoConnection, options: KustoClientOptions) KustoClient {
-        return .{
-            .runtime = .{ .shared = connection },
+            .connection = connection,
             .application_name = options.application_name,
             .client_version = options.client_version,
         };
@@ -362,10 +341,7 @@ pub const KustoClient = struct {
     }
 
     fn engineUrl(self: *const KustoClient) []const u8 {
-        return switch (self.runtime) {
-            .legacy => |legacy| legacy.connection.cluster_url,
-            .shared => |connection| connection.engineUrl(),
-        };
+        return self.connection.engineUrl();
     }
 
     fn configureRequest(
@@ -383,25 +359,12 @@ pub const KustoClient = struct {
         try request.setHeader("x-ms-version", "2024-12-12");
         if (props.client_request_id) |request_id|
             try request.setHeader("x-ms-client-request-id", request_id);
-        try core.pipeline.ensureRequestId(request);
+        try core.http.ensureRequestId(request, self.connection.runtime);
         request.operation_timeout_ms = try props.effectiveClientTimeoutMs(kind);
     }
 
     fn send(self: *KustoClient, request: *core.http.Request) !core.http.Response {
-        return switch (self.runtime) {
-            .shared => |connection| connection.send(request),
-            .legacy => |*legacy| {
-                const connection = legacy.connection;
-                if (connection.credential != null or
-                    connection.authority_id != null or
-                    connection.application_client_id != null or
-                    connection.application_key != null)
-                {
-                    return error.AuthenticatedConnectionRequired;
-                }
-                return legacy.pipeline.send(request);
-            },
-        };
+        return self.connection.send(request);
     }
 
     fn open(
@@ -409,20 +372,7 @@ pub const KustoClient = struct {
         request: *core.http.Request,
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        return switch (self.runtime) {
-            .shared => |connection| connection.open(request, options),
-            .legacy => |*legacy| {
-                const connection = legacy.connection;
-                if (connection.credential != null or
-                    connection.authority_id != null or
-                    connection.application_client_id != null or
-                    connection.application_key != null)
-                {
-                    return error.AuthenticatedConnectionRequired;
-                }
-                return legacy.pipeline.open(request, options);
-            },
-        };
+        return self.connection.open(request, options);
     }
 };
 
@@ -532,6 +482,7 @@ const TestTokenCredential = struct {
         credential: *core.credentials.TokenCredential,
         request_context: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         const self: *TestTokenCredential = @alignCast(@fieldParentPtr("credential", credential));
         self.call_count += 1;
@@ -550,6 +501,29 @@ const empty_v2_response =
     \\]
 ;
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+var testing_token_credential = TestTokenCredential{};
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
+fn testConnection(
+    allocator: std.mem.Allocator,
+    cluster_url: []const u8,
+    runtime: core.http.HttpRuntime,
+) !*KustoConnection {
+    return KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = cluster_url,
+            .credential = testing_token_credential.asCredential(),
+        },
+        runtime,
+        .{ .metadata_mode = .disabled },
+    );
+}
+
 test "KustoClient executes a normal V2 query" {
     const allocator = std.testing.allocator;
     const response_body =
@@ -561,11 +535,9 @@ test "KustoClient executes a normal V2 query" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://mycluster.eastus.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
 
     var dataset = try client.executeQuery(allocator, "TestDB", "StormEvents | count", null);
     defer dataset.deinit(allocator);
@@ -592,12 +564,12 @@ test "shared KustoClient authenticates queries" {
             .cluster_url = "https://cluster.kusto.windows.net/",
             .credential = credential.asCredential(),
         },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
-    var client = KustoClient.initWithConnection(connection, .{});
+    var client = KustoClient.init(connection, .{});
     var dataset = try client.executeQuery(
         allocator,
         "db",
@@ -633,7 +605,7 @@ test "shared KustoClient uses an explicit engine endpoint" {
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = credential.asCredential(),
         },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{
             .metadata_mode = .disabled,
             .engine_endpoint = "https://query-engine.kusto.windows.net",
@@ -642,7 +614,7 @@ test "shared KustoClient uses an explicit engine endpoint" {
     );
     defer connection.deinit();
 
-    var client = KustoClient.initWithConnection(connection, .{});
+    var client = KustoClient.init(connection, .{});
     var dataset = try client.executeQuery(allocator, "db", "print 1", null);
     defer dataset.deinit(allocator);
     try std.testing.expectEqualStrings(
@@ -662,39 +634,17 @@ test "copied shared KustoClient remains usable" {
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = credential.asCredential(),
         },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
-    const copied = KustoClient.initWithConnection(connection, .{});
+    const copied = KustoClient.init(connection, .{});
     var moved = copied;
     var dataset = try moved.executeQuery(allocator, "db", "print 1", null);
     defer dataset.deinit(allocator);
     try std.testing.expect(mock.last_url != null);
     try std.testing.expectEqual(@as(usize, 1), credential.call_count);
-}
-
-test "legacy authenticated KustoClient fails before transport" {
-    const allocator = std.testing.allocator;
-    var credential = TestTokenCredential{};
-    var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
-    defer mock.deinit();
-    var client = KustoClient.init(
-        .{
-            .cluster_url = "https://cluster.kusto.windows.net",
-            .credential = credential.asCredential(),
-        },
-        mock.asTransport(),
-        .{},
-    );
-
-    try std.testing.expectError(
-        error.AuthenticatedConnectionRequired,
-        client.executeQuery(allocator, "db", "print 1", null),
-    );
-    try std.testing.expect(mock.last_url == null);
-    try std.testing.expectEqual(@as(usize, 0), credential.call_count);
 }
 
 test "shared KustoClient retries queries but not management commands" {
@@ -711,14 +661,14 @@ test "shared KustoClient retries queries but not management commands" {
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = query_credential.asCredential(),
         },
-        query_sequence.asTransport(),
+        testRuntime(query_sequence.asTransport()),
         .{
             .metadata_mode = .disabled,
             .retry = .{ .max_retries = 1, .initial_delay_ms = 0, .max_delay_ms = 0 },
         },
     );
     defer query_connection.deinit();
-    var query_client = KustoClient.initWithConnection(query_connection, .{});
+    var query_client = KustoClient.init(query_connection, .{});
     var dataset = try query_client.executeQuery(allocator, "db", "print 1", null);
     defer dataset.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 2), query_sequence.call_count);
@@ -735,14 +685,14 @@ test "shared KustoClient retries queries but not management commands" {
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = management_credential.asCredential(),
         },
-        management_sequence.asTransport(),
+        testRuntime(management_sequence.asTransport()),
         .{
             .metadata_mode = .disabled,
             .retry = .{ .max_retries = 1, .initial_delay_ms = 0, .max_delay_ms = 0 },
         },
     );
     defer management_connection.deinit();
-    var management_client = KustoClient.initWithConnection(management_connection, .{});
+    var management_client = KustoClient.init(management_connection, .{});
     try std.testing.expectError(
         error.KustoQueryFailed,
         management_client.executeMgmt(allocator, "db", ".show tables", null),
@@ -757,11 +707,9 @@ test "KustoClient executes management and auto-routes requests" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
 
     var management = try client.executeMgmt(allocator, "TestDB", ".show databases", null);
     defer management.deinit(allocator);
@@ -785,11 +733,9 @@ test "KustoClient returns query HTTP failures" {
         \\{"error":{"code":"BadRequest","message":"Invalid query"}}
     );
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     try std.testing.expectError(
         error.KustoQueryFailed,
         client.executeQuery(allocator, "db", "INVALID", null),
@@ -800,11 +746,9 @@ test "Kusto request bodies round trip caller strings" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     const database = "db\"\\\n\t\x01";
     const query = "print value = \"a\\\\b\"\n\t\r";
     var query_dataset = try client.executeQuery(
@@ -873,7 +817,7 @@ test "KustoClient applies diagnostic headers and owns response correlation" {
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = credential.asCredential(),
         },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
@@ -890,7 +834,7 @@ test "KustoClient applies diagnostic headers and owns response correlation" {
     try properties.setOption(allocator, "best_effort", true);
     try properties.setParameter(allocator, "limit", @as(i64, 5));
 
-    var client = KustoClient.initWithConnection(connection, .{
+    var client = KustoClient.init(connection, .{
         .application_name = "default-app",
         .client_version = "default-version",
     });
@@ -914,11 +858,9 @@ test "KustoClient rejects invalid request properties before transport" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     try std.testing.expectError(
         error.InvalidServerTimeout,
         client.executeQuery(allocator, "db", "print 1", .{ .server_timeout_ms = 999 }),
@@ -930,11 +872,9 @@ test "Kusto non-2xx malformed body is a structured HTTP failure" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 502, "gateway said no");
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var response_result = try client.executeQueryResult(allocator, "db", "print 1", null);
     defer response_result.deinit(allocator);
     switch (response_result) {
@@ -957,11 +897,9 @@ test "KustoClient decodes V1 management responses" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
 
     var dataset = try client.executeMgmt(allocator, "db", ".show databases", null);
     defer dataset.deinit(allocator);
@@ -977,11 +915,9 @@ test "KustoClient preserves structured HTTP failures" {
         \\{"error":{"code":"BadRequest","message":"Invalid query"}}
     );
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
 
     var response_result = try client.executeQueryResult(allocator, "db", "bad", null);
     defer response_result.deinit(allocator);
@@ -1010,11 +946,9 @@ test "KustoClient returns completion failures with buffered V2 tables" {
         .{ .name = "x-ms-activity-id", .value = "response-activity" },
     };
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
 
     var response_result = try client.executeQueryResult(allocator, "db", "print 1", null);
     defer response_result.deinit(allocator);
@@ -1040,11 +974,9 @@ test "KustoClient returns V1 exceptions as partial buffered results" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
 
     var response_result = try client.executeMgmtResult(allocator, "db", ".show tables", null);
     defer response_result.deinit(allocator);
@@ -1069,11 +1001,9 @@ test "KustoClient honors varying-result-width request property" {
     ;
     var mock = core.http.MockTransport.init(allocator, 200, response_body);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var properties = ClientRequestProperties{};
     defer properties.deinit(allocator);
     try properties.setClientResultsReaderAllowVaryingRowWidths(allocator, true);
@@ -1097,11 +1027,9 @@ test "typed parameter bindings stay in properties rather than query text" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, empty_v2_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var properties = try Binding.bind(allocator, .{
         .secret = "'; .drop table T //",
         .limit = 7,
@@ -1157,11 +1085,9 @@ test "KustoClient progressively pulls tiny chunks with explicit replace and comp
         .{ .name = "x-ms-client-request-id", .value = "service-request-id" },
         .{ .name = "x-ms-activity-id", .value = "service-activity-id" },
     };
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var properties = ClientRequestProperties{};
     defer properties.deinit(allocator);
     try properties.setProgressiveRowCount(allocator, 10);
@@ -1248,11 +1174,11 @@ test "shared KustoClient opens progressive queries through authenticated no-redi
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = credential.asCredential(),
         },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
-    var client = KustoClient.initWithConnection(connection, .{});
+    var client = KustoClient.init(connection, .{});
     const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const query_stream = switch (opened) {
         .ok => |value| value,
@@ -1272,11 +1198,9 @@ test "progressive query reports non-success opens as structured errors" {
         "{\"error\":{\"code\":\"Throttled\",\"message\":\"retry later\"}}",
     );
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var opened = try client.executeProgressiveQuery(
         allocator,
         "db",
@@ -1302,11 +1226,9 @@ test "progressive row iterator exposes zero row replacement reset" {
     var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer mock.deinit();
     mock.stream_response_chunk_size = 2;
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const query_stream = switch (opened) {
         .ok => |value| value,
@@ -1342,11 +1264,9 @@ test "progressive row iterator resets once and preserves every partial failure" 
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, progressive_replace_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const query_stream = switch (opened) {
         .ok => |value| value,
@@ -1378,11 +1298,9 @@ test "progressive fragment events own their row schema" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, progressive_replace_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const query_stream = switch (opened) {
         .ok => |value| value,
@@ -1410,11 +1328,9 @@ test "KustoResult deinitializes an owned progressive stream pointer" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     opened.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
@@ -1425,11 +1341,9 @@ test "progressive query cannot send remote cancellation after dataset completion
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const query_stream = switch (opened) {
         .ok => |value| value,
@@ -1454,11 +1368,9 @@ test "progressive stream releases early operations and does not retain many fram
     const allocator = std.testing.allocator;
     var early_mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer early_mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        early_mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(early_mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     const early_opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const early_stream = switch (early_opened) {
         .ok => |value| value,
@@ -1489,11 +1401,13 @@ test "progressive stream releases early operations and does not retain many fram
     var mock = core.http.MockTransport.init(allocator, 200, response.items);
     defer mock.deinit();
     mock.stream_response_chunk_size = 3;
-    client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
+    const stream_connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(mock.asTransport()),
     );
+    defer stream_connection.deinit();
+    client = KustoClient.init(stream_connection, .{});
     const opened = try client.executeProgressiveQuery(
         allocator,
         "db",
@@ -1521,11 +1435,9 @@ test "progressive stream bounds frames and rejects malformed order or reader fai
     const allocator = std.testing.allocator;
     var too_large = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer too_large.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        too_large.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(too_large.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{ .max_frame_bytes = 8 });
     const limited = switch (opened) {
         .ok => |value| value,
@@ -1540,11 +1452,13 @@ test "progressive stream bounds frames and rejects malformed order or reader fai
     ;
     var bad_mock = core.http.MockTransport.init(allocator, 200, malformed);
     defer bad_mock.deinit();
-    client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        bad_mock.asTransport(),
-        .{},
+    const bad_connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(bad_mock.asTransport()),
     );
+    defer bad_connection.deinit();
+    client = KustoClient.init(bad_connection, .{});
     opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const bad_stream = switch (opened) {
         .ok => |value| value,
@@ -1559,11 +1473,13 @@ test "progressive stream bounds frames and rejects malformed order or reader fai
     ;
     var comma_mock = core.http.MockTransport.init(allocator, 200, trailing_comma);
     defer comma_mock.deinit();
-    client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        comma_mock.asTransport(),
-        .{},
+    const comma_connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(comma_mock.asTransport()),
     );
+    defer comma_connection.deinit();
+    client = KustoClient.init(comma_connection, .{});
     opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const comma_stream = switch (opened) {
         .ok => |value| value,
@@ -1581,11 +1497,13 @@ test "progressive stream bounds frames and rejects malformed order or reader fai
     ;
     var header_mock = core.http.MockTransport.init(allocator, 200, invalid_header);
     defer header_mock.deinit();
-    client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        header_mock.asTransport(),
-        .{},
+    const header_connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(header_mock.asTransport()),
     );
+    defer header_connection.deinit();
+    client = KustoClient.init(header_connection, .{});
     opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const header_stream = switch (opened) {
         .ok => |value| value,
@@ -1602,11 +1520,13 @@ test "progressive stream bounds frames and rejects malformed order or reader fai
     ;
     var table_mock = core.http.MockTransport.init(allocator, 200, too_many_tables);
     defer table_mock.deinit();
-    client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        table_mock.asTransport(),
-        .{},
+    const table_connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(table_mock.asTransport()),
     );
+    defer table_connection.deinit();
+    client = KustoClient.init(table_connection, .{});
     opened = try client.executeProgressiveQuery(
         allocator,
         "db",
@@ -1631,11 +1551,13 @@ test "progressive stream bounds frames and rejects malformed order or reader fai
     var failed_mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer failed_mock.deinit();
     failed_mock.stream_fail_response_after = 0;
-    client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        failed_mock.asTransport(),
-        .{},
+    const failed_connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(failed_mock.asTransport()),
     );
+    defer failed_connection.deinit();
+    client = KustoClient.init(failed_connection, .{});
     opened = try client.executeProgressiveQuery(allocator, "db", "print 1", null, .{});
     const failed_stream = switch (opened) {
         .ok => |value| value,
@@ -1649,11 +1571,9 @@ test "progressive query cancellation uses original request ID and management req
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     const target_id = "query-request-id";
     const properties = ClientRequestProperties{ .client_request_id = target_id };
     const opened = try client.executeProgressiveQuery(allocator, "db", "print 1", properties, .{});
@@ -1685,11 +1605,9 @@ test "progressive query checks pre-cancellation and deadlines between pulls" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, progressive_v2_response);
     defer mock.deinit();
-    var client = KustoClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-        .{},
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = KustoClient.init(connection, .{});
     var token = core.http.CancellationToken{};
     token.cancel();
     try std.testing.expectError(

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -18,7 +18,7 @@ entirely into memory. Direct ingestion is limited to 4 MiB uncompressed.
 
 ```zig
 const ingest = @import("azure_sdk_kusto").ingest;
-var client = ingest.StreamingIngestClient.initWithConnection(connection);
+var client = ingest.StreamingIngestClient.init(connection);
 var result = try client.ingestFromFileResult(
     allocator,
     .{ .database = "db", .table = "events" },
@@ -81,7 +81,7 @@ complete-SAS Blob client, then posted through the complete-SAS Queue client.
 Storage requests never carry Kusto bearer authorization.
 
 ```zig
-var executor = ingest.DataManagementCommandExecutor.initWithConnection(connection);
+var executor = ingest.DataManagementCommandExecutor.init(connection);
 var io_thread = std.Io.Threaded.init_single_threaded;
 var manager = try ingest.ResourceManager.init(
     allocator,
@@ -92,10 +92,10 @@ var manager = try ingest.ResourceManager.init(
 );
 defer manager.deinit();
 
-var client = ingest.QueuedIngestClient.initWithConnectionAndResourceManager(
-    connection,
-    &manager,
-);
+var client = ingest.QueuedIngestClient.init(connection.runtime, .{
+    .connection = connection,
+    .resource_manager = &manager,
+});
 var submission = try client.ingest(
     allocator,
     .{ .database = "db", .table = "events" },
@@ -134,7 +134,8 @@ if (submission.takeTracking()) |owned| {
 
 Polling retries idempotent transient/ambiguous GETs within its explicit
 budget. Authentication, permanent HTTP, and malformed-entity failures stop
-polling without becoming ingestion failures. The handle borrows its transport,
+polling without becoming ingestion failures. The handle copies its runtime and
+borrows the runtime transport and crypto contexts,
 is single-owner, and is not concurrency-safe.
 
 Use `.failures_and_successes` reporting when terminal success must be observed.

--- a/ingest/managed.zig
+++ b/ingest/managed.zig
@@ -82,64 +82,24 @@ pub const ManagedIngestionResult = union(enum) {
 
 /// Managed direct-to-queued ingestion.
 ///
-/// This value borrows its transport, optional `ResourceManager`, and optional
-/// shared `KustoConnection`. They must outlive this client, all copies of it,
-/// and all calls. A shared connection (and a manager backed by one) is not
+/// This value borrows its `ResourceManager`, shared `KustoConnection`, and the
+/// connection runtime contexts. They must outlive this client, all copies of
+/// it, and all calls. A shared connection (and a manager backed by one) is not
 /// concurrent-safe; callers must externally serialize use.
 pub const ManagedIngestClient = struct {
     streaming: streaming.StreamingIngestClient,
     queued: queued.QueuedIngestClient,
 
-    /// Legacy unauthenticated constructor. Queue fallback requires an
-    /// injected ResourceManager or a shared connection, so a streaming
-    /// fallback from this constructor reports
-    /// `QueuedIngestionResourceManagerRequired`.
     pub fn init(
-        connection: kusto_common.ConnectionProperties,
-        transport: *core.http.HttpTransport,
-    ) ManagedIngestClient {
-        return .{
-            .streaming = streaming.StreamingIngestClient.init(connection, transport),
-            .queued = queued.QueuedIngestClient.init(connection, transport),
-        };
-    }
-
-    /// Creates a client borrowing a shared authenticated connection. A
-    /// short-lived resource manager is created for queue operations.
-    pub fn initWithConnection(connection: *kusto_common.KustoConnection) ManagedIngestClient {
-        return .{
-            .streaming = streaming.StreamingIngestClient.initWithConnection(connection),
-            .queued = queued.QueuedIngestClient.initWithConnection(connection),
-        };
-    }
-
-    /// Creates a client with an injected ResourceManager and raw transport.
-    /// The manager and transport are borrowed. The legacy streaming client
-    /// cannot authenticate; use `initWithConnectionAndResourceManager` for
-    /// authenticated direct ingestion.
-    pub fn initWithResourceManager(
-        connection: kusto_common.ConnectionProperties,
-        manager: *resources.ResourceManager,
-        transport: *core.http.HttpTransport,
-    ) ManagedIngestClient {
-        return .{
-            .streaming = streaming.StreamingIngestClient.init(connection, transport),
-            .queued = queued.QueuedIngestClient.initWithResourceManager(manager, transport),
-        };
-    }
-
-    /// Creates a client borrowing both a shared connection and an injected
-    /// resource manager. This retains resource discovery caching and ranking.
-    pub fn initWithConnectionAndResourceManager(
         connection: *kusto_common.KustoConnection,
-        manager: *resources.ResourceManager,
+        manager: ?*resources.ResourceManager,
     ) ManagedIngestClient {
         return .{
-            .streaming = streaming.StreamingIngestClient.initWithConnection(connection),
-            .queued = queued.QueuedIngestClient.initWithConnectionAndResourceManager(
-                connection,
-                manager,
-            ),
+            .streaming = streaming.StreamingIngestClient.init(connection),
+            .queued = queued.QueuedIngestClient.init(connection.runtime, .{
+                .connection = connection,
+                .resource_manager = manager,
+            }),
         };
     }
 
@@ -161,7 +121,11 @@ pub const ManagedIngestClient = struct {
 
         // Queue may be selected before direct streaming, so IDs always obey
         // Queue's canonical UUID contract even for a streaming-only success.
-        const canonical_id = try queued.makeLogicalSourceId(allocator, options.source_id);
+        const canonical_id = try queued.makeLogicalSourceId(
+            allocator,
+            self.queued.runtime.crypto,
+            options.source_id,
+        );
         defer allocator.free(canonical_id);
         var normalized_options = options;
         normalized_options.source_id = canonical_id;
@@ -537,6 +501,43 @@ const PrefixTailReader = struct {
     }
 };
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
+const TestTokenCredential = struct {
+    credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
+
+    fn getToken(
+        _: *core.credentials.TokenCredential,
+        _: core.credentials.TokenRequestContext,
+        _: core.context.Context,
+        _: core.http.HttpRuntime,
+    ) anyerror!core.credentials.AccessToken {
+        return .{ .token = "managed-test-token", .expires_on = std.math.maxInt(i64) };
+    }
+};
+
+var testing_token_credential = TestTokenCredential{};
+
+fn testConnection(
+    allocator: std.mem.Allocator,
+    cluster_url: []const u8,
+    runtime: core.http.HttpRuntime,
+) !*kusto_common.KustoConnection {
+    return kusto_common.KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = cluster_url,
+            .credential = &testing_token_credential.credential,
+        },
+        runtime,
+        .{ .metadata_mode = .disabled },
+    );
+}
+
 test "managed routing decisions honor threshold formats properties and blob size" {
     const options = IngestOptions{ .managed_streaming_threshold_bytes = 4 };
     try std.testing.expect(!requiresQueueBeforeStreaming(.{ .bytes = "four" }, options));
@@ -624,10 +625,9 @@ test "managed small unknown reader streams as replayable bytes with canonical ID
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = ManagedIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
     var reader = std.Io.Reader.fixed("tiny");
 
     var result = try client.ingestResult(
@@ -662,35 +662,33 @@ test "managed small unknown reader streams as replayable bytes with canonical ID
     );
 }
 
-test "managed preflight queue does not enter direct transport" {
+test "managed preflight queue reports resource discovery failure without streaming" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = ManagedIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
 
-    try std.testing.expectError(
-        error.QueuedIngestionResourceManagerRequired,
-        client.ingestResult(
-            allocator,
-            .{ .database = "DB", .table = "Table" },
-            .{ .bytes = "large" },
-            .{ .managed_streaming_threshold_bytes = 4 },
-        ),
+    var result = try client.ingestResult(
+        allocator,
+        .{ .database = "DB", .table = "Table" },
+        .{ .bytes = "large" },
+        .{ .managed_streaming_threshold_bytes = 4 },
     );
-    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(queued.QueuedSubmissionOutcome.pre_queue_failed, result.ok.queued.outcome);
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+    try std.testing.expect(std.mem.endsWith(u8, transport.last_url.?, "/v1/rest/mgmt"));
 }
 
 test "managed small blob streams with direct URI compression normalized" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = ManagedIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
     var result = try client.ingestResult(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -718,10 +716,9 @@ test "managed permanent ambiguous and one-shot streaming failures never queue" {
             "{\"error\":{\"code\":\"BadRequest\",\"message\":\"permanent\"}}",
         );
         defer transport.deinit();
-        var client = ManagedIngestClient.init(
-            .{ .cluster_url = "https://cluster.kusto.windows.net" },
-            transport.asTransport(),
-        );
+        const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+        defer connection.deinit();
+        var client = ManagedIngestClient.init(connection, null);
         var result = try client.ingestResult(
             allocator,
             .{ .database = "DB", .table = "Table" },
@@ -737,10 +734,9 @@ test "managed permanent ambiguous and one-shot streaming failures never queue" {
         var transport = core.http.MockTransport.init(allocator, 200, "{}");
         transport.stream_fail_upload_after = 0;
         defer transport.deinit();
-        var client = ManagedIngestClient.init(
-            .{ .cluster_url = "https://cluster.kusto.windows.net" },
-            transport.asTransport(),
-        );
+        const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+        defer connection.deinit();
+        var client = ManagedIngestClient.init(connection, null);
         var result = try client.ingestResult(
             allocator,
             .{ .database = "DB", .table = "Table" },
@@ -759,10 +755,9 @@ test "managed permanent ambiguous and one-shot streaming failures never queue" {
             "{\"error\":{\"code\":\"ServiceUnavailable\",\"message\":\"retry\"}}",
         );
         defer transport.deinit();
-        var client = ManagedIngestClient.init(
-            .{ .cluster_url = "https://cluster.kusto.windows.net" },
-            transport.asTransport(),
-        );
+        const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+        defer connection.deinit();
+        var client = ManagedIngestClient.init(connection, null);
         var reader = std.Io.Reader.fixed("body");
         var result = try client.ingestResult(
             allocator,
@@ -782,10 +777,9 @@ test "managed cancellation prevents either route" {
     defer transport.deinit();
     var token = core.http.CancellationToken{};
     token.cancel();
-    var client = ManagedIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
     try std.testing.expectError(
         error.OperationCancelled,
         client.ingestResult(
@@ -859,7 +853,10 @@ const ManagedTestExecutor = struct {
 const ManagedFallbackTransport = struct {
     direct: core.http.MockTransport,
     storage: core.http.MockTransport,
-    transport: core.http.HttpTransport = .{ .sendFn = &send, .openFn = &open },
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &send,
+        .open = &open,
+    };
 
     fn init(allocator: std.mem.Allocator) ManagedFallbackTransport {
         return .{
@@ -877,36 +874,32 @@ const ManagedFallbackTransport = struct {
         self.storage.deinit();
     }
 
-    fn asTransport(self: *ManagedFallbackTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *ManagedFallbackTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn send(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
     ) !core.http.Response {
-        const self: *ManagedFallbackTransport = @alignCast(
-            @fieldParentPtr("transport", transport),
-        );
+        const self: *ManagedFallbackTransport = @ptrCast(@alignCast(context));
         self.storage.response_status =
             if (std.mem.indexOf(u8, request.url, ".table.core.windows.net") != null) 204 else 201;
-        return self.storage.transport.sendFn(&self.storage.transport, request);
+        return self.storage.asTransport().send(request);
     }
 
     fn open(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        const self: *ManagedFallbackTransport = @alignCast(
-            @fieldParentPtr("transport", transport),
-        );
+        const self: *ManagedFallbackTransport = @ptrCast(@alignCast(context));
         if (std.mem.indexOf(u8, request.url, ".core.windows.net") != null) {
             self.storage.response_status =
                 if (std.mem.indexOf(u8, request.url, ".table.core.windows.net") != null) 204 else 201;
-            return self.storage.transport.openFn.?(&self.storage.transport, request, options);
+            return self.storage.asTransport().open(request, options);
         }
-        return self.direct.transport.openFn.?(&self.direct.transport, request, options);
+        return self.direct.asTransport().open(request, options);
     }
 };
 
@@ -969,11 +962,9 @@ test "managed retryable known failure falls back once with one canonical ID" {
     defer manager.deinit();
     var transport = ManagedFallbackTransport.init(allocator);
     defer transport.deinit();
-    var client = ManagedIngestClient.initWithResourceManager(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        &manager,
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, &manager);
 
     var result = try client.ingestResult(
         allocator,
@@ -1028,11 +1019,9 @@ test "managed large unknown reader queues its prefix and tail once" {
     defer manager.deinit();
     var transport = ManagedFallbackTransport.init(allocator);
     defer transport.deinit();
-    var client = ManagedIngestClient.initWithResourceManager(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        &manager,
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, &manager);
     var reader = std.Io.Reader.fixed("prefix and tail");
 
     var result = try client.ingestResult(
@@ -1082,11 +1071,9 @@ test "managed cancellation during resource refresh starts no storage request" {
     defer manager.deinit();
     var transport = ManagedFallbackTransport.init(allocator);
     defer transport.deinit();
-    var client = ManagedIngestClient.initWithResourceManager(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        &manager,
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, &manager);
 
     try std.testing.expectError(
         error.OperationCancelled,
@@ -1117,11 +1104,9 @@ test "managed cancellation in a classified reader surfaces as cancellation" {
     defer manager.deinit();
     var transport = ManagedFallbackTransport.init(allocator);
     defer transport.deinit();
-    var client = ManagedIngestClient.initWithResourceManager(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        &manager,
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, &manager);
     var token = core.http.CancellationToken{};
     var reader = CancelOnTailReader.init(&token, "prefix and tail", 5);
 
@@ -1145,10 +1130,9 @@ test "managed cancellation in a classified reader surfaces as cancellation" {
 fn managedAllocationFixture(allocator: std.mem.Allocator) !void {
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = ManagedIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
     var reader = std.Io.Reader.fixed("tiny");
     var result = try client.ingestResult(
         allocator,

--- a/ingest/queued.zig
+++ b/ingest/queued.zig
@@ -124,45 +124,29 @@ pub const QueuedIngestionResult = struct {
 pub const QueuedIngestClient = struct {
     manager: ?*resources.ResourceManager = null,
     connection: ?*kusto_common.KustoConnection = null,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 
-    /// Compatibility constructor. It cannot discover authenticated resources;
-    /// use `initWithResourceManager` or
-    /// `initWithConnectionAndResourceManager` before submitting ingestion.
+    pub const Options = struct {
+        connection: ?*kusto_common.KustoConnection = null,
+        resource_manager: ?*resources.ResourceManager = null,
+    };
+
+    /// Copies the runtime descriptors and borrows their contexts plus the
+    /// optional connection and resource manager. When a connection is
+    /// supplied, its runtime is authoritative so Kusto and Storage operations
+    /// use the same provider. All borrowed values must outlive this client and
+    /// every operation.
     pub fn init(
-        _: kusto_common.ConnectionProperties,
-        transport: *core.http.HttpTransport,
-    ) QueuedIngestClient {
-        return .{ .transport = transport };
-    }
-
-    /// Creates a client borrowing a shared connection. Calls create a
-    /// short-lived ResourceManager when no injected manager is available;
-    /// inject one to retain discovery cache and ranking state across calls.
-    pub fn initWithConnection(connection: *kusto_common.KustoConnection) QueuedIngestClient {
-        return .{ .connection = connection, .transport = connection.transport };
-    }
-
-    /// Creates a queued client borrowing a ResourceManager and raw transport.
-    /// The transport is used only by complete-SAS Blob and Queue clients, so
-    /// Kusto bearer policies cannot attach to those storage requests.
-    pub fn initWithResourceManager(
-        manager: *resources.ResourceManager,
-        transport: *core.http.HttpTransport,
-    ) QueuedIngestClient {
-        return .{ .manager = manager, .transport = transport };
-    }
-
-    /// Creates a queued client borrowing a shared connection and a manager
-    /// whose executor normally borrows that same connection.
-    pub fn initWithConnectionAndResourceManager(
-        connection: *kusto_common.KustoConnection,
-        manager: *resources.ResourceManager,
+        runtime: core.http.HttpRuntime,
+        options: Options,
     ) QueuedIngestClient {
         return .{
-            .manager = manager,
-            .connection = connection,
-            .transport = connection.transport,
+            .manager = options.resource_manager,
+            .connection = options.connection,
+            .runtime = if (options.connection) |connection|
+                connection.runtime
+            else
+                runtime,
         };
     }
 
@@ -181,7 +165,7 @@ pub const QueuedIngestClient = struct {
         const manager = if (self.manager) |injected|
             injected
         else if (self.connection) |connection| blk: {
-            executor = resources.DataManagementCommandExecutor.initWithConnection(connection);
+            executor = resources.DataManagementCommandExecutor.init(connection);
             owned_manager = try resources.ResourceManager.init(
                 allocator,
                 threaded.io(),
@@ -196,7 +180,11 @@ pub const QueuedIngestClient = struct {
         const source_info = try sourceInfo(source, options);
         try checkCancelled(options.cancellation);
 
-        const source_id = try makeLogicalSourceId(allocator, options.source_id);
+        const source_id = try makeLogicalSourceId(
+            allocator,
+            self.runtime.crypto,
+            options.source_id,
+        );
         const attempt_capacity = attemptCapacity(options.queued_max_resource_attempts) catch |err| {
             allocator.free(source_id);
             return err;
@@ -390,7 +378,7 @@ pub const QueuedIngestClient = struct {
             var blob_client = blobs.SasBlobClient.init(
                 allocator,
                 blob_uri,
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 if (err == error.OutOfMemory) return err;
                 result.attempts[result_attempt].outcome = .local_failure;
@@ -543,7 +531,7 @@ pub const QueuedIngestClient = struct {
             var tracking = status.StatusTrackingHandle.init(
                 allocator,
                 selection.resource.uri(),
-                self.transport,
+                self.runtime,
                 result.ingestion_id,
                 target.database,
                 target.table,
@@ -679,7 +667,7 @@ pub const QueuedIngestClient = struct {
             var queue_client = queues.SasQueueClient.init(
                 allocator,
                 selection.resource.uri(),
-                self.transport,
+                self.runtime,
             ) catch |err| {
                 if (err == error.OutOfMemory) return err;
                 result.attempts[result_attempt].outcome = .local_failure;
@@ -954,18 +942,18 @@ fn temporaryBlobExtension(info: SourceInfo, options: IngestOptions) []const u8 {
 /// Creates a secure nonzero canonical UUID for Queue-compatible ingestion.
 /// Managed ingestion shares this helper so a streaming attempt and a fallback
 /// queue submission always use the exact same normalized ID.
-pub fn makeLogicalSourceId(allocator: std.mem.Allocator, provided: ?[]const u8) ![]u8 {
+pub fn makeLogicalSourceId(
+    allocator: std.mem.Allocator,
+    crypto_provider: core.crypto.CryptoProvider,
+    provided: ?[]const u8,
+) ![]u8 {
     const output = try allocator.alloc(u8, 36);
     errdefer allocator.free(output);
     if (provided) |source_id| {
         try canonicalizeQueuedSourceId(source_id, output);
         return output;
     }
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
-    try threaded.io().randomSecure(&seed);
-    var csprng = std.Random.DefaultCsprng.init(seed);
-    const uuid = core.uuid.Uuid.init(csprng.random()).toString();
+    const uuid = (try core.uuid.Uuid.init(crypto_provider)).toString();
     @memcpy(output, &uuid);
     return output;
 }
@@ -1475,10 +1463,10 @@ const QueuedOutcomeTransport = struct {
     call_count: usize = 0,
     capture_body: bool = false,
     last_body: ?[]u8 = null,
-    transport: core.http.HttpTransport = .{ .sendFn = &send },
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
 
-    fn asTransport(self: *QueuedOutcomeTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *QueuedOutcomeTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn deinit(self: *QueuedOutcomeTransport) void {
@@ -1487,10 +1475,10 @@ const QueuedOutcomeTransport = struct {
     }
 
     fn send(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         request: *core.http.Request,
     ) !core.http.Response {
-        const self: *QueuedOutcomeTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *QueuedOutcomeTransport = @ptrCast(@alignCast(context));
         const index = @min(self.call_count, self.steps.len - 1);
         self.call_count += 1;
         if (self.capture_body) {
@@ -1531,6 +1519,12 @@ fn queueMessageJson(allocator: std.mem.Allocator, xml: []const u8) ![]u8 {
     return core.base64.decode(allocator, outer);
 }
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
 test "queued bytes upload uses gzip message envelope and isolated SAS requests" {
     const allocator = std.testing.allocator;
     var executor = QueuedTestExecutor{};
@@ -1538,7 +1532,7 @@ test "queued bytes upload uses gzip message envelope and isolated SAS requests" 
     defer manager.deinit();
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
 
     var result = try client.ingest(
         allocator,
@@ -1602,7 +1596,7 @@ test "queued existing blob does not upload and keeps raw size optional" {
     defer manager.deinit();
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
 
     var result = try client.ingest(
         allocator,
@@ -1629,7 +1623,7 @@ test "queued unknown-length readers block upload and omit raw data size" {
         defer manager.deinit();
         var transport = core.http.MockTransport.init(allocator, 201, "");
         defer transport.deinit();
-        var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+        var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
         var reader = std.Io.Reader.fixed("unknown reader\n");
 
         var result = try client.ingest(
@@ -1669,7 +1663,7 @@ test "queued table reporting creates a reference entity before queue acceptance"
         .capture_body = true,
     };
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
 
     var result = try client.ingest(
         allocator,
@@ -1717,7 +1711,7 @@ test "queued unknown queue outcome never exposes a tracking handle" {
         .unknown,
     };
     var transport = QueuedOutcomeTransport{ .allocator = allocator, .steps = &steps };
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
     var result = try client.ingest(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -1781,7 +1775,7 @@ test "queued file reader and replay reader sources submit through temporary blob
         defer manager.deinit();
         var transport = core.http.MockTransport.init(allocator, 201, "");
         defer transport.deinit();
-        var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+        var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
         var result = try client.ingest(
             allocator,
             .{ .database = "DB", .table = "Table" },
@@ -1832,7 +1826,7 @@ test "queued retries known blob rejection with a stable ID and reports resources
         .{ .status = 201 },
     };
     var transport = QueuedOutcomeTransport{ .allocator = allocator, .steps = &steps };
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
 
     var result = try client.ingest(
         allocator,
@@ -1863,7 +1857,7 @@ test "queued one-shot reader does not retry after a Blob request" {
     };
     var transport = QueuedOutcomeTransport{ .allocator = allocator, .steps = &steps };
     var reader = std.Io.Reader.fixed("reader\n");
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
 
     var result = try client.ingest(
         allocator,
@@ -1892,7 +1886,7 @@ test "queued queue rejection is known and queue transport ambiguity is never dup
             .{ .status = 403 },
         };
         var transport = QueuedOutcomeTransport{ .allocator = allocator, .steps = &steps };
-        var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+        var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
         var result = try client.ingest(
             allocator,
             .{ .database = "DB", .table = "Table" },
@@ -1917,7 +1911,7 @@ test "queued queue rejection is known and queue transport ambiguity is never dup
             .{ .status = 201 },
         };
         var transport = QueuedOutcomeTransport{ .allocator = allocator, .steps = &steps };
-        var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+        var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
         var result = try client.ingest(
             allocator,
             .{ .database = "DB", .table = "Table" },
@@ -1935,6 +1929,7 @@ test "queued source IDs are canonical nonzero UUIDs" {
     const allocator = std.testing.allocator;
     const normalized = try makeLogicalSourceId(
         allocator,
+        testing_crypto_provider.asProvider(),
         "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
     );
     defer allocator.free(normalized);
@@ -1944,14 +1939,14 @@ test "queued source IDs are canonical nonzero UUIDs" {
     );
     try std.testing.expectError(
         error.InvalidQueuedSourceId,
-        makeLogicalSourceId(allocator, "not-a-uuid"),
+        makeLogicalSourceId(allocator, testing_crypto_provider.asProvider(), "not-a-uuid"),
     );
     try std.testing.expectError(
         error.InvalidQueuedSourceId,
-        makeLogicalSourceId(allocator, "00000000-0000-0000-0000-000000000000"),
+        makeLogicalSourceId(allocator, testing_crypto_provider.asProvider(), "00000000-0000-0000-0000-000000000000"),
     );
 
-    const generated = try makeLogicalSourceId(allocator, null);
+    const generated = try makeLogicalSourceId(allocator, testing_crypto_provider.asProvider(), null);
     defer allocator.free(generated);
     try validateQueuedSourceId(generated);
     try std.testing.expectEqual(@as(u8, '4'), generated[14]);
@@ -1964,7 +1959,7 @@ test "queued validation rejects invalid policies before requests" {
     defer manager.deinit();
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
     const target: StreamingIngestTarget = .{ .database = "DB", .table = "Table" };
     const source: StreamingIngestSource = .{ .bytes = "data" };
     const source_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
@@ -2042,7 +2037,7 @@ test "queued precompressed files preserve their extension and raw-size honesty" 
     defer manager.deinit();
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
     var result = try client.ingest(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -2105,7 +2100,7 @@ test "queued rejection retries without reopening a one-shot reader" {
     };
     var transport = QueuedOutcomeTransport{ .allocator = allocator, .steps = &steps };
     var reader = std.Io.Reader.fixed("reader\n");
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
     var result = try client.ingest(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -2141,7 +2136,7 @@ test "queued result diagnostics use the caller allocator" {
     defer manager.deinit();
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
     var result = try client.ingest(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -2192,7 +2187,7 @@ test "queued compatibility result transfers resource-manager Kusto errors" {
     defer manager.deinit();
     var transport = core.http.MockTransport.init(allocator, 201, "");
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
     var result = try client.ingestFromBlobResult(
         allocator,
         .{ .database = "DB", .table = "Table", .format = .json },
@@ -2220,7 +2215,7 @@ test "queued compatibility result keeps storage rejection explicit" {
     defer manager.deinit();
     var transport = core.http.MockTransport.init(allocator, 403, "denied");
     defer transport.deinit();
-    var client = QueuedIngestClient.initWithResourceManager(&manager, transport.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(transport.asTransport()), .{ .resource_manager = &manager });
     var result = try client.ingestFromBlobResult(
         allocator,
         .{

--- a/ingest/resources.zig
+++ b/ingest/resources.zig
@@ -333,11 +333,11 @@ pub const ResourceCommandExecutor = struct {
 pub const DataManagementCommandExecutor = struct {
     connection: *kusto_common.KustoConnection,
     application_name: []const u8 = "azure-sdk-zig",
-    client_version: []const u8 = "azsdk-zig-kusto/0.1.0",
+    client_version: []const u8 = "azsdk-zig-kusto/0.2.0",
 
     pub const supports_concurrent_use = false;
 
-    pub fn initWithConnection(connection: *kusto_common.KustoConnection) DataManagementCommandExecutor {
+    pub fn init(connection: *kusto_common.KustoConnection) DataManagementCommandExecutor {
         return .{ .connection = connection };
     }
 
@@ -375,7 +375,7 @@ pub const DataManagementCommandExecutor = struct {
         try request.setHeader("x-ms-app", self.application_name);
         try request.setHeader("x-ms-client-version", self.client_version);
         try request.setHeader("x-ms-version", "2024-12-12");
-        try core.pipeline.ensureRequestId(&request);
+        try core.http.ensureRequestId(&request, self.connection.runtime);
         request.operation_timeout_ms = try properties.effectiveClientTimeoutMs(.management);
         request.body = body;
         // Discovery commands are read-only but intentionally non-retryable:
@@ -1629,6 +1629,12 @@ fn expectLease(result: *ResourceSnapshotResult) !*ResourceSnapshotLease {
     };
 }
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
 test "resource manager decodes complete V1 resources by names and redacts secrets" {
     const allocator = std.testing.allocator;
     var clock = TestClock{};
@@ -1673,6 +1679,7 @@ fn resourceTestToken(
     _: *core.credentials.TokenCredential,
     _: core.credentials.TokenRequestContext,
     _: core.context.Context,
+    _: core.http.HttpRuntime,
 ) anyerror!core.credentials.AccessToken {
     return .{ .token = "resource-manager-test-token", .expires_on = std.math.maxInt(i64) };
 }
@@ -1688,14 +1695,14 @@ test "data-management executor authenticates requests at the DM endpoint without
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = &credential,
         },
-        mock.asTransport(),
+        testRuntime(mock.asTransport()),
         .{
             .metadata_mode = .disabled,
             .data_management_endpoint = "https://ingest-dm.kusto.windows.net",
         },
     );
     defer connection.deinit();
-    var command_executor = DataManagementCommandExecutor.initWithConnection(connection);
+    var command_executor = DataManagementCommandExecutor.init(connection);
     var result = try command_executor.asExecutor().execute(
         allocator,
         "db",

--- a/ingest/root.zig
+++ b/ingest/root.zig
@@ -94,18 +94,21 @@ pub const ManagedIngestClient = managed.ManagedIngestClient;
 // ─────────────────────── Tests ───────────────────────
 
 const TransportFailure = struct {
-    transport: core.http.HttpTransport = .{ .sendFn = &send, .openFn = &open },
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &send,
+        .open = &open,
+    };
 
-    fn asTransport(self: *TransportFailure) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *TransportFailure) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
-    fn send(_: *core.http.HttpTransport, _: *core.http.Request) anyerror!core.http.Response {
+    fn send(_: *anyopaque, _: *core.http.Request) anyerror!core.http.Response {
         return error.ConnectionResetByPeer;
     }
 
     fn open(
-        _: *core.http.HttpTransport,
+        _: *anyopaque,
         _: *core.http.Request,
         _: core.http.OpenOptions,
     ) anyerror!*core.http.HttpOperation {
@@ -113,13 +116,41 @@ const TransportFailure = struct {
     }
 };
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
+var testing_token_credential = core.credentials.TokenCredential{
+    .getTokenFn = &successfulTokenRequest,
+};
+
+fn testConnection(
+    allocator: std.mem.Allocator,
+    cluster_url: []const u8,
+    runtime: core.http.HttpRuntime,
+) !*KustoConnection {
+    return KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = cluster_url,
+            .credential = &testing_token_credential,
+        },
+        runtime,
+        .{ .metadata_mode = .disabled },
+    );
+}
+
 test "StreamingIngestClient ingestFromSlice" {
     const allocator = std.testing.allocator;
     var mock = core.http.MockTransport.init(allocator, 200, "{}");
     defer mock.deinit();
 
     const conn = ConnectionProperties{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" };
-    var client = StreamingIngestClient.init(conn, mock.asTransport());
+    const connection = try testConnection(allocator, conn.cluster_url, testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     var result = try client.ingestFromSlice(allocator, "TestDB", "Logs", "{\"ts\":\"2024-01-01\"}\n", .{
         .format = .json,
@@ -138,7 +169,9 @@ test "StreamingIngestClient with mapping name" {
     defer mock.deinit();
 
     const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = StreamingIngestClient.init(conn, mock.asTransport());
+    const connection = try testConnection(allocator, conn.cluster_url, testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     var result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{
         .format = .csv,
@@ -151,38 +184,26 @@ test "StreamingIngestClient with mapping name" {
 
 test "shared StreamingIngestClient authenticates through KustoConnection" {
     const allocator = std.testing.allocator;
-    var token_mock = core.http.MockTransport.init(allocator, 200,
-        \\{"access_token":"shared-token","expires_in":3600}
-    );
-    defer token_mock.deinit();
     var service_mock = core.http.MockTransport.init(allocator, 200, "{}");
     defer service_mock.deinit();
 
-    const identity = core.identity;
-    var credential = identity.ClientSecretCredential.init(
-        allocator,
-        token_mock.asTransport(),
-        "tenant",
-        "client",
-        "secret",
-    );
+    var credential = core.credentials.TokenCredential{ .getTokenFn = &successfulTokenRequest };
     const properties = ConnectionProperties{
         .cluster_url = "https://cluster.kusto.windows.net",
-        .credential = credential.asCredential(),
+        .credential = &credential,
     };
     const connection = try KustoConnection.init(
         allocator,
         properties,
-        service_mock.asTransport(),
+        testRuntime(service_mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
-    var client = StreamingIngestClient.initWithConnection(connection);
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
     defer result.deinit(allocator);
     try std.testing.expectEqual(IngestionStatus.success, result.status);
-    try std.testing.expect(token_mock.last_url != null);
     try std.testing.expect(service_mock.last_headers.get("Authorization") != null);
     try std.testing.expectEqual(false, service_mock.last_retryable.?);
 }
@@ -200,7 +221,7 @@ test "shared StreamingIngestClient uses explicit engine endpoint" {
     const connection = try KustoConnection.init(
         allocator,
         properties,
-        service_mock.asTransport(),
+        testRuntime(service_mock.asTransport()),
         .{
             .metadata_mode = .disabled,
             .engine_endpoint = "https://streaming-engine.kusto.windows.net",
@@ -209,7 +230,7 @@ test "shared StreamingIngestClient uses explicit engine endpoint" {
     );
     defer connection.deinit();
 
-    var client = StreamingIngestClient.initWithConnection(connection);
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
     defer result.deinit(allocator);
 
@@ -233,12 +254,12 @@ test "shared StreamingIngestClient can be copied" {
     const connection = try KustoConnection.init(
         allocator,
         properties,
-        service_mock.asTransport(),
+        testRuntime(service_mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
-    const original = StreamingIngestClient.initWithConnection(connection);
+    const original = StreamingIngestClient.init(connection);
     var copied = original;
     var result = try copied.ingestFromSlice(allocator, "DB", "Table", "data", .{});
     defer result.deinit(allocator);
@@ -258,12 +279,12 @@ test "ManagedIngestClient shared initialization composes borrowed clients" {
     const connection = try KustoConnection.init(
         allocator,
         properties,
-        service_mock.asTransport(),
+        testRuntime(service_mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
-    var client = ManagedIngestClient.initWithConnection(connection);
+    var client = ManagedIngestClient.init(connection, null);
     defer client.deinit(allocator);
     var result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
     defer result.deinit(allocator);
@@ -286,12 +307,12 @@ test "shared connection retries replayable streaming bytes outside generic pipel
     const connection = try KustoConnection.init(
         allocator,
         properties,
-        service_mock.asTransport(),
+        testRuntime(service_mock.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
 
-    var client = StreamingIngestClient.initWithConnection(connection);
+    var client = StreamingIngestClient.init(connection);
     const result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{
         .retry = .{ .initial_delay_ms = 0 },
     });
@@ -308,7 +329,9 @@ test "StreamingIngestClient percent-encodes URL components independently" {
     defer mock.deinit();
 
     const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = StreamingIngestClient.init(conn, mock.asTransport());
+    const connection = try testConnection(allocator, conn.cluster_url, testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     var result = try client.ingestFromSlice(allocator, "DB /&?=+", "Table /&?=+", "data", .{
         .mapping_name = "Mapping /&?=+",
@@ -328,7 +351,9 @@ test "StreamingIngestClient failure" {
     defer mock.deinit();
 
     const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = StreamingIngestClient.init(conn, mock.asTransport());
+    const connection = try testConnection(allocator, conn.cluster_url, testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     const result = try client.ingestFromSlice(allocator, "DB", "Table", "bad", .{});
     try std.testing.expectEqual(IngestionStatus.failed, result.status);
@@ -341,10 +366,9 @@ test "streaming non-2xx is known not accepted" {
         \\{"error":{"code":"BadRequest","message":"Invalid data"}}
     );
     defer mock.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        mock.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(mock.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     var result = try client.ingestFromSliceResult(allocator, "DB", "Table", "bad", .{});
     defer result.deinit(allocator);
@@ -361,6 +385,7 @@ fn unexpectedTokenRequest(
     _: *core.credentials.TokenCredential,
     _: core.credentials.TokenRequestContext,
     _: core.context.Context,
+    _: core.http.HttpRuntime,
 ) anyerror!core.credentials.AccessToken {
     return error.UnexpectedTokenRequest;
 }
@@ -369,6 +394,7 @@ fn successfulTokenRequest(
     _: *core.credentials.TokenCredential,
     _: core.credentials.TokenRequestContext,
     _: core.context.Context,
+    _: core.http.HttpRuntime,
 ) anyerror!core.credentials.AccessToken {
     return .{
         .token = "shared-token",
@@ -376,32 +402,12 @@ fn successfulTokenRequest(
     };
 }
 
-test "legacy authenticated StreamingIngestClient requires shared connection" {
-    const allocator = std.testing.allocator;
-    var mock = core.http.MockTransport.init(allocator, 200, "{}");
-    defer mock.deinit();
-
-    var credential = core.credentials.TokenCredential{ .getTokenFn = &unexpectedTokenRequest };
-    const conn = ConnectionProperties{
-        .cluster_url = "https://cluster.kusto.windows.net",
-        .credential = &credential,
-    };
-    var client = StreamingIngestClient.init(conn, mock.asTransport());
-
-    try std.testing.expectError(
-        error.AuthenticatedConnectionRequired,
-        client.ingestFromSliceResult(allocator, "DB", "Table", "data", .{}),
-    );
-    try std.testing.expect(mock.last_url == null);
-}
-
 test "streaming transport failure has unknown outcome after transport entry" {
     const allocator = std.testing.allocator;
     var failing_transport = TransportFailure{};
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        failing_transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(failing_transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     var result = try client.ingestFromSliceResult(allocator, "DB", "Table", "data", .{});
     defer result.deinit(allocator);
@@ -420,10 +426,13 @@ test "streaming transport failure has unknown outcome after transport entry" {
 test "managed ingestion does not fall back after an unknown outcome" {
     const allocator = std.testing.allocator;
     var failing_transport = TransportFailure{};
-    var client = ManagedIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        failing_transport.asTransport(),
+    const connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(failing_transport.asTransport()),
     );
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
     defer client.deinit(allocator);
 
     var result = try client.ingestFromSliceResult(allocator, "DB", "Table", "data", .{});
@@ -458,8 +467,7 @@ test "QueuedIngestClient requires a resource manager" {
     var mock = core.http.MockTransport.init(allocator, 200, "{}");
     defer mock.deinit();
 
-    const conn = ConnectionProperties{ .cluster_url = "https://mycluster.eastus.kusto.windows.net" };
-    var client = QueuedIngestClient.init(conn, mock.asTransport());
+    var client = QueuedIngestClient.init(testRuntime(mock.asTransport()), .{});
     defer client.deinit(allocator);
 
     const properties = IngestionProperties{
@@ -484,8 +492,13 @@ test "ManagedIngestClient ingestFromSlice success" {
     var mock = core.http.MockTransport.init(allocator, 200, "{}");
     defer mock.deinit();
 
-    const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = ManagedIngestClient.init(conn, mock.asTransport());
+    const connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(mock.asTransport()),
+    );
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
     defer client.deinit(allocator);
 
     var result = try client.ingestFromSlice(allocator, "DB", "Table", "data", .{});
@@ -500,8 +513,13 @@ test "ManagedIngestClient no longer returns unimplemented fallback" {
     );
     defer mock.deinit();
 
-    const conn = ConnectionProperties{ .cluster_url = "https://cluster.kusto.windows.net" };
-    var client = ManagedIngestClient.init(conn, mock.asTransport());
+    const connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(mock.asTransport()),
+    );
+    defer connection.deinit();
+    var client = ManagedIngestClient.init(connection, null);
     defer client.deinit(allocator);
 
     try std.testing.expectError(

--- a/ingest/status.zig
+++ b/ingest/status.zig
@@ -157,18 +157,18 @@ pub const StatusPollOptions = struct {
 pub const SasStatusTableClient = struct {
     allocator: std.mem.Allocator,
     uri: sas.CompleteSasUri,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 
     pub fn init(
         allocator: std.mem.Allocator,
         complete_table_sas_uri: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
     ) !SasStatusTableClient {
         var uri = try sas.CompleteSasUri.init(allocator, complete_table_sas_uri);
         errdefer uri.deinit();
         if (!uri.hasAzureStorageServiceHost("table"))
             return error.UnexpectedTableSasHost;
-        return .{ .allocator = allocator, .uri = uri, .transport = transport };
+        return .{ .allocator = allocator, .uri = uri, .runtime = runtime };
     }
 
     pub fn deinit(self: *SasStatusTableClient) void {
@@ -211,7 +211,7 @@ pub const SasStatusTableClient = struct {
         try request.setHeader("Prefer", "return-no-content");
         try request.setHeader("x-ms-version", storage_api_version);
         request.body = body;
-        const outcome = try sas.send(self.transport, &request, null);
+        const outcome = try sas.send(self.runtime, &request, null);
         return switch (outcome) {
             .accepted => |value| if (value.status_code == 204)
                 outcome
@@ -237,10 +237,7 @@ pub const SasStatusTableClient = struct {
         request.retryable = false;
         request.redirect_policy = .not_allowed;
 
-        var pipeline = core.pipeline.HttpPipeline{
-            .policies = &.{},
-            .transport_impl = self.transport,
-        };
+        var pipeline = core.http.HttpPipeline.init(self.runtime, &.{});
         const operation = pipeline.open(&request, .{}) catch |err| {
             if (request.transport_started) return .{ .unknown = .{ .cause = err } };
             return err;
@@ -288,8 +285,9 @@ pub const StatusTableReadOutcome = union(enum) {
 
 /// An owned, pollable reference to the entity pre-created for an accepted
 /// queued submission. It borrows only `transport`; the manager and any Kusto
-/// connection need not remain alive after submission, but the transport must.
-/// It is single-owner and not safe for concurrent polling.
+/// connection need not remain alive after submission, but the copied runtime's
+/// borrowed transport and crypto contexts must. It is single-owner and not
+/// safe for concurrent polling.
 pub const StatusTrackingHandle = struct {
     allocator: std.mem.Allocator,
     table: SasStatusTableClient,
@@ -302,7 +300,7 @@ pub const StatusTrackingHandle = struct {
     pub fn init(
         allocator: std.mem.Allocator,
         complete_table_sas_uri: []const u8,
-        transport: *core.http.HttpTransport,
+        runtime: core.http.HttpRuntime,
         ingestion_source_id: []const u8,
         database: []const u8,
         target_table: []const u8,
@@ -310,7 +308,7 @@ pub const StatusTrackingHandle = struct {
         try validateTrackingKey(ingestion_source_id);
         var handle = StatusTrackingHandle{
             .allocator = allocator,
-            .table = try SasStatusTableClient.init(allocator, complete_table_sas_uri, transport),
+            .table = try SasStatusTableClient.init(allocator, complete_table_sas_uri, runtime),
             .partition_key = &.{},
             .row_key = &.{},
             .ingestion_source_id = &.{},
@@ -432,7 +430,11 @@ pub const StatusTrackingHandle = struct {
                         } };
                     }
                     transient_retries += 1;
-                    delay_ms = retryDelay(options, transient_retries);
+                    delay_ms = try retryDelay(
+                        options,
+                        self.table.runtime.crypto,
+                        transient_retries,
+                    );
                 },
                 .unknown => |value| {
                     // GET is idempotent: the server cannot ingest data because
@@ -445,7 +447,11 @@ pub const StatusTrackingHandle = struct {
                         } };
                     }
                     transient_retries += 1;
-                    delay_ms = retryDelay(options, transient_retries);
+                    delay_ms = try retryDelay(
+                        options,
+                        self.table.runtime.crypto,
+                        transient_retries,
+                    );
                 },
                 .malformed_response => return .{ .stopped = .{
                     .reason = .malformed_response,
@@ -640,7 +646,11 @@ fn saturatingAdd(base: i64, milliseconds: u64) i64 {
     return std.math.add(i64, base, value) catch std.math.maxInt(i64);
 }
 
-fn retryDelay(options: StatusPollOptions, retry: u32) u64 {
+fn retryDelay(
+    options: StatusPollOptions,
+    crypto_provider: core.crypto.CryptoProvider,
+    retry: u32,
+) !u64 {
     var delay = options.transient_retry_initial_delay_ms;
     var exponent: u32 = 1;
     while (exponent < retry) : (exponent += 1) {
@@ -655,11 +665,10 @@ fn retryDelay(options: StatusPollOptions, retry: u32) u64 {
     else if (options.random) |random|
         random.below(options.max_jitter_ms + 1)
     else blk: {
-        var threaded: std.Io.Threaded = .init_single_threaded;
-        var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
-        threaded.io().randomSecure(&seed) catch break :blk 0;
-        var random = std.Random.DefaultCsprng.init(seed);
-        break :blk random.random().uintLessThan(u64, options.max_jitter_ms + 1);
+        var bytes: [8]u8 = undefined;
+        try crypto_provider.randomBytes(&bytes);
+        const value = std.mem.readInt(u64, &bytes, .little);
+        break :blk value % (options.max_jitter_ms + 1);
     };
     return std.math.add(u64, delay, jitter) catch std.math.maxInt(u64);
 }
@@ -669,6 +678,12 @@ fn isTransientStorageStatus(status_code: u16) bool {
         status_code == 500 or status_code == 502 or status_code == 503 or status_code == 504;
 }
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
 test "status table initial entity uses opaque SAS without authorization" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 204, "");
@@ -676,7 +691,7 @@ test "status table initial entity uses opaque SAS without authorization" {
     var handle = try StatusTrackingHandle.init(
         allocator,
         "https://account.table.core.windows.net/status?sig=a%2Bb%3D&sp=raud",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
         "11111111-1111-4111-8111-111111111111",
         "DB",
         "Table",
@@ -717,7 +732,7 @@ test "status table reads encode reference keys without authorization" {
     var client = try SasStatusTableClient.init(
         allocator,
         "https://account.table.core.windows.net/status?sig=a%2Bb%3D&sp=r",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
     var outcome = try client.readEntity(
@@ -748,7 +763,7 @@ test "oversized status entities stop as malformed without retry classification" 
     var client = try SasStatusTableClient.init(
         allocator,
         "https://account.table.core.windows.net/status?sig=opaque",
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
     );
     defer client.deinit();
 
@@ -822,7 +837,7 @@ test "status tracking rejects unsafe SAS and status keys" {
         StatusTrackingHandle.init(
             allocator,
             "https://account.queue.core.windows.net/status?sig=x",
-            transport.asTransport(),
+            testRuntime(transport.asTransport()),
             "11111111-1111-4111-8111-111111111111",
             "DB",
             "T",
@@ -833,7 +848,7 @@ test "status tracking rejects unsafe SAS and status keys" {
         StatusTrackingHandle.init(
             allocator,
             "https://account.table.core.windows.net/status?sig=x",
-            transport.asTransport(),
+            testRuntime(transport.asTransport()),
             "not-a-status-key",
             "DB",
             "T",
@@ -853,17 +868,17 @@ const StatusPollTransport = struct {
     seams: ?*PollSeams = null,
     advance_on_send_ms: u64 = 0,
     cancel_on_send: bool = false,
-    transport: core.http.HttpTransport = .{ .sendFn = &send },
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
 
-    fn asTransport(self: *StatusPollTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn asTransport(self: *StatusPollTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     fn send(
-        transport: *core.http.HttpTransport,
+        context: *anyopaque,
         _: *core.http.Request,
     ) !core.http.Response {
-        const self: *StatusPollTransport = @alignCast(@fieldParentPtr("transport", transport));
+        const self: *StatusPollTransport = @ptrCast(@alignCast(context));
         const index = @min(self.call_count, self.steps.len - 1);
         self.call_count += 1;
         if (self.seams) |seams| {
@@ -934,12 +949,12 @@ const PollSeams = struct {
 
 fn testTrackingHandle(
     allocator: std.mem.Allocator,
-    transport: *core.http.HttpTransport,
+    runtime: core.http.HttpRuntime,
 ) !StatusTrackingHandle {
     return StatusTrackingHandle.init(
         allocator,
         "https://account.table.core.windows.net/status?sig=opaque",
-        transport,
+        runtime,
         "11111111-1111-4111-8111-111111111111",
         "DB",
         "Table",
@@ -954,7 +969,7 @@ test "status polling retries pending and transient reads with bounded jitter" {
         .{ .response = .{ .status_code = 200, .body = "{\"Status\":\"Succeeded\",\"OperationId\":\"op\"}" } },
     };
     var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-    var tracking = try testTrackingHandle(allocator, transport.asTransport());
+    var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
     defer tracking.deinit();
     var seams = PollSeams{};
     defer seams.deinit(allocator);
@@ -979,7 +994,7 @@ test "status polling retries idempotent transport ambiguity" {
         .{ .response = .{ .status_code = 200, .body = "{\"Status\":\"Failed\",\"FailureStatus\":\"Transient\"}" } },
     };
     var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-    var tracking = try testTrackingHandle(allocator, transport.asTransport());
+    var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
     defer tracking.deinit();
     var seams = PollSeams{};
     defer seams.deinit(allocator);
@@ -1004,7 +1019,7 @@ test "status polling stops on permanent auth and malformed table responses" {
             .{ .response = .{ .status_code = 403, .body = "denied" } },
         };
         var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var seams = PollSeams{};
         defer seams.deinit(allocator);
@@ -1024,7 +1039,7 @@ test "status polling stops on permanent auth and malformed table responses" {
             .{ .response = .{ .status_code = 200, .body = "{\"Status\":" } },
         };
         var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var seams = PollSeams{};
         defer seams.deinit(allocator);
@@ -1048,7 +1063,7 @@ test "status polling does not request or sleep after timeout or cancellation" {
     };
     {
         var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var seams = PollSeams{ .timeout_on_second_clock = true };
         defer seams.deinit(allocator);
@@ -1065,7 +1080,7 @@ test "status polling does not request or sleep after timeout or cancellation" {
     }
     {
         var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var seams = PollSeams{};
         defer seams.deinit(allocator);
@@ -1083,7 +1098,7 @@ test "status polling does not request or sleep after timeout or cancellation" {
     }
     {
         var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var cancellation = core.http.CancellationToken{};
         cancellation.cancel();
@@ -1101,7 +1116,7 @@ test "status polling does not request or sleep after timeout or cancellation" {
     }
     {
         var transport = StatusPollTransport{ .allocator = allocator, .steps = &steps };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var cancellation = core.http.CancellationToken{};
         var seams = PollSeams{ .cancellation = &cancellation, .cancel_on_sleep = true };
@@ -1128,7 +1143,7 @@ test "status polling does not request or sleep after timeout or cancellation" {
             .seams = &seams,
             .cancel_on_send = true,
         };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var options = seams.options();
         options.cancellation = &cancellation;
@@ -1152,7 +1167,7 @@ test "status polling does not request or sleep after timeout or cancellation" {
             .seams = &seams,
             .advance_on_send_ms = 5,
         };
-        var tracking = try testTrackingHandle(allocator, transport.asTransport());
+        var tracking = try testTrackingHandle(allocator, testRuntime(transport.asTransport()));
         defer tracking.deinit();
         var options = seams.options();
         options.timeout_ms = 5;
@@ -1185,9 +1200,13 @@ fn statusEntityAllocationTest(allocator: std.mem.Allocator) !void {
 
 fn statusHandleAllocationTest(allocator: std.mem.Allocator) !void {
     const NoopTransport = struct {
-        transport: core.http.HttpTransport = .{ .sendFn = &send },
+        const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
 
-        fn send(_: *core.http.HttpTransport, _: *core.http.Request) !core.http.Response {
+        fn asTransport(self: *@This()) core.http.HttpTransport {
+            return .{ .context = self, .vtable = &vtable };
+        }
+
+        fn send(_: *anyopaque, _: *core.http.Request) !core.http.Response {
             return error.UnexpectedRequest;
         }
     };
@@ -1195,7 +1214,7 @@ fn statusHandleAllocationTest(allocator: std.mem.Allocator) !void {
     var handle = try StatusTrackingHandle.init(
         allocator,
         "https://account.table.core.windows.net/status?sig=opaque",
-        &transport.transport,
+        testRuntime(transport.asTransport()),
         "11111111-1111-4111-8111-111111111111",
         "DB",
         "Table",

--- a/ingest/streaming.zig
+++ b/ingest/streaming.zig
@@ -211,31 +211,12 @@ pub const IngestionResult = struct {
 
 /// Direct streaming ingestion via the Kusto engine endpoint.
 pub const StreamingIngestClient = struct {
-    runtime: Runtime,
+    connection: *KustoConnection,
 
-    const Runtime = union(enum) {
-        legacy: struct {
-            connection: ConnectionProperties,
-            pipeline: core.pipeline.HttpPipeline,
-        },
-        shared: *KustoConnection,
-    };
-
-    pub fn init(
-        connection: ConnectionProperties,
-        transport: *core.http.HttpTransport,
-    ) StreamingIngestClient {
-        return .{
-            .runtime = .{ .legacy = .{
-                .connection = connection,
-                .pipeline = .{ .policies = &.{}, .transport_impl = transport },
-            } },
-        };
-    }
-
-    /// Creates a client borrowing an authenticated shared Kusto connection.
-    pub fn initWithConnection(connection: *KustoConnection) StreamingIngestClient {
-        return .{ .runtime = .{ .shared = connection } };
+    /// Copies only the connection pointer. The connection, credential, and
+    /// borrowed runtime contexts must outlive this client and every operation.
+    pub fn init(connection: *KustoConnection) StreamingIngestClient {
+        return .{ .connection = connection };
     }
 
     /// Ingests a runtime source. Service failures are logged and returned as a
@@ -280,7 +261,11 @@ pub const StreamingIngestClient = struct {
         const prepared = try prepareSource(source, options);
         try validateOptions(target, source.kind(), options, prepared.raw_size);
 
-        const logical_source_id = try makeLogicalSourceId(allocator, options.source_id);
+        const logical_source_id = try makeLogicalSourceId(
+            allocator,
+            self.connection.runtime.crypto,
+            options.source_id,
+        );
         var source_id_owned = true;
         defer if (source_id_owned) allocator.free(logical_source_id);
 
@@ -500,10 +485,7 @@ pub const StreamingIngestClient = struct {
         const encoded_table = try core.url.percentEncode(allocator, target.table);
         defer allocator.free(encoded_table);
 
-        const endpoint = switch (self.runtime) {
-            .legacy => |legacy| legacy.connection.cluster_url,
-            .shared => |connection| connection.engineUrl(),
-        };
+        const endpoint = self.connection.engineUrl();
 
         var query = std.ArrayList(u8).empty;
         defer query.deinit(allocator);
@@ -529,23 +511,9 @@ pub const StreamingIngestClient = struct {
         request: *core.http.Request,
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
-        return switch (self.runtime) {
-            .shared => |connection| connection.open(request, options),
-            .legacy => |*legacy| {
-                if (connectionHasAuthentication(legacy.connection))
-                    return error.AuthenticatedConnectionRequired;
-                return legacy.pipeline.open(request, options);
-            },
-        };
+        return self.connection.open(request, options);
     }
 };
-
-fn connectionHasAuthentication(connection: ConnectionProperties) bool {
-    return connection.credential != null or
-        connection.application_client_id != null or
-        connection.application_key != null or
-        connection.authority_id != null;
-}
 
 const PreparedSource = struct {
     raw_size: u64,
@@ -614,15 +582,16 @@ fn validateSourceId(source_id: []const u8) !void {
     }
 }
 
-fn makeLogicalSourceId(allocator: std.mem.Allocator, provided: ?[]const u8) ![]u8 {
+fn makeLogicalSourceId(
+    allocator: std.mem.Allocator,
+    crypto_provider: core.crypto.CryptoProvider,
+    provided: ?[]const u8,
+) ![]u8 {
     if (provided) |source_id| {
         try validateSourceId(source_id);
         return allocator.dupe(u8, source_id);
     }
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const timestamp = std.Io.Timestamp.now(threaded.io(), .real).toNanoseconds();
-    var prng = std.Random.DefaultPrng.init(@truncate(@as(u96, @bitCast(timestamp))));
-    const uuid = core.uuid.Uuid.init(prng.random()).toString();
+    const uuid = (try core.uuid.Uuid.init(crypto_provider)).toString();
     return allocator.dupe(u8, &uuid);
 }
 
@@ -994,14 +963,67 @@ pub fn JsonRows(comptime Row: type) type {
     };
 }
 
+var testing_crypto_provider = core.crypto.StdCryptoProvider.init(std.testing.io);
+
+fn testRuntime(transport: core.http.HttpTransport) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, testing_crypto_provider.asProvider());
+}
+
+const RoutingCryptoProvider = struct {
+    calls: usize = 0,
+    fail: bool = false,
+
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
+    };
+
+    fn provider(self: *RoutingCryptoProvider) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn randomBytes(context: *anyopaque, out: []u8) !void {
+        const self: *RoutingCryptoProvider = @ptrCast(@alignCast(context));
+        self.calls += 1;
+        if (self.fail) return error.ProviderFailure;
+        for (out, 0..) |*byte, index| byte.* = @truncate(index);
+    }
+
+    fn md5(_: *anyopaque, _: []const u8, _: *core.crypto.Md5Digest) !void {
+        return error.Unused;
+    }
+
+    fn sha256(_: *anyopaque, _: []const u8, _: *core.crypto.Sha256Digest) !void {
+        return error.Unused;
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return error.Unused;
+    }
+
+    fn sha256Init(
+        _: *anyopaque,
+        _: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        return error.Unused;
+    }
+};
+
 test "direct bytes streaming uses gzip and a stable logical source ID" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     var result = try client.ingestResult(
         allocator,
@@ -1024,6 +1046,75 @@ test "direct bytes streaming uses gzip and a stable logical source ID" {
     try std.testing.expectEqualStrings("hello streaming\n", body);
 }
 
+test "streaming source IDs use the selected provider and failures prevent transport" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
+    defer transport.deinit();
+    var crypto_provider = RoutingCryptoProvider{};
+    const runtime = core.http.HttpRuntime.init(
+        transport.asTransport(),
+        crypto_provider.provider(),
+    );
+    const connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        runtime,
+    );
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
+
+    var result = try client.ingestResult(
+        allocator,
+        .{ .database = "DB", .table = "Table" },
+        .{ .bytes = "provider" },
+        .{ .compression = .none },
+    );
+    defer result.deinit(allocator);
+    try std.testing.expectEqualStrings(
+        "00010203-0405-4607-8809-0a0b0c0d0e0f",
+        result.ok.ingestion_id.?,
+    );
+    try std.testing.expectEqual(@as(usize, 1), crypto_provider.calls);
+
+    crypto_provider.fail = true;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        client.ingestResult(
+            allocator,
+            .{ .database = "DB", .table = "Table" },
+            .{ .bytes = "provider failure" },
+            .{ .compression = .none },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 2), crypto_provider.calls);
+    try std.testing.expectEqual(@as(usize, 1), transport.call_count);
+}
+
+test "stream upload failure is reported as unknown without leaking" {
+    const allocator = std.testing.allocator;
+    var transport = core.http.MockTransport.init(allocator, 200, "{}");
+    defer transport.deinit();
+    transport.stream_fail_upload_after = 0;
+    const connection = try testConnection(
+        allocator,
+        "https://cluster.kusto.windows.net",
+        testRuntime(transport.asTransport()),
+    );
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
+
+    var result = try client.ingestResult(
+        allocator,
+        .{ .database = "DB", .table = "Table" },
+        .{ .bytes = "upload failure" },
+        .{ .compression = .none },
+    );
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(KustoOperationOutcome.unknown, result.err.outcome);
+    try std.testing.expectEqual(error.InjectedUploadFailure, result.err.transport_error.?);
+    try std.testing.expectEqual(@as(usize, 0), transport.call_count);
+}
+
 const StreamingToken = struct {
     credential: core.credentials.TokenCredential = .{ .getTokenFn = &getToken },
 
@@ -1031,6 +1122,7 @@ const StreamingToken = struct {
         _: *core.credentials.TokenCredential,
         _: core.credentials.TokenRequestContext,
         _: core.context.Context,
+        _: core.http.HttpRuntime,
     ) anyerror!core.credentials.AccessToken {
         return .{
             .token = "streaming-token",
@@ -1038,6 +1130,24 @@ const StreamingToken = struct {
         };
     }
 };
+
+var streaming_test_token = StreamingToken{};
+
+fn testConnection(
+    allocator: std.mem.Allocator,
+    cluster_url: []const u8,
+    runtime: core.http.HttpRuntime,
+) !*KustoConnection {
+    return KustoConnection.init(
+        allocator,
+        .{
+            .cluster_url = cluster_url,
+            .credential = &streaming_test_token.credential,
+        },
+        runtime,
+        .{ .metadata_mode = .disabled },
+    );
+}
 
 test "shared connections authenticate streamed reader uploads" {
     const allocator = std.testing.allocator;
@@ -1050,12 +1160,12 @@ test "shared connections authenticate streamed reader uploads" {
             .cluster_url = "https://cluster.kusto.windows.net",
             .credential = &token.credential,
         },
-        transport.asTransport(),
+        testRuntime(transport.asTransport()),
         .{ .metadata_mode = .disabled },
     );
     defer connection.deinit();
     var reader = std.Io.Reader.fixed("authenticated reader");
-    var client = StreamingIngestClient.initWithConnection(connection);
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestFromReaderResult(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -1075,10 +1185,9 @@ test "direct URI source uses typed JSON and sourceKind uri" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestResult(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -1115,10 +1224,9 @@ test "file sources are streamed through open without whole-file buffering" {
 
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestFromFileResult(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -1175,10 +1283,9 @@ test "large readers use bounded gzip working storage" {
     var source = ChunkedReader.init(bytes);
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestFromReaderResult(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -1195,10 +1302,9 @@ test "direct URL components are independently encoded" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestResult(
         allocator,
         .{ .database = "DB /&?=+", .table = "Table /&?=+" },
@@ -1216,10 +1322,9 @@ test "unsupported direct options fail before transport" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     try std.testing.expectError(
         error.StreamingExtentTagsUnsupported,
         client.ingestResult(
@@ -1236,10 +1341,9 @@ test "unsupported direct formats and required mappings fail before transport" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     try std.testing.expectError(
         error.StreamingFormatUnsupported,
         client.ingestResult(
@@ -1270,10 +1374,9 @@ test "reader sources require known raw size and are never retried" {
         "{\"error\":{\"message\":\"retry\"}}",
     );
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
 
     var result = try client.ingestResult(
         allocator,
@@ -1332,10 +1435,9 @@ test "replay factories reopen only after known retryable responses" {
         .{ .name = "Retry-After", .value = "10" },
     };
     var fixture = ReplayFixture{ .bytes = "retry body" };
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestResult(
         allocator,
         .{ .database = "DB", .table = "Table" },
@@ -1378,10 +1480,9 @@ test "payload limits and raw sizes are validated before transport" {
     const allocator = std.testing.allocator;
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     const too_large = try allocator.alloc(u8, @as(usize, @intCast(max_streaming_payload_bytes + 1)));
     defer allocator.free(too_large);
     try std.testing.expectError(
@@ -1399,10 +1500,9 @@ test "payload limits and raw sizes are validated before transport" {
 fn ingestAllocationFixture(allocator: std.mem.Allocator) !void {
     var transport = core.http.MockTransport.init(allocator, 200, "{}");
     defer transport.deinit();
-    var client = StreamingIngestClient.init(
-        .{ .cluster_url = "https://cluster.kusto.windows.net" },
-        transport.asTransport(),
-    );
+    const connection = try testConnection(allocator, "https://cluster.kusto.windows.net", testRuntime(transport.asTransport()));
+    defer connection.deinit();
+    var client = StreamingIngestClient.init(connection);
     var result = try client.ingestResult(
         allocator,
         .{ .database = "DB", .table = "Table" },


### PR DESCRIPTION
## Summary

Completes the Kusto package migration for #412 and #414:

- derives Data, streaming, managed, queued, resource, and status clients from the canonical `HttpRuntime`/current `HttpPipeline`
- removes transport-only and `initWithConnection` constructor variants
- copies runtime descriptors while preserving borrowed backend-context and open-operation lifetime contracts
- routes generated request IDs, ingestion UUIDs, status jitter, and complete-SAS Storage clients through `runtime.crypto` with no fallback
- preserves progressive/ingestion streaming cancellation, ambiguity, replay, and cleanup behavior
- bumps `azure_sdk_kusto` to `0.2.0`

## Exact dependency pins

- Core `0.3.0`: `git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41` — `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- Storage Common `0.3.0`: `git+https://github.com/cataggar/azure-sdk-for-zig.git#5291e5d7224b4d69989d403f605345d949c41db7` — `azure_sdk_storage_common-0.3.0-JzoreF0KAQDsbNtEXsub-0AZ1oiyzWJ-CGf1S5XSmQK4`
- Storage Blobs `0.3.0`: `git+https://github.com/cataggar/azure-sdk-for-zig.git#2bd2b47df464e2bd548d6aad6f5d8d425f2e74a9` — `azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d`
- Storage Queues `0.2.0`: `git+https://github.com/cataggar/azure-sdk-for-zig.git#fc0cd875afed13f246390143a83610525d3cb96d` — `azure_sdk_storage_queues-0.2.0-LKTiC_-GAADCn39zCwbaY707DVIVlEa-C-kcPSl1JWgI`

## Tests

- `zig fmt --check common data ingest root.zig build.zig`
- `zig build`
- `zig build test --summary all` — 192/192 passed
- provider-routing/failure coverage proves the selected crypto backend generates ingestion IDs and failures stop before another transport dispatch
- stream upload failure coverage preserves unknown-outcome classification without leaks

`package-check` and `package-history-check` are not defined on this package branch; both commands were attempted and reported no such build step.
