### PR TITLE
release: azure_sdk_amqp 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,13 @@ recorded but not applied: it is a threshold the peer picks, with no room for
 the annotations a broker adds on delivery, and going over detaches the link.
 Applying it would buy a tighter ceiling but not a qualitatively different one,
 since unbounded growth is already closed by your limit — and that tightening
-does not pay for tearing links down on a number the peer chose. Setting yours
-to `null` restores unlimited reassembly, which is what let a sender open a
-delivery, never end it, and grow the buffer until the process died.
+does not pay for tearing links down on a number the peer chose.
+
+Setting `max_message_size` to null or zero restores unlimited per-message
+reassembly only when `max_buffered_bytes` is also null. With a finite aggregate
+budget, that budget is advertised and enforced as the effective
+`max-message-size`, so a conforming peer is never granted credit for a legal
+message this receiver would have to reject.
 
 `max_buffered_bytes` separately bounds the aggregate payload retained in the
 ready queue and the delivery currently being reassembled. It defaults to
@@ -200,6 +204,14 @@ and remains valid until the next successful `receive`; it is still bounded by
 service's smaller message limit should set `max_message_size` accordingly:
 that both advertises the real limit and permits proportionally more of the
 requested prefetch window.
+
+Credit and delivery count are charged on the initial transfer, exactly once.
+An aborted multi-frame delivery releases its partial bytes without entering the
+ready queue, while a new delivery id arriving before the current delivery ends
+is a protocol error that terminally detaches the receiver. Any allocation
+failure after a transfer has been consumed does the same: the missing frame
+cannot be replayed, so keeping its old prefix for a later continuation would
+surface truncated data.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`
@@ -282,8 +294,11 @@ If a multi-frame send fails after its opening transfer reached the wire, the
 link is poisoned and detached best-effort. The peer is already holding an
 unterminated delivery, so starting another delivery on that link would instead
 continue the failed bytes and corrupt the protocol stream. Recovery must open a
-new sender. Link credit and delivery count are consumed when the first frame
-succeeds, while no settlement entry is created for the incomplete delivery.
+new sender. The poisoned object is terminal and must first be removed with
+`Session.closeSender`; late attach or flow frames cannot reactivate it or bind
+to a replacement with the same name. Link credit and delivery count are
+consumed when the first frame succeeds, while no settlement entry is created
+for the incomplete delivery.
 
 `abandonInFlight` is the way out of a pipeline that failed partway. Waiting is
 what just failed, so the caller cannot wait the remaining deliveries out, and a

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ active only after its `Flow` is emitted. A compliant drain response may omit
 `link-credit`; the remaining credit is then derived with serial arithmetic
 from the prior delivery limit and the reported `delivery-count`.
 
+Only a locally emitted `Flow` advances that delivery limit. A sender's incoming
+`Flow` may reconcile its view and reduce remaining credit, but `link-credit`
+from the sender can never create receiver authorization or pay down overrun
+debt.
+
 The delivery already returned to the caller is outside the aggregate budget
 and remains valid until the next successful `receive`; it is still bounded by
 `max_message_size`. Callers that know a service's smaller message limit should
@@ -368,8 +373,15 @@ until it is asked for more. `sendBytes` waits for the oldest delivery, which is
 only its own when nothing else is outstanding, so it reports
 `error.DeliveriesInFlight` rather than mixing with `sendBytesAsync` and
 attributing one delivery's verdict to another. A send that never reaches a
-verdict retires its own entry, so a timed-out send leaves the sender as usable
-as it was before.
+verdict retires its own entry. In receiver-settle-mode first that leaves the
+sender reusable; in mode second the sender terminally detaches before
+discarding an undecided id, because a late first-phase disposition would
+otherwise require an acknowledgment the sender could no longer correlate.
+
+`SenderOptions.snd_settle_mode` is negotiated through Attach and honored on
+Transfer. In sender-settled mode every transfer carries `settled = true`;
+synchronous and asynchronous sends complete after emission without retaining
+an in-flight entry or waiting for a disposition.
 
 Deliveries settle in the order they were sent, and the ring holding them is
 allocated once at attach, so a silent peer costs a fixed amount of memory rather
@@ -388,9 +400,11 @@ for the incomplete delivery.
 `abandonInFlight` is the way out of a pipeline that failed partway. Waiting is
 what just failed, so the caller cannot wait the remaining deliveries out, and a
 sender still holding unsettled ones refuses every later blocking send — without
-it a single timed-out pipeline would wedge the link for good. Any disposition
-that arrives after the abandon is ignored, so resending an abandoned delivery
-the broker went on to accept publishes it twice.
+it a single timed-out pipeline would wedge the link for good. In settlement
+mode second, abandoning any undecided delivery closes the bounded link state
+before its ids are discarded. In other modes a later disposition is ignored,
+so resending an abandoned delivery the broker went on to accept publishes it
+twice.
 
 Some of those verdicts may already be in hand, though. A disposition is recorded
 on whichever delivery the peer names, wherever it sits in the window, while

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ const receiver = try amqp.openReceiver(&session, .{
     .name = link_name,
     .source_address = "myhub/ConsumerGroups/$Default/Partitions/0",
     .max_message_size = 4 * 1024 * 1024,
+    .max_buffered_bytes = 256 * 1024 * 1024,
 }, deadline_ms);
 ```
 
@@ -181,9 +182,24 @@ does not pay for tearing links down on a number the peer chose. Setting yours
 to `null` restores unlimited reassembly, which is what let a sender open a
 delivery, never end it, and grow the buffer until the process died.
 
-This bounds one message. A receiver holds up to its outstanding credit plus
-`max_overrun` completed deliveries at once, so the memory one link can tie up
-is that product: at the default prefetch, ~600 times this.
+`max_buffered_bytes` separately bounds the aggregate payload retained in the
+ready queue and the delivery currently being reassembled. It defaults to
+256 MiB. Initial credit and every top-up are capped conservatively by the
+remaining byte budget divided by `max_message_size`, so the default 128 MiB
+message limit advertises at most two credits even though `prefetch` defaults to
+300. As deliveries leave the queue their bytes are released and credit is
+replenished. A sender that ignores credit is detached with
+`amqp:resource-limit-exceeded` before the chunk that would cross the budget is
+retained.
+
+The delivery already returned to the caller is outside the aggregate budget
+and remains valid until the next successful `receive`; it is still bounded by
+`max_message_size`. Thus the default worst case is 256 MiB buffered plus one
+128 MiB caller-held delivery, not roughly 75 GiB. Set
+`max_buffered_bytes = null` only to opt out explicitly. Callers that know a
+service's smaller message limit should set `max_message_size` accordingly:
+that both advertises the real limit and permits proportionally more of the
+requested prefetch window.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`
@@ -261,6 +277,13 @@ as it was before.
 Deliveries settle in the order they were sent, and the ring holding them is
 allocated once at attach, so a silent peer costs a fixed amount of memory rather
 than a growing one.
+
+If a multi-frame send fails after its opening transfer reached the wire, the
+link is poisoned and detached best-effort. The peer is already holding an
+unterminated delivery, so starting another delivery on that link would instead
+continue the failed bytes and corrupt the protocol stream. Recovery must open a
+new sender. Link credit and delivery count are consumed when the first frame
+succeeds, while no settlement entry is created for the incomplete delivery.
 
 `abandonInFlight` is the way out of a pipeline that failed partway. Waiting is
 what just failed, so the caller cannot wait the remaining deliveries out, and a

--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ frame is encoded, written, and flushed. An encode allocation failure therefore
 leaves the request retryable without a phantom local grant or double count; a
 write or flush failure leaves the local counters uncommitted and terminalizes
 the dirty connection instead. Drain intent follows the same rule and becomes
-active only after its `Flow` is emitted.
+active only after its `Flow` is emitted. A compliant drain response may omit
+`link-credit`; the remaining credit is then derived with serial arithmetic
+from the prior delivery limit and the reported `delivery-count`.
 
 The delivery already returned to the caller is outside the aggregate budget
 and remains valid until the next successful `receive`; it is still bounded by
@@ -229,7 +231,10 @@ A continuation may omit `delivery-id` or repeat the initial value without
 being charged again. Settlement is cumulative across the transfer sequence:
 `settled = true` on any continuation remains true when later frames omit it,
 releases the active delivery id, and is reported on the completed delivery. An
-aborted multi-frame delivery, including one that repeats the id, releases its
+already sender-settled delivery ignores `rcv-settle-mode`, including on the
+frame that first makes cumulative settlement true; unsettled deliveries still
+enforce the locally negotiated mode. An aborted multi-frame delivery, including
+one that repeats the id, releases its
 partial bytes without entering the ready queue, while a different delivery id
 arriving before the current delivery ends is a protocol error that terminally
 detaches the receiver. Any allocation
@@ -242,7 +247,9 @@ connection transport. A header or body may already be buffered, so allowing a
 later send to reuse that byte stream could flush a corrupt partial frame.
 Protocol-header and heartbeat writes follow the same rule. Likewise, an error
 after any inbound frame header byte is consumed closes the connection; an
-unread body can no longer be parsed from a known boundary.
+unread body can no longer be parsed from a known boundary. EOF and terminal
+transport read failures also close the driver and every session link when they
+arrive before any frame byte; only a zero-byte deadline remains retryable.
 
 An acknowledgement timeout after a successfully emitted SASL or AMQP protocol
 header, Open, Begin, or End is terminal at the corresponding connection/session

--- a/README.md
+++ b/README.md
@@ -380,12 +380,11 @@ otherwise require an acknowledgment the sender could no longer correlate.
 
 `SenderOptions.snd_settle_mode` is the sender's authoritative settlement mode
 and is honored on Attach and Transfer. The remote receiver's Attach field is a
-desired preference: omission or `mixed` accepts the selected local mode, while
-an opposite fixed `settled`/`unsettled` preference rejects the attach instead
-of silently changing transfer settlement. In sender-settled mode every
-transfer carries `settled = true`; synchronous and asynchronous sends complete
-after emission without retaining an in-flight entry or waiting for a
-disposition.
+desired preference only: omission, `mixed`, or an opposite fixed preference
+cannot replace the actual mode selected by this locally initiated sender. In
+sender-settled mode every transfer carries `settled = true`; synchronous and
+asynchronous sends complete after emission without retaining an in-flight
+entry or waiting for a disposition.
 
 Deliveries settle in the order they were sent, and the ring holding them is
 allocated once at attach, so a silent peer costs a fixed amount of memory rather

--- a/README.md
+++ b/README.md
@@ -191,10 +191,12 @@ ready queue and the delivery currently being reassembled. It defaults to
 256 MiB. Initial credit and every top-up are capped conservatively by the
 remaining byte budget divided by `max_message_size`, so the default 128 MiB
 message limit advertises at most two credits even though `prefetch` defaults to
-300. As deliveries leave the queue their bytes are released and credit is
-replenished. A sender that ignores credit is detached with
-`amqp:resource-limit-exceeded` before the chunk that would cross the budget is
-retained.
+300. While a multi-frame delivery is in progress, its full legal size remains
+reserved: ready bytes plus that reservation plus all outstanding credit can
+never exceed the aggregate budget. As deliveries leave the queue their bytes
+are released and credit is replenished. A sender that ignores credit is
+detached with `amqp:resource-limit-exceeded` before the chunk that would cross
+the budget is retained.
 
 The delivery already returned to the caller is outside the aggregate budget
 and remains valid until the next successful `receive`; it is still bounded by
@@ -206,12 +208,18 @@ that both advertises the real limit and permits proportionally more of the
 requested prefetch window.
 
 Credit and delivery count are charged on the initial transfer, exactly once.
-An aborted multi-frame delivery releases its partial bytes without entering the
-ready queue, while a new delivery id arriving before the current delivery ends
-is a protocol error that terminally detaches the receiver. Any allocation
+A continuation may omit `delivery-id` or repeat the initial value without
+being charged again. An aborted multi-frame delivery, including one that
+repeats the id, releases its partial bytes without entering the ready queue,
+while a different delivery id arriving before the current delivery ends is a
+protocol error that terminally detaches the receiver. Any allocation
 failure after a transfer has been consumed does the same: the missing frame
 cannot be replayed, so keeping its old prefix for a later continuation would
 surface truncated data.
+
+Any write or flush failure while emitting a frame terminally closes the
+connection transport. A header or body may already be buffered, so allowing a
+later send to reuse that byte stream could flush a corrupt partial frame.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`

--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ budget cannot safely put the whole request on the wire, the remainder is held
 and issued automatically as queued deliveries leave, so callers need not loop
 just to restate the same requested count.
 
+Credit issuance is transactional with its `Flow` frame. The prospective
+credit, deferred request, and overrun debt are committed only after the whole
+frame is encoded, written, and flushed. An encode allocation failure therefore
+leaves the request retryable without a phantom local grant or double count; a
+write or flush failure leaves the local counters uncommitted and terminalizes
+the dirty connection instead. Drain intent follows the same rule and becomes
+active only after its `Flow` is emitted.
+
 The delivery already returned to the caller is outside the aggregate budget
 and remains valid until the next successful `receive`; it is still bounded by
 `max_message_size`. Callers that know a service's smaller message limit should

--- a/README.md
+++ b/README.md
@@ -187,14 +187,15 @@ budget, that budget is advertised and enforced as the effective
 message this receiver would have to reject.
 
 `max_buffered_bytes` separately bounds the aggregate payload retained in the
-ready queue and the delivery currently being reassembled. It is unbounded by
-default so the existing 300-credit Event Hubs and Service Bus window never
-promises traffic the receiver would later reject. Set it explicitly to opt in
-to an aggregate ceiling; `default_max_buffered_bytes` provides a recommended
-256 MiB value. With a finite budget, credit is capped conservatively and a
-multi-frame delivery reserves its full legal size: ready bytes plus that
-reservation plus all outstanding credit can never exceed the aggregate
-budget. A sender that ignores the capped credit is detached with
+ready queue and the delivery currently being reassembled. The default is a
+finite 256 MiB (`default_max_buffered_bytes`); null explicitly opts out and
+makes the caller responsible for bounding retention above this layer. With a
+finite budget, credit is capped conservatively and a multi-frame delivery
+reserves its full legal size: ready bytes plus that reservation plus all
+outstanding credit can never exceed the aggregate budget. The default 128 MiB
+message limit therefore grants at most two deliveries at once. Service clients
+that know a smaller protocol maximum should set both limits explicitly to gain
+a deeper safe window. A sender that ignores the capped credit is detached with
 `amqp:resource-limit-exceeded` before the crossing chunk is retained.
 
 `issueCredit` also preserves one-shot manual receive requests. If a custom byte
@@ -204,10 +205,9 @@ just to restate the same requested count.
 
 The delivery already returned to the caller is outside the aggregate budget
 and remains valid until the next successful `receive`; it is still bounded by
-`max_message_size`. Callers that require an aggregate memory ceiling must set
-`max_buffered_bytes`; callers that know a service's smaller message limit
-should set `max_message_size` too, which permits proportionally more of the
-requested prefetch window under that ceiling.
+`max_message_size`. Callers that know a service's smaller message limit should
+set it explicitly, which permits proportionally more of the requested prefetch
+window under the aggregate ceiling.
 
 Credit and delivery count are charged on the initial transfer, exactly once.
 A continuation may omit `delivery-id` or repeat the initial value without
@@ -228,6 +228,13 @@ later send to reuse that byte stream could flush a corrupt partial frame.
 Protocol-header and heartbeat writes follow the same rule. Likewise, an error
 after any inbound frame header byte is consumed closes the connection; an
 unread body can no longer be parsed from a known boundary.
+
+An acknowledgement timeout after a successfully emitted SASL or AMQP protocol
+header, Begin, or End is terminal at the corresponding connection/session
+scope. A retry cannot emit a duplicate control onto a stream where the peer may
+already have advanced. Attach uses the same invariant: if its response does not
+arrive, the session and transport are invalidated before the half-attached
+object is destroyed, so a delayed response cannot bind a same-name replacement.
 
 Every initial transfer, including aborted and pre-settled transfers, is checked
 against unsettled delivery ids active across every receiver on the session. An
@@ -250,6 +257,14 @@ not emit a duplicate terminal frame. Later sender and receiver operations fail
 without emission. Remote Detach is acknowledged with `closed = true` and
 terminally poisons only the named link, even when the peer requested suspension
 with `closed = false`; resumable link state is not retained.
+
+Receiver settlement follows the mode negotiated on Attach. In
+receiver-settle-mode `first`, the receiver disposition carries `settled = true`
+and releases the delivery ids immediately. In mode `second`, it carries
+`settled = false`; the ids remain active until a sender-role disposition
+acknowledges the range with `settled = true`. Timeout leaves that pending state
+intact, while terminal emission failure, detach, or deinitialization releases
+it safely.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`

--- a/README.md
+++ b/README.md
@@ -378,20 +378,26 @@ sender reusable; in mode second the sender terminally detaches before
 discarding an undecided id, because a late first-phase disposition would
 otherwise require an acknowledgment the sender could no longer correlate.
 
-`SenderOptions.snd_settle_mode` is negotiated through Attach and honored on
-Transfer. In sender-settled mode every transfer carries `settled = true`;
-synchronous and asynchronous sends complete after emission without retaining
-an in-flight entry or waiting for a disposition.
+`SenderOptions.snd_settle_mode` is the sender's authoritative settlement mode
+and is honored on Attach and Transfer. The remote receiver's Attach field is a
+desired preference: omission or `mixed` accepts the selected local mode, while
+an opposite fixed `settled`/`unsettled` preference rejects the attach instead
+of silently changing transfer settlement. In sender-settled mode every
+transfer carries `settled = true`; synchronous and asynchronous sends complete
+after emission without retaining an in-flight entry or waiting for a
+disposition.
 
 Deliveries settle in the order they were sent, and the ring holding them is
 allocated once at attach, so a silent peer costs a fixed amount of memory rather
 than a growing one.
 
 If a multi-frame send fails after its opening transfer reached the wire, the
-link is poisoned and detached best-effort. The peer is already holding an
-unterminated delivery, so starting another delivery on that link would instead
-continue the failed bytes and corrupt the protocol stream. Recovery must open a
-new sender. The poisoned object is terminal and must first be removed with
+link is poisoned and detached best-effort. Cleanup is idempotent and
+scope-aware: a remote Detach is answered once, and a remote End is never
+followed by a link-level Detach. The peer is already holding an unterminated
+delivery, so starting another delivery on that link would instead continue the
+failed bytes and corrupt the protocol stream. Recovery must open a new sender.
+The poisoned object is terminal and must first be removed with
 `Session.closeSender`; late attach or flow frames cannot reactivate it or bind
 to a replacement with the same name. Link credit and delivery count are
 consumed when the first frame succeeds, while no settlement entry is created

--- a/README.md
+++ b/README.md
@@ -211,10 +211,13 @@ requested prefetch window under that ceiling.
 
 Credit and delivery count are charged on the initial transfer, exactly once.
 A continuation may omit `delivery-id` or repeat the initial value without
-being charged again. An aborted multi-frame delivery, including one that
-repeats the id, releases its partial bytes without entering the ready queue,
-while a different delivery id arriving before the current delivery ends is a
-protocol error that terminally detaches the receiver. Any allocation
+being charged again. Settlement is cumulative across the transfer sequence:
+`settled = true` on any continuation remains true when later frames omit it,
+releases the active delivery id, and is reported on the completed delivery. An
+aborted multi-frame delivery, including one that repeats the id, releases its
+partial bytes without entering the ready queue, while a different delivery id
+arriving before the current delivery ends is a protocol error that terminally
+detaches the receiver. Any allocation
 failure after a transfer has been consumed does the same: the missing frame
 cannot be replayed, so keeping its old prefix for a later continuation would
 surface truncated data.
@@ -239,9 +242,14 @@ Consumed SASL, Open, Begin, End, Close, and connection-pump controls are guarded
 the same way: decode or apply failure invalidates the driver and closes the
 transport before retry is possible. A valid remote End terminalizes its session
 and links and emits the End response; a valid remote Close responds, then
-terminalizes the connection and transport. Later sender and receiver operations
-fail without emission. Remote Detach is acknowledged and terminally poisons
-only the named link.
+terminalizes the connection and transport. Close is recognized globally before
+channel routing, on any negotiated channel. Locally emitted Close, End, and
+closing Detach enter terminal output state immediately; acknowledgement timeout
+cannot leave the connection, session, or link writable, and teardown retry does
+not emit a duplicate terminal frame. Later sender and receiver operations fail
+without emission. Remote Detach is acknowledged with `closed = true` and
+terminally poisons only the named link, even when the peer requested suspension
+with `closed = false`; resumable link state is not retained.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`

--- a/README.md
+++ b/README.md
@@ -187,14 +187,15 @@ budget, that budget is advertised and enforced as the effective
 message this receiver would have to reject.
 
 `max_buffered_bytes` separately bounds the aggregate payload retained in the
-ready queue and the delivery currently being reassembled. It defaults to
-256 MiB. The default limits preserve the existing 300-credit wire window used
-by Event Hubs and Service Bus; the byte limit is still hard, and a sender is
-detached with `amqp:resource-limit-exceeded` before a chunk that would cross it
-is retained. Custom message or aggregate limits additionally cap credit
-conservatively. While a multi-frame delivery is in progress, its full legal
-size remains reserved: ready bytes plus that reservation plus all outstanding
-credit can never exceed the custom aggregate budget.
+ready queue and the delivery currently being reassembled. It is unbounded by
+default so the existing 300-credit Event Hubs and Service Bus window never
+promises traffic the receiver would later reject. Set it explicitly to opt in
+to an aggregate ceiling; `default_max_buffered_bytes` provides a recommended
+256 MiB value. With a finite budget, credit is capped conservatively and a
+multi-frame delivery reserves its full legal size: ready bytes plus that
+reservation plus all outstanding credit can never exceed the aggregate
+budget. A sender that ignores the capped credit is detached with
+`amqp:resource-limit-exceeded` before the crossing chunk is retained.
 
 `issueCredit` also preserves one-shot manual receive requests. If a custom byte
 budget cannot safely put the whole request on the wire, the remainder is held
@@ -203,12 +204,10 @@ just to restate the same requested count.
 
 The delivery already returned to the caller is outside the aggregate budget
 and remains valid until the next successful `receive`; it is still bounded by
-`max_message_size`. Thus the default worst case is 256 MiB buffered plus one
-128 MiB caller-held delivery, not roughly 75 GiB. Set
-`max_buffered_bytes = null` only to opt out explicitly. Callers that know a
-service's smaller message limit should set `max_message_size` accordingly:
-that both advertises the real limit and permits proportionally more of the
-requested prefetch window.
+`max_message_size`. Callers that require an aggregate memory ceiling must set
+`max_buffered_bytes`; callers that know a service's smaller message limit
+should set `max_message_size` too, which permits proportionally more of the
+requested prefetch window under that ceiling.
 
 Credit and delivery count are charged on the initial transfer, exactly once.
 A continuation may omit `delivery-id` or repeat the initial value without
@@ -227,13 +226,22 @@ Protocol-header and heartbeat writes follow the same rule. Likewise, an error
 after any inbound frame header byte is consumed closes the connection; an
 unread body can no longer be parsed from a known boundary.
 
-Unsettled inbound delivery ids are unique across every receiver on a session.
-An id remains active through completion and is released only by terminal
+Every initial transfer, including aborted and pre-settled transfers, is checked
+against unsettled delivery ids active across every receiver on the session. An
+unsettled id remains active through completion and is released only by terminal
 settlement, abort, detach, error, or deinitialization. Repeating it while its
-multi-frame delivery is still in progress remains a valid continuation.
+own multi-frame delivery is still in progress remains a valid continuation.
 If a consumed disposition range cannot allocate rejection detail, every
 matching outbound delivery is still marked terminal before the connection is
 invalidated, so none can remain silently reusable or wait forever.
+
+Consumed SASL, Open, Begin, End, Close, and connection-pump controls are guarded
+the same way: decode or apply failure invalidates the driver and closes the
+transport before retry is possible. A valid remote End terminalizes its session
+and links and emits the End response; a valid remote Close responds, then
+terminalizes the connection and transport. Later sender and receiver operations
+fail without emission. Remote Detach is acknowledged and terminally poisons
+only the named link.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`

--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ and remains valid until the next successful `receive`; it is still bounded by
 set it explicitly, which permits proportionally more of the requested prefetch
 window under the aggregate ceiling.
 
+`max_unsettled_deliveries` independently bounds delivery-id bookkeeping, with
+a default of 1024. Credit reserves both payload bytes and unsettled slots, so a
+mode-second peer withholding settlement acknowledgments cannot make the
+session maps or per-link scans grow without bound after payloads leave the
+ready queue. Acknowledgments and mode-first local settlement release slots and
+replenish withheld credit.
+
 Credit and delivery count are charged on the initial transfer, exactly once.
 A continuation may omit `delivery-id` or repeat the initial value without
 being charged again. Settlement is cumulative across the transfer sequence:
@@ -230,11 +237,13 @@ after any inbound frame header byte is consumed closes the connection; an
 unread body can no longer be parsed from a known boundary.
 
 An acknowledgement timeout after a successfully emitted SASL or AMQP protocol
-header, Begin, or End is terminal at the corresponding connection/session
-scope. A retry cannot emit a duplicate control onto a stream where the peer may
-already have advanced. Attach uses the same invariant: if its response does not
-arrive, the session and transport are invalidated before the half-attached
-object is destroyed, so a delayed response cannot bind a same-name replacement.
+header, Open, Begin, or End is terminal at the corresponding connection/session
+scope. Open encoding/allocation failure after the AMQP header exchange is
+terminal too: the peer is already waiting for Open, so returning to the start
+would duplicate the header. Attach uses the same invariant: if its response
+does not arrive, the session and transport are invalidated before the
+half-attached object is destroyed, so a delayed response cannot bind a
+same-name replacement.
 
 Every initial transfer, including aborted and pre-settled transfers, is checked
 against unsettled delivery ids active across every receiver on the session. An
@@ -258,13 +267,21 @@ without emission. Remote Detach is acknowledged with `closed = true` and
 terminally poisons only the named link, even when the peer requested suspension
 with `closed = false`; resumable link state is not retained.
 
-Receiver settlement follows the mode negotiated on Attach. In
-receiver-settle-mode `first`, the receiver disposition carries `settled = true`
-and releases the delivery ids immediately. In mode `second`, it carries
-`settled = false`; the ids remain active until a sender-role disposition
-acknowledges the range with `settled = true`. Timeout leaves that pending state
-intact, while terminal emission failure, detach, or deinitialization releases
-it safely.
+Receiver settlement preserves the mode selected by the local receiver's
+Attach; the remote sender's Attach preference does not replace it. An initial
+Transfer may override a mode-second link to `first` for that delivery.
+`settleRange` records each effective mode and splits a mixed range into
+correctly settled runs. Mode first carries `settled = true` and releases ids
+immediately. Mode second carries `settled = false`; ids remain active until a
+sender-role disposition acknowledges only previously dispositioned ids with
+`settled = true`.
+
+On the outbound side, the remote receiver's Attach selects the sender's actual
+receiver-settle-mode. When mode second returns a receiver-role disposition with
+`settled = false`, the sender emits the corresponding sender-role
+`settled = true` acknowledgment before the delivery can be retired. Duplicate
+dispositions do not duplicate acknowledgments, and acknowledgment emission
+failure terminalizes the consumed-frame session.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`

--- a/README.md
+++ b/README.md
@@ -188,15 +188,18 @@ message this receiver would have to reject.
 
 `max_buffered_bytes` separately bounds the aggregate payload retained in the
 ready queue and the delivery currently being reassembled. It defaults to
-256 MiB. Initial credit and every top-up are capped conservatively by the
-remaining byte budget divided by `max_message_size`, so the default 128 MiB
-message limit advertises at most two credits even though `prefetch` defaults to
-300. While a multi-frame delivery is in progress, its full legal size remains
-reserved: ready bytes plus that reservation plus all outstanding credit can
-never exceed the aggregate budget. As deliveries leave the queue their bytes
-are released and credit is replenished. A sender that ignores credit is
-detached with `amqp:resource-limit-exceeded` before the chunk that would cross
-the budget is retained.
+256 MiB. The default limits preserve the existing 300-credit wire window used
+by Event Hubs and Service Bus; the byte limit is still hard, and a sender is
+detached with `amqp:resource-limit-exceeded` before a chunk that would cross it
+is retained. Custom message or aggregate limits additionally cap credit
+conservatively. While a multi-frame delivery is in progress, its full legal
+size remains reserved: ready bytes plus that reservation plus all outstanding
+credit can never exceed the custom aggregate budget.
+
+`issueCredit` also preserves one-shot manual receive requests. If a custom byte
+budget cannot safely put the whole request on the wire, the remainder is held
+and issued automatically as queued deliveries leave, so callers need not loop
+just to restate the same requested count.
 
 The delivery already returned to the caller is outside the aggregate budget
 and remains valid until the next successful `receive`; it is still bounded by
@@ -220,6 +223,17 @@ surface truncated data.
 Any write or flush failure while emitting a frame terminally closes the
 connection transport. A header or body may already be buffered, so allowing a
 later send to reuse that byte stream could flush a corrupt partial frame.
+Protocol-header and heartbeat writes follow the same rule. Likewise, an error
+after any inbound frame header byte is consumed closes the connection; an
+unread body can no longer be parsed from a known boundary.
+
+Unsettled inbound delivery ids are unique across every receiver on a session.
+An id remains active through completion and is released only by terminal
+settlement, abort, detach, error, or deinitialization. Repeating it while its
+multi-frame delivery is still in progress remains a valid continuation.
+If a consumed disposition range cannot allocate rejection detail, every
+matching outbound delivery is still marked terminal before the connection is
+invalidated, so none can remain silently reusable or wait forever.
 
 Settling one delivery at a time costs a frame per message, which at a 300-deep
 prefetch is 300 frames of bookkeeping. A disposition can name a `first`..`last`

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_amqp,
-    .version = "0.4.0",
+    .version = "0.5.0",
     .fingerprint = 0xe0a2f9e77f72407d,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/connection.zig
+++ b/connection.zig
@@ -638,10 +638,27 @@ pub const Driver = struct {
             .channel = channel,
         };
         const header_bytes = header.serialize();
-        try self.writeBytes(&header_bytes);
-        try self.writeBytes(body);
-        self.transport.flush() catch |e| return mapTransportError(e);
+        self.writeBytes(&header_bytes) catch |err| {
+            self.abortEmission();
+            return err;
+        };
+        self.writeBytes(body) catch |err| {
+            self.abortEmission();
+            return err;
+        };
+        self.transport.flush() catch |err| {
+            self.abortEmission();
+            return mapTransportError(err);
+        };
         self.last_sent_ms = self.clock.nowMillis();
+    }
+
+    /// Once any part of a frame emission fails, the byte stream cannot be
+    /// resumed at a frame boundary. Close it immediately so buffered header or
+    /// body bytes cannot be flushed by a later operation.
+    fn abortEmission(self: *Driver) void {
+        self.state = .err;
+        self.transport.close();
     }
 
     /// Read the next non-empty frame.

--- a/connection.zig
+++ b/connection.zig
@@ -744,7 +744,11 @@ pub const Driver = struct {
         if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
         while (true) {
             var consumed = false;
-            errdefer if (consumed) self.invalidate();
+            // A terminal transport read means the stream is gone even when no
+            // byte of this frame was buffered. Only a zero-byte deadline is
+            // retryable; once any frame byte was consumed, even timeout leaves
+            // the parser unable to resume that frame safely.
+            errdefer |err| if (consumed or err != error.Timeout) self.invalidate();
 
             var header_bytes: [frame.frame_header_size]u8 = undefined;
             try self.readExactTracked(&header_bytes, deadline_ms, &consumed);

--- a/connection.zig
+++ b/connection.zig
@@ -529,6 +529,10 @@ pub const Driver = struct {
     /// Send `close` and wait for the peer's `close`.
     pub fn close(self: *Driver, err: ?perf.AmqpError, deadline_ms: i64) ConnectionError!void {
         if (self.state == .closed) return;
+        if (self.state == .close_sent) {
+            self.terminate();
+            return error.ConnectionClosed;
+        }
         try self.sendPerformative(.amqp, 0, .{ .close = .{ .err = err } });
         self.state = .close_sent;
 
@@ -537,7 +541,10 @@ pub const Driver = struct {
                 self.terminate();
                 return;
             },
-            else => return e,
+            else => {
+                self.terminate();
+                return e;
+            },
         };
         var processed = false;
         defer if (!processed) self.invalidate();
@@ -588,11 +595,7 @@ pub const Driver = struct {
     pub fn pump(self: *Driver, deadline_ms: i64) ConnectionError!?InboundFrame {
         try self.doWork();
         const inbound = try self.receiveFrame(deadline_ms);
-        if (self.handlers.get(inbound.header.channel)) |handler| {
-            handler.onFrame(inbound.header, inbound.body);
-            return null;
-        }
-        if (inbound.header.channel == 0 and isClose(inbound.body)) {
+        if (isClose(inbound.body)) {
             var processed = false;
             defer if (!processed) self.invalidate();
             var decoded = try self.decodeBody(inbound.body);
@@ -600,6 +603,10 @@ pub const Driver = struct {
             try self.respondToRemoteClose(decoded.performative.close.err);
             processed = true;
             return error.RemoteClosed;
+        }
+        if (self.handlers.get(inbound.header.channel)) |handler| {
+            handler.onFrame(inbound.header, inbound.body);
+            return null;
         }
         return inbound;
     }
@@ -636,7 +643,8 @@ pub const Driver = struct {
         channel: u16,
         performative: perf.Performative,
     ) ConnectionError!void {
-        if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
+        if (self.state == .err or self.state == .closed or self.state == .close_sent)
+            return error.ConnectionClosed;
         var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
         defer buf.deinit();
         try perf.encode(self.allocator, performative, &buf);
@@ -650,10 +658,11 @@ pub const Driver = struct {
         channel: u16,
         body: []const u8,
     ) ConnectionError!void {
-        if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
+        if (self.state == .err or self.state == .closed or self.state == .close_sent)
+            return error.ConnectionClosed;
         const total = frame.frame_header_size + body.len;
         // Before `open` the peer has only guaranteed the spec minimum.
-        const limit: usize = if (self.state == .opened or self.state == .close_sent)
+        const limit: usize = if (self.state == .opened)
             self.remote_max_frame_size
         else
             @max(self.remote_max_frame_size, frame.min_max_frame_size);
@@ -700,7 +709,8 @@ pub const Driver = struct {
     /// Emit bytes that form one indivisible protocol unit, such as the
     /// eight-byte SASL or AMQP protocol header.
     fn emitRaw(self: *Driver, bytes: []const u8) ConnectionError!void {
-        if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
+        if (self.state == .err or self.state == .closed or self.state == .close_sent)
+            return error.ConnectionClosed;
         self.writeBytes(bytes) catch |err| {
             self.invalidate();
             return err;
@@ -1130,6 +1140,78 @@ test "a mid-session close is surfaced by pump" {
     try testing.expectError(error.RemoteClosed, driver.pump(10_000));
     try testing.expectEqualStrings("amqp:connection:forced", driver.remoteError().?.condition);
     try testing.expectEqual(State.closed, driver.state);
+}
+
+test "Close is recognized globally before registered channel routing" {
+    const Sink = struct {
+        called: bool = false,
+
+        fn handler(self: *@This()) FrameHandler {
+            return .{ .ptr = self, .onFrameFn = onFrame };
+        }
+
+        fn onFrame(ptr: *anyopaque, _: FrameHeader, _: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.called = true;
+        }
+    };
+
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try peer.pushHeader(&frame.amqp_header);
+    try peer.push(.amqp, 0, .{ .open = .{
+        .container_id = "service-bus",
+        .channel_max = 16,
+    } });
+    try peer.push(.amqp, 4, .{ .close = .{} });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    try driver.open(10_000);
+    var sink = Sink{};
+    try driver.registerChannel(4, sink.handler());
+
+    mem.clearWritten();
+    try testing.expectError(error.RemoteClosed, driver.pump(10_000));
+    try testing.expect(!sink.called);
+    try testing.expectEqual(State.closed, driver.state);
+    try testing.expect(mem.closed);
+
+    const written = mem.written().len;
+    try testing.expectError(error.ConnectionClosed, driver.sendEmptyFrame());
+    try testing.expectEqual(written, mem.written().len);
+}
+
+test "Close acknowledgement timeout closes transport and cannot emit twice" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try peer.pushHeader(&frame.amqp_header);
+    try peer.push(.amqp, 0, .{ .open = .{ .container_id = "service-bus" } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    try driver.open(10_000);
+
+    mem.clearWritten();
+    mem.starve = true;
+    try testing.expectError(error.Timeout, driver.close(null, 0));
+    try testing.expectEqual(State.closed, driver.state);
+    try testing.expect(mem.closed);
+    const written = mem.written().len;
+    try testing.expect(written > 0);
+
+    try driver.close(null, 10_000);
+    try testing.expectEqual(written, mem.written().len);
+    try testing.expectError(error.ConnectionClosed, driver.sendEmptyFrame());
+    try testing.expectEqual(written, mem.written().len);
 }
 
 test "an inbound frame past max-frame-size is rejected" {

--- a/connection.zig
+++ b/connection.zig
@@ -340,6 +340,8 @@ pub const Driver = struct {
 
         try self.exchangeHeader(&frame.amqp_header, deadline_ms);
         self.state = .header_exchanged;
+        var completed = false;
+        defer if (!completed) self.invalidate();
 
         try self.sendOpen();
         self.state = .open_sent;
@@ -355,10 +357,12 @@ pub const Driver = struct {
                 try self.applyRemoteOpen(remote);
                 self.state = .opened;
                 processed = true;
+                completed = true;
             },
             .close => |c| {
                 try self.respondToRemoteClose(c.err);
                 processed = true;
+                completed = true;
                 return error.RemoteClosed;
             },
             else => return error.UnexpectedPerformative,
@@ -1133,6 +1137,82 @@ test "a zero-byte protocol-header timeout terminalizes without duplicate emissio
         try testing.expectError(error.InvalidState, driver.open(20));
         try testing.expectEqual(written, mem.written().len);
     }
+}
+
+test "a zero-byte Open timeout terminalizes without duplicate emission" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{ .auto_advance_ms = 1 };
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try peer.pushHeader(&frame.amqp_header);
+    mem.starve = true;
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+
+    try testing.expectError(error.Timeout, driver.open(10));
+    try testing.expectEqual(State.err, driver.state);
+    try testing.expect(mem.closed);
+    const written = mem.written().len;
+    try testing.expect(written > frame.amqp_header.len);
+
+    try testing.expectError(error.InvalidState, driver.open(20));
+    try testing.expectEqual(written, mem.written().len);
+}
+
+test "Open allocation failure after header exchange terminalizes the stream" {
+    var mem = MemoryTransport.init(testing.allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{};
+    const peer = Peer{ .allocator = testing.allocator, .mem = &mem };
+    try peer.pushHeader(&frame.amqp_header);
+
+    var backing: [Driver.in_buf_len]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&backing);
+    var driver = try Driver.init(
+        fixed.allocator(),
+        mem.transport(),
+        clock.clock(),
+        test_options,
+    );
+    defer driver.deinit();
+
+    try testing.expectError(error.OutOfMemory, driver.open(10_000));
+    try testing.expectEqual(State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expectEqual(@as(usize, frame.amqp_header.len), mem.written().len);
+    try testing.expectError(error.InvalidState, driver.open(10_000));
+    try testing.expectEqual(@as(usize, frame.amqp_header.len), mem.written().len);
+}
+
+test "Open encode failure after header exchange terminalizes the stream" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try peer.pushHeader(&frame.amqp_header);
+
+    var mixed = [_]uamqp.AmqpValue{
+        .{ .uint = 1 },
+        .{ .string = "not-a-uint" },
+    };
+    const properties = [_]uamqp.MapEntry{.{
+        .key = .{ .symbol = "invalid-array" },
+        .value = .{ .array = &mixed },
+    }};
+    var options = test_options;
+    options.properties = &properties;
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), options);
+    defer driver.deinit();
+    try testing.expectError(error.MixedArrayElements, driver.open(10_000));
+    try testing.expectEqual(State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expectEqual(@as(usize, frame.amqp_header.len), mem.written().len);
+    try testing.expectError(error.InvalidState, driver.open(10_000));
+    try testing.expectEqual(@as(usize, frame.amqp_header.len), mem.written().len);
 }
 
 test "zero-byte Begin and End timeouts cannot re-emit controls" {

--- a/connection.zig
+++ b/connection.zig
@@ -376,6 +376,8 @@ pub const Driver = struct {
 
     fn runSasl(self: *Driver, deadline_ms: i64) ConnectionError!void {
         try self.exchangeHeader(&frame.sasl_header, deadline_ms);
+        var completed = false;
+        defer if (!completed) self.invalidate();
 
         {
             const inbound = try self.receiveFrame(deadline_ms);
@@ -412,15 +414,18 @@ pub const Driver = struct {
         };
         if (outcome.code != .ok) return error.SaslFailed;
         processed = true;
+        completed = true;
     }
 
     fn exchangeHeader(self: *Driver, header: *const [8]u8, deadline_ms: i64) ConnectionError!void {
         try self.emitRaw(header);
-        var consumed = false;
-        errdefer if (consumed) self.invalidate();
+        var completed = false;
+        defer if (!completed) self.invalidate();
         var received: [8]u8 = undefined;
+        var consumed = false;
         try self.readExactTracked(&received, deadline_ms, &consumed);
         if (!std.mem.eql(u8, &received, header)) return error.ProtocolMismatch;
+        completed = true;
     }
 
     fn sendOpen(self: *Driver) ConnectionError!void {
@@ -472,9 +477,9 @@ pub const Driver = struct {
             .handle_max = options.handle_max,
         } });
 
-        const inbound = try self.receiveFrame(deadline_ms);
         var processed = false;
         defer if (!processed) self.invalidate();
+        const inbound = try self.receiveFrame(deadline_ms);
         var decoded = try self.decodeBody(inbound.body);
         defer decoded.deinit();
         switch (decoded.performative) {
@@ -505,9 +510,9 @@ pub const Driver = struct {
     /// Send `end` on `channel` and wait for the peer's `end`.
     pub fn endSession(self: *Driver, channel: u16, deadline_ms: i64) ConnectionError!void {
         try self.sendPerformative(.amqp, channel, .{ .end = .{} });
-        const inbound = try self.receiveFrame(deadline_ms);
         var processed = false;
         defer if (!processed) self.invalidate();
+        const inbound = try self.receiveFrame(deadline_ms);
         var decoded = try self.decodeBody(inbound.body);
         defer decoded.deinit();
         switch (decoded.performative) {
@@ -1095,6 +1100,95 @@ test "a mismatched protocol header is rejected" {
     var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
     defer driver.deinit();
     try testing.expectError(error.ProtocolMismatch, driver.open(10_000));
+}
+
+test "a zero-byte protocol-header timeout terminalizes without duplicate emission" {
+    const Phase = enum { amqp, sasl, amqp_after_sasl };
+    inline for (std.meta.tags(Phase)) |phase| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: ManualClock = .{ .auto_advance_ms = 1 };
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        var options = test_options;
+        if (phase != .amqp) options.sasl = .anonymous;
+        if (phase == .amqp_after_sasl) {
+            try peer.pushHeader(&frame.sasl_header);
+            try peer.push(.sasl, 0, .{
+                .sasl_mechanisms = .{ .sasl_server_mechanisms = &.{"ANONYMOUS"} },
+            });
+            try peer.push(.sasl, 0, .{ .sasl_outcome = .{ .code = .ok } });
+        }
+        mem.starve = true;
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), options);
+        defer driver.deinit();
+        try testing.expectError(error.Timeout, driver.open(10));
+        try testing.expectEqual(State.err, driver.state);
+        try testing.expect(mem.closed);
+        const written = mem.written().len;
+        try testing.expect(written >= frame.amqp_header.len);
+
+        try testing.expectError(error.InvalidState, driver.open(20));
+        try testing.expectEqual(written, mem.written().len);
+    }
+}
+
+test "zero-byte Begin and End timeouts cannot re-emit controls" {
+    const Phase = enum { begin, end };
+    inline for (std.meta.tags(Phase)) |phase| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: ManualClock = .{ .auto_advance_ms = 1 };
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try peer.pushHeader(&frame.amqp_header);
+        try peer.push(.amqp, 0, .{ .open = .{ .container_id = "service-bus" } });
+        if (phase == .end) {
+            try peer.push(.amqp, 7, .{ .begin = .{
+                .remote_channel = 0,
+                .next_outgoing_id = 1,
+                .incoming_window = 100,
+                .outgoing_window = 100,
+            } });
+        }
+        mem.starve = true;
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        try driver.open(10);
+        if (phase == .end) {
+            _ = try driver.beginSession(0, .{}, 10);
+        }
+
+        mem.clearWritten();
+        const deadline = clock.millis + 10;
+        switch (phase) {
+            .begin => try testing.expectError(
+                error.Timeout,
+                driver.beginSession(0, .{}, deadline),
+            ),
+            .end => try testing.expectError(error.Timeout, driver.endSession(0, deadline)),
+        }
+        try testing.expectEqual(State.err, driver.state);
+        try testing.expect(mem.closed);
+        const written = mem.written().len;
+        try testing.expect(written > 0);
+
+        switch (phase) {
+            .begin => try testing.expectError(
+                error.InvalidState,
+                driver.beginSession(0, .{}, deadline + 10),
+            ),
+            .end => try testing.expectError(
+                error.ConnectionClosed,
+                driver.endSession(0, deadline + 10),
+            ),
+        }
+        try testing.expectEqual(written, mem.written().len);
+    }
 }
 
 test "a peer that closes with a condition surfaces it" {

--- a/connection.zig
+++ b/connection.zig
@@ -345,22 +345,24 @@ pub const Driver = struct {
         self.state = .open_sent;
 
         const inbound = try self.receiveFrame(deadline_ms);
+        var processed = false;
+        defer if (!processed) self.invalidate();
         var decoded = try self.decodeBody(inbound.body);
         defer decoded.deinit();
 
         switch (decoded.performative) {
-            .open => |remote| try self.applyRemoteOpen(remote),
+            .open => |remote| {
+                try self.applyRemoteOpen(remote);
+                self.state = .opened;
+                processed = true;
+            },
             .close => |c| {
-                try self.recordRemoteError(c.err);
-                self.state = .closed;
+                try self.respondToRemoteClose(c.err);
+                processed = true;
                 return error.RemoteClosed;
             },
-            else => {
-                self.state = .err;
-                return error.UnexpectedPerformative;
-            },
+            else => return error.UnexpectedPerformative,
         }
-        self.state = .opened;
     }
 
     fn applyRemoteOpen(self: *Driver, remote: perf.Open) ConnectionError!void {
@@ -377,6 +379,8 @@ pub const Driver = struct {
 
         {
             const inbound = try self.receiveFrame(deadline_ms);
+            var processed = false;
+            defer if (!processed) self.invalidate();
             var decoded = try self.decodeBody(inbound.body);
             defer decoded.deinit();
             const mechanisms = switch (decoded.performative) {
@@ -388,6 +392,7 @@ pub const Driver = struct {
                 if (std.mem.eql(u8, name, sasl_anonymous)) supported = true;
             }
             if (!supported) return error.SaslMechanismUnsupported;
+            processed = true;
         }
 
         try self.sendPerformative(.sasl, 0, .{ .sasl_init = .{
@@ -397,6 +402,8 @@ pub const Driver = struct {
         } });
 
         const inbound = try self.receiveFrame(deadline_ms);
+        var processed = false;
+        defer if (!processed) self.invalidate();
         var decoded = try self.decodeBody(inbound.body);
         defer decoded.deinit();
         const outcome = switch (decoded.performative) {
@@ -404,6 +411,7 @@ pub const Driver = struct {
             else => return error.UnexpectedPerformative,
         };
         if (outcome.code != .ok) return error.SaslFailed;
+        processed = true;
     }
 
     fn exchangeHeader(self: *Driver, header: *const [8]u8, deadline_ms: i64) ConnectionError!void {
@@ -465,21 +473,29 @@ pub const Driver = struct {
         } });
 
         const inbound = try self.receiveFrame(deadline_ms);
+        var processed = false;
+        defer if (!processed) self.invalidate();
         var decoded = try self.decodeBody(inbound.body);
         defer decoded.deinit();
         switch (decoded.performative) {
-            .begin => |b| return .{
-                .channel = inbound.header.channel,
-                .next_outgoing_id = b.next_outgoing_id,
-                .incoming_window = b.incoming_window,
+            .begin => |b| {
+                const remote = RemoteSession{
+                    .channel = inbound.header.channel,
+                    .next_outgoing_id = b.next_outgoing_id,
+                    .incoming_window = b.incoming_window,
+                };
+                processed = true;
+                return remote;
             },
             .close => |c| {
-                try self.recordRemoteError(c.err);
-                self.state = .closed;
+                try self.respondToRemoteClose(c.err);
+                processed = true;
                 return error.RemoteClosed;
             },
             .end => |e| {
                 try self.recordRemoteError(e.err);
+                try self.sendPerformative(.amqp, inbound.header.channel, .{ .end = .{} });
+                processed = true;
                 return error.RemoteClosed;
             },
             else => return error.UnexpectedPerformative,
@@ -490,13 +506,18 @@ pub const Driver = struct {
     pub fn endSession(self: *Driver, channel: u16, deadline_ms: i64) ConnectionError!void {
         try self.sendPerformative(.amqp, channel, .{ .end = .{} });
         const inbound = try self.receiveFrame(deadline_ms);
+        var processed = false;
+        defer if (!processed) self.invalidate();
         var decoded = try self.decodeBody(inbound.body);
         defer decoded.deinit();
         switch (decoded.performative) {
-            .end => |e| try self.recordRemoteError(e.err),
+            .end => |e| {
+                try self.recordRemoteError(e.err);
+                processed = true;
+            },
             .close => |c| {
-                try self.recordRemoteError(c.err);
-                self.state = .closed;
+                try self.respondToRemoteClose(c.err);
+                processed = true;
                 return error.RemoteClosed;
             },
             else => return error.UnexpectedPerformative,
@@ -513,18 +534,23 @@ pub const Driver = struct {
 
         const inbound = self.receiveFrame(deadline_ms) catch |e| switch (e) {
             error.ConnectionClosed => {
-                self.state = .closed;
+                self.terminate();
                 return;
             },
             else => return e,
         };
+        var processed = false;
+        defer if (!processed) self.invalidate();
         var decoded = try self.decodeBody(inbound.body);
         defer decoded.deinit();
         switch (decoded.performative) {
-            .close => |c| try self.recordRemoteError(c.err),
+            .close => |c| {
+                try self.recordRemoteError(c.err);
+                self.terminate();
+                processed = true;
+            },
             else => return error.UnexpectedPerformative,
         }
-        self.state = .closed;
     }
 
     pub fn recordRemoteError(self: *Driver, err: ?perf.AmqpError) ConnectionError!void {
@@ -532,6 +558,12 @@ pub const Driver = struct {
         const copy = try RemoteError.dupe(self.allocator, e);
         if (self.remote_error) |old| old.deinit(self.allocator);
         self.remote_error = copy;
+    }
+
+    fn respondToRemoteClose(self: *Driver, err: ?perf.AmqpError) ConnectionError!void {
+        try self.recordRemoteError(err);
+        try self.sendPerformative(.amqp, 0, .{ .close = .{} });
+        self.terminate();
     }
 
     // ── Channel routing ──
@@ -561,10 +593,12 @@ pub const Driver = struct {
             return null;
         }
         if (inbound.header.channel == 0 and isClose(inbound.body)) {
+            var processed = false;
+            defer if (!processed) self.invalidate();
             var decoded = try self.decodeBody(inbound.body);
             defer decoded.deinit();
-            try self.recordRemoteError(decoded.performative.close.err);
-            self.state = .closed;
+            try self.respondToRemoteClose(decoded.performative.close.err);
+            processed = true;
             return error.RemoteClosed;
         }
         return inbound;
@@ -654,6 +688,12 @@ pub const Driver = struct {
     /// boundary is unknown.
     pub fn invalidate(self: *Driver) void {
         self.state = .err;
+        self.transport.close();
+    }
+
+    /// Enter the clean terminal state after a valid remote or local close.
+    pub fn terminate(self: *Driver) void {
+        self.state = .closed;
         self.transport.close();
     }
 
@@ -1165,6 +1205,120 @@ test "protocol-header write and flush failures make the driver terminal" {
         mem.fail_flush = false;
         try testing.expectError(error.InvalidState, driver.open(10_000));
     }
+}
+
+test "malformed consumed SASL and Open controls make handshake retry impossible" {
+    const Phase = enum { sasl, open };
+    inline for (std.meta.tags(Phase)) |phase| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+        var options = test_options;
+
+        switch (phase) {
+            .sasl => {
+                options.sasl = .anonymous;
+                try peer.pushHeader(&frame.sasl_header);
+                try peer.pushRaw(.sasl, 0, &.{ 0x00, 0x53, 0x40 });
+            },
+            .open => {
+                try peer.pushHeader(&frame.amqp_header);
+                try peer.pushRaw(.amqp, 0, &.{ 0x00, 0x53, 0x10 });
+            },
+        }
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), options);
+        defer driver.deinit();
+        try testing.expectError(error.MalformedFrame, driver.open(10_000));
+        try testing.expectEqual(State.err, driver.state);
+        try testing.expect(mem.closed);
+
+        const writes = mem.write_count;
+        try testing.expectError(error.InvalidState, driver.open(10_000));
+        try testing.expectEqual(writes, mem.write_count);
+    }
+}
+
+test "malformed consumed Begin End and Close controls make the driver terminal" {
+    const Phase = enum { begin, end, close };
+    inline for (std.meta.tags(Phase)) |phase| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try peer.pushHeader(&frame.amqp_header);
+        try peer.push(.amqp, 0, .{ .open = .{ .container_id = "service-bus" } });
+        if (phase == .end) {
+            try peer.push(.amqp, 0, .{ .begin = .{
+                .remote_channel = 0,
+                .next_outgoing_id = 1,
+                .incoming_window = 100,
+                .outgoing_window = 100,
+            } });
+        }
+        const descriptor: u8 = switch (phase) {
+            .begin => 0x11,
+            .end => 0x17,
+            .close => 0x18,
+        };
+        try peer.pushRaw(.amqp, 0, &.{ 0x00, 0x53, descriptor });
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        try driver.open(10_000);
+
+        switch (phase) {
+            .begin => try testing.expectError(
+                error.MalformedFrame,
+                driver.beginSession(0, .{}, 10_000),
+            ),
+            .end => {
+                _ = try driver.beginSession(0, .{}, 10_000);
+                try testing.expectError(error.MalformedFrame, driver.endSession(0, 10_000));
+            },
+            .close => try testing.expectError(error.MalformedFrame, driver.close(null, 10_000)),
+        }
+        try testing.expectEqual(State.err, driver.state);
+        try testing.expect(mem.closed);
+
+        const writes = mem.write_count;
+        switch (phase) {
+            .begin => try testing.expectError(
+                error.InvalidState,
+                driver.beginSession(0, .{}, 10_000),
+            ),
+            .end => try testing.expectError(error.ConnectionClosed, driver.endSession(0, 10_000)),
+            .close => try testing.expectError(error.ConnectionClosed, driver.close(null, 10_000)),
+        }
+        try testing.expectEqual(writes, mem.write_count);
+    }
+}
+
+test "a malformed consumed Close in connection pump closes retry state" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try peer.pushHeader(&frame.amqp_header);
+    try peer.push(.amqp, 0, .{ .open = .{ .container_id = "service-bus" } });
+    try peer.pushRaw(.amqp, 0, &.{ 0x00, 0x53, 0x18 });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    try driver.open(10_000);
+    try testing.expectError(error.MalformedFrame, driver.pump(10_000));
+    try testing.expectEqual(State.err, driver.state);
+    try testing.expect(mem.closed);
+
+    const writes = mem.write_count;
+    try testing.expectError(error.ConnectionClosed, driver.pump(10_000));
+    try testing.expectEqual(writes, mem.write_count);
 }
 
 test "a keepalive is emitted before the negotiated idle deadline" {

--- a/connection.zig
+++ b/connection.zig
@@ -407,10 +407,11 @@ pub const Driver = struct {
     }
 
     fn exchangeHeader(self: *Driver, header: *const [8]u8, deadline_ms: i64) ConnectionError!void {
-        try self.writeBytes(header);
-        self.transport.flush() catch |e| return mapTransportError(e);
+        try self.emitRaw(header);
+        var consumed = false;
+        errdefer if (consumed) self.invalidate();
         var received: [8]u8 = undefined;
-        try self.readExact(&received, deadline_ms);
+        try self.readExactTracked(&received, deadline_ms, &consumed);
         if (!std.mem.eql(u8, &received, header)) return error.ProtocolMismatch;
     }
 
@@ -589,16 +590,7 @@ pub const Driver = struct {
 
     /// Write an empty frame, the AMQP heartbeat.
     pub fn sendEmptyFrame(self: *Driver) ConnectionError!void {
-        const header = FrameHeader{
-            .size = @intCast(frame.frame_header_size),
-            .doff = 2,
-            .frame_type = .amqp,
-            .channel = 0,
-        };
-        const bytes = header.serialize();
-        try self.writeBytes(&bytes);
-        self.transport.flush() catch |e| return mapTransportError(e);
-        self.last_sent_ms = self.clock.nowMillis();
+        try self.sendFrame(.amqp, 0, &.{});
     }
 
     // ── Frame IO ──
@@ -610,6 +602,7 @@ pub const Driver = struct {
         channel: u16,
         performative: perf.Performative,
     ) ConnectionError!void {
+        if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
         var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
         defer buf.deinit();
         try perf.encode(self.allocator, performative, &buf);
@@ -623,6 +616,7 @@ pub const Driver = struct {
         channel: u16,
         body: []const u8,
     ) ConnectionError!void {
+        if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
         const total = frame.frame_header_size + body.len;
         // Before `open` the peer has only guaranteed the spec minimum.
         const limit: usize = if (self.state == .opened or self.state == .close_sent)
@@ -639,26 +633,43 @@ pub const Driver = struct {
         };
         const header_bytes = header.serialize();
         self.writeBytes(&header_bytes) catch |err| {
-            self.abortEmission();
+            self.invalidate();
             return err;
         };
-        self.writeBytes(body) catch |err| {
-            self.abortEmission();
-            return err;
-        };
+        if (body.len != 0) {
+            self.writeBytes(body) catch |err| {
+                self.invalidate();
+                return err;
+            };
+        }
         self.transport.flush() catch |err| {
-            self.abortEmission();
+            self.invalidate();
             return mapTransportError(err);
         };
         self.last_sent_ms = self.clock.nowMillis();
     }
 
-    /// Once any part of a frame emission fails, the byte stream cannot be
-    /// resumed at a frame boundary. Close it immediately so buffered header or
-    /// body bytes cannot be flushed by a later operation.
-    fn abortEmission(self: *Driver) void {
+    /// Make the byte stream terminal after a partial emission or consumed
+    /// frame error. A later operation must never retry on a stream whose frame
+    /// boundary is unknown.
+    pub fn invalidate(self: *Driver) void {
         self.state = .err;
         self.transport.close();
+    }
+
+    /// Emit bytes that form one indivisible protocol unit, such as the
+    /// eight-byte SASL or AMQP protocol header.
+    fn emitRaw(self: *Driver, bytes: []const u8) ConnectionError!void {
+        if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
+        self.writeBytes(bytes) catch |err| {
+            self.invalidate();
+            return err;
+        };
+        self.transport.flush() catch |err| {
+            self.invalidate();
+            return mapTransportError(err);
+        };
+        self.last_sent_ms = self.clock.nowMillis();
     }
 
     /// Read the next non-empty frame.
@@ -671,9 +682,13 @@ pub const Driver = struct {
     /// handed, which cannot work across the protocol-header exchange that
     /// separates the SASL layer from the AMQP layer.
     pub fn receiveFrame(self: *Driver, deadline_ms: i64) ConnectionError!InboundFrame {
+        if (self.state == .err or self.state == .closed) return error.ConnectionClosed;
         while (true) {
+            var consumed = false;
+            errdefer if (consumed) self.invalidate();
+
             var header_bytes: [frame.frame_header_size]u8 = undefined;
-            try self.readExact(&header_bytes, deadline_ms);
+            try self.readExactTracked(&header_bytes, deadline_ms, &consumed);
             const header = FrameHeader.parse(&header_bytes) catch return error.MalformedFrame;
             if (header.size > self.acceptMaxFrameSize()) return error.FrameTooLarge;
 
@@ -683,7 +698,7 @@ pub const Driver = struct {
             while (skip > 0) {
                 var scratch: [64]u8 = undefined;
                 const n = @min(skip, scratch.len);
-                try self.readExact(scratch[0..n], deadline_ms);
+                try self.readExactTracked(scratch[0..n], deadline_ms, &consumed);
                 skip -= @intCast(n);
             }
 
@@ -774,6 +789,16 @@ pub const Driver = struct {
     }
 
     fn readExact(self: *Driver, dst: []u8, deadline_ms: i64) ConnectionError!void {
+        var consumed = false;
+        return self.readExactTracked(dst, deadline_ms, &consumed);
+    }
+
+    fn readExactTracked(
+        self: *Driver,
+        dst: []u8,
+        deadline_ms: i64,
+        consumed: *bool,
+    ) ConnectionError!void {
         var filled: usize = 0;
         while (filled < dst.len) {
             const available = self.buffered();
@@ -782,6 +807,7 @@ pub const Driver = struct {
                 @memcpy(dst[filled..][0..n], available[0..n]);
                 self.in_start += n;
                 filled += n;
+                consumed.* = true;
                 continue;
             }
             try self.fillMore(deadline_ms);
@@ -1115,6 +1141,32 @@ test "an outbound frame past the peer's max-frame-size is rejected" {
     try testing.expectError(error.FrameTooLarge, driver.sendFrame(.amqp, 0, body));
 }
 
+test "protocol-header write and flush failures make the driver terminal" {
+    const Failure = enum { write, flush };
+    inline for (std.meta.tags(Failure)) |failure| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: ManualClock = .{};
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        switch (failure) {
+            .write => mem.fail_write = true,
+            .flush => mem.fail_flush = true,
+        }
+        try testing.expectError(error.WriteFailed, driver.open(10_000));
+        try testing.expectEqual(State.err, driver.state);
+        try testing.expect(mem.closed);
+        try testing.expectEqual(@as(usize, 0), mem.pending.items.len);
+        try testing.expectEqual(@as(usize, 0), mem.written().len);
+
+        mem.fail_write = false;
+        mem.fail_flush = false;
+        try testing.expectError(error.InvalidState, driver.open(10_000));
+    }
+}
+
 test "a keepalive is emitted before the negotiated idle deadline" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
@@ -1146,6 +1198,43 @@ test "a keepalive is emitted before the negotiated idle deadline" {
         &.{ 0x00, 0x00, 0x00, 0x08, 0x02, 0x00, 0x00, 0x00 },
         mem.written(),
     );
+}
+
+test "heartbeat write and flush failures close the dirty byte stream" {
+    const Failure = enum { write, flush };
+    inline for (std.meta.tags(Failure)) |failure| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try peer.pushHeader(&frame.amqp_header);
+        try peer.push(.amqp, 0, .{ .open = .{
+            .container_id = "service-bus",
+            .idle_time_out = 30_000,
+        } });
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        try driver.open(10_000);
+
+        mem.clearWritten();
+        switch (failure) {
+            .write => mem.fail_write = true,
+            .flush => mem.fail_flush = true,
+        }
+        try testing.expectError(error.WriteFailed, driver.sendEmptyFrame());
+        try testing.expectEqual(State.err, driver.state);
+        try testing.expect(mem.closed);
+        try testing.expectEqual(@as(usize, 0), mem.pending.items.len);
+        try testing.expectEqual(@as(usize, 0), mem.written().len);
+
+        mem.fail_write = false;
+        mem.fail_flush = false;
+        try testing.expectError(error.ConnectionClosed, driver.sendEmptyFrame());
+        try testing.expectEqual(@as(usize, 0), mem.written().len);
+    }
 }
 
 test "a peer that goes quiet past the advertised idle timeout fails" {

--- a/link.zig
+++ b/link.zig
@@ -45,6 +45,8 @@ pub const LinkError = connection.ConnectionError || error{
     LinkNameInUse,
     /// Receiver limits cannot be represented safely on the wire.
     InvalidReceiverOptions,
+    /// An unsettled delivery id was reused before its terminal disposition.
+    DuplicateDeliveryId,
 };
 
 /// Set on a receiver so Event Hubs can name the owner in its error text.
@@ -109,6 +111,7 @@ pub const Session = struct {
     next_handle: u32 = 0,
     senders: std.ArrayList(*Sender) = .empty,
     receivers: std.ArrayList(*Receiver) = .empty,
+    incoming_deliveries: std.AutoHashMapUnmanaged(u32, *Receiver) = .empty,
 
     /// Begin a session on `channel`.
     pub fn begin(
@@ -152,6 +155,7 @@ pub const Session = struct {
         for (self.receivers.items) |r| r.deinit();
         self.senders.deinit(self.allocator);
         self.receivers.deinit(self.allocator);
+        self.incoming_deliveries.deinit(self.allocator);
         self.* = undefined;
     }
 
@@ -189,16 +193,15 @@ pub const Session = struct {
     /// is ignored, which keeps a single-session connection simple.
     pub fn pump(self: *Session, deadline_ms: i64) LinkError!bool {
         const inbound = self.driver.receiveFrame(deadline_ms) catch |err| {
-            if (err == error.OutOfMemory) self.poisonReceivingLinks();
+            if (self.driver.state == .err) self.invalidateLinks();
             return err;
         };
         if (inbound.header.channel != self.remote_channel) return false;
 
         const decoded = self.driver.decodeBodyReusing(inbound.body) catch |err| {
-            // The frame has already been consumed and cannot be replayed. If
-            // decoding it fails, no receiver can safely assume its partial
-            // prefix is still contiguous with the next transfer.
-            if (err == error.OutOfMemory) self.poisonReceivingLinks();
+            // The frame has already been consumed and cannot be replayed.
+            self.driver.invalidate();
+            self.invalidateLinks();
             return err;
         };
 
@@ -206,20 +209,25 @@ pub const Session = struct {
         // is the remainder. `bytes_consumed` is what the decoder read out of
         // `body`, so it cannot exceed it, but a corrupt length would slice out
         // of bounds rather than fail cleanly.
-        if (decoded.bytes_consumed > inbound.body.len) return error.MalformedFrame;
+        if (decoded.bytes_consumed > inbound.body.len) {
+            return self.failConsumedFrame(error.MalformedFrame);
+        }
         const payload = inbound.body[decoded.bytes_consumed..];
         switch (decoded.performative) {
-            .flow => |f| try self.applyFlow(f),
-            .disposition => |d| try self.applyDisposition(d),
-            .transfer => |t| try self.applyTransfer(t, payload),
-            .attach => |a| try self.applyAttach(a),
-            .detach => |d| try self.applyDetach(d),
+            .flow => |f| self.applyFlow(f) catch |err| return self.failConsumedFrame(err),
+            .disposition => |d| self.applyDisposition(d) catch |err| return self.failConsumedFrame(err),
+            .transfer => |t| self.applyTransfer(t, payload) catch |err| {
+                if (err == error.OutOfMemory) return self.failConsumedFrame(err);
+                return err;
+            },
+            .attach => |a| self.applyAttach(a) catch |err| return self.failConsumedFrame(err),
+            .detach => |d| self.applyDetach(d) catch |err| return self.failConsumedFrame(err),
             .end => |e| {
-                try self.driver.recordRemoteError(e.err);
+                self.driver.recordRemoteError(e.err) catch |err| return self.failConsumedFrame(err);
                 return error.RemoteClosed;
             },
             .close => |c| {
-                try self.driver.recordRemoteError(c.err);
+                self.driver.recordRemoteError(c.err) catch |err| return self.failConsumedFrame(err);
                 return error.RemoteClosed;
             },
             else => return false,
@@ -227,9 +235,63 @@ pub const Session = struct {
         return true;
     }
 
-    fn poisonReceivingLinks(self: *Session) void {
+    fn failConsumedFrame(self: *Session, err: LinkError) LinkError {
+        self.driver.invalidate();
+        self.invalidateLinks();
+        return err;
+    }
+
+    fn invalidateLinks(self: *Session) void {
+        for (self.senders.items) |sender| {
+            sender.attached = false;
+            sender.awaiting_attach = false;
+            sender.poisoned = true;
+        }
         for (self.receivers.items) |receiver| {
-            if (receiver.attached) receiver.poisonAfterConsumedTransfer();
+            receiver.attached = false;
+            receiver.awaiting_attach = false;
+            receiver.poisoned = true;
+            receiver.clearPartialAndFree();
+            self.releaseReceiverDeliveries(receiver);
+        }
+    }
+
+    fn reserveIncomingDelivery(self: *Session, receiver: *Receiver, id: u32) LinkError!void {
+        if (self.incoming_deliveries.contains(id)) return error.DuplicateDeliveryId;
+        try receiver.unsettled_ids.append(self.allocator, id);
+        errdefer _ = receiver.unsettled_ids.pop();
+        try self.incoming_deliveries.put(self.allocator, id, receiver);
+    }
+
+    fn releaseIncomingDelivery(self: *Session, receiver: *Receiver, id: u32) void {
+        if (self.incoming_deliveries.get(id) != receiver) return;
+        _ = self.incoming_deliveries.remove(id);
+        for (receiver.unsettled_ids.items, 0..) |active, i| {
+            if (active != id) continue;
+            _ = receiver.unsettled_ids.swapRemove(i);
+            return;
+        }
+    }
+
+    fn releaseReceiverDeliveries(self: *Session, receiver: *Receiver) void {
+        for (receiver.unsettled_ids.items) |id| {
+            if (self.incoming_deliveries.get(id) == receiver) {
+                _ = self.incoming_deliveries.remove(id);
+            }
+        }
+        receiver.unsettled_ids.clearRetainingCapacity();
+    }
+
+    fn releaseIncomingRange(self: *Session, receiver: *Receiver, first: u32, last: u32) void {
+        const span = last -% first;
+        if (span >= 1 << 31) return;
+        var i = receiver.unsettled_ids.items.len;
+        while (i > 0) {
+            i -= 1;
+            const id = receiver.unsettled_ids.items[i];
+            if (id -% first > span) continue;
+            _ = self.incoming_deliveries.remove(id);
+            _ = receiver.unsettled_ids.swapRemove(i);
         }
     }
 
@@ -334,7 +396,16 @@ pub const Session = struct {
         if (d.role != .receiver) return;
         const last = d.last orelse d.first;
         for (self.senders.items) |s| {
-            try s.applyDisposition(d.first, last, d.state);
+            s.applyDisposition(d.first, last, d.state) catch |err| {
+                // The disposition frame is consumed and cannot be replayed.
+                // Ensure every id in its range has a terminal outcome before
+                // the session is invalidated, including entries on senders we
+                // had not reached yet.
+                for (self.senders.items) |sender| {
+                    sender.terminalizeDispositionRange(d.first, last, d.state);
+                }
+                return err;
+            };
         }
     }
 
@@ -372,6 +443,7 @@ pub const Session = struct {
             // A detached link can still hand already completed deliveries to
             // its caller, but an in-progress one can never finish.
             r.clearPartialAndFree();
+            self.releaseReceiverDeliveries(r);
             try r.recordDetach(d.err);
         }
     }
@@ -486,6 +558,15 @@ pub const DeliveryToken = struct { id: u32 };
 /// matters — a rejection's condition — is duplicated into `Rejection` instead
 /// and reported alongside.
 pub const Outcome = enum { accepted, rejected, released, modified };
+
+fn outcomeFromDeliveryState(state: perf.DeliveryState) Outcome {
+    return switch (state) {
+        .accepted => .accepted,
+        .released => .released,
+        .modified => .modified,
+        .rejected => .rejected,
+    };
+}
 
 /// The peer's verdict on one delivery, paired with the token it answers.
 ///
@@ -714,12 +795,6 @@ pub const Sender = struct {
             if (entry.id -% first > span) continue;
 
             const decided = state orelse .accepted;
-            entry.outcome = switch (decided) {
-                .accepted => .accepted,
-                .released => .released,
-                .modified => .modified,
-                .rejected => .rejected,
-            };
             // An entry only reaches here while undecided, and an undecided
             // entry has never been given a rejection.
             std.debug.assert(entry.rejection == null);
@@ -745,6 +820,23 @@ pub const Sender = struct {
                     };
                 }
             }
+            entry.outcome = outcomeFromDeliveryState(decided);
+        }
+    }
+
+    fn terminalizeDispositionRange(
+        self: *Sender,
+        first: u32,
+        last: u32,
+        state: ?perf.DeliveryState,
+    ) void {
+        const span = last -% first;
+        if (span >= 1 << 31) return;
+        const outcome = outcomeFromDeliveryState(state orelse .accepted);
+        for (0..self.in_flight_len) |i| {
+            const entry = self.entryAt(i);
+            if (entry.outcome != null or entry.id -% first > span) continue;
+            entry.outcome = outcome;
         }
     }
 
@@ -1156,9 +1248,11 @@ pub const ReceiverOptions = struct {
     /// Aggregate payload bytes retained in completed deliveries and the
     /// delivery currently being reassembled.
     ///
-    /// Credit is capped so a conforming peer cannot fill more than this even
-    /// when every delivery reaches `max_message_size`. A peer that ignores
-    /// credit is detached before accepting the chunk that would cross it.
+    /// Custom limits cap credit so a conforming peer cannot fill more than
+    /// this even when every delivery reaches `max_message_size`. The default
+    /// limits preserve the long-standing 300-credit wire window required by
+    /// Event Hubs and Service Bus, while still detaching before retaining a
+    /// chunk that would cross this hard byte bound.
     /// The delivery already handed to the caller is outside this budget; it is
     /// bounded separately by `max_message_size` and remains valid until the
     /// next successful `receive`.
@@ -1185,11 +1279,8 @@ pub const default_max_message_size: u64 = 128 * 1024 * 1024;
 
 /// Default aggregate ceiling for payload bytes retained by one receiver.
 ///
-/// Two maximum-size deliveries fit, so Service Bus Premium's 100 MB messages
-/// retain useful read-ahead while a default receiver is bounded at 256 MiB
-/// rather than the roughly 75 GiB implied by 300 credits plus overrun. Event
-/// Hubs callers that advertise its smaller service limit get proportionally
-/// more of their requested prefetch window.
+/// Payload retention is bounded independently of the legacy 300-credit
+/// default. Custom limits additionally reserve worst-case bytes per credit.
 pub const default_max_buffered_bytes: u64 = 256 * 1024 * 1024;
 
 /// §2.7.3: an absent *or zero* `max-message-size` means no limit.
@@ -1232,6 +1323,9 @@ pub const Receiver = struct {
     /// paid off by reducing the next grant rather than by consuming messages.
     overrun: u32 = 0,
     max_overrun: u32 = 0,
+    /// Manual credit requested through `issueCredit` but not yet safe to put
+    /// on the wire under the aggregate byte budget.
+    deferred_credit: u32 = 0,
     drain: bool = false,
     delivery_count: u32 = 0,
     /// The limit declared in our `attach`; see `maxMessageSize` for the rule
@@ -1246,6 +1340,10 @@ pub const Receiver = struct {
     /// delivery handed to the caller is no longer buffered and is not counted.
     buffered_bytes: u64 = 0,
     max_buffered_bytes: ?u64 = null,
+    /// Custom limits reserve a worst-case message for every credit. The
+    /// legacy default keeps the requested 300-credit wire contract while the
+    /// aggregate limit remains a hard bound on bytes actually retained.
+    reserve_credit_bytes: bool = true,
     detach_error: ?connection.RemoteError = null,
 
     /// Bytes of the delivery currently being assembled.
@@ -1253,6 +1351,9 @@ pub const Receiver = struct {
     partial_id: ?u32 = null,
     partial_tag: std.ArrayList(u8) = .empty,
     partial_settled: bool = false,
+    /// Unsettled ids owned by this link, mirrored in the session-wide map so
+    /// reuse is rejected across every receiver on the channel.
+    unsettled_ids: std.ArrayList(u32) = .empty,
     /// Completed deliveries not yet handed to the caller.
     ///
     /// Drained with a head cursor rather than by removing the front element:
@@ -1267,11 +1368,13 @@ pub const Receiver = struct {
     current_tag: ?[]const u8 = null,
 
     pub fn deinit(self: *Receiver) void {
+        self.session.releaseReceiverDeliveries(self);
         self.allocator.free(self.name);
         if (self.detach_error) |e| e.deinit(self.allocator);
         self.releaseBuffered(self.partial.items.len);
         self.partial.deinit(self.allocator);
         self.partial_tag.deinit(self.allocator);
+        self.unsettled_ids.deinit(self.allocator);
         // Everything before `ready_head` was already handed out, so its
         // buffers belong to `current` and are freed by `releaseCurrent`.
         for (self.ready.items[self.ready_head..]) |d| {
@@ -1300,17 +1403,25 @@ pub const Receiver = struct {
     }
 
     fn clearPartialRetainingCapacity(self: *Receiver) void {
+        if (self.partial_id) |id| {
+            if (!self.partial_settled) self.session.releaseIncomingDelivery(self, id);
+        }
         self.releaseBuffered(self.partial.items.len);
         self.partial.clearRetainingCapacity();
         self.partial_tag.clearRetainingCapacity();
         self.partial_id = null;
+        self.partial_settled = false;
     }
 
     fn clearPartialAndFree(self: *Receiver) void {
+        if (self.partial_id) |id| {
+            if (!self.partial_settled) self.session.releaseIncomingDelivery(self, id);
+        }
         self.releaseBuffered(self.partial.items.len);
         self.partial.clearAndFree(self.allocator);
         self.partial_tag.clearAndFree(self.allocator);
         self.partial_id = null;
+        self.partial_settled = false;
     }
 
     /// A consumed transfer cannot be replayed. Any failure incorporating it
@@ -1321,6 +1432,7 @@ pub const Receiver = struct {
         self.awaiting_attach = false;
         self.poisoned = true;
         self.clearPartialAndFree();
+        self.session.releaseReceiverDeliveries(self);
         self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1449,6 +1561,16 @@ pub const Receiver = struct {
 
             if (t.aborted) return;
 
+            const settled = t.settled orelse false;
+            if (!settled) {
+                self.session.reserveIncomingDelivery(self, t.delivery_id.?) catch |err| {
+                    if (err == error.DuplicateDeliveryId) {
+                        self.refuseDuplicateDelivery();
+                    }
+                    return err;
+                };
+            }
+
             // A delivery that arrives whole in a single transfer — nearly all
             // Azure messages — bypasses the reassembly buffer.
             if (!t.more) {
@@ -1471,11 +1593,11 @@ pub const Receiver = struct {
                     return err;
                 };
                 errdefer self.allocator.free(tag);
-                return self.enqueue(id, tag, payload, t.settled orelse false);
+                return self.enqueue(id, tag, payload, settled);
             }
 
             self.partial_id = t.delivery_id.?;
-            self.partial_settled = t.settled orelse false;
+            self.partial_settled = settled;
             if (!self.partialReservationFits()) try self.refuseBufferLimit();
             if (t.delivery_tag) |tag| {
                 self.partial_tag.appendSlice(self.allocator, tag) catch |err| {
@@ -1553,6 +1675,7 @@ pub const Receiver = struct {
     /// Maximum credit that can be outstanding without letting a conforming
     /// sender exceed the aggregate payload budget.
     fn byteCreditCapacity(self: *const Receiver) u32 {
+        if (!self.reserve_credit_bytes) return std.math.maxInt(u32);
         const limit = self.max_buffered_bytes orelse return std.math.maxInt(u32);
         // With no per-message bound, one delivery may consume the whole
         // aggregate budget. If the configured message limit is larger than
@@ -1576,6 +1699,7 @@ pub const Receiver = struct {
     }
 
     fn partialReservationFits(self: *const Receiver) bool {
+        if (!self.reserve_credit_bytes) return true;
         const limit = self.max_buffered_bytes orelse return true;
         const message_size = self.maxMessageSize() orelse limit;
         return self.reservedBufferedBytes(message_size) <= limit;
@@ -1588,8 +1712,27 @@ pub const Receiver = struct {
     /// and forgiving the overrun.
     pub fn issueCredit(self: *Receiver, count: u32) LinkError!void {
         if (self.poisoned or !self.attached) return error.LinkDetached;
-        self.grant(self.credit +| count);
+        try self.reserveIncomingCapacity(count);
+        self.deferred_credit +|= count;
+        self.grantDeferredCredit();
         try self.session.sendFlow(self);
+    }
+
+    fn reserveIncomingCapacity(self: *Receiver, count: u32) Allocator.Error!void {
+        // Keep the common 300-credit window allocation-free per delivery
+        // without letting one caller-requested maxInt credit force a huge
+        // eager allocation.
+        const reserve_count = @min(count, 4096);
+        try self.unsettled_ids.ensureUnusedCapacity(self.allocator, @intCast(reserve_count));
+        try self.session.incoming_deliveries.ensureUnusedCapacity(self.allocator, reserve_count);
+    }
+
+    fn grantDeferredCredit(self: *Receiver) void {
+        const capacity = self.byteCreditCapacity();
+        if (self.credit >= capacity or self.deferred_credit == 0) return;
+        const issued = @min(self.deferred_credit, capacity - self.credit);
+        self.deferred_credit -= issued;
+        self.grant(self.credit + issued);
     }
 
     /// Set credit to `amount`, charging any outstanding overrun against it.
@@ -1608,6 +1751,14 @@ pub const Receiver = struct {
     /// Top prefetch credit back up once half of it has been consumed, so a
     /// prefetching receiver never stalls waiting for the caller.
     fn replenish(self: *Receiver) LinkError!void {
+        if (self.deferred_credit != 0) {
+            const before = self.credit;
+            self.grantDeferredCredit();
+            if (self.credit != before) {
+                try self.session.sendFlow(self);
+                return;
+            }
+        }
         if (self.prefetch == 0) return;
         const target = @min(self.prefetch, self.byteCreditCapacity());
         if (target == 0) return;
@@ -1662,6 +1813,7 @@ pub const Receiver = struct {
         self.awaiting_attach = false;
         self.poisoned = true;
         self.clearPartialAndFree();
+        self.session.releaseReceiverDeliveries(self);
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1682,6 +1834,7 @@ pub const Receiver = struct {
         self.awaiting_attach = false;
         self.poisoned = true;
         self.clearPartialAndFree();
+        self.session.releaseReceiverDeliveries(self);
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1693,6 +1846,24 @@ pub const Receiver = struct {
             },
         });
         return error.BufferLimitExceeded;
+    }
+
+    fn refuseDuplicateDelivery(self: *Receiver) void {
+        self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
+        self.clearPartialAndFree();
+        self.session.releaseReceiverDeliveries(self);
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{
+                .handle = self.handle,
+                .closed = true,
+                .err = .{
+                    .condition = "amqp:link:transfer-limit-exceeded",
+                    .description = "unsettled delivery-id was reused",
+                },
+            },
+        }) catch {};
     }
 
     /// Tear the link down once a peer has run too far past its credit.
@@ -1719,6 +1890,7 @@ pub const Receiver = struct {
         self.awaiting_attach = false;
         self.poisoned = true;
         self.clearPartialAndFree();
+        self.session.releaseReceiverDeliveries(self);
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1796,6 +1968,7 @@ pub const Receiver = struct {
                 .state = state,
             },
         });
+        self.session.releaseIncomingRange(self, first, last);
     }
 
     pub fn accept(self: *Receiver, delivery: Delivery) LinkError!void {
@@ -1923,7 +2096,10 @@ pub fn openReceiver(
             @max(options.prefetch, min_overrun_allowance),
         .max_message_size = max_message_size,
         .max_buffered_bytes = options.max_buffered_bytes,
+        .reserve_credit_bytes = options.max_message_size != default_max_message_size or
+            options.max_buffered_bytes != default_max_buffered_bytes,
     };
+    errdefer receiver.unsettled_ids.deinit(session.allocator);
 
     try session.receivers.append(session.allocator, receiver);
     errdefer _ = session.receivers.pop();
@@ -1974,16 +2150,18 @@ fn expectReceiverAccounting(receiver: *const Receiver) !void {
     if (receiver.partial_id == null) {
         try testing.expectEqual(@as(usize, 0), receiver.partial.items.len);
     }
-    if (receiver.max_buffered_bytes) |budget| {
-        const message_size = receiver.maxMessageSize().?;
-        const partial_reservation: u128 =
-            if (receiver.partial_id != null) message_size else 0;
-        const ready_bytes = receiver.bufferedBytes() -|
-            @as(u64, @intCast(receiver.partial.items.len));
-        const authorised: u128 = @as(u128, ready_bytes) +
-            partial_reservation +
-            @as(u128, receiver.credit) * @as(u128, message_size);
-        try testing.expect(authorised <= budget);
+    if (receiver.reserve_credit_bytes) {
+        if (receiver.max_buffered_bytes) |budget| {
+            const message_size = receiver.maxMessageSize().?;
+            const partial_reservation: u128 =
+                if (receiver.partial_id != null) message_size else 0;
+            const ready_bytes = receiver.bufferedBytes() -|
+                @as(u64, @intCast(receiver.partial.items.len));
+            const authorised: u128 = @as(u128, ready_bytes) +
+                partial_reservation +
+                @as(u128, receiver.credit) * @as(u128, message_size);
+            try testing.expect(authorised <= budget);
+        }
     }
 }
 
@@ -4199,6 +4377,7 @@ const CountingAllocator = struct {
 const SwitchAllocator = struct {
     child: Allocator,
     failing: bool = false,
+    allocations_before_failure: ?usize = null,
 
     fn allocator(self: *SwitchAllocator) Allocator {
         return .{ .ptr = self, .vtable = &.{
@@ -4211,19 +4390,19 @@ const SwitchAllocator = struct {
 
     fn alloc(ctx: *anyopaque, len: usize, a: std.mem.Alignment, ra: usize) ?[*]u8 {
         const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
-        if (self.failing) return null;
+        if (self.shouldFail()) return null;
         return self.child.rawAlloc(len, a, ra);
     }
 
     fn resize(ctx: *anyopaque, buf: []u8, a: std.mem.Alignment, new_len: usize, ra: usize) bool {
         const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
-        if (self.failing) return false;
+        if (self.shouldFail()) return false;
         return self.child.rawResize(buf, a, new_len, ra);
     }
 
     fn remap(ctx: *anyopaque, buf: []u8, a: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
         const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
-        if (self.failing) return null;
+        if (self.shouldFail()) return null;
         return self.child.rawRemap(buf, a, new_len, ra);
     }
 
@@ -4231,7 +4410,120 @@ const SwitchAllocator = struct {
         const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
         self.child.rawFree(buf, a, ra);
     }
+
+    fn shouldFail(self: *SwitchAllocator) bool {
+        if (self.failing) return true;
+        if (self.allocations_before_failure) |remaining| {
+            if (remaining == 0) return true;
+            self.allocations_before_failure = remaining - 1;
+        }
+        return false;
+    }
 };
+
+test "body-buffer OOM after a frame header invalidates the session and sender" {
+    var switching = SwitchAllocator{ .child = testing.allocator };
+    const allocator = switching.allocator();
+    var mem = MemoryTransport.init(testing.allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = testing.allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 1);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+    _ = try fixture.session.pump(10_000); // sender flow
+
+    // Larger than every handshake body, so receiveFrame consumes this frame's
+    // header and then has to grow body_buf before it can read the body.
+    try peer.pushRaw(0, "x" ** 400);
+    switching.failing = true;
+    try testing.expectError(error.OutOfMemory, fixture.session.pump(10_000));
+    switching.failing = false;
+
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expect(sender.poisoned);
+    try testing.expect(!sender.attached);
+    try testing.expectError(error.LinkDetached, sender.sendBytes("no reuse", 10_000));
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+}
+
+test "disposition range OOM terminalizes every matching in-flight delivery" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 3);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+        .max_in_flight = 3,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000); // sender flow
+    for (0..3) |_| _ = try sender.sendBytesAsync("payload", .{}, 10_000);
+
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 2,
+        .settled = true,
+        .state = .{ .rejected = .{
+            .condition = "amqp:resource-limit-exceeded",
+            .description = "rejected range",
+        } },
+    } });
+
+    // Two allocations complete the first rejection. Fail the condition copy
+    // for the second entry, after the range has already begun mutating.
+    var switching = SwitchAllocator{ .child = allocator, .allocations_before_failure = 2 };
+    sender.allocator = switching.allocator();
+    const result = fixture.session.pump(10_000);
+    sender.allocator = allocator;
+    switching.allocations_before_failure = null;
+    try testing.expectError(error.OutOfMemory, result);
+
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expect(sender.poisoned);
+    try testing.expectEqual(@as(usize, 3), sender.inFlight());
+    for (0..3) |i| {
+        try testing.expectEqual(Outcome.rejected, sender.entryAt(i).outcome.?);
+    }
+
+    // All three terminal outcomes remain drainable even though only the first
+    // rejection detail could be represented before the allocator failed.
+    for (0..3) |i| {
+        const settlement = try sender.awaitSettlement(10_000);
+        try testing.expectEqual(@as(u32, @intCast(i)), settlement.token.id);
+        try testing.expectEqual(Outcome.rejected, settlement.outcome);
+        if (i == 0) {
+            try testing.expectEqualStrings(
+                "amqp:resource-limit-exceeded",
+                settlement.rejection.?.condition,
+            );
+        } else {
+            try testing.expectEqual(@as(?Rejection, null), settlement.rejection);
+        }
+    }
+    try testing.expectError(error.LinkDetached, sender.sendBytes("no reuse", 10_000));
+}
 
 test "the window this endpoint advertises slides forward with what it receives" {
     // A peer computes its own capacity from `next-incoming-id +
@@ -6659,10 +6951,10 @@ test "a receiver is bounded by default" {
     }, 10_000);
     try testing.expectEqual(default_max_message_size, receiver.maxMessageSize().?);
     try testing.expectEqual(default_max_buffered_bytes, receiver.max_buffered_bytes.?);
-    // Two worst-case messages fit in the default aggregate budget, so the
-    // requested prefetch of 300 is advertised as two rather than reserving
-    // roughly 38 GiB before overrun is considered.
-    try testing.expectEqual(@as(u32, 2), receiver.credit);
+    // Existing Event Hubs and Service Bus consumers rely on the requested
+    // default window. Retained payload is still hard-capped at 256 MiB.
+    try testing.expectEqual(@as(u32, 300), receiver.credit);
+    try testing.expect(!receiver.reserve_credit_bytes);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
@@ -6677,7 +6969,7 @@ test "a receiver is bounded by default" {
     try testing.expectEqual(@as(usize, 1), flows.len);
     var flow = try perf.decode(allocator, flows[0]);
     defer flow.deinit();
-    try testing.expectEqual(@as(u32, 2), flow.performative.flow.link_credit.?);
+    try testing.expectEqual(@as(u32, 300), flow.performative.flow.link_credit.?);
 }
 
 test "a finite aggregate budget is also the advertised per-message ceiling" {
@@ -6886,6 +7178,59 @@ test "an in-progress delivery reserves its remaining maximum before credit top-u
     try receiver.issueCredit(1);
     try testing.expectEqual(@as(u32, 1), receiver.credit);
     try expectReceiverAccounting(receiver);
+}
+
+test "one bounded manual credit request is issued repeatedly until satisfied" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    for (0..5) |i| {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = @intCast(i),
+            .delivery_tag = "t",
+            .settled = true,
+        }, "1234567890");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 10,
+        .max_buffered_bytes = 20,
+    }, 10_000);
+
+    // Event Hubs and Service Bus request a whole receive count once. Only two
+    // maximum-sized deliveries may be outstanding, but the remaining request
+    // is remembered and reissued as bounded queue space becomes available.
+    try receiver.issueCredit(300);
+    try testing.expectEqual(@as(u32, 2), receiver.credit);
+    try testing.expectEqual(@as(u32, 298), receiver.deferred_credit);
+
+    for (0..5) |i| {
+        const delivery = try receiver.receive(10_000);
+        try testing.expectEqual(@as(u32, @intCast(i)), delivery.id);
+        try testing.expectEqualStrings("1234567890", delivery.payload);
+        try expectReceiverAccounting(receiver);
+    }
+    try testing.expect(receiver.attached);
+    try testing.expect(receiver.deferred_credit < 298);
 }
 
 test "a credit-ignoring sender cannot cross the aggregate buffered budget" {
@@ -7120,6 +7465,7 @@ test "continuations may repeat the original delivery id without consuming credit
     try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
     try testing.expectEqual(@as(u32, 0), receiver.credit);
     try expectReceiverAccounting(receiver);
+    try testing.expect(fixture.session.incoming_deliveries.contains(7));
 
     const delivery = try receiver.receive(10_000);
     try testing.expectEqual(@as(u32, 7), delivery.id);
@@ -7173,7 +7519,155 @@ test "an aborted continuation may repeat the original delivery id" {
     try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
     try testing.expectEqual(@as(?u32, null), receiver.partial_id);
     try testing.expect(receiver.attached);
+    try testing.expect(!fixture.session.incoming_deliveries.contains(3));
     try expectReceiverAccounting(receiver);
+}
+
+test "a completed unsettled delivery id cannot be reused on the same link" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    for (0..2) |_| {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = 7,
+            .delivery_tag = "t",
+        }, "payload");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 2,
+        .max_message_size = 16,
+        .max_buffered_bytes = 32,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expect(fixture.session.incoming_deliveries.contains(7));
+    try testing.expectError(error.DuplicateDeliveryId, fixture.session.pump(10_000));
+    try testing.expect(receiver.poisoned);
+    try testing.expect(!receiver.attached);
+    try testing.expect(!fixture.session.incoming_deliveries.contains(7));
+}
+
+test "an unsettled delivery id cannot be reused across receiver links" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    inline for (.{ "first", "second" }, 0..) |name, handle| {
+        try peer.push(0, .{ .attach = .{
+            .name = name,
+            .handle = handle,
+            .role = .sender,
+            .initial_delivery_count = 0,
+        } });
+    }
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 9,
+        .delivery_tag = "a",
+    }, "first");
+    try peer.pushTransfer(0, .{
+        .handle = 1,
+        .delivery_id = 9,
+        .delivery_tag = "b",
+    }, "duplicate");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const first = try openReceiver(&fixture.session, .{
+        .name = "first",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+    const second = try openReceiver(&fixture.session, .{
+        .name = "second",
+        .source_address = "partition/1",
+        .prefetch = 1,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(first, fixture.session.incoming_deliveries.get(9).?);
+    try testing.expectError(error.DuplicateDeliveryId, fixture.session.pump(10_000));
+    try testing.expect(first.attached);
+    try testing.expect(second.poisoned);
+    try testing.expectEqual(first, fixture.session.incoming_deliveries.get(9).?);
+}
+
+test "a delivery id may be reused after terminal settlement" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 5,
+        .delivery_tag = "a",
+    }, "first");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 2,
+        .max_message_size = 16,
+        .max_buffered_bytes = 32,
+    }, 10_000);
+
+    const first = try receiver.receive(10_000);
+    try testing.expect(fixture.session.incoming_deliveries.contains(5));
+    try receiver.accept(first);
+    try testing.expect(!fixture.session.incoming_deliveries.contains(5));
+
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 5,
+        .delivery_tag = "b",
+    }, "second");
+    const second = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 5), second.id);
+    try testing.expectEqualStrings("second", second.payload);
+    try testing.expect(fixture.session.incoming_deliveries.contains(5));
 }
 
 test "a new delivery id cannot replace an unfinished delivery or bypass credit" {
@@ -7287,9 +7781,11 @@ test "allocation failure after a consumed continuation poisons the receiver" {
     try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
     try expectReceiverAccounting(receiver);
 
-    // The later continuation is consumed as a straggler for the dead link,
-    // never combined with the old prefix or surfaced as a delivery.
-    _ = try fixture.session.pump(10_000);
+    // The consumed frame cannot be replayed, so the whole connection is
+    // terminal and the unread continuation is never parsed as a new frame.
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expectError(error.ConnectionClosed, fixture.session.pump(10_000));
     try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
     try expectReceiverAccounting(receiver);
     try testing.expectError(error.LinkDetached, receiver.receive(10_000));
@@ -7335,11 +7831,13 @@ test "a remote detach releases an in-progress delivery's budget" {
 
     _ = try fixture.session.pump(10_000);
     try testing.expectEqual(@as(u64, 10), receiver.bufferedBytes());
+    try testing.expect(fixture.session.incoming_deliveries.contains(0));
     try expectReceiverAccounting(receiver);
     _ = try fixture.session.pump(10_000);
     try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
     try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
     try testing.expect(!receiver.attached);
+    try testing.expect(!fixture.session.incoming_deliveries.contains(0));
     try expectReceiverAccounting(receiver);
 }
 

--- a/link.zig
+++ b/link.zig
@@ -162,11 +162,9 @@ pub const Session = struct {
 
     /// End the session on the wire.
     pub fn end(self: *Session, deadline_ms: i64) LinkError!void {
-        self.driver.endSession(self.channel, deadline_ms) catch |err| {
-            if (self.driver.state == .err) self.terminate();
-            return err;
-        };
+        if (self.ended) return error.LinkDetached;
         self.terminate();
+        try self.driver.endSession(self.channel, deadline_ms);
     }
 
     /// Detach one sender and drop it from the session.
@@ -202,9 +200,7 @@ pub const Session = struct {
             if (self.driver.state == .err) self.terminate();
             return err;
         };
-        if (inbound.header.channel == 0 and
-            perf.peekDescriptor(inbound.body) == perf.descriptor.close)
-        {
+        if (perf.peekDescriptor(inbound.body) == perf.descriptor.close) {
             const decoded = self.driver.decodeBodyReusing(inbound.body) catch |err|
                 return self.failConsumedFrame(err);
             const c = decoded.performative.close;
@@ -472,7 +468,7 @@ pub const Session = struct {
             try s.recordDetach(d.err);
             if (respond) {
                 try self.driver.sendPerformative(.amqp, self.channel, .{
-                    .detach = .{ .handle = s.handle, .closed = d.closed },
+                    .detach = .{ .handle = s.handle, .closed = true },
                 });
             }
             return;
@@ -489,7 +485,7 @@ pub const Session = struct {
             try r.recordDetach(d.err);
             if (respond) {
                 try self.driver.sendPerformative(.amqp, self.channel, .{
-                    .detach = .{ .handle = r.handle, .closed = d.closed },
+                    .detach = .{ .handle = r.handle, .closed = true },
                 });
             }
         }
@@ -790,11 +786,18 @@ pub const Sender = struct {
     /// the link is detached either way, and reporting an error would make a
     /// caller tearing down think it had to retry.
     pub fn detach(self: *Sender, deadline_ms: i64) LinkError!void {
-        if (self.poisoned or !self.attached or self.session.ended) return error.LinkDetached;
-        self.detach_sent = true;
-        try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+        if (self.poisoned or !self.attached or self.detach_sent or self.session.ended)
+            return error.LinkDetached;
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{ .handle = self.handle, .closed = true },
-        });
+        }) catch |err| {
+            if (self.session.driver.state == .err) {
+                self.attached = false;
+                self.poisoned = true;
+            }
+            return err;
+        };
+        self.detach_sent = true;
         while (self.attached) {
             _ = self.session.pump(deadline_ms) catch |e| switch (e) {
                 error.RemoteClosed, error.ConnectionClosed => return,
@@ -902,7 +905,8 @@ pub const Sender = struct {
         options: SendOptions,
         deadline_ms: i64,
     ) LinkError!void {
-        if (self.poisoned or !self.attached) return error.LinkDetached;
+        if (self.poisoned or !self.attached or self.detach_sent or self.session.ended)
+            return error.LinkDetached;
         const payload = try message.encodeAlloc(self.allocator, msg);
         defer self.allocator.free(payload);
         try self.sendBytesWithOptions(payload, options, deadline_ms);
@@ -921,7 +925,8 @@ pub const Sender = struct {
         options: SendOptions,
         deadline_ms: i64,
     ) LinkError!void {
-        if (self.poisoned or !self.attached) return error.LinkDetached;
+        if (self.poisoned or !self.attached or self.detach_sent or self.session.ended)
+            return error.LinkDetached;
         // This call waits for the oldest delivery, so it is only waiting for
         // its own if nothing else is outstanding. Mixing it with
         // `sendBytesAsync` would either report another delivery's verdict as
@@ -976,7 +981,8 @@ pub const Sender = struct {
         options: SendOptions,
         deadline_ms: i64,
     ) LinkError!DeliveryToken {
-        if (self.poisoned or !self.attached) return error.LinkDetached;
+        if (self.poisoned or !self.attached or self.detach_sent or self.session.ended)
+            return error.LinkDetached;
         if (self.maxMessageSize()) |limit| {
             if (payload.len > limit) return error.MessageTooLarge;
         }
@@ -1591,6 +1597,15 @@ pub const Receiver = struct {
                     return error.MalformedFrame;
                 }
             }
+            // Settlement may be asserted on any transfer in the delivery.
+            // Once true it is terminal and remains true when later frames
+            // omit the field.
+            if (t.settled orelse false) {
+                if (!self.partial_settled) {
+                    self.partial_settled = true;
+                    self.session.releaseIncomingDelivery(self, partial_id);
+                }
+            }
             if (t.aborted) {
                 self.clearPartialAndFree();
                 return;
@@ -1759,7 +1774,8 @@ pub const Receiver = struct {
     /// this one, so credit stays a running authorisation rather than resetting
     /// and forgiving the overrun.
     pub fn issueCredit(self: *Receiver, count: u32) LinkError!void {
-        if (self.poisoned or !self.attached) return error.LinkDetached;
+        if (self.poisoned or !self.attached or self.detach_sent or self.session.ended)
+            return error.LinkDetached;
         try self.reserveIncomingCapacity(count);
         self.deferred_credit +|= count;
         self.grantDeferredCredit();
@@ -1956,7 +1972,7 @@ pub const Receiver = struct {
     ///
     /// The returned slices stay valid until the next `receive`.
     pub fn receive(self: *Receiver, deadline_ms: i64) LinkError!Delivery {
-        if (self.session.ended) return error.LinkDetached;
+        if (self.session.ended or self.detach_sent) return error.LinkDetached;
         while (self.ready.items.len == self.ready_head) {
             if (!self.attached) return error.LinkDetached;
             try self.replenish();
@@ -2008,7 +2024,8 @@ pub const Receiver = struct {
         last: u32,
         state: perf.DeliveryState,
     ) LinkError!void {
-        if (self.session.ended or self.poisoned or !self.attached) return error.LinkDetached;
+        if (self.session.ended or self.poisoned or !self.attached or self.detach_sent)
+            return error.LinkDetached;
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .disposition = .{
                 .role = .receiver,
@@ -2031,7 +2048,8 @@ pub const Receiver = struct {
 
     /// Drain outstanding credit so the peer reports what it has left.
     pub fn drainCredit(self: *Receiver, deadline_ms: i64) LinkError!void {
-        if (self.session.ended or self.poisoned or !self.attached) return error.LinkDetached;
+        if (self.session.ended or self.poisoned or !self.attached or self.detach_sent)
+            return error.LinkDetached;
         self.drain = true;
         try self.session.sendFlow(self);
         // The sender answers a drain by advancing its delivery count over the
@@ -2048,11 +2066,18 @@ pub const Receiver = struct {
 
     /// Detach the link, waiting for the peer's detach.
     pub fn detach(self: *Receiver, deadline_ms: i64) LinkError!void {
-        if (self.session.ended or self.poisoned or !self.attached) return error.LinkDetached;
-        self.detach_sent = true;
-        try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+        if (self.session.ended or self.poisoned or !self.attached or self.detach_sent)
+            return error.LinkDetached;
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{ .handle = self.handle, .closed = true },
-        });
+        }) catch |err| {
+            if (self.session.driver.state == .err) {
+                self.attached = false;
+                self.poisoned = true;
+            }
+            return err;
+        };
+        self.detach_sent = true;
         while (self.attached) {
             _ = self.session.pump(deadline_ms) catch |e| switch (e) {
                 error.RemoteClosed, error.ConnectionClosed => return,
@@ -2662,7 +2687,7 @@ test "remote End and Close terminalize the session before returning" {
         } });
         switch (case) {
             .end => try peer.push(0, .{ .end = .{} }),
-            .close => try peer.push(0, .{ .close = .{} }),
+            .close => try peer.push(7, .{ .close = .{} }),
         }
 
         var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
@@ -2741,6 +2766,121 @@ test "a malformed consumed End response terminalizes the local session" {
     const writes = mem.write_count;
     try testing.expectError(error.LinkDetached, sender.sendBytes("blocked", 10_000));
     try testing.expectEqual(writes, mem.write_count);
+}
+
+test "End acknowledgement timeout leaves the session terminal without duplicate output" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 1);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+    _ = try fixture.session.pump(10_000); // sender flow
+
+    mem.clearWritten();
+    mem.starve = true;
+    try testing.expectError(error.Timeout, fixture.session.end(0));
+    try testing.expect(fixture.session.ended);
+    try testing.expect(sender.poisoned);
+    const written = mem.written().len;
+    try testing.expect(written > 0);
+
+    try testing.expectError(error.LinkDetached, fixture.session.end(10_000));
+    try testing.expectError(error.LinkDetached, sender.sendBytes("blocked", 10_000));
+    try testing.expectEqual(written, mem.written().len);
+}
+
+test "Detach acknowledgement timeout blocks transfer flow disposition and retry output" {
+    const Case = enum { sender, receiver };
+    inline for (std.meta.tags(Case)) |case| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        switch (case) {
+            .sender => {
+                try peer.push(0, .{ .attach = .{
+                    .name = "link",
+                    .handle = 0,
+                    .role = .receiver,
+                    .initial_delivery_count = 0,
+                } });
+                try peer.push(0, .{ .flow = .{
+                    .next_incoming_id = 0,
+                    .incoming_window = 1000,
+                    .next_outgoing_id = 1,
+                    .outgoing_window = 1000,
+                    .handle = 0,
+                    .delivery_count = 0,
+                    .link_credit = 1,
+                } });
+            },
+            .receiver => try peer.push(0, .{ .attach = .{
+                .name = "link",
+                .handle = 0,
+                .role = .sender,
+                .initial_delivery_count = 0,
+            } }),
+        }
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        mem.clearWritten();
+        mem.starve = true;
+        switch (case) {
+            .sender => {
+                const sender = try openSender(&fixture.session, .{
+                    .name = "link",
+                    .target_address = "entity",
+                }, 10_000);
+                _ = try fixture.session.pump(10_000); // sender flow
+                mem.clearWritten();
+                try testing.expectError(error.Timeout, sender.detach(0));
+                try testing.expect(sender.detach_sent);
+                const written = mem.written().len;
+                try testing.expect(written > 0);
+                try testing.expectError(error.LinkDetached, sender.detach(10_000));
+                try testing.expectError(error.LinkDetached, sender.sendBytes("blocked", 10_000));
+                try testing.expectEqual(written, mem.written().len);
+            },
+            .receiver => {
+                const receiver = try openReceiver(&fixture.session, .{
+                    .name = "link",
+                    .source_address = "entity",
+                    .prefetch = 0,
+                }, 10_000);
+                mem.clearWritten();
+                try testing.expectError(error.Timeout, receiver.detach(0));
+                try testing.expect(receiver.detach_sent);
+                const written = mem.written().len;
+                try testing.expect(written > 0);
+                try testing.expectError(error.LinkDetached, receiver.detach(10_000));
+                try testing.expectError(error.LinkDetached, receiver.issueCredit(1));
+                try testing.expectError(
+                    error.LinkDetached,
+                    receiver.settleRange(0, 0, .accepted),
+                );
+                try testing.expectEqual(written, mem.written().len);
+            },
+        }
+    }
 }
 
 test "a delivery carries the requested message format" {
@@ -7679,12 +7819,72 @@ test "continuations may repeat the original delivery id without consuming credit
     try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
     try testing.expectEqual(@as(u32, 0), receiver.credit);
     try expectReceiverAccounting(receiver);
-    try testing.expect(fixture.session.incoming_deliveries.contains(7));
+    try testing.expect(!fixture.session.incoming_deliveries.contains(7));
 
     const delivery = try receiver.receive(10_000);
     try testing.expectEqual(@as(u32, 7), delivery.id);
     try testing.expectEqualStrings("first-second-third", delivery.payload);
     try testing.expectEqualStrings("tag", delivery.tag);
+    try testing.expect(delivery.settled);
+}
+
+test "continuation settlement accumulates true and omission preserves state" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 20,
+        .delivery_tag = "a",
+        .more = true,
+    }, "a");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .settled = true,
+        .more = true,
+    }, "b");
+    try peer.pushTransfer(0, .{ .handle = 0 }, "c");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 21,
+        .delivery_tag = "b",
+        .more = true,
+    }, "x");
+    try peer.pushTransfer(0, .{ .handle = 0 }, "y");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 2,
+        .max_message_size = 16,
+        .max_buffered_bytes = 32,
+    }, 10_000);
+
+    for (0..5) |_| _ = try fixture.session.pump(10_000);
+    try testing.expect(!fixture.session.incoming_deliveries.contains(20));
+    try testing.expect(fixture.session.incoming_deliveries.contains(21));
+
+    const settled = try receiver.receive(10_000);
+    try testing.expectEqualStrings("abc", settled.payload);
+    try testing.expect(settled.settled);
+    const unsettled = try receiver.receive(10_000);
+    try testing.expectEqualStrings("xy", unsettled.payload);
+    try testing.expect(!unsettled.settled);
 }
 
 test "an aborted continuation may repeat the original delivery id" {
@@ -8118,6 +8318,75 @@ test "a remote detach releases an in-progress delivery's budget" {
     const detaches = try frames.of(allocator, perf.descriptor.detach);
     defer allocator.free(detaches);
     try testing.expectEqual(@as(usize, 1), detaches.len);
+}
+
+test "a remote non-closing Detach is answered closed and cannot resume the poisoned link" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 4,
+        .delivery_tag = "t",
+        .more = true,
+    }, "prefix");
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = false,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 2,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expect(fixture.session.incoming_deliveries.contains(4));
+    mem.clearWritten();
+    _ = try fixture.session.pump(10_000);
+    try testing.expect(receiver.poisoned);
+    try testing.expect(!fixture.session.incoming_deliveries.contains(4));
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const detaches = try frames.of(allocator, perf.descriptor.detach);
+    defer allocator.free(detaches);
+    try testing.expectEqual(@as(usize, 1), detaches.len);
+    var decoded = try perf.decode(allocator, detaches[0]);
+    defer decoded.deinit();
+    try testing.expect(decoded.performative.detach.closed);
+
+    _ = try fixture.session.pump(10_000); // late attach is ignored
+    try testing.expect(receiver.poisoned);
+    try testing.expect(!receiver.attached);
+    try testing.expectEqual(@as(u32, 0), receiver.remote_handle);
+    const written = mem.written().len;
+    try testing.expectError(error.LinkDetached, receiver.issueCredit(1));
+    try testing.expectEqual(written, mem.written().len);
 }
 
 test "one receiver exhausting its budget does not block another link" {

--- a/link.zig
+++ b/link.zig
@@ -824,9 +824,10 @@ pub const Sender = struct {
     /// already unsettled. Blocking instead would deadlock: only the caller
     /// can retire a delivery, and it cannot do so from inside this call.
     ///
-    /// If a continuation fails after the opening frame was written, the link
-    /// is poisoned and later sends return `error.LinkDetached`; recovery must
-    /// open a new sender.
+    /// If emitting any transfer frame fails, or if a continuation cannot be
+    /// emitted after the opening frame succeeded, the link is poisoned and
+    /// later sends return `error.LinkDetached`; recovery must open a new
+    /// connection or sender as appropriate.
     pub fn sendBytesAsync(
         self: *Sender,
         payload: []const u8,
@@ -857,7 +858,8 @@ pub const Sender = struct {
             first_budget;
         var begun = false;
         var complete = false;
-        errdefer if (begun and !complete) self.poisonPartialDelivery();
+        errdefer if ((begun or self.session.driver.state == .err) and !complete)
+            self.poisonPartialDelivery();
 
         while (first or offset < payload.len) {
             const budget = if (first) first_budget else cont_budget;
@@ -1421,13 +1423,22 @@ pub const Receiver = struct {
     }
 
     fn acceptTransfer(self: *Receiver, t: perf.Transfer, chunk: []const u8) LinkError!void {
-        const starts = t.delivery_id != null;
-        if (starts) {
-            // Deliveries cannot interleave on one link. Silently replacing the
-            // prefix let a peer send repeated `more=true` delivery ids without
-            // consuming credit and made the final continuation name whichever
-            // prefix happened to survive.
-            if (self.partial_id != null) {
+        if (self.partial_id) |partial_id| {
+            // §2.7.5 permits continuations to omit delivery-id or repeat the
+            // original value. Only a different id attempts to interleave a
+            // new delivery and is terminal.
+            if (t.delivery_id) |id| {
+                if (id != partial_id) {
+                    self.poisonAfterConsumedTransfer();
+                    return error.MalformedFrame;
+                }
+            }
+            if (t.aborted) {
+                self.clearPartialAndFree();
+                return;
+            }
+        } else {
+            if (t.delivery_id == null) {
                 self.poisonAfterConsumedTransfer();
                 return error.MalformedFrame;
             }
@@ -1465,20 +1476,12 @@ pub const Receiver = struct {
 
             self.partial_id = t.delivery_id.?;
             self.partial_settled = t.settled orelse false;
+            if (!self.partialReservationFits()) try self.refuseBufferLimit();
             if (t.delivery_tag) |tag| {
                 self.partial_tag.appendSlice(self.allocator, tag) catch |err| {
                     self.poisonAfterConsumedTransfer();
                     return err;
                 };
-            }
-        } else {
-            if (self.partial_id == null) {
-                self.poisonAfterConsumedTransfer();
-                return error.MalformedFrame;
-            }
-            if (t.aborted) {
-                self.clearPartialAndFree();
-                return;
             }
         }
 
@@ -1551,14 +1554,31 @@ pub const Receiver = struct {
     /// sender exceed the aggregate payload budget.
     fn byteCreditCapacity(self: *const Receiver) u32 {
         const limit = self.max_buffered_bytes orelse return std.math.maxInt(u32);
-        if (self.buffered_bytes >= limit) return 0;
-        const free = limit - self.buffered_bytes;
         // With no per-message bound, one delivery may consume the whole
         // aggregate budget. If the configured message limit is larger than
         // the aggregate budget, the aggregate limit remains authoritative.
         const reservation = @min(self.maxMessageSize() orelse limit, limit);
         if (reservation == 0) return 0;
+        const reserved = self.reservedBufferedBytes(reservation);
+        if (reserved >= limit) return 0;
+        const free = limit - reserved;
         return @intCast(@min(free / reservation, std.math.maxInt(u32)));
+    }
+
+    /// Ready deliveries consume their actual size. An in-progress delivery
+    /// reserves its full legal size: its current prefix plus the maximum
+    /// remaining continuation bytes. Consuming one credit and creating this
+    /// reservation are therefore a lossless exchange for a conforming peer.
+    fn reservedBufferedBytes(self: *const Receiver, message_size: u64) u64 {
+        const partial_bytes: u64 = @intCast(self.partial.items.len);
+        const ready_bytes = self.buffered_bytes -| partial_bytes;
+        return ready_bytes +| if (self.partial_id != null) message_size else 0;
+    }
+
+    fn partialReservationFits(self: *const Receiver) bool {
+        const limit = self.max_buffered_bytes orelse return true;
+        const message_size = self.maxMessageSize() orelse limit;
+        return self.reservedBufferedBytes(message_size) <= limit;
     }
 
     /// Grant `count` more credit to the peer.
@@ -1954,6 +1974,17 @@ fn expectReceiverAccounting(receiver: *const Receiver) !void {
     if (receiver.partial_id == null) {
         try testing.expectEqual(@as(usize, 0), receiver.partial.items.len);
     }
+    if (receiver.max_buffered_bytes) |budget| {
+        const message_size = receiver.maxMessageSize().?;
+        const partial_reservation: u128 =
+            if (receiver.partial_id != null) message_size else 0;
+        const ready_bytes = receiver.bufferedBytes() -|
+            @as(u64, @intCast(receiver.partial.items.len));
+        const authorised: u128 = @as(u128, ready_bytes) +
+            partial_reservation +
+            @as(u128, receiver.credit) * @as(u128, message_size);
+        try testing.expect(authorised <= budget);
+    }
 }
 
 test "a sender attaches and reports the peer's max-message-size" {
@@ -2236,6 +2267,59 @@ test "a socket failure after the first frame poisons the sender" {
     const before = mem.written().len;
     try testing.expectError(error.LinkDetached, sender.sendBytesAsync("new", .{}, 10_000));
     try testing.expectEqual(before, mem.written().len);
+}
+
+test "an opening frame emission failure closes the transport and poisons the sender" {
+    const Failure = enum { header, body, flush };
+    inline for (std.meta.tags(Failure)) |failure| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptSenderAttach(peer, 5);
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        const sender = try openSender(&fixture.session, .{
+            .name = "producer",
+            .target_address = "eh",
+        }, 10_000);
+
+        mem.clearWritten();
+        switch (failure) {
+            .header => mem.fail_write_after = mem.write_count,
+            .body => mem.fail_write_after = mem.write_count + 1,
+            .flush => mem.fail_flush = true,
+        }
+        try testing.expectError(
+            error.WriteFailed,
+            sender.sendBytesAsync("opening frame", .{}, 10_000),
+        );
+
+        try testing.expectEqual(connection.State.err, driver.state);
+        try testing.expect(mem.closed);
+        try testing.expectEqual(@as(usize, 0), mem.pending.items.len);
+        try testing.expectEqual(@as(usize, 0), mem.written().len);
+        try testing.expect(sender.poisoned);
+        try testing.expect(!sender.attached);
+        try testing.expectEqual(@as(u32, 0), sender.delivery_count);
+        try testing.expectEqual(@as(u32, 5), sender.credit);
+        try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+        mem.fail_write_after = null;
+        mem.fail_flush = false;
+        try testing.expectError(
+            error.LinkDetached,
+            sender.sendBytesAsync("must not be reused", .{}, 10_000),
+        );
+        try testing.expectEqual(@as(usize, 0), mem.pending.items.len);
+        try testing.expectEqual(@as(usize, 0), mem.written().len);
+    }
 }
 
 test "a poisoned sender ignores late attach and must be removed before replacement" {
@@ -6729,6 +6813,81 @@ test "aggregate budget caps credit and replenishes as deliveries leave the queue
     try testing.expectEqual(@as(u32, 3), decoded.performative.flow.link_credit.?);
 }
 
+test "an in-progress delivery reserves its remaining maximum before credit top-up" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "t",
+        .more = true,
+    }, "1");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .settled = true,
+    }, "234567890");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 2,
+        .max_message_size = 10,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+    // Only one maximum-sized delivery initially fits.
+    try testing.expectEqual(@as(u32, 1), receiver.credit);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 1), receiver.bufferedBytes());
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try expectReceiverAccounting(receiver);
+
+    // The one-byte prefix still reserves all ten bytes that this delivery may
+    // legally reach, leaving only six bytes: not enough for another credit.
+    mem.clearWritten();
+    try receiver.issueCredit(1);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try expectReceiverAccounting(receiver);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u32, 0), decoded.performative.flow.link_credit.?);
+
+    // Continuations consume no additional link credit, so the conforming peer
+    // can complete the already authorised delivery.
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("1234567890", delivery.payload);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+
+    // Once the completed delivery leaves the queue, its reservation is
+    // released and a new maximum-sized delivery can be authorised.
+    try receiver.issueCredit(1);
+    try testing.expectEqual(@as(u32, 1), receiver.credit);
+    try expectReceiverAccounting(receiver);
+}
+
 test "a credit-ignoring sender cannot cross the aggregate buffered budget" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
@@ -6789,7 +6948,7 @@ test "a credit-ignoring sender cannot cross the aggregate buffered budget" {
     );
 }
 
-test "aggregate budget releases an in-progress delivery when it is exceeded" {
+test "aggregate budget rejects an unreserved in-progress delivery before retaining it" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -6831,15 +6990,20 @@ test "aggregate budget releases an in-progress delivery when it is exceeded" {
     }, 10_000);
 
     _ = try fixture.session.pump(10_000);
-    _ = try fixture.session.pump(10_000);
-    try testing.expectEqual(@as(u64, 13), receiver.bufferedBytes());
-    try expectReceiverAccounting(receiver);
     try testing.expectError(error.BufferLimitExceeded, fixture.session.pump(10_000));
     try testing.expectEqual(@as(u64, 8), receiver.bufferedBytes());
     try testing.expectEqual(@as(usize, 1), receiver.ready.items.len);
     try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
+    try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 1), receiver.overrun);
     try expectReceiverAccounting(receiver);
     try testing.expect(!receiver.attached);
+
+    // The continuation for the rejected delivery is discarded as a straggler
+    // and cannot change the retained accounting.
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 8), receiver.bufferedBytes());
+    try expectReceiverAccounting(receiver);
 }
 
 test "an aborted multi-frame delivery consumes credit once and is not queued" {
@@ -6904,6 +7068,112 @@ test "an aborted multi-frame delivery consumes credit once and is not queued" {
     const delivery = try receiver.receive(10_000);
     try testing.expectEqual(@as(u32, 1), delivery.id);
     try testing.expectEqualStrings("good", delivery.payload);
+}
+
+test "continuations may repeat the original delivery id without consuming credit" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 7,
+        .delivery_tag = "tag",
+        .more = true,
+    }, "first-");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 7,
+        .more = true,
+    }, "second-");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 7,
+        .settled = true,
+    }, "third");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 32,
+        .max_buffered_bytes = 32,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    _ = try fixture.session.pump(10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try expectReceiverAccounting(receiver);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 7), delivery.id);
+    try testing.expectEqualStrings("first-second-third", delivery.payload);
+    try testing.expectEqualStrings("tag", delivery.tag);
+}
+
+test "an aborted continuation may repeat the original delivery id" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 3,
+        .delivery_tag = "a",
+        .more = true,
+    }, "prefix");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 3,
+        .aborted = true,
+    }, "ignored");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+    try testing.expectEqual(@as(?u32, null), receiver.partial_id);
+    try testing.expect(receiver.attached);
+    try expectReceiverAccounting(receiver);
 }
 
 test "a new delivery id cannot replace an unfinished delivery or bypass credit" {

--- a/link.zig
+++ b/link.zig
@@ -41,6 +41,10 @@ pub const LinkError = connection.ConnectionError || error{
     /// A blocking `send` was attempted while pipelined deliveries were still
     /// outstanding. Retire them with `awaitSettlement` first.
     DeliveriesInFlight,
+    /// Another live or poisoned link already owns this name.
+    LinkNameInUse,
+    /// Receiver limits cannot be represented safely on the wire.
+    InvalidReceiverOptions,
 };
 
 /// Set on a receiver so Event Hubs can name the owner in its error text.
@@ -184,10 +188,19 @@ pub const Session = struct {
     /// Returns true when the frame was consumed. A frame for another channel
     /// is ignored, which keeps a single-session connection simple.
     pub fn pump(self: *Session, deadline_ms: i64) LinkError!bool {
-        const inbound = try self.driver.receiveFrame(deadline_ms);
+        const inbound = self.driver.receiveFrame(deadline_ms) catch |err| {
+            if (err == error.OutOfMemory) self.poisonReceivingLinks();
+            return err;
+        };
         if (inbound.header.channel != self.remote_channel) return false;
 
-        const decoded = try self.driver.decodeBodyReusing(inbound.body);
+        const decoded = self.driver.decodeBodyReusing(inbound.body) catch |err| {
+            // The frame has already been consumed and cannot be replayed. If
+            // decoding it fails, no receiver can safely assume its partial
+            // prefix is still contiguous with the next transfer.
+            if (err == error.OutOfMemory) self.poisonReceivingLinks();
+            return err;
+        };
 
         // The decode above already measured the performative, so the payload
         // is the remainder. `bytes_consumed` is what the decoder read out of
@@ -212,6 +225,12 @@ pub const Session = struct {
             else => return false,
         }
         return true;
+    }
+
+    fn poisonReceivingLinks(self: *Session) void {
+        for (self.receivers.items) |receiver| {
+            if (receiver.attached) receiver.poisonAfterConsumedTransfer();
+        }
     }
 
     // A handle in an inbound frame is scoped to the peer that sent it
@@ -322,19 +341,21 @@ pub const Session = struct {
     fn applyAttach(self: *Session, a: perf.Attach) LinkError!void {
         // Match by link name: the peer echoes it and picks its own handle.
         for (self.senders.items) |s| {
-            if (std.mem.eql(u8, s.name, a.name)) {
+            if (s.awaiting_attach and !s.poisoned and std.mem.eql(u8, s.name, a.name)) {
                 s.remote_handle = a.handle;
                 s.max_message_size = a.max_message_size;
                 if (a.initial_delivery_count) |c| s.delivery_count = c;
                 s.attached = true;
+                s.awaiting_attach = false;
                 return;
             }
         }
         for (self.receivers.items) |r| {
-            if (std.mem.eql(u8, r.name, a.name)) {
+            if (r.awaiting_attach and !r.poisoned and std.mem.eql(u8, r.name, a.name)) {
                 r.remote_handle = a.handle;
                 r.peer_max_message_size = a.max_message_size;
                 r.attached = true;
+                r.awaiting_attach = false;
                 return;
             }
         }
@@ -518,6 +539,8 @@ pub const Sender = struct {
     handle: u32,
     remote_handle: u32 = std.math.maxInt(u32),
     attached: bool = false,
+    awaiting_attach: bool = true,
+    poisoned: bool = false,
 
     credit: u32 = 0,
     drain: bool = false,
@@ -737,6 +760,7 @@ pub const Sender = struct {
         options: SendOptions,
         deadline_ms: i64,
     ) LinkError!void {
+        if (self.poisoned or !self.attached) return error.LinkDetached;
         const payload = try message.encodeAlloc(self.allocator, msg);
         defer self.allocator.free(payload);
         try self.sendBytesWithOptions(payload, options, deadline_ms);
@@ -755,6 +779,7 @@ pub const Sender = struct {
         options: SendOptions,
         deadline_ms: i64,
     ) LinkError!void {
+        if (self.poisoned or !self.attached) return error.LinkDetached;
         // This call waits for the oldest delivery, so it is only waiting for
         // its own if nothing else is outstanding. Mixing it with
         // `sendBytesAsync` would either report another delivery's verdict as
@@ -808,7 +833,7 @@ pub const Sender = struct {
         options: SendOptions,
         deadline_ms: i64,
     ) LinkError!DeliveryToken {
-        if (!self.attached) return error.LinkDetached;
+        if (self.poisoned or !self.attached) return error.LinkDetached;
         if (self.maxMessageSize()) |limit| {
             if (payload.len > limit) return error.MessageTooLarge;
         }
@@ -903,6 +928,8 @@ pub const Sender = struct {
     /// caller can only recover by opening a new link.
     fn poisonPartialDelivery(self: *Sender) void {
         self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
         self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1034,6 +1061,10 @@ pub fn openSender(
     options: SenderOptions,
     deadline_ms: i64,
 ) LinkError!*Sender {
+    for (session.senders.items) |sender| {
+        if (std.mem.eql(u8, sender.name, options.name)) return error.LinkNameInUse;
+    }
+
     const sender = try session.allocator.create(Sender);
     errdefer session.allocator.destroy(sender);
 
@@ -1113,9 +1144,12 @@ pub const ReceiverOptions = struct {
     /// the field the sender's obligation and a peer under no obligation to be
     /// honest is exactly the one this defends against.
     ///
-    /// Null means unlimited, which is what let a delivery that never ends grow
-    /// the reassembly buffer until the process died (#347). The peer's own
-    /// declaration is not consulted; `Receiver.maxMessageSize` says why.
+    /// Null or zero means unlimited only when `max_buffered_bytes` is also
+    /// null. With a finite aggregate budget, that budget becomes the effective
+    /// per-message limit and is what the receiver advertises.
+    ///
+    /// The peer's own declaration is not consulted;
+    /// `Receiver.maxMessageSize` says why.
     max_message_size: ?u64 = default_max_message_size,
     /// Aggregate payload bytes retained in completed deliveries and the
     /// delivery currently being reassembled.
@@ -1128,6 +1162,7 @@ pub const ReceiverOptions = struct {
     /// next successful `receive`.
     ///
     /// Null explicitly disables the aggregate bound.
+    /// A zero-byte finite budget is invalid.
     max_buffered_bytes: ?u64 = default_max_buffered_bytes,
 };
 
@@ -1161,6 +1196,15 @@ fn normalizeMaxMessageSize(size: ?u64) ?u64 {
     return if (n == 0) null else n;
 }
 
+/// A finite aggregate budget is also the largest message that can be accepted
+/// without violating it, so advertise that effective limit to a conforming
+/// peer rather than granting credit for a message we would later detach.
+fn effectiveMaxMessageSize(message_size: ?u64, buffered_bytes: ?u64) LinkError!?u64 {
+    const budget = buffered_bytes orelse return message_size;
+    if (budget == 0) return error.InvalidReceiverOptions;
+    return @min(normalizeMaxMessageSize(message_size) orelse budget, budget);
+}
+
 /// One received message, valid until the next `receive`.
 pub const Delivery = struct {
     id: u32,
@@ -1176,6 +1220,8 @@ pub const Receiver = struct {
     handle: u32,
     remote_handle: u32 = std.math.maxInt(u32),
     attached: bool = false,
+    awaiting_attach: bool = true,
+    poisoned: bool = false,
 
     credit: u32 = 0,
     prefetch: u32 = 0,
@@ -1265,6 +1311,35 @@ pub const Receiver = struct {
         self.partial_id = null;
     }
 
+    /// A consumed transfer cannot be replayed. Any failure incorporating it
+    /// makes the receiver terminal, otherwise a later continuation could be
+    /// appended to an older prefix and surfaced as a truncated delivery.
+    fn poisonAfterConsumedTransfer(self: *Receiver) void {
+        self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
+        self.clearPartialAndFree();
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{
+                .handle = self.handle,
+                .closed = true,
+                .err = .{
+                    .condition = "amqp:link:detach-forced",
+                    .description = "receiver could not incorporate a consumed transfer",
+                },
+            },
+        }) catch {};
+    }
+
+    fn chargeDeliveryStart(self: *Receiver) void {
+        self.delivery_count +%= 1;
+        if (self.credit == 0) {
+            self.overrun +|= 1;
+        } else {
+            self.credit -= 1;
+        }
+    }
+
     fn ensurePartialCapacity(self: *Receiver, needed: usize) Allocator.Error!void {
         if (self.partial.capacity >= needed) return;
 
@@ -1298,16 +1373,15 @@ pub const Receiver = struct {
     /// Queue a completed delivery. The buffers stay the caller's until this
     /// succeeds, so a failed append does not free them twice.
     fn enqueue(self: *Receiver, id: u32, tag: []u8, payload: []u8, settled: bool) LinkError!void {
-        try self.ready.append(self.allocator, .{
+        self.ready.append(self.allocator, .{
             .id = id,
             .tag = tag,
             .payload = payload,
             .settled = settled,
-        });
-        self.delivery_count +%= 1;
-        // Not `-|= 1`: saturating here is what let an overrun vanish, since
-        // credit simply stayed at zero however far past it the peer ran.
-        if (self.credit == 0) self.overrun += 1 else self.credit -= 1;
+        }) catch |err| {
+            self.poisonAfterConsumedTransfer();
+            return err;
+        };
     }
 
     /// Drop the entries the cursor has already passed.
@@ -1347,50 +1421,66 @@ pub const Receiver = struct {
     }
 
     fn acceptTransfer(self: *Receiver, t: perf.Transfer, chunk: []const u8) LinkError!void {
-        // Checked before anything is duped, so a refused delivery costs no
-        // allocation. This bounds *deliveries accepted past credit*, not
-        // bytes; reassembly is bounded separately by `maxMessageSize()`, which
-        // since #347 is our own declared limit. The peer's declaration is
-        // recorded but never consulted.
-        //
-        // Only where a delivery starts, so that refusing cannot strand frames
-        // already reassembled. The condition survives mutation, because
-        // `overrun` rises only in `enqueue` (delivery completion) and `grant`
-        // only lowers it, so it cannot cross the bound part-way through a
-        // delivery. It is a guard against that stopping being true, not
-        // behaviour any test can currently distinguish.
-        if (t.delivery_id != null) try self.refuseOverrun();
+        const starts = t.delivery_id != null;
+        if (starts) {
+            // Deliveries cannot interleave on one link. Silently replacing the
+            // prefix let a peer send repeated `more=true` delivery ids without
+            // consuming credit and made the final continuation name whichever
+            // prefix happened to survive.
+            if (self.partial_id != null) {
+                self.poisonAfterConsumedTransfer();
+                return error.MalformedFrame;
+            }
+            try self.refuseOverrun();
+            // Link credit and delivery-count are consumed by the initial
+            // transfer, whether the delivery later completes or is aborted.
+            self.chargeDeliveryStart();
 
-        // A delivery that arrives whole in a single transfer — which is every
-        // delivery below the peer's frame size, so nearly all of them — does
-        // not need the reassembly buffer. Staging it there copies the body in
-        // and then copies it straight back out.
-        if (t.delivery_id) |id| {
-            if (!t.more and self.partial_id == null) {
+            if (t.aborted) return;
+
+            // A delivery that arrives whole in a single transfer — nearly all
+            // Azure messages — bypasses the reassembly buffer.
+            if (!t.more) {
+                const id = t.delivery_id.?;
                 if (self.maxMessageSize()) |limit| {
                     if (chunk.len > limit) try self.refuseOversize();
                 }
                 if (self.bufferWouldOverflow(chunk.len)) try self.refuseBufferLimit();
-                const payload = try self.allocator.dupe(u8, chunk);
+                const payload = self.allocator.dupe(u8, chunk) catch |err| {
+                    self.poisonAfterConsumedTransfer();
+                    return err;
+                };
                 self.retainBuffered(payload.len);
                 errdefer {
                     self.releaseBuffered(payload.len);
                     self.allocator.free(payload);
                 }
-                const tag = try self.allocator.dupe(u8, t.delivery_tag orelse "");
+                const tag = self.allocator.dupe(u8, t.delivery_tag orelse "") catch |err| {
+                    self.poisonAfterConsumedTransfer();
+                    return err;
+                };
                 errdefer self.allocator.free(tag);
                 return self.enqueue(id, tag, payload, t.settled orelse false);
             }
-        }
 
-        if (t.delivery_id) |id| {
-            // A new delivery starts here.
-            self.clearPartialRetainingCapacity();
-            self.partial_id = id;
+            self.partial_id = t.delivery_id.?;
             self.partial_settled = t.settled orelse false;
-            if (t.delivery_tag) |tag| try self.partial_tag.appendSlice(self.allocator, tag);
+            if (t.delivery_tag) |tag| {
+                self.partial_tag.appendSlice(self.allocator, tag) catch |err| {
+                    self.poisonAfterConsumedTransfer();
+                    return err;
+                };
+            }
+        } else {
+            if (self.partial_id == null) {
+                self.poisonAfterConsumedTransfer();
+                return error.MalformedFrame;
+            }
+            if (t.aborted) {
+                self.clearPartialAndFree();
+                return;
+            }
         }
-        if (self.partial_id == null) return error.MalformedFrame;
 
         const new_len = std.math.add(usize, self.partial.items.len, chunk.len) catch {
             try self.refuseOversize();
@@ -1400,19 +1490,28 @@ pub const Receiver = struct {
             if (new_len > limit) try self.refuseOversize();
         }
         if (self.bufferWouldOverflow(chunk.len)) try self.refuseBufferLimit();
-        try self.ensurePartialCapacity(new_len);
+        self.ensurePartialCapacity(new_len) catch |err| {
+            self.poisonAfterConsumedTransfer();
+            return err;
+        };
         self.partial.appendSliceAssumeCapacity(chunk);
         self.retainBuffered(chunk.len);
 
         if (t.more) return;
 
         // The delivery is complete.
-        const payload = try self.partial.toOwnedSlice(self.allocator);
+        const payload = self.partial.toOwnedSlice(self.allocator) catch |err| {
+            self.poisonAfterConsumedTransfer();
+            return err;
+        };
         errdefer {
             self.releaseBuffered(payload.len);
             self.allocator.free(payload);
         }
-        const tag = try self.partial_tag.toOwnedSlice(self.allocator);
+        const tag = self.partial_tag.toOwnedSlice(self.allocator) catch |err| {
+            self.poisonAfterConsumedTransfer();
+            return err;
+        };
         errdefer self.allocator.free(tag);
 
         const id = self.partial_id.?;
@@ -1468,6 +1567,7 @@ pub const Receiver = struct {
     /// this one, so credit stays a running authorisation rather than resetting
     /// and forgiving the overrun.
     pub fn issueCredit(self: *Receiver, count: u32) LinkError!void {
+        if (self.poisoned or !self.attached) return error.LinkDetached;
         self.grant(self.credit +| count);
         try self.session.sendFlow(self);
     }
@@ -1539,6 +1639,8 @@ pub const Receiver = struct {
         // `refuseOverrun`: a send failure must not leave the link looking
         // attached and retrying this on every subsequent transfer.
         self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
         self.clearPartialAndFree();
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
@@ -1557,6 +1659,8 @@ pub const Receiver = struct {
     /// receiver budget.
     fn refuseBufferLimit(self: *Receiver) LinkError!void {
         self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
         self.clearPartialAndFree();
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
@@ -1592,6 +1696,8 @@ pub const Receiver = struct {
         // subsequent transfer. The caller then sees the send error rather than
         // `CreditExceeded`, which is the more urgent of the two.
         self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
         self.clearPartialAndFree();
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
@@ -1773,6 +1879,14 @@ pub fn openReceiver(
     options: ReceiverOptions,
     deadline_ms: i64,
 ) LinkError!*Receiver {
+    for (session.receivers.items) |receiver| {
+        if (std.mem.eql(u8, receiver.name, options.name)) return error.LinkNameInUse;
+    }
+    const max_message_size = try effectiveMaxMessageSize(
+        options.max_message_size,
+        options.max_buffered_bytes,
+    );
+
     const receiver = try session.allocator.create(Receiver);
     errdefer session.allocator.destroy(receiver);
 
@@ -1787,7 +1901,7 @@ pub fn openReceiver(
         .prefetch = options.prefetch,
         .max_overrun = options.max_overrun orelse
             @max(options.prefetch, min_overrun_allowance),
-        .max_message_size = options.max_message_size,
+        .max_message_size = max_message_size,
         .max_buffered_bytes = options.max_buffered_bytes,
     };
 
@@ -1805,7 +1919,7 @@ pub fn openReceiver(
         },
         .target = .{ .address = options.target_address },
         .initial_delivery_count = 0,
-        .max_message_size = options.max_message_size,
+        .max_message_size = max_message_size,
         .desired_capabilities = options.desired_capabilities,
         .properties = options.properties,
     } });
@@ -1830,6 +1944,17 @@ const EmittedFrames = harness.EmittedFrames;
 const test_options = harness.driver_options;
 const Fixture = harness.Fixture;
 const scriptHandshake = harness.scriptHandshake;
+
+fn expectReceiverAccounting(receiver: *const Receiver) !void {
+    var expected: u64 = @intCast(receiver.partial.items.len);
+    for (receiver.ready.items[receiver.ready_head..]) |delivery| {
+        expected += @intCast(delivery.payload.len);
+    }
+    try testing.expectEqual(expected, receiver.bufferedBytes());
+    if (receiver.partial_id == null) {
+        try testing.expectEqual(@as(usize, 0), receiver.partial.items.len);
+    }
+}
 
 test "a sender attaches and reports the peer's max-message-size" {
     const allocator = testing.allocator;
@@ -2111,6 +2236,86 @@ test "a socket failure after the first frame poisons the sender" {
     const before = mem.written().len;
     try testing.expectError(error.LinkDetached, sender.sendBytesAsync("new", .{}, 10_000));
     try testing.expectEqual(before, mem.written().len);
+}
+
+test "a poisoned sender ignores late attach and must be removed before replacement" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 5);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const old = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    old.poisonPartialDelivery();
+    try testing.expect(old.poisoned);
+
+    // A late response cannot turn the terminal object back into a live link.
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 7,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 7,
+        .delivery_count = 0,
+        .link_credit = 99,
+    } });
+    _ = try fixture.session.pump(10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expect(!old.attached);
+    try testing.expect(old.poisoned);
+    try testing.expectEqual(@as(u32, 0), old.remote_handle);
+    try testing.expectEqual(@as(u32, 5), old.credit);
+    try testing.expectError(error.LinkDetached, old.sendBytes("blocked", 10_000));
+    try testing.expectError(error.LinkDetached, old.sendBytesAsync("blocked", .{}, 10_000));
+
+    try testing.expectError(error.LinkNameInUse, openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000));
+
+    fixture.session.closeSender(old, 0);
+
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 8,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 8,
+        .delivery_count = 0,
+        .link_credit = 3,
+    } });
+    const replacement = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expect(replacement.attached);
+    try testing.expect(!replacement.poisoned);
+    try testing.expectEqual(@as(u32, 8), replacement.remote_handle);
+    try testing.expectEqual(@as(u32, 3), replacement.credit);
 }
 
 test "a delivery carries the requested message format" {
@@ -3900,6 +4105,46 @@ const CountingAllocator = struct {
 
     fn free(ctx: *anyopaque, buf: []u8, a: std.mem.Alignment, ra: usize) void {
         const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.child.rawFree(buf, a, ra);
+    }
+};
+
+/// Fails every allocation operation while switched on, then resumes normally.
+/// This lets a test fail one consumed transfer and continue pumping the same
+/// connection to prove the receiver cannot reuse a stale prefix.
+const SwitchAllocator = struct {
+    child: Allocator,
+    failing: bool = false,
+
+    fn allocator(self: *SwitchAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, a: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
+        if (self.failing) return null;
+        return self.child.rawAlloc(len, a, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, a: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
+        if (self.failing) return false;
+        return self.child.rawResize(buf, a, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, a: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
+        if (self.failing) return null;
+        return self.child.rawRemap(buf, a, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, a: std.mem.Alignment, ra: usize) void {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
         self.child.rawFree(buf, a, ra);
     }
 };
@@ -5741,6 +5986,53 @@ test "an overrun bound of zero disables the detach but not the charging" {
     try testing.expectEqual(min_overrun_allowance + 4, receiver.overrun);
 }
 
+test "disabled overrun detachment saturates debt instead of overflowing" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    var i: u32 = 0;
+    while (i < 2) : (i += 1) {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = i,
+            .delivery_tag = "t",
+            .settled = true,
+        }, "x");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_overrun = 0,
+        .max_message_size = 8,
+        .max_buffered_bytes = null,
+    }, 10_000);
+    receiver.overrun = std.math.maxInt(u32) - 1;
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(std.math.maxInt(u32), receiver.overrun);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(std.math.maxInt(u32), receiver.overrun);
+    try testing.expect(receiver.attached);
+    try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
+}
+
 test "a flow that names a delivery count has the debt charged against it too" {
     // The branch above it. A flow carrying `delivery-count` is rebased onto
     // this endpoint's own count before the credit is taken, and that rebase
@@ -6233,6 +6525,7 @@ test "a null max-message-size declares and enforces no limit" {
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 0,
         .max_message_size = null,
+        .max_buffered_bytes = null,
     }, 10_000);
     try testing.expectEqual(@as(?u64, null), receiver.maxMessageSize());
 
@@ -6301,6 +6594,72 @@ test "a receiver is bounded by default" {
     var flow = try perf.decode(allocator, flows[0]);
     defer flow.deinit();
     try testing.expectEqual(@as(u32, 2), flow.performative.flow.link_credit.?);
+}
+
+test "a finite aggregate budget is also the advertised per-message ceiling" {
+    try testing.expectEqual(
+        @as(?u64, 16),
+        try effectiveMaxMessageSize(64, 16),
+    );
+    try testing.expectEqual(
+        @as(?u64, 16),
+        try effectiveMaxMessageSize(null, 16),
+    );
+    try testing.expectEqual(
+        @as(?u64, 16),
+        try effectiveMaxMessageSize(0, 16),
+    );
+    try testing.expectError(
+        error.InvalidReceiverOptions,
+        effectiveMaxMessageSize(0, 0),
+    );
+
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "t",
+        .settled = true,
+    }, "1234567890abcdef");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    mem.clearWritten();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 64,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+    try testing.expectEqual(@as(u64, 16), receiver.maxMessageSize().?);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const attaches = try frames.of(allocator, perf.descriptor.attach);
+    defer allocator.free(attaches);
+    var decoded = try perf.decode(allocator, attaches[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u64, 16), decoded.performative.attach.max_message_size.?);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("1234567890abcdef", delivery.payload);
+    try testing.expect(receiver.attached);
 }
 
 test "aggregate budget caps credit and replenishes as deliveries leave the queue" {
@@ -6448,9 +6807,15 @@ test "aggregate budget releases an in-progress delivery when it is exceeded" {
         .handle = 0,
         .delivery_id = 0,
         .delivery_tag = "t",
+        .more = false,
+    }, "12345678");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 1,
+        .delivery_tag = "t",
         .more = true,
-    }, "0123456789");
-    try peer.pushTransfer(0, .{ .handle = 0, .more = true }, "0123456789");
+    }, "12345");
+    try peer.pushTransfer(0, .{ .handle = 0, .more = true }, "67890");
 
     var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
     defer driver.deinit();
@@ -6466,11 +6831,198 @@ test "aggregate budget releases an in-progress delivery when it is exceeded" {
     }, 10_000);
 
     _ = try fixture.session.pump(10_000);
-    try testing.expectEqual(@as(u64, 10), receiver.bufferedBytes());
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 13), receiver.bufferedBytes());
+    try expectReceiverAccounting(receiver);
     try testing.expectError(error.BufferLimitExceeded, fixture.session.pump(10_000));
+    try testing.expectEqual(@as(u64, 8), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 1), receiver.ready.items.len);
+    try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
+    try expectReceiverAccounting(receiver);
+    try testing.expect(!receiver.attached);
+}
+
+test "an aborted multi-frame delivery consumes credit once and is not queued" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "a",
+        .more = true,
+    }, "prefix");
+    try peer.pushTransfer(0, .{ .handle = 0, .aborted = true }, "ignored");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 1,
+        .delivery_tag = "b",
+        .settled = true,
+    }, "good");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 2,
+        .max_message_size = 16,
+        .max_buffered_bytes = 32,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 1), receiver.credit);
+    try testing.expectEqual(@as(u64, 6), receiver.bufferedBytes());
+    try expectReceiverAccounting(receiver);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 1), receiver.credit);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
+    try expectReceiverAccounting(receiver);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(usize, 1), receiver.ready.items.len);
+    try expectReceiverAccounting(receiver);
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 1), delivery.id);
+    try testing.expectEqualStrings("good", delivery.payload);
+}
+
+test "a new delivery id cannot replace an unfinished delivery or bypass credit" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "a",
+        .more = true,
+    }, "first");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 1,
+        .delivery_tag = "b",
+        .more = true,
+    }, "replacement");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_overrun = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectError(error.MalformedFrame, fixture.session.pump(10_000));
+    try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.overrun);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
+    try testing.expect(receiver.poisoned);
+    try testing.expect(!receiver.attached);
+    try expectReceiverAccounting(receiver);
+}
+
+test "allocation failure after a consumed continuation poisons the receiver" {
+    var switching = SwitchAllocator{ .child = testing.allocator };
+    const allocator = switching.allocator();
+
+    var mem = MemoryTransport.init(testing.allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = testing.allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "t",
+        .more = true,
+    }, "prefix");
+    var large: [400]u8 = undefined;
+    @memset(&large, 'x');
+    try peer.pushTransfer(0, .{ .handle = 0, .more = true }, &large);
+    try peer.pushTransfer(0, .{ .handle = 0, .more = false }, "tail");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 512,
+        .max_buffered_bytes = 512,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 6), receiver.bufferedBytes());
+    // Keep the frame reader and performative arena out of the injection: the
+    // failure belongs to incorporating the already decoded payload into the
+    // receiver's partial buffer.
+    driver.body_buf = try allocator.realloc(driver.body_buf, 512);
+
+    switching.failing = true;
+    try testing.expectError(error.OutOfMemory, fixture.session.pump(10_000));
+    switching.failing = false;
+
+    try testing.expect(receiver.poisoned);
+    try testing.expect(!receiver.attached);
     try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
     try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
-    try testing.expect(!receiver.attached);
+    try expectReceiverAccounting(receiver);
+
+    // The later continuation is consumed as a straggler for the dead link,
+    // never combined with the old prefix or surfaced as a delivery.
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
+    try expectReceiverAccounting(receiver);
+    try testing.expectError(error.LinkDetached, receiver.receive(10_000));
 }
 
 test "a remote detach releases an in-progress delivery's budget" {
@@ -6513,10 +7065,12 @@ test "a remote detach releases an in-progress delivery's budget" {
 
     _ = try fixture.session.pump(10_000);
     try testing.expectEqual(@as(u64, 10), receiver.bufferedBytes());
+    try expectReceiverAccounting(receiver);
     _ = try fixture.session.pump(10_000);
     try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
     try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
     try testing.expect(!receiver.attached);
+    try expectReceiverAccounting(receiver);
 }
 
 test "one receiver exhausting its budget does not block another link" {
@@ -6617,6 +7171,7 @@ test "a zero max-message-size means unlimited, not zero" {
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 0,
         .max_message_size = 0,
+        .max_buffered_bytes = null,
     }, 10_000);
     try receiver.issueCredit(1);
 

--- a/link.zig
+++ b/link.zig
@@ -101,6 +101,7 @@ pub const Session = struct {
     /// room on offer slides forward with the id instead of running down.
     incoming_window: u32,
     outgoing_window: u32,
+    ended: bool = false,
     /// Our first transfer id. §2.5.6 falls back to this when a peer's flow
     /// omits `next-incoming-id`, which it may until it has seen a transfer.
     initial_outgoing_id: u32 = 0,
@@ -161,7 +162,11 @@ pub const Session = struct {
 
     /// End the session on the wire.
     pub fn end(self: *Session, deadline_ms: i64) LinkError!void {
-        try self.driver.endSession(self.channel, deadline_ms);
+        self.driver.endSession(self.channel, deadline_ms) catch |err| {
+            if (self.driver.state == .err) self.terminate();
+            return err;
+        };
+        self.terminate();
     }
 
     /// Detach one sender and drop it from the session.
@@ -192,16 +197,30 @@ pub const Session = struct {
     /// Returns true when the frame was consumed. A frame for another channel
     /// is ignored, which keeps a single-session connection simple.
     pub fn pump(self: *Session, deadline_ms: i64) LinkError!bool {
+        if (self.ended) return error.LinkDetached;
         const inbound = self.driver.receiveFrame(deadline_ms) catch |err| {
-            if (self.driver.state == .err) self.invalidateLinks();
+            if (self.driver.state == .err) self.terminate();
             return err;
         };
+        if (inbound.header.channel == 0 and
+            perf.peekDescriptor(inbound.body) == perf.descriptor.close)
+        {
+            const decoded = self.driver.decodeBodyReusing(inbound.body) catch |err|
+                return self.failConsumedFrame(err);
+            const c = decoded.performative.close;
+            self.driver.recordRemoteError(c.err) catch |err| return self.failConsumedFrame(err);
+            self.terminate();
+            self.driver.sendPerformative(.amqp, 0, .{ .close = .{} }) catch |err|
+                return self.failConsumedFrame(err);
+            self.driver.terminate();
+            return error.RemoteClosed;
+        }
         if (inbound.header.channel != self.remote_channel) return false;
 
         const decoded = self.driver.decodeBodyReusing(inbound.body) catch |err| {
             // The frame has already been consumed and cannot be replayed.
             self.driver.invalidate();
-            self.invalidateLinks();
+            self.terminate();
             return err;
         };
 
@@ -224,10 +243,17 @@ pub const Session = struct {
             .detach => |d| self.applyDetach(d) catch |err| return self.failConsumedFrame(err),
             .end => |e| {
                 self.driver.recordRemoteError(e.err) catch |err| return self.failConsumedFrame(err);
+                self.terminate();
+                self.driver.sendPerformative(.amqp, self.channel, .{ .end = .{} }) catch |err|
+                    return self.failConsumedFrame(err);
                 return error.RemoteClosed;
             },
             .close => |c| {
                 self.driver.recordRemoteError(c.err) catch |err| return self.failConsumedFrame(err);
+                self.terminate();
+                self.driver.sendPerformative(.amqp, 0, .{ .close = .{} }) catch |err|
+                    return self.failConsumedFrame(err);
+                self.driver.terminate();
                 return error.RemoteClosed;
             },
             else => return false,
@@ -237,7 +263,7 @@ pub const Session = struct {
 
     fn failConsumedFrame(self: *Session, err: LinkError) LinkError {
         self.driver.invalidate();
-        self.invalidateLinks();
+        self.terminate();
         return err;
     }
 
@@ -254,6 +280,11 @@ pub const Session = struct {
             receiver.clearPartialAndFree();
             self.releaseReceiverDeliveries(receiver);
         }
+    }
+
+    fn terminate(self: *Session) void {
+        self.ended = true;
+        self.invalidateLinks();
     }
 
     fn reserveIncomingDelivery(self: *Session, receiver: *Receiver, id: u32) LinkError!void {
@@ -434,17 +465,33 @@ pub const Session = struct {
 
     fn applyDetach(self: *Session, d: perf.Detach) LinkError!void {
         if (self.senderFor(d.handle)) |s| {
+            const respond = !s.detach_sent;
             s.attached = false;
+            s.awaiting_attach = false;
+            s.poisoned = true;
             try s.recordDetach(d.err);
+            if (respond) {
+                try self.driver.sendPerformative(.amqp, self.channel, .{
+                    .detach = .{ .handle = s.handle, .closed = d.closed },
+                });
+            }
             return;
         }
         if (self.receiverFor(d.handle)) |r| {
+            const respond = !r.detach_sent;
             r.attached = false;
+            r.awaiting_attach = false;
+            r.poisoned = true;
             // A detached link can still hand already completed deliveries to
             // its caller, but an in-progress one can never finish.
             r.clearPartialAndFree();
             self.releaseReceiverDeliveries(r);
             try r.recordDetach(d.err);
+            if (respond) {
+                try self.driver.sendPerformative(.amqp, self.channel, .{
+                    .detach = .{ .handle = r.handle, .closed = d.closed },
+                });
+            }
         }
     }
 
@@ -622,6 +669,7 @@ pub const Sender = struct {
     attached: bool = false,
     awaiting_attach: bool = true,
     poisoned: bool = false,
+    detach_sent: bool = false,
 
     credit: u32 = 0,
     drain: bool = false,
@@ -742,6 +790,8 @@ pub const Sender = struct {
     /// the link is detached either way, and reporting an error would make a
     /// caller tearing down think it had to retry.
     pub fn detach(self: *Sender, deadline_ms: i64) LinkError!void {
+        if (self.poisoned or !self.attached or self.session.ended) return error.LinkDetached;
+        self.detach_sent = true;
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{ .handle = self.handle, .closed = true },
         });
@@ -1248,18 +1298,15 @@ pub const ReceiverOptions = struct {
     /// Aggregate payload bytes retained in completed deliveries and the
     /// delivery currently being reassembled.
     ///
-    /// Custom limits cap credit so a conforming peer cannot fill more than
-    /// this even when every delivery reaches `max_message_size`. The default
-    /// limits preserve the long-standing 300-credit wire window required by
-    /// Event Hubs and Service Bus, while still detaching before retaining a
-    /// chunk that would cross this hard byte bound.
+    /// When finite, credit is capped so a conforming peer cannot fill more
+    /// than this even when every delivery reaches `max_message_size`.
     /// The delivery already handed to the caller is outside this budget; it is
     /// bounded separately by `max_message_size` and remains valid until the
     /// next successful `receive`.
     ///
     /// Null explicitly disables the aggregate bound.
     /// A zero-byte finite budget is invalid.
-    max_buffered_bytes: ?u64 = default_max_buffered_bytes,
+    max_buffered_bytes: ?u64 = null,
 };
 
 /// The floor for a derived `max_overrun`, so a receiver driving credit by
@@ -1277,10 +1324,12 @@ const min_overrun_allowance: u32 = 64;
 ///
 pub const default_max_message_size: u64 = 128 * 1024 * 1024;
 
-/// Default aggregate ceiling for payload bytes retained by one receiver.
+/// Recommended opt-in aggregate ceiling for payload bytes retained by one
+/// receiver.
 ///
-/// Payload retention is bounded independently of the legacy 300-credit
-/// default. Custom limits additionally reserve worst-case bytes per credit.
+/// The default is unbounded so the legacy 300-credit window never authorizes
+/// traffic the receiver would then reject. Set this value explicitly when a
+/// smaller, byte-reserved window is acceptable.
 pub const default_max_buffered_bytes: u64 = 256 * 1024 * 1024;
 
 /// §2.7.3: an absent *or zero* `max-message-size` means no limit.
@@ -1315,6 +1364,7 @@ pub const Receiver = struct {
     attached: bool = false,
     awaiting_attach: bool = true,
     poisoned: bool = false,
+    detach_sent: bool = false,
 
     credit: u32 = 0,
     prefetch: u32 = 0,
@@ -1340,10 +1390,6 @@ pub const Receiver = struct {
     /// delivery handed to the caller is no longer buffered and is not counted.
     buffered_bytes: u64 = 0,
     max_buffered_bytes: ?u64 = null,
-    /// Custom limits reserve a worst-case message for every credit. The
-    /// legacy default keeps the requested 300-credit wire contract while the
-    /// aggregate limit remains a hard bound on bytes actually retained.
-    reserve_credit_bytes: bool = true,
     detach_error: ?connection.RemoteError = null,
 
     /// Bytes of the delivery currently being assembled.
@@ -1559,11 +1605,16 @@ pub const Receiver = struct {
             // transfer, whether the delivery later completes or is aborted.
             self.chargeDeliveryStart();
 
+            const id = t.delivery_id.?;
+            if (self.session.incoming_deliveries.contains(id)) {
+                self.refuseDuplicateDelivery();
+                return error.DuplicateDeliveryId;
+            }
             if (t.aborted) return;
 
             const settled = t.settled orelse false;
             if (!settled) {
-                self.session.reserveIncomingDelivery(self, t.delivery_id.?) catch |err| {
+                self.session.reserveIncomingDelivery(self, id) catch |err| {
                     if (err == error.DuplicateDeliveryId) {
                         self.refuseDuplicateDelivery();
                     }
@@ -1574,7 +1625,6 @@ pub const Receiver = struct {
             // A delivery that arrives whole in a single transfer — nearly all
             // Azure messages — bypasses the reassembly buffer.
             if (!t.more) {
-                const id = t.delivery_id.?;
                 if (self.maxMessageSize()) |limit| {
                     if (chunk.len > limit) try self.refuseOversize();
                 }
@@ -1675,7 +1725,6 @@ pub const Receiver = struct {
     /// Maximum credit that can be outstanding without letting a conforming
     /// sender exceed the aggregate payload budget.
     fn byteCreditCapacity(self: *const Receiver) u32 {
-        if (!self.reserve_credit_bytes) return std.math.maxInt(u32);
         const limit = self.max_buffered_bytes orelse return std.math.maxInt(u32);
         // With no per-message bound, one delivery may consume the whole
         // aggregate budget. If the configured message limit is larger than
@@ -1699,7 +1748,6 @@ pub const Receiver = struct {
     }
 
     fn partialReservationFits(self: *const Receiver) bool {
-        if (!self.reserve_credit_bytes) return true;
         const limit = self.max_buffered_bytes orelse return true;
         const message_size = self.maxMessageSize() orelse limit;
         return self.reservedBufferedBytes(message_size) <= limit;
@@ -1908,6 +1956,7 @@ pub const Receiver = struct {
     ///
     /// The returned slices stay valid until the next `receive`.
     pub fn receive(self: *Receiver, deadline_ms: i64) LinkError!Delivery {
+        if (self.session.ended) return error.LinkDetached;
         while (self.ready.items.len == self.ready_head) {
             if (!self.attached) return error.LinkDetached;
             try self.replenish();
@@ -1959,6 +2008,7 @@ pub const Receiver = struct {
         last: u32,
         state: perf.DeliveryState,
     ) LinkError!void {
+        if (self.session.ended or self.poisoned or !self.attached) return error.LinkDetached;
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .disposition = .{
                 .role = .receiver,
@@ -1981,6 +2031,7 @@ pub const Receiver = struct {
 
     /// Drain outstanding credit so the peer reports what it has left.
     pub fn drainCredit(self: *Receiver, deadline_ms: i64) LinkError!void {
+        if (self.session.ended or self.poisoned or !self.attached) return error.LinkDetached;
         self.drain = true;
         try self.session.sendFlow(self);
         // The sender answers a drain by advancing its delivery count over the
@@ -1997,6 +2048,8 @@ pub const Receiver = struct {
 
     /// Detach the link, waiting for the peer's detach.
     pub fn detach(self: *Receiver, deadline_ms: i64) LinkError!void {
+        if (self.session.ended or self.poisoned or !self.attached) return error.LinkDetached;
+        self.detach_sent = true;
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{ .handle = self.handle, .closed = true },
         });
@@ -2096,8 +2149,6 @@ pub fn openReceiver(
             @max(options.prefetch, min_overrun_allowance),
         .max_message_size = max_message_size,
         .max_buffered_bytes = options.max_buffered_bytes,
-        .reserve_credit_bytes = options.max_message_size != default_max_message_size or
-            options.max_buffered_bytes != default_max_buffered_bytes,
     };
     errdefer receiver.unsettled_ids.deinit(session.allocator);
 
@@ -2150,18 +2201,16 @@ fn expectReceiverAccounting(receiver: *const Receiver) !void {
     if (receiver.partial_id == null) {
         try testing.expectEqual(@as(usize, 0), receiver.partial.items.len);
     }
-    if (receiver.reserve_credit_bytes) {
-        if (receiver.max_buffered_bytes) |budget| {
-            const message_size = receiver.maxMessageSize().?;
-            const partial_reservation: u128 =
-                if (receiver.partial_id != null) message_size else 0;
-            const ready_bytes = receiver.bufferedBytes() -|
-                @as(u64, @intCast(receiver.partial.items.len));
-            const authorised: u128 = @as(u128, ready_bytes) +
-                partial_reservation +
-                @as(u128, receiver.credit) * @as(u128, message_size);
-            try testing.expect(authorised <= budget);
-        }
+    if (receiver.max_buffered_bytes) |budget| {
+        const message_size = receiver.maxMessageSize().?;
+        const partial_reservation: u128 =
+            if (receiver.partial_id != null) message_size else 0;
+        const ready_bytes = receiver.bufferedBytes() -|
+            @as(u64, @intCast(receiver.partial.items.len));
+        const authorised: u128 = @as(u128, ready_bytes) +
+            partial_reservation +
+            @as(u128, receiver.credit) * @as(u128, message_size);
+        try testing.expect(authorised <= budget);
     }
 }
 
@@ -2578,6 +2627,120 @@ test "a poisoned sender ignores late attach and must be removed before replaceme
     try testing.expect(!replacement.poisoned);
     try testing.expectEqual(@as(u32, 8), replacement.remote_handle);
     try testing.expectEqual(@as(u32, 3), replacement.credit);
+}
+
+test "remote End and Close terminalize the session before returning" {
+    const Case = enum { end, close };
+    inline for (std.meta.tags(Case)) |case| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        try peer.push(0, .{ .attach = .{
+            .name = "producer",
+            .handle = 0,
+            .role = .receiver,
+            .initial_delivery_count = 0,
+        } });
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1000,
+            .next_outgoing_id = 1,
+            .outgoing_window = 1000,
+            .handle = 0,
+            .delivery_count = 0,
+            .link_credit = 1,
+        } });
+        try peer.push(0, .{ .attach = .{
+            .name = "consumer",
+            .handle = 1,
+            .role = .sender,
+            .initial_delivery_count = 0,
+        } });
+        switch (case) {
+            .end => try peer.push(0, .{ .end = .{} }),
+            .close => try peer.push(0, .{ .close = .{} }),
+        }
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        const sender = try openSender(&fixture.session, .{
+            .name = "producer",
+            .target_address = "eh",
+        }, 10_000);
+        const receiver = try openReceiver(&fixture.session, .{
+            .name = "consumer",
+            .source_address = "partition/0",
+            .prefetch = 0,
+        }, 10_000);
+
+        mem.clearWritten();
+        try testing.expectError(error.RemoteClosed, fixture.session.pump(10_000));
+        try testing.expect(fixture.session.ended);
+        try testing.expect(sender.poisoned);
+        try testing.expect(receiver.poisoned);
+        if (case == .close) {
+            try testing.expectEqual(connection.State.closed, driver.state);
+            try testing.expect(mem.closed);
+        } else {
+            try testing.expectEqual(connection.State.opened, driver.state);
+            try testing.expect(!mem.closed);
+        }
+
+        var frames = try EmittedFrames.parse(allocator, mem.written());
+        defer frames.deinit();
+        const descriptor = if (case == .end) perf.descriptor.end else perf.descriptor.close;
+        const responses = try frames.of(allocator, descriptor);
+        defer allocator.free(responses);
+        try testing.expectEqual(@as(usize, 1), responses.len);
+
+        const written = mem.written().len;
+        try testing.expectError(error.LinkDetached, sender.sendBytes("blocked", 10_000));
+        try testing.expectError(error.LinkDetached, receiver.receive(10_000));
+        try testing.expectError(error.LinkDetached, receiver.issueCredit(1));
+        try testing.expectError(
+            error.LinkDetached,
+            receiver.settleRange(0, 0, .accepted),
+        );
+        try testing.expectEqual(written, mem.written().len);
+    }
+}
+
+test "a malformed consumed End response terminalizes the local session" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 1);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+    _ = try fixture.session.pump(10_000); // sender flow
+    try peer.pushRaw(0, &.{ 0x00, 0x53, 0x17 });
+
+    try testing.expectError(error.MalformedFrame, fixture.session.end(10_000));
+    try testing.expect(fixture.session.ended);
+    try testing.expect(sender.poisoned);
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    const writes = mem.write_count;
+    try testing.expectError(error.LinkDetached, sender.sendBytes("blocked", 10_000));
+    try testing.expectEqual(writes, mem.write_count);
 }
 
 test "a delivery carries the requested message format" {
@@ -4451,10 +4614,49 @@ test "body-buffer OOM after a frame header invalidates the session and sender" {
 
     try testing.expectEqual(connection.State.err, driver.state);
     try testing.expect(mem.closed);
+    try testing.expect(fixture.session.ended);
     try testing.expect(sender.poisoned);
     try testing.expect(!sender.attached);
     try testing.expectError(error.LinkDetached, sender.sendBytes("no reuse", 10_000));
     try testing.expectEqual(@as(usize, 0), sender.inFlight());
+}
+
+test "remote Close error-copy OOM invalidates the consumed control frame" {
+    var switching = SwitchAllocator{ .child = testing.allocator };
+    const allocator = switching.allocator();
+    var mem = MemoryTransport.init(testing.allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = testing.allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 1);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+    _ = try fixture.session.pump(10_000); // flow also warms the decode arena
+    try peer.push(0, .{ .close = .{ .err = .{
+        .condition = "amqp:connection:forced",
+        .description = "closing",
+    } } });
+
+    switching.failing = true;
+    try testing.expectError(error.OutOfMemory, fixture.session.pump(10_000));
+    switching.failing = false;
+
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expect(fixture.session.ended);
+    try testing.expect(sender.poisoned);
+    const writes = mem.write_count;
+    try testing.expectError(error.LinkDetached, sender.sendBytes("blocked", 10_000));
+    try testing.expectEqual(writes, mem.write_count);
 }
 
 test "disposition range OOM terminalizes every matching in-flight delivery" {
@@ -6922,7 +7124,7 @@ test "a null max-message-size declares and enforces no limit" {
     try testing.expectEqual(@as(?u64, null), decoded.performative.attach.max_message_size);
 }
 
-test "a receiver is bounded by default" {
+test "the default receiver accepts every delivery in its granted credit window" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -6936,6 +7138,14 @@ test "a receiver is bounded by default" {
         .role = .sender,
         .initial_delivery_count = 0,
     } });
+    for (0..300) |i| {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = @intCast(i),
+            .delivery_tag = "t",
+            .settled = true,
+        }, "legal");
+    }
 
     var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
     defer driver.deinit();
@@ -6943,18 +7153,16 @@ test "a receiver is bounded by default" {
     defer fixture.deinit();
 
     mem.clearWritten();
-    // No `max_message_size` given. The whole point of #347 is that this case
-    // — the one every caller gets without thinking about it — is bounded.
+    // Per-message safety remains on by default. Aggregate retention is opt-in
+    // because a finite budget smaller than the full granted window would
+    // authorize legal traffic and then detach the conforming sender for it.
     const receiver = try openReceiver(&fixture.session, .{
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
     }, 10_000);
     try testing.expectEqual(default_max_message_size, receiver.maxMessageSize().?);
-    try testing.expectEqual(default_max_buffered_bytes, receiver.max_buffered_bytes.?);
-    // Existing Event Hubs and Service Bus consumers rely on the requested
-    // default window. Retained payload is still hard-capped at 256 MiB.
+    try testing.expectEqual(@as(?u64, null), receiver.max_buffered_bytes);
     try testing.expectEqual(@as(u32, 300), receiver.credit);
-    try testing.expect(!receiver.reserve_credit_bytes);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
@@ -6970,6 +7178,12 @@ test "a receiver is bounded by default" {
     var flow = try perf.decode(allocator, flows[0]);
     defer flow.deinit();
     try testing.expectEqual(@as(u32, 300), flow.performative.flow.link_credit.?);
+
+    for (0..300) |_| _ = try fixture.session.pump(10_000);
+    try testing.expect(receiver.attached);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u64, 1500), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 300), receiver.ready.items.len);
 }
 
 test "a finite aggregate budget is also the advertised per-message ceiling" {
@@ -7621,6 +7835,62 @@ test "an unsettled delivery id cannot be reused across receiver links" {
     try testing.expectEqual(first, fixture.session.incoming_deliveries.get(9).?);
 }
 
+test "settled and aborted initial transfers still check cross-link id collisions" {
+    const Case = enum { settled, aborted };
+    inline for (std.meta.tags(Case)) |case| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        inline for (.{ "first", "second" }, 0..) |name, handle| {
+            try peer.push(0, .{ .attach = .{
+                .name = name,
+                .handle = handle,
+                .role = .sender,
+                .initial_delivery_count = 0,
+            } });
+        }
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = 11,
+            .delivery_tag = "a",
+        }, "active");
+        try peer.pushTransfer(0, .{
+            .handle = 1,
+            .delivery_id = 11,
+            .delivery_tag = "b",
+            .settled = if (case == .settled) true else null,
+            .aborted = case == .aborted,
+        }, if (case == .aborted) "discarded" else "settled");
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        const first = try openReceiver(&fixture.session, .{
+            .name = "first",
+            .source_address = "partition/0",
+            .prefetch = 1,
+        }, 10_000);
+        const second = try openReceiver(&fixture.session, .{
+            .name = "second",
+            .source_address = "partition/1",
+            .prefetch = 1,
+        }, 10_000);
+
+        _ = try fixture.session.pump(10_000);
+        try testing.expectEqual(first, fixture.session.incoming_deliveries.get(11).?);
+        try testing.expectError(error.DuplicateDeliveryId, fixture.session.pump(10_000));
+        try testing.expect(first.attached);
+        try testing.expect(second.poisoned);
+        try testing.expectEqual(first, fixture.session.incoming_deliveries.get(11).?);
+    }
+}
+
 test "a delivery id may be reused after terminal settlement" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
@@ -7785,7 +8055,7 @@ test "allocation failure after a consumed continuation poisons the receiver" {
     // terminal and the unread continuation is never parsed as a new frame.
     try testing.expectEqual(connection.State.err, driver.state);
     try testing.expect(mem.closed);
-    try testing.expectError(error.ConnectionClosed, fixture.session.pump(10_000));
+    try testing.expectError(error.LinkDetached, fixture.session.pump(10_000));
     try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
     try expectReceiverAccounting(receiver);
     try testing.expectError(error.LinkDetached, receiver.receive(10_000));
@@ -7837,8 +8107,17 @@ test "a remote detach releases an in-progress delivery's budget" {
     try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
     try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
     try testing.expect(!receiver.attached);
+    try testing.expect(receiver.poisoned);
     try testing.expect(!fixture.session.incoming_deliveries.contains(0));
     try expectReceiverAccounting(receiver);
+    const written = mem.written().len;
+    try testing.expectError(error.LinkDetached, receiver.issueCredit(1));
+    try testing.expectEqual(written, mem.written().len);
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const detaches = try frames.of(allocator, perf.descriptor.detach);
+    defer allocator.free(detaches);
+    try testing.expectEqual(@as(usize, 1), detaches.len);
 }
 
 test "one receiver exhausting its budget does not block another link" {

--- a/link.zig
+++ b/link.zig
@@ -31,6 +31,8 @@ pub const LinkError = connection.ConnectionError || error{
     UnknownHandle,
     /// The peer sent a transfer without the credit to do so.
     CreditExceeded,
+    /// Buffered deliveries reached `ReceiverOptions.max_buffered_bytes`.
+    BufferLimitExceeded,
     /// `max_in_flight` deliveries are already unsettled; retire one with
     /// `awaitSettlement` before sending again.
     InFlightWindowFull,
@@ -346,6 +348,9 @@ pub const Session = struct {
         }
         if (self.receiverFor(d.handle)) |r| {
             r.attached = false;
+            // A detached link can still hand already completed deliveries to
+            // its caller, but an in-progress one can never finish.
+            r.clearPartialAndFree();
             try r.recordDetach(d.err);
         }
     }
@@ -793,12 +798,17 @@ pub const Sender = struct {
     /// Returns `error.InFlightWindowFull` when `max_in_flight` deliveries are
     /// already unsettled. Blocking instead would deadlock: only the caller
     /// can retire a delivery, and it cannot do so from inside this call.
+    ///
+    /// If a continuation fails after the opening frame was written, the link
+    /// is poisoned and later sends return `error.LinkDetached`; recovery must
+    /// open a new sender.
     pub fn sendBytesAsync(
         self: *Sender,
         payload: []const u8,
         options: SendOptions,
         deadline_ms: i64,
     ) LinkError!DeliveryToken {
+        if (!self.attached) return error.LinkDetached;
         if (self.maxMessageSize()) |limit| {
             if (payload.len > limit) return error.MessageTooLarge;
         }
@@ -820,6 +830,9 @@ pub const Sender = struct {
             try self.chunkBudget(delivery_id, &tag, false, options.message_format)
         else
             first_budget;
+        var begun = false;
+        var complete = false;
+        errdefer if (begun and !complete) self.poisonPartialDelivery();
 
         while (first or offset < payload.len) {
             const budget = if (first) first_budget else cont_budget;
@@ -845,6 +858,17 @@ pub const Sender = struct {
             const frame_cap = self.session.driver.maxOutgoingBody() - budget + take;
             try self.sendTransfer(xfer, payload[offset..][0..take], frame_cap);
 
+            if (first) {
+                // Link credit and delivery-count are consumed when a delivery
+                // begins, not when its final continuation is written. Keeping
+                // them until the end made a failed multi-frame delivery look
+                // as though it had never existed even though the peer had
+                // already accepted its opening transfer.
+                self.delivery_count +%= 1;
+                self.credit -|= 1;
+                begun = true;
+            }
+
             // Session ids count transfer *frames*, not deliveries (§2.5.6):
             // every frame of a multi-frame delivery consumes one, even though
             // only the first carries the delivery id. Advancing once per
@@ -858,17 +882,37 @@ pub const Sender = struct {
             first = false;
         }
 
-        self.delivery_count +%= 1;
-        self.credit -|= 1;
+        complete = true;
 
-        // Pushed only once every frame is away: a partially written delivery
-        // has no outcome to wait for, and leaving it in the ring would stall
-        // the next `awaitSettlement` on a disposition that cannot arrive.
+        // Pushed only once every frame is away. A failure after the opening
+        // frame poisons the link instead: the peer is holding an unterminated
+        // delivery, so reusing the link would make the next transfer a
+        // continuation of bytes the caller believed had failed.
         self.in_flight[(self.in_flight_head + self.in_flight_len) % self.in_flight.len] = .{
             .id = delivery_id,
         };
         self.in_flight_len += 1;
         return .{ .id = delivery_id };
+    }
+
+    /// Make a link with an unterminated outbound delivery unusable.
+    ///
+    /// A detach is best effort. A session-window timeout leaves the transport
+    /// usable and the peer benefits from being told; a socket failure may make
+    /// this write fail too. Local poisoning is unconditional either way, so a
+    /// caller can only recover by opening a new link.
+    fn poisonPartialDelivery(self: *Sender) void {
+        self.attached = false;
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{
+                .handle = self.handle,
+                .closed = true,
+                .err = .{
+                    .condition = "amqp:link:detach-forced",
+                    .description = "outbound delivery did not reach its final transfer",
+                },
+            },
+        }) catch {};
     }
 
     /// Wait for the oldest delivery still in flight to settle and retire it.
@@ -1072,11 +1116,19 @@ pub const ReceiverOptions = struct {
     /// Null means unlimited, which is what let a delivery that never ends grow
     /// the reassembly buffer until the process died (#347). The peer's own
     /// declaration is not consulted; `Receiver.maxMessageSize` says why.
-    ///
-    /// This bounds one message. A receiver holds up to its outstanding credit
-    /// plus `max_overrun` completed deliveries at once, so raising this
-    /// multiplies against that: at the default prefetch, ~600 of these.
     max_message_size: ?u64 = default_max_message_size,
+    /// Aggregate payload bytes retained in completed deliveries and the
+    /// delivery currently being reassembled.
+    ///
+    /// Credit is capped so a conforming peer cannot fill more than this even
+    /// when every delivery reaches `max_message_size`. A peer that ignores
+    /// credit is detached before accepting the chunk that would cross it.
+    /// The delivery already handed to the caller is outside this budget; it is
+    /// bounded separately by `max_message_size` and remains valid until the
+    /// next successful `receive`.
+    ///
+    /// Null explicitly disables the aggregate bound.
+    max_buffered_bytes: ?u64 = default_max_buffered_bytes,
 };
 
 /// The floor for a derived `max_overrun`, so a receiver driving credit by
@@ -1092,10 +1144,16 @@ const min_overrun_allowance: u32 = 64;
 /// (`x-opt-sequence-number`, `x-opt-enqueued-time`, and friends), and going
 /// over detaches the link rather than returning something retryable.
 ///
-/// This bounds one message. A receiver holds up to its outstanding credit plus
-/// `max_overrun` completed deliveries at once, so the memory one link can tie
-/// up is that product — with the default prefetch, ~600 x this.
 pub const default_max_message_size: u64 = 128 * 1024 * 1024;
+
+/// Default aggregate ceiling for payload bytes retained by one receiver.
+///
+/// Two maximum-size deliveries fit, so Service Bus Premium's 100 MB messages
+/// retain useful read-ahead while a default receiver is bounded at 256 MiB
+/// rather than the roughly 75 GiB implied by 300 credits plus overrun. Event
+/// Hubs callers that advertise its smaller service limit get proportionally
+/// more of their requested prefetch window.
+pub const default_max_buffered_bytes: u64 = 256 * 1024 * 1024;
 
 /// §2.7.3: an absent *or zero* `max-message-size` means no limit.
 fn normalizeMaxMessageSize(size: ?u64) ?u64 {
@@ -1136,6 +1194,10 @@ pub const Receiver = struct {
     /// `maxMessageSize` says why. It is the largest message the *peer*
     /// supports, which is a bound on a sender rather than on us.
     peer_max_message_size: ?u64 = null,
+    /// Payload bytes in `partial` and the live portion of `ready`. The
+    /// delivery handed to the caller is no longer buffered and is not counted.
+    buffered_bytes: u64 = 0,
+    max_buffered_bytes: ?u64 = null,
     detach_error: ?connection.RemoteError = null,
 
     /// Bytes of the delivery currently being assembled.
@@ -1159,17 +1221,71 @@ pub const Receiver = struct {
     pub fn deinit(self: *Receiver) void {
         self.allocator.free(self.name);
         if (self.detach_error) |e| e.deinit(self.allocator);
+        self.releaseBuffered(self.partial.items.len);
         self.partial.deinit(self.allocator);
         self.partial_tag.deinit(self.allocator);
         // Everything before `ready_head` was already handed out, so its
         // buffers belong to `current` and are freed by `releaseCurrent`.
         for (self.ready.items[self.ready_head..]) |d| {
+            self.releaseBuffered(d.payload.len);
             self.allocator.free(d.payload);
             self.allocator.free(d.tag);
         }
         self.ready.deinit(self.allocator);
         self.releaseCurrent();
+        std.debug.assert(self.buffered_bytes == 0);
         self.allocator.destroy(self);
+    }
+
+    fn retainBuffered(self: *Receiver, bytes: usize) void {
+        self.buffered_bytes +|= @intCast(bytes);
+    }
+
+    fn releaseBuffered(self: *Receiver, bytes: usize) void {
+        self.buffered_bytes -|= @intCast(bytes);
+    }
+
+    fn bufferWouldOverflow(self: *const Receiver, bytes: usize) bool {
+        const limit = self.max_buffered_bytes orelse return false;
+        const add = std.math.cast(u64, bytes) orelse return true;
+        return self.buffered_bytes > limit or add > limit - self.buffered_bytes;
+    }
+
+    fn clearPartialRetainingCapacity(self: *Receiver) void {
+        self.releaseBuffered(self.partial.items.len);
+        self.partial.clearRetainingCapacity();
+        self.partial_tag.clearRetainingCapacity();
+        self.partial_id = null;
+    }
+
+    fn clearPartialAndFree(self: *Receiver) void {
+        self.releaseBuffered(self.partial.items.len);
+        self.partial.clearAndFree(self.allocator);
+        self.partial_tag.clearAndFree(self.allocator);
+        self.partial_id = null;
+    }
+
+    fn ensurePartialCapacity(self: *Receiver, needed: usize) Allocator.Error!void {
+        if (self.partial.capacity >= needed) return;
+
+        var ceiling: usize = std.math.maxInt(usize);
+        if (self.maxMessageSize()) |limit| {
+            ceiling = @min(ceiling, std.math.cast(usize, limit) orelse ceiling);
+        }
+        if (self.max_buffered_bytes) |limit| {
+            const other = self.buffered_bytes -| @as(u64, @intCast(self.partial.items.len));
+            const available = limit -| other;
+            ceiling = @min(ceiling, std.math.cast(usize, available) orelse ceiling);
+        }
+
+        // Grow geometrically, but never reserve bytes beyond either ceiling.
+        // Exact growth on every continuation would make a long delivery
+        // quadratic; unconstrained ArrayList growth could retain more than the
+        // aggregate budget even when the logical payload remained within it.
+        const geometric = self.partial.capacity +|
+            (self.partial.capacity / 2) +| 8;
+        const target = @min(@max(needed, geometric), ceiling);
+        try self.partial.ensureTotalCapacityPrecise(self.allocator, target);
     }
 
     fn recordDetach(self: *Receiver, err: ?perf.AmqpError) LinkError!void {
@@ -1254,8 +1370,13 @@ pub const Receiver = struct {
                 if (self.maxMessageSize()) |limit| {
                     if (chunk.len > limit) try self.refuseOversize();
                 }
+                if (self.bufferWouldOverflow(chunk.len)) try self.refuseBufferLimit();
                 const payload = try self.allocator.dupe(u8, chunk);
-                errdefer self.allocator.free(payload);
+                self.retainBuffered(payload.len);
+                errdefer {
+                    self.releaseBuffered(payload.len);
+                    self.allocator.free(payload);
+                }
                 const tag = try self.allocator.dupe(u8, t.delivery_tag orelse "");
                 errdefer self.allocator.free(tag);
                 return self.enqueue(id, tag, payload, t.settled orelse false);
@@ -1264,31 +1385,38 @@ pub const Receiver = struct {
 
         if (t.delivery_id) |id| {
             // A new delivery starts here.
-            self.partial.clearRetainingCapacity();
-            self.partial_tag.clearRetainingCapacity();
+            self.clearPartialRetainingCapacity();
             self.partial_id = id;
             self.partial_settled = t.settled orelse false;
             if (t.delivery_tag) |tag| try self.partial_tag.appendSlice(self.allocator, tag);
         }
         if (self.partial_id == null) return error.MalformedFrame;
 
+        const new_len = std.math.add(usize, self.partial.items.len, chunk.len) catch {
+            try self.refuseOversize();
+            unreachable;
+        };
         if (self.maxMessageSize()) |limit| {
-            if (self.partial.items.len + chunk.len > limit) try self.refuseOversize();
+            if (new_len > limit) try self.refuseOversize();
         }
-        try self.partial.appendSlice(self.allocator, chunk);
+        if (self.bufferWouldOverflow(chunk.len)) try self.refuseBufferLimit();
+        try self.ensurePartialCapacity(new_len);
+        self.partial.appendSliceAssumeCapacity(chunk);
+        self.retainBuffered(chunk.len);
 
         if (t.more) return;
 
         // The delivery is complete.
-        const payload = try self.allocator.dupe(u8, self.partial.items);
-        errdefer self.allocator.free(payload);
-        const tag = try self.allocator.dupe(u8, self.partial_tag.items);
+        const payload = try self.partial.toOwnedSlice(self.allocator);
+        errdefer {
+            self.releaseBuffered(payload.len);
+            self.allocator.free(payload);
+        }
+        const tag = try self.partial_tag.toOwnedSlice(self.allocator);
         errdefer self.allocator.free(tag);
 
         const id = self.partial_id.?;
         const settled = self.partial_settled;
-        self.partial.clearRetainingCapacity();
-        self.partial_tag.clearRetainingCapacity();
         self.partial_id = null;
 
         try self.enqueue(id, tag, payload, settled);
@@ -1315,6 +1443,25 @@ pub const Receiver = struct {
         return normalizeMaxMessageSize(self.max_message_size);
     }
 
+    /// Aggregate payload bytes currently waiting in this receiver.
+    pub fn bufferedBytes(self: *const Receiver) u64 {
+        return self.buffered_bytes;
+    }
+
+    /// Maximum credit that can be outstanding without letting a conforming
+    /// sender exceed the aggregate payload budget.
+    fn byteCreditCapacity(self: *const Receiver) u32 {
+        const limit = self.max_buffered_bytes orelse return std.math.maxInt(u32);
+        if (self.buffered_bytes >= limit) return 0;
+        const free = limit - self.buffered_bytes;
+        // With no per-message bound, one delivery may consume the whole
+        // aggregate budget. If the configured message limit is larger than
+        // the aggregate budget, the aggregate limit remains authoritative.
+        const reservation = @min(self.maxMessageSize() orelse limit, limit);
+        if (reservation == 0) return 0;
+        return @intCast(@min(free / reservation, std.math.maxInt(u32)));
+    }
+
     /// Grant `count` more credit to the peer.
     ///
     /// Anything the peer already took beyond its last grant is charged against
@@ -1332,29 +1479,51 @@ pub const Receiver = struct {
     /// credit onto this endpoint's delivery count: a peer must not be able to
     /// clear the debt it ran up simply by asserting a new window.
     fn grant(self: *Receiver, amount: u32) void {
-        const charged = @min(self.overrun, amount);
+        const bounded = @min(amount, self.byteCreditCapacity());
+        const charged = @min(self.overrun, bounded);
         self.overrun -= charged;
-        self.credit = amount - charged;
+        self.credit = bounded - charged;
     }
 
     /// Top prefetch credit back up once half of it has been consumed, so a
     /// prefetching receiver never stalls waiting for the caller.
     fn replenish(self: *Receiver) LinkError!void {
         if (self.prefetch == 0) return;
-        if (self.credit > self.prefetch / 2) return;
+        const target = @min(self.prefetch, self.byteCreditCapacity());
+        if (target == 0) return;
+        // A one- or two-delivery byte window has no useful half-window: using
+        // its last credit avoids a flow write before every second delivery.
+        if (self.credit > 0 and
+            (target <= 2 or self.credit > target / 2))
+        {
+            return;
+        }
         // A peer that ran past its last grant is granted that much less now,
         // so it is slowed rather than handed the same window again. Run far
         // enough past and the charge cancels the window entirely, which is
         // what "stop granting credit" means here; keep going and
         // `refuseOverrun` ends the link.
+        const before = self.credit;
         self.grant(self.prefetch);
         // No flow when the charge cancelled the whole window. A peer only gets
         // here by ignoring credit already, so announcing zero to it buys
         // nothing and would put a frame on the wire per `receive` for as long
         // as it misbehaves. A peer merely racing a flow is usually charged
         // less than a window and is still told its reduced credit below.
-        if (self.credit == 0) return;
+        if (self.credit == 0 or self.credit == before) return;
         try self.session.sendFlow(self);
+    }
+
+    /// Charge overrun debt as buffered deliveries are released, but defer a
+    /// positive top-up while a ready backlog already exists. This preserves
+    /// the running credit accounting without making `receive` fail while
+    /// handing back events that arrived before a connection failure.
+    fn chargeOverrunAfterRelease(self: *Receiver, bytes: usize) void {
+        if (self.prefetch == 0 or self.overrun == 0) return;
+        self.releaseBuffered(bytes);
+        defer self.retainBuffered(bytes);
+        const allowance = @min(self.prefetch, self.byteCreditCapacity());
+        self.overrun -= @min(self.overrun, allowance);
     }
 
     /// Detach because the peer sent a message past our declared limit.
@@ -1370,9 +1539,7 @@ pub const Receiver = struct {
         // `refuseOverrun`: a send failure must not leave the link looking
         // attached and retrying this on every subsequent transfer.
         self.attached = false;
-        self.partial.clearAndFree(self.allocator);
-        self.partial_tag.clearAndFree(self.allocator);
-        self.partial_id = null;
+        self.clearPartialAndFree();
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1384,6 +1551,24 @@ pub const Receiver = struct {
             },
         });
         return error.MessageTooLarge;
+    }
+
+    /// Detach before retaining payload bytes past the configured aggregate
+    /// receiver budget.
+    fn refuseBufferLimit(self: *Receiver) LinkError!void {
+        self.attached = false;
+        self.clearPartialAndFree();
+        try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{
+                .handle = self.handle,
+                .closed = true,
+                .err = .{
+                    .condition = "amqp:resource-limit-exceeded",
+                    .description = "receiver buffered payload budget exhausted",
+                },
+            },
+        });
+        return error.BufferLimitExceeded;
     }
 
     /// Tear the link down once a peer has run too far past its credit.
@@ -1407,6 +1592,7 @@ pub const Receiver = struct {
         // subsequent transfer. The caller then sees the send error rather than
         // `CreditExceeded`, which is the more urgent of the two.
         self.attached = false;
+        self.clearPartialAndFree();
         try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1431,8 +1617,10 @@ pub const Receiver = struct {
         }
 
         const delivery = self.ready.items[self.ready_head];
+        self.chargeOverrunAfterRelease(delivery.payload.len);
         self.ready_head += 1;
         self.compactReady();
+        self.releaseBuffered(delivery.payload.len);
 
         // Only now that a replacement is in hand, so a `receive` that fails or
         // times out leaves the previously returned delivery readable, as it
@@ -1444,7 +1632,6 @@ pub const Receiver = struct {
         self.current = delivery.payload;
         self.current_tag = delivery.tag;
 
-        try self.replenish();
         return delivery;
     }
 
@@ -1601,6 +1788,7 @@ pub fn openReceiver(
         .max_overrun = options.max_overrun orelse
             @max(options.prefetch, min_overrun_allowance),
         .max_message_size = options.max_message_size,
+        .max_buffered_bytes = options.max_buffered_bytes,
     };
 
     try session.receivers.append(session.allocator, receiver);
@@ -1789,6 +1977,140 @@ test "a message past max-frame-size is split and reassembles to the original" {
     for (frames.bodies.items) |body| {
         try testing.expect(body.len + frame.frame_header_size <= 512);
     }
+}
+
+test "a session-window timeout after the first frame poisons the sender" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try peer.pushHeader(&frame.amqp_header);
+    try peer.push(0, .{ .open = .{
+        .container_id = "service-bus",
+        .max_frame_size = 512,
+        .channel_max = 255,
+    } });
+    // Exactly one transfer frame fits. The continuation has to wait for a
+    // flow that this peer deliberately never sends.
+    try peer.push(0, .{ .begin = .{
+        .remote_channel = 0,
+        .next_outgoing_id = 1,
+        .incoming_window = 1,
+        .outgoing_window = 1000,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 5,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    const big = try allocator.alloc(u8, 1500);
+    defer allocator.free(big);
+    @memset(big, 'x');
+
+    mem.clearWritten();
+    mem.starve = true;
+    try testing.expectError(error.Timeout, sender.sendBytesAsync(big, .{}, 0));
+
+    try testing.expect(!sender.attached);
+    try testing.expectEqual(@as(u32, 1), sender.delivery_count);
+    try testing.expectEqual(@as(u32, 4), sender.credit);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, perf.descriptor.transfer);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+    var decoded = try perf.decode(allocator, transfers[0]);
+    defer decoded.deinit();
+    try testing.expect(decoded.performative.transfer.more);
+    const detaches = try frames.of(allocator, perf.descriptor.detach);
+    defer allocator.free(detaches);
+    try testing.expectEqual(@as(usize, 1), detaches.len);
+
+    // A crossing disposition for the incomplete id has no phantom ring entry
+    // to retire or settle twice.
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    const before = mem.written().len;
+    try testing.expectError(error.LinkDetached, sender.sendBytesAsync("new", .{}, 10_000));
+    try testing.expectEqual(before, mem.written().len);
+}
+
+test "a socket failure after the first frame poisons the sender" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSenderAttach(peer, 5);
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+
+    const big = try allocator.alloc(u8, 150_000);
+    defer allocator.free(big);
+    @memset(big, 'x');
+
+    mem.clearWritten();
+    // A frame is two writes, header then body. Fail the continuation's header.
+    mem.fail_write_after = mem.write_count + 2;
+    try testing.expectError(error.WriteFailed, sender.sendBytesAsync(big, .{}, 10_000));
+
+    try testing.expect(!sender.attached);
+    try testing.expectEqual(@as(u32, 1), sender.delivery_count);
+    try testing.expectEqual(@as(u32, 4), sender.credit);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, perf.descriptor.transfer);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+
+    mem.fail_write_after = null;
+    const before = mem.written().len;
+    try testing.expectError(error.LinkDetached, sender.sendBytesAsync("new", .{}, 10_000));
+    try testing.expectEqual(before, mem.written().len);
 }
 
 test "a delivery carries the requested message format" {
@@ -3242,6 +3564,43 @@ fn multiFrameReceiveUnderAllocator(allocator: Allocator) !void {
     try receiver.accept(delivery);
 }
 
+fn bufferedReceiveUnderAllocator(allocator: Allocator) !void {
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "t",
+        .settled = true,
+    }, "event");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 8,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("event", delivery.payload);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+}
+
 test "reassembling a delivery leaks nothing however the allocator fails" {
     // A multi-frame delivery is the receive path's allocating shape: the
     // payload buffer grows per frame, and on completion the payload and the
@@ -3257,6 +3616,14 @@ test "reassembling a delivery leaks nothing however the allocator fails" {
     try testing.checkAllAllocationFailures(
         testing.allocator,
         multiFrameReceiveUnderAllocator,
+        .{},
+    );
+}
+
+test "aggregate receive accounting survives every allocation failure" {
+    try testing.checkAllAllocationFailures(
+        testing.allocator,
+        bufferedReceiveUnderAllocator,
         .{},
     );
 }
@@ -3814,6 +4181,7 @@ test "draining an already queued backlog allocates nothing" {
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 128,
+        .max_buffered_bytes = null,
     }, 10_000);
 
     // Queue the whole backlog first, so the receives below are pure drain.
@@ -4040,6 +4408,7 @@ test "a prefetching receiver replenishes credit rather than stalling" {
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = prefetch,
+        .max_buffered_bytes = null,
     }, 10_000);
 
     mem.clearWritten();
@@ -4091,6 +4460,7 @@ test "the attach flow issues the requested prefetch credit" {
         .name = "consumer",
         .source_address = "eh",
         .prefetch = 250,
+        .max_buffered_bytes = null,
     }, 10_000);
     try testing.expectEqual(@as(u32, 250), receiver.credit);
 
@@ -4359,6 +4729,7 @@ test "draining a receiver waits for the sender to consume the outstanding credit
         .name = "drainable",
         .source_address = "partition/0",
         .prefetch = 5,
+        .max_buffered_bytes = null,
     }, 10_000);
     try testing.expectEqual(@as(u32, 5), receiver.credit);
 
@@ -4796,6 +5167,7 @@ test "a peer that overruns its credit is absorbed and charged for it" {
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 0,
+        .max_buffered_bytes = null,
     }, 10_000);
     try receiver.issueCredit(2);
 
@@ -4921,7 +5293,7 @@ test "a prefetching receiver charges an overrun against its next top-up" {
         .initial_delivery_count = 0,
     } });
     var i: u32 = 0;
-    while (i < 6) : (i += 1) {
+    while (i < 7) : (i += 1) {
         try peer.pushTransfer(0, .{
             .handle = 0,
             .delivery_id = i,
@@ -4941,6 +5313,7 @@ test "a prefetching receiver charges an overrun against its next top-up" {
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = prefetch,
+        .max_buffered_bytes = null,
     }, 10_000);
 
     while (receiver.ready.items.len < 6) _ = try fixture.session.pump(10_000);
@@ -4961,9 +5334,14 @@ test "a prefetching receiver charges an overrun against its next top-up" {
     defer allocator.free(none);
     try testing.expectEqual(@as(usize, 0), none.len);
 
-    // Debt cleared, so the next one grants the full window again.
-    _ = try receiver.receive(10_000);
-    try testing.expectEqual(prefetch, receiver.credit);
+    // Positive credit is deferred while a ready backlog exists: there is no
+    // reason to risk a flow write hiding events already in hand. Drain the
+    // other four, then the next receive replenishes before pumping delivery 6.
+    i = 0;
+    while (i < 4) : (i += 1) _ = try receiver.receive(10_000);
+    const next = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 6), next.id);
+    try testing.expectEqual(@as(u32, 1), receiver.credit);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
@@ -5018,6 +5396,7 @@ test "the overrun bound is on by default, not only when asked for" {
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 0,
+        .max_buffered_bytes = null,
     }, 10_000);
     try testing.expectEqual(min_overrun_allowance, receiver.max_overrun);
 
@@ -5209,6 +5588,7 @@ test "a flow that does grant credit has the debt charged against it" {
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 0,
+        .max_buffered_bytes = null,
     }, 10_000);
 
     i = 0;
@@ -5346,6 +5726,7 @@ test "an overrun bound of zero disables the detach but not the charging" {
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 0,
         .max_overrun = 0,
+        .max_buffered_bytes = null,
     }, 10_000);
 
     // Far past what the derived bound would have been, with no detach.
@@ -5413,6 +5794,7 @@ test "a flow that names a delivery count has the debt charged against it too" {
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
         .prefetch = 0,
+        .max_buffered_bytes = null,
     }, 10_000);
 
     i = 0;
@@ -5897,9 +6279,13 @@ test "a receiver is bounded by default" {
     const receiver = try openReceiver(&fixture.session, .{
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
-        .prefetch = 0,
     }, 10_000);
     try testing.expectEqual(default_max_message_size, receiver.maxMessageSize().?);
+    try testing.expectEqual(default_max_buffered_bytes, receiver.max_buffered_bytes.?);
+    // Two worst-case messages fit in the default aggregate budget, so the
+    // requested prefetch of 300 is advertised as two rather than reserving
+    // roughly 38 GiB before overrun is considered.
+    try testing.expectEqual(@as(u32, 2), receiver.credit);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
@@ -5908,6 +6294,294 @@ test "a receiver is bounded by default" {
     var decoded = try perf.decode(allocator, attaches[0]);
     defer decoded.deinit();
     try testing.expectEqual(default_max_message_size, decoded.performative.attach.max_message_size.?);
+
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var flow = try perf.decode(allocator, flows[0]);
+    defer flow.deinit();
+    try testing.expectEqual(@as(u32, 2), flow.performative.flow.link_credit.?);
+}
+
+test "aggregate budget caps credit and replenishes as deliveries leave the queue" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    var i: u32 = 0;
+    while (i < 4) : (i += 1) {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = i,
+            .delivery_tag = "t",
+            .settled = true,
+            .more = false,
+        }, "12345678");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 10,
+        .max_message_size = 8,
+        .max_buffered_bytes = 24,
+    }, 10_000);
+    try testing.expectEqual(@as(u32, 3), receiver.credit);
+
+    while (receiver.ready.items.len < 3) _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 24), receiver.bufferedBytes());
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+
+    mem.clearWritten();
+    const first = try receiver.receive(10_000);
+    try testing.expectEqualStrings("12345678", first.payload);
+    try testing.expectEqual(@as(u64, 16), receiver.bufferedBytes());
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+
+    _ = try receiver.receive(10_000);
+    _ = try receiver.receive(10_000);
+    // The fourth receive finds the ready queue empty, advertises the byte
+    // budget released by the first three, and then accepts the next delivery.
+    const fourth = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 3), fourth.id);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u32, 3), decoded.performative.flow.link_credit.?);
+}
+
+test "a credit-ignoring sender cannot cross the aggregate buffered budget" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    var i: u32 = 0;
+    while (i < 2) : (i += 1) {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = i,
+            .delivery_tag = "t",
+            .settled = true,
+            .more = false,
+        }, "twelve-bytes");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_overrun = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    mem.clearWritten();
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 12), receiver.bufferedBytes());
+    try testing.expectError(error.BufferLimitExceeded, fixture.session.pump(10_000));
+    try testing.expectEqual(@as(u64, 12), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 1), receiver.ready.items.len);
+    try testing.expect(!receiver.attached);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const detaches = try frames.of(allocator, perf.descriptor.detach);
+    defer allocator.free(detaches);
+    try testing.expectEqual(@as(usize, 1), detaches.len);
+    var decoded = try perf.decode(allocator, detaches[0]);
+    defer decoded.deinit();
+    try testing.expectEqualStrings(
+        "amqp:resource-limit-exceeded",
+        decoded.performative.detach.err.?.condition,
+    );
+}
+
+test "aggregate budget releases an in-progress delivery when it is exceeded" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "t",
+        .more = true,
+    }, "0123456789");
+    try peer.pushTransfer(0, .{ .handle = 0, .more = true }, "0123456789");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 64,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 10), receiver.bufferedBytes());
+    try testing.expectError(error.BufferLimitExceeded, fixture.session.pump(10_000));
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
+    try testing.expect(!receiver.attached);
+}
+
+test "a remote detach releases an in-progress delivery's budget" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "t",
+        .more = true,
+    }, "0123456789");
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 64,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 10), receiver.bufferedBytes());
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 0), receiver.partial.capacity);
+    try testing.expect(!receiver.attached);
+}
+
+test "one receiver exhausting its budget does not block another link" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    for ([_][]const u8{ "hostile", "healthy" }, 0..) |name, handle| {
+        try peer.push(0, .{ .attach = .{
+            .name = name,
+            .handle = @intCast(handle),
+            .role = .sender,
+            .initial_delivery_count = 0,
+        } });
+    }
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "t",
+        .settled = true,
+    }, "123456");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 1,
+        .delivery_tag = "t",
+        .settled = true,
+    }, "123456");
+    try peer.pushTransfer(0, .{
+        .handle = 1,
+        .delivery_id = 2,
+        .delivery_tag = "t",
+        .settled = true,
+    }, "good");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const hostile = try openReceiver(&fixture.session, .{
+        .name = "hostile",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_overrun = 0,
+        .max_message_size = 8,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+    const healthy = try openReceiver(&fixture.session, .{
+        .name = "healthy",
+        .source_address = "partition/1",
+        .prefetch = 1,
+        .max_message_size = 8,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectError(error.BufferLimitExceeded, fixture.session.pump(10_000));
+    try testing.expect(!hostile.attached);
+
+    const delivery = try healthy.receive(10_000);
+    try testing.expectEqualStrings("good", delivery.payload);
+    try testing.expect(healthy.attached);
 }
 
 test "a zero max-message-size means unlimited, not zero" {

--- a/link.zig
+++ b/link.zig
@@ -97,13 +97,6 @@ fn remainingToDeliveryLimit(limit: u32, count: u32) u32 {
     return if (remaining > 0) @intCast(remaining) else 0;
 }
 
-fn senderSettleModesCompatible(
-    actual: perf.SenderSettleMode,
-    desired: perf.SenderSettleMode,
-) bool {
-    return actual == .mixed or desired == .mixed or actual == desired;
-}
-
 pub const Session = struct {
     allocator: Allocator,
     driver: *Driver,
@@ -564,12 +557,9 @@ pub const Session = struct {
         // Match by link name: the peer echoes it and picks its own handle.
         for (self.senders.items) |s| {
             if (s.awaiting_attach and !s.poisoned and std.mem.eql(u8, s.name, a.name)) {
-                // The sender declares the actual mode. A receiver's field is
-                // only its desired preference; omission decodes as mixed and
-                // must not silently rewrite settled into unsettled or vice
-                // versa.
-                if (!senderSettleModesCompatible(s.snd_settle_mode, a.snd_settle_mode))
-                    return error.MalformedFrame;
+                // `openSender` initiated this link, so its Attach declared the
+                // actual mode. The receiver's response is advisory even when
+                // it expresses the opposite fixed preference.
                 s.remote_handle = a.handle;
                 s.max_message_size = a.max_message_size;
                 s.rcv_settle_mode = a.rcv_settle_mode;
@@ -730,9 +720,9 @@ pub const SenderOptions = struct {
     /// The entity the messages go to, such as `eh` or `eh/Partitions/3`.
     target_address: []const u8,
     source_address: ?[]const u8 = null,
-    /// Actual sender settlement mode. The receiver's Attach carries only its
-    /// desired preference: mixed/omitted accepts this selection, while a
-    /// conflicting fixed preference rejects the Attach.
+    /// Actual sender settlement mode. For this locally initiated link, the
+    /// receiver's Attach carries only an advisory desired preference and
+    /// cannot replace this selection.
     snd_settle_mode: perf.SenderSettleMode = .mixed,
     rcv_settle_mode: perf.ReceiverSettleMode = .first,
     desired_capabilities: ?[]const []const u8 = null,
@@ -4112,7 +4102,7 @@ test "an omitted receiver preference does not pre-settle an unsettled sender" {
     try testing.expect(!(decoded.performative.transfer.settled orelse false));
 }
 
-test "a conflicting fixed receiver settlement preference rejects Attach" {
+test "a conflicting receiver preference preserves actual mode and other links" {
     const Case = struct {
         local: perf.SenderSettleMode,
         remote: perf.SenderSettleMode,
@@ -4130,11 +4120,35 @@ test "a conflicting fixed receiver settlement preference rejects Attach" {
 
         try scriptHandshake(peer, 65536);
         try peer.push(0, .{ .attach = .{
+            .name = "survivor",
+            .handle = 10,
+            .role = .receiver,
+            .initial_delivery_count = 0,
+        } });
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1000,
+            .next_outgoing_id = 1,
+            .outgoing_window = 1000,
+            .handle = 10,
+            .delivery_count = 0,
+            .link_credit = 1,
+        } });
+        try peer.push(0, .{ .attach = .{
             .name = "producer",
-            .handle = 0,
+            .handle = 11,
             .role = .receiver,
             .snd_settle_mode = case.remote,
             .initial_delivery_count = 0,
+        } });
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1000,
+            .next_outgoing_id = 1,
+            .outgoing_window = 1000,
+            .handle = 11,
+            .delivery_count = 0,
+            .link_credit = 1,
         } });
 
         var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
@@ -4142,19 +4156,47 @@ test "a conflicting fixed receiver settlement preference rejects Attach" {
         var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
         defer fixture.deinit();
 
-        try testing.expectError(error.MalformedFrame, openSender(&fixture.session, .{
+        const survivor = try openSender(&fixture.session, .{
+            .name = "survivor",
+            .target_address = "other",
+            .snd_settle_mode = .settled,
+        }, 10_000);
+        const sender = try openSender(&fixture.session, .{
             .name = "producer",
             .target_address = "entity",
             .snd_settle_mode = case.local,
-        }, 10_000));
-        try testing.expectEqual(connection.State.err, driver.state);
-        try testing.expect(fixture.session.ended);
+        }, 10_000);
+        _ = try fixture.session.pump(10_000);
 
+        try testing.expectEqual(connection.State.opened, driver.state);
+        try testing.expect(!fixture.session.ended);
+        try testing.expect(survivor.attached);
+        try testing.expect(sender.attached);
+        try testing.expectEqual(case.local, sender.snd_settle_mode);
+
+        mem.clearWritten();
+        _ = try survivor.sendBytesAsync("other", .{}, 10_000);
+        _ = try sender.sendBytesAsync("actual", .{}, 10_000);
         var frames = try EmittedFrames.parse(allocator, mem.written());
         defer frames.deinit();
         const transfers = try frames.of(allocator, perf.descriptor.transfer);
         defer allocator.free(transfers);
-        try testing.expectEqual(@as(usize, 0), transfers.len);
+        try testing.expectEqual(@as(usize, 2), transfers.len);
+
+        var survivor_transfer = try perf.decode(allocator, transfers[0]);
+        defer survivor_transfer.deinit();
+        try testing.expect(survivor_transfer.performative.transfer.settled orelse false);
+
+        var actual_transfer = try perf.decode(allocator, transfers[1]);
+        defer actual_transfer.deinit();
+        try testing.expectEqual(
+            case.local == .settled,
+            actual_transfer.performative.transfer.settled orelse false,
+        );
+        try testing.expectEqual(
+            @as(usize, if (case.local == .settled) 0 else 1),
+            sender.inFlight(),
+        );
     }
 }
 

--- a/link.zig
+++ b/link.zig
@@ -90,6 +90,13 @@ fn removeLink(comptime T: type, list: *std.ArrayList(*T), link: *T) void {
     }
 }
 
+/// Remaining serial-number distance from `count` to `limit`. A value in the
+/// undefined/backwards half of RFC 1982 cannot authorize deliveries.
+fn remainingToDeliveryLimit(limit: u32, count: u32) u32 {
+    const remaining: i32 = @bitCast(limit -% count);
+    return if (remaining > 0) @intCast(remaining) else 0;
+}
+
 pub const Session = struct {
     allocator: Allocator,
     driver: *Driver,
@@ -378,41 +385,35 @@ pub const Session = struct {
             s.drain = f.drain;
         }
         if (self.receiverFor(handle)) |r| {
-            // For a receiving link the peer is the sender, so its flow reports
-            // where its delivery count has reached. Rebase the credit we still
-            // hold onto our own count; a drain response advances the count to
-            // consume the remainder, leaving us at zero.
-            const credit = f.link_credit orelse r.credit;
+            // Only this receiver grants credit. A sender's Flow may reconcile
+            // its view and reduce what remains, but can never manufacture a
+            // larger local authorization.
+            var reconciled = @min(
+                r.credit,
+                remainingToDeliveryLimit(r.delivery_limit, r.delivery_count),
+            );
+            if (f.link_credit) |peer_credit| {
+                const peer_count = f.delivery_count orelse r.delivery_count;
+                const peer_limit = peer_count +% peer_credit;
+                reconciled = @min(
+                    reconciled,
+                    remainingToDeliveryLimit(peer_limit, r.delivery_count),
+                );
+            }
             if (f.drain) {
                 // A drain response advances the sender's count over whatever
-                // credit went unused, so its count is authoritative. Link
-                // credit is optional; when omitted, derive what remains from
-                // the delivery limit established by our previous grant.
+                // credit went unused, so its count is authoritative. When
+                // link-credit is omitted, the locally emitted delivery limit
+                // still determines what remains.
                 if (f.delivery_count) |their_count| {
-                    const prior_limit = r.delivery_count +% r.credit;
-                    const remaining: i32 = @bitCast(prior_limit -% their_count);
+                    reconciled = @min(
+                        reconciled,
+                        remainingToDeliveryLimit(r.delivery_limit, their_count),
+                    );
                     r.delivery_count = their_count;
-                    r.grant(f.link_credit orelse
-                        if (remaining > 0)
-                            @min(r.credit, @as(u32, @intCast(remaining)))
-                        else
-                            0);
-                } else {
-                    r.grant(credit);
                 }
-            } else if (f.delivery_count) |their_count| {
-                // Serial arithmetic (RFC 1982). A flow whose count lags the
-                // transfers already on the wire — an ordinary crossing, not a
-                // malformed frame — leaves a negative remainder, and read as
-                // `u32` that wraps to billions. Taking it as signed and
-                // clamping keeps a lagging flow from handing this endpoint
-                // effectively unlimited credit, which would make any bound
-                // built on credit meaningless.
-                const remaining: i32 = @bitCast(their_count +% credit -% r.delivery_count);
-                r.grant(if (remaining > 0) @intCast(remaining) else 0);
-            } else {
-                r.grant(credit);
             }
+            r.credit = reconciled;
         }
         if (f.echo) try self.sendFlow(null);
     }
@@ -558,6 +559,7 @@ pub const Session = struct {
             if (s.awaiting_attach and !s.poisoned and std.mem.eql(u8, s.name, a.name)) {
                 s.remote_handle = a.handle;
                 s.max_message_size = a.max_message_size;
+                s.snd_settle_mode = a.snd_settle_mode;
                 s.rcv_settle_mode = a.rcv_settle_mode;
                 if (a.initial_delivery_count) |c| s.delivery_count = c;
                 s.attached = true;
@@ -714,7 +716,9 @@ pub const SenderOptions = struct {
     /// The entity the messages go to, such as `eh` or `eh/Partitions/3`.
     target_address: []const u8,
     source_address: ?[]const u8 = null,
-    /// Go asks for mixed settlement with receiver-settle-mode first.
+    /// Desired sender settlement mode. The receiver's Attach selects the
+    /// actual mode: settled deliveries complete once emitted and retain no
+    /// in-flight entry; mixed and unsettled deliveries await disposition.
     snd_settle_mode: perf.SenderSettleMode = .mixed,
     rcv_settle_mode: perf.ReceiverSettleMode = .first,
     desired_capabilities: ?[]const []const u8 = null,
@@ -815,6 +819,8 @@ pub const Sender = struct {
     credit: u32 = 0,
     drain: bool = false,
     delivery_count: u32 = 0,
+    /// Sender settlement mode selected by the remote receiver's Attach.
+    snd_settle_mode: perf.SenderSettleMode = .mixed,
     /// Receiver settlement mode selected by the remote receiver's Attach.
     rcv_settle_mode: perf.ReceiverSettleMode = .first,
     /// Peer's `max-message-size`; null or 0 means unlimited.
@@ -864,10 +870,12 @@ pub const Sender = struct {
     ///
     /// Their verdicts are lost — including any the peer has already sent but
     /// the caller has not collected, since `awaitSettlement` retires strictly
-    /// in send order and a peer may settle out of it. The peer may also settle
-    /// those ids later, and those dispositions are then ignored. So this is
-    /// at-least-once: a caller that abandons a delivery the broker went on to
-    /// accept and then resends it has published it twice.
+    /// in send order and a peer may settle out of it. In receiver-settle-mode
+    /// second, abandoning an undecided id terminally detaches the link because
+    /// a later first-phase disposition could no longer be acknowledged after
+    /// the id was discarded. Other modes remain at-least-once: a caller that
+    /// abandons a delivery the broker went on to accept and then resends it has
+    /// published it twice.
     ///
     /// This is the way out of a pipelined send that failed partway. A sender
     /// still holding unsettled deliveries refuses every later blocking send
@@ -907,6 +915,7 @@ pub const Sender = struct {
     /// comparing the result against `out.len` can tell that it was. Sizing
     /// `out` to `inFlight()` before the call is always enough.
     pub fn abandonInFlightInto(self: *Sender, out: []DecidedDelivery) usize {
+        self.terminalizeAbandonedModeSecond();
         var decided: usize = 0;
         while (self.in_flight_len > 0) {
             const entry = self.entryAt(0);
@@ -920,6 +929,44 @@ pub const Sender = struct {
             self.discardOldest();
         }
         return decided;
+    }
+
+    /// Receiver-settle-mode second requires us to acknowledge a late
+    /// unsettled receiver disposition. Once an undecided entry is discarded,
+    /// its id is gone and that acknowledgment cannot be produced safely.
+    /// Close the link instead of retaining unbounded tombstones or pretending
+    /// it remains reusable.
+    fn terminalizeAbandonedModeSecond(self: *Sender) void {
+        if (self.rcv_settle_mode != .second or self.poisoned) return;
+        var has_undecided = false;
+        for (0..self.in_flight_len) |i| {
+            if (self.entryAt(i).outcome == null) {
+                has_undecided = true;
+                break;
+            }
+        }
+        if (!has_undecided) return;
+
+        self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
+        self.detach_sent = true;
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{
+                .handle = self.handle,
+                .closed = true,
+                .err = .{
+                    .condition = "amqp:link:detach-forced",
+                    .description = "mode-second delivery was abandoned before settlement",
+                },
+            },
+        }) catch {
+            // Without the Detach the peer would retain an id we are about to
+            // forget. Close the whole stream rather than leave an
+            // unacknowledgeable mode-second delivery on a reusable session.
+            self.session.driver.invalidate();
+            self.session.terminate();
+        };
     }
 
     /// How many deliveries are written but not yet settled.
@@ -1079,13 +1126,18 @@ pub const Sender = struct {
         // `sendBytesAsync` would either report another delivery's verdict as
         // this one's or discard that delivery's verdict entirely, so refuse
         // rather than guess. A caller that never pipelines never sees this.
-        if (self.in_flight_len != 0) return error.DeliveriesInFlight;
+        if (self.snd_settle_mode != .settled and self.in_flight_len != 0)
+            return error.DeliveriesInFlight;
 
         const token = try self.sendBytesAsync(payload, options, deadline_ms);
+        if (self.snd_settle_mode == .settled) return;
         // A send that never reaches a verdict — a timeout, a detach — used to
         // leave no trace. Keeping the entry would wedge the sender: with the
         // default window of one, every later send would find it full.
-        errdefer self.discardOldest();
+        errdefer {
+            self.terminalizeAbandonedModeSecond();
+            self.discardOldest();
+        }
 
         const settlement = try self.awaitSettlement(deadline_ms);
         std.debug.assert(settlement.token.id == token.id);
@@ -1112,7 +1164,9 @@ pub const Sender = struct {
     /// The returned token names the delivery in the `Settlement` that
     /// `awaitSettlement` later produces, so a caller keeping several
     /// deliveries in flight can tell which one the peer refused. Deliveries
-    /// settle in the order they were sent.
+    /// settle in the order they were sent. In negotiated sender-settled mode,
+    /// the token identifies the emitted delivery but no settlement entry is
+    /// retained and `awaitSettlement` has nothing to return.
     ///
     /// Returns `error.InFlightWindowFull` when `max_in_flight` deliveries are
     /// already unsettled. Blocking instead would deadlock: only the caller
@@ -1133,7 +1187,9 @@ pub const Sender = struct {
         if (self.maxMessageSize()) |limit| {
             if (payload.len > limit) return error.MessageTooLarge;
         }
-        if (self.in_flight_len == self.in_flight.len) return error.InFlightWindowFull;
+        const sender_settled = self.snd_settle_mode == .settled;
+        if (!sender_settled and self.in_flight_len == self.in_flight.len)
+            return error.InFlightWindowFull;
         try self.awaitCredit(deadline_ms);
 
         const delivery_id = self.session.next_outgoing_id;
@@ -1146,9 +1202,21 @@ pub const Sender = struct {
         // the delivery id, tag and message format, and every continuation
         // carries none of them. Measuring per chunk re-encoded the same
         // performative once per frame to learn the same two numbers.
-        const first_budget = try self.chunkBudget(delivery_id, &tag, true, options.message_format);
+        const first_budget = try self.chunkBudget(
+            delivery_id,
+            &tag,
+            true,
+            options.message_format,
+            sender_settled,
+        );
         const cont_budget: usize = if (payload.len > first_budget)
-            try self.chunkBudget(delivery_id, &tag, false, options.message_format)
+            try self.chunkBudget(
+                delivery_id,
+                &tag,
+                false,
+                options.message_format,
+                sender_settled,
+            )
         else
             first_budget;
         var begun = false;
@@ -1172,7 +1240,7 @@ pub const Sender = struct {
                 .delivery_id = if (first) delivery_id else null,
                 .delivery_tag = if (first) &tag else null,
                 .message_format = if (first) options.message_format else null,
-                .settled = false,
+                .settled = sender_settled,
                 .more = more,
             };
             // The frame is the performative plus the chunk, and `chunkBudget`
@@ -1205,6 +1273,8 @@ pub const Sender = struct {
         }
 
         complete = true;
+
+        if (sender_settled) return .{ .id = delivery_id };
 
         // Pushed only once every frame is away. A failure after the opening
         // frame poisons the link instead: the peer is holding an unterminated
@@ -1281,6 +1351,7 @@ pub const Sender = struct {
         tag: *const [4]u8,
         first: bool,
         message_format: u32,
+        settled: bool,
     ) LinkError!usize {
         var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
         defer buf.deinit();
@@ -1293,7 +1364,7 @@ pub const Sender = struct {
             .delivery_id = if (first) delivery_id else null,
             .delivery_tag = if (first) tag else null,
             .message_format = if (first) message_format else null,
-            .settled = false,
+            .settled = settled,
             .more = true,
         }, &buf);
 
@@ -1380,6 +1451,7 @@ pub fn openSender(
         .name = name,
         .handle = session.allocateHandle(),
         .in_flight = in_flight,
+        .snd_settle_mode = options.snd_settle_mode,
         .rcv_settle_mode = options.rcv_settle_mode,
     };
 
@@ -1554,6 +1626,9 @@ pub const Receiver = struct {
     deferred_credit: u32 = 0,
     drain: bool = false,
     delivery_count: u32 = 0,
+    /// Exclusive delivery id limit established only by a successfully emitted
+    /// local Flow. Remote Flow state may reduce credit but never advances it.
+    delivery_limit: u32 = 0,
     /// The limit declared in our `attach`; see `maxMessageSize` for the rule
     /// actually enforced, and `ReceiverOptions.max_message_size` for what null
     /// means.
@@ -1975,8 +2050,13 @@ pub const Receiver = struct {
     /// Maximum credit that can be outstanding without letting a conforming
     /// sender exceed the aggregate payload budget.
     fn byteCreditCapacity(self: *const Receiver) u32 {
-        const slots = self.max_unsettled_deliveries -|
-            @as(u32, @intCast(self.unsettled_ids.items.len));
+        // Delivery limits are serial numbers; a grant spanning the undefined
+        // half-range cannot later be reconciled safely across wrap.
+        const slots = @min(
+            self.max_unsettled_deliveries -|
+                @as(u32, @intCast(self.unsettled_ids.items.len)),
+            @as(u32, std.math.maxInt(i32)),
+        );
         const limit = self.max_buffered_bytes orelse return slots;
         // With no per-message bound, one delivery may consume the whole
         // aggregate budget. If the configured message limit is larger than
@@ -2019,7 +2099,7 @@ pub const Receiver = struct {
         prospective.deferred_credit +|= count;
         self.grantDeferredCredit(&prospective);
         try self.session.sendFlowWithCredit(self, prospective.credit);
-        self.commitCreditState(prospective);
+        self.commitEmittedCreditState(prospective);
     }
 
     fn reserveIncomingCapacity(self: *Receiver, count: u32) Allocator.Error!void {
@@ -2051,6 +2131,11 @@ pub const Receiver = struct {
         self.overrun = state.overrun;
     }
 
+    fn commitEmittedCreditState(self: *Receiver, state: CreditState) void {
+        self.commitCreditState(state);
+        self.delivery_limit = self.delivery_count +% state.credit;
+    }
+
     fn grantDeferredCredit(self: *const Receiver, state: *CreditState) void {
         const capacity = self.byteCreditCapacity();
         if (state.credit >= capacity or state.deferred_credit == 0) return;
@@ -2059,18 +2144,7 @@ pub const Receiver = struct {
         self.grantCreditState(state, state.credit + issued);
     }
 
-    /// Set credit to `amount`, charging any outstanding overrun against it.
-    ///
-    /// The single place credit is established. `replenish` and `issueCredit`
-    /// go through it, and so does `Session.applyFlow`, where the peer rebases
-    /// credit onto this endpoint's delivery count: a peer must not be able to
-    /// clear the debt it ran up simply by asserting a new window.
-    fn grant(self: *Receiver, amount: u32) void {
-        var state = self.creditState();
-        self.grantCreditState(&state, amount);
-        self.commitCreditState(state);
-    }
-
+    /// Set prospective locally authorized credit, charging overrun debt.
     fn grantCreditState(self: *const Receiver, state: *CreditState, amount: u32) void {
         const bounded = @min(amount, self.byteCreditCapacity());
         const charged = @min(state.overrun, bounded);
@@ -2087,7 +2161,7 @@ pub const Receiver = struct {
             self.grantDeferredCredit(&prospective);
             if (prospective.credit != before) {
                 try self.session.sendFlowWithCredit(self, prospective.credit);
-                self.commitCreditState(prospective);
+                self.commitEmittedCreditState(prospective);
                 return;
             }
         }
@@ -2125,7 +2199,7 @@ pub const Receiver = struct {
             return;
         }
         try self.session.sendFlowWithCredit(self, prospective.credit);
-        self.commitCreditState(prospective);
+        self.commitEmittedCreditState(prospective);
     }
 
     /// Charge overrun debt as buffered deliveries are released, but defer a
@@ -2236,8 +2310,9 @@ pub const Receiver = struct {
     fn refuseOverrun(self: *Receiver) LinkError!void {
         if (self.max_overrun == 0) return;
         if (self.overrun < self.max_overrun) return;
-        // Every path that establishes credit charges the debt first, so this
-        // should be unreachable — and it survives mutation for that reason.
+        // Every local path that establishes credit charges the debt first, and
+        // incoming sender Flow can only reduce credit, so this should be
+        // unreachable — and it survives mutation for that reason.
         // It stays a guard rather than an assert because `credit` is computed
         // from values the peer supplies in a flow, and an assert on an
         // invariant a remote peer participates in is a way to be aborted
@@ -2661,6 +2736,10 @@ fn expectReceiverAccounting(receiver: *const Receiver) !void {
     try testing.expect(
         receiver.unsettled_ids.items.len + @as(usize, receiver.credit) <=
             receiver.max_unsettled_deliveries,
+    );
+    try testing.expect(
+        receiver.credit <=
+            remainingToDeliveryLimit(receiver.delivery_limit, receiver.delivery_count),
     );
     try testing.expect(receiver.unsettled_ids.capacity <= receiver.max_unsettled_deliveries);
 }
@@ -3734,6 +3813,275 @@ fn scriptSenderAttach(peer: Peer, credit: u32) !void {
         .delivery_count = 0,
         .link_credit = credit,
     } });
+}
+
+fn scriptSettledSenderAttach(peer: Peer, credit: u32) !void {
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .snd_settle_mode = .settled,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = credit,
+    } });
+}
+
+fn scriptModeSecondSenderAttach(peer: Peer, credit: u32) !void {
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .rcv_settle_mode = .second,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = credit,
+    } });
+}
+
+test "negotiated settled sender completes sync and async sends on emission" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSettledSenderAttach(peer, 3);
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+        .snd_settle_mode = .settled,
+        .max_in_flight = 1,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(perf.SenderSettleMode.settled, sender.snd_settle_mode);
+
+    mem.clearWritten();
+    try sender.sendBytes("sync", 10_000);
+    const token = try sender.sendBytesAsync("async", .{}, 10_000);
+    try testing.expectEqual(@as(u32, 1), token.id);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+    try testing.expectError(error.NoDeliveryInFlight, sender.awaitSettlement(10_000));
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, perf.descriptor.transfer);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 2), transfers.len);
+    for (transfers, 0..) |body, id| {
+        var decoded = try perf.decode(allocator, body);
+        defer decoded.deinit();
+        const transfer = decoded.performative.transfer;
+        try testing.expect(transfer.settled orelse false);
+        try testing.expectEqual(@as(?u32, @intCast(id)), transfer.delivery_id);
+    }
+}
+
+test "remote receiver Attach selects the actual sender settlement mode" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    // The local sender requests settled, but the receiver answers with the
+    // default mixed mode. Transfers must follow the negotiated response.
+    try scriptSenderAttach(peer, 1);
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+        .snd_settle_mode = .settled,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(perf.SenderSettleMode.mixed, sender.snd_settle_mode);
+
+    mem.clearWritten();
+    const token = try sender.sendBytesAsync("mixed", .{}, 10_000);
+    try testing.expectEqual(@as(usize, 1), sender.inFlight());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, perf.descriptor.transfer);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+    var decoded = try perf.decode(allocator, transfers[0]);
+    defer decoded.deinit();
+    try testing.expect(!(decoded.performative.transfer.settled orelse false));
+
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = token.id,
+        .settled = true,
+        .state = .accepted,
+    } });
+    const settlement = try sender.awaitSettlement(10_000);
+    try testing.expectEqual(Outcome.accepted, settlement.outcome);
+}
+
+test "settled sender emission failure poisons without retaining in-flight state" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptSettledSenderAttach(peer, 1);
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+        .snd_settle_mode = .settled,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+
+    mem.clearWritten();
+    mem.fail_write_after = mem.write_count + 1;
+    try testing.expectError(
+        error.WriteFailed,
+        sender.sendBytesAsync("settled", .{}, 10_000),
+    );
+    mem.fail_write_after = null;
+
+    try testing.expect(sender.poisoned);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expectError(error.LinkDetached, sender.sendBytes("no reuse", 10_000));
+}
+
+test "mode-second settlement timeout closes the link before forgetting its id" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{ .auto_advance_ms = 1 };
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptModeSecondSenderAttach(peer, 1);
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+        .rcv_settle_mode = .second,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+
+    mem.clearWritten();
+    mem.starve = true;
+    try testing.expectError(
+        error.Timeout,
+        sender.sendBytes("payload", clock.millis + 10),
+    );
+    try testing.expect(sender.poisoned);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, perf.descriptor.transfer);
+    defer allocator.free(transfers);
+    const detaches = try frames.of(allocator, perf.descriptor.detach);
+    defer allocator.free(detaches);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+    try testing.expectEqual(@as(usize, 1), detaches.len);
+    var decoded = try perf.decode(allocator, detaches[0]);
+    defer decoded.deinit();
+    try testing.expect(decoded.performative.detach.closed);
+
+    // A late first-phase disposition needs no acknowledgment: the peer was
+    // already told this link is terminal before the id was discarded.
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .settled = false,
+        .state = .accepted,
+    } });
+    mem.clearWritten();
+    _ = try fixture.session.pump(clock.millis + 10_000);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+    try testing.expectError(
+        error.LinkDetached,
+        sender.sendBytes("no reuse", clock.millis + 10_000),
+    );
+}
+
+test "abandoning undecided mode-second deliveries closes the bounded link state" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptModeSecondSenderAttach(peer, 2);
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+        .rcv_settle_mode = .second,
+        .max_in_flight = 2,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    _ = try sender.sendBytesAsync("a", .{}, 10_000);
+    _ = try sender.sendBytesAsync("b", .{}, 10_000);
+
+    mem.clearWritten();
+    sender.abandonInFlight();
+    sender.abandonInFlight();
+    try testing.expect(sender.poisoned);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const detaches = try frames.of(allocator, perf.descriptor.detach);
+    defer allocator.free(detaches);
+    try testing.expectEqual(@as(usize, 1), detaches.len);
+
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 1,
+        .settled = false,
+        .state = .accepted,
+    } });
+    mem.clearWritten();
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+    try testing.expectError(error.LinkDetached, sender.sendBytes("no reuse", 10_000));
 }
 
 test "session ids count transfer frames, so a delivery id follows the frames before it" {
@@ -6780,6 +7128,7 @@ fn creditFlowFailureIsTransactional(path: CreditFlowPath, failure: CreditFlowFai
     receiver.overrun = 1;
     receiver.delivery_count = 7;
     const before = receiver.creditState();
+    const before_limit = receiver.delivery_limit;
     mem.clearWritten();
 
     var switching = SwitchAllocator{ .child = allocator };
@@ -6809,6 +7158,7 @@ fn creditFlowFailureIsTransactional(path: CreditFlowPath, failure: CreditFlowFai
     try testing.expectEqual(before.credit, receiver.credit);
     try testing.expectEqual(before.deferred_credit, receiver.deferred_credit);
     try testing.expectEqual(before.overrun, receiver.overrun);
+    try testing.expectEqual(before_limit, receiver.delivery_limit);
     try testing.expectEqual(@as(usize, 0), mem.written().len);
     try testing.expectEqual(@as(usize, 0), mem.pending.items.len);
 
@@ -6820,6 +7170,7 @@ fn creditFlowFailureIsTransactional(path: CreditFlowPath, failure: CreditFlowFai
         try testing.expectEqual(@as(u32, 3), receiver.credit);
         try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
         try testing.expectEqual(@as(u32, 0), receiver.overrun);
+        try testing.expectEqual(@as(u32, 10), receiver.delivery_limit);
 
         var frames = try EmittedFrames.parse(allocator, mem.written());
         defer frames.deinit();
@@ -6851,6 +7202,7 @@ fn creditFlowFailureIsTransactional(path: CreditFlowPath, failure: CreditFlowFai
     try testing.expectEqual(before.credit, receiver.credit);
     try testing.expectEqual(before.deferred_credit, receiver.deferred_credit);
     try testing.expectEqual(before.overrun, receiver.overrun);
+    try testing.expectEqual(before_limit, receiver.delivery_limit);
     try testing.expectEqual(@as(usize, 0), mem.written().len);
 }
 
@@ -6900,6 +7252,7 @@ test "drain state commits only after its Flow is emitted" {
     }, 10_000);
     receiver.credit = 4;
     receiver.delivery_count = 7;
+    receiver.delivery_limit = 11;
     mem.clearWritten();
 
     var switching = SwitchAllocator{ .child = allocator, .failing = true };
@@ -7235,6 +7588,7 @@ test "omitted drain credit derives remaining across delivery-count wrap" {
     }, 10_000);
     receiver.delivery_count = std.math.maxInt(u32) - 1;
     receiver.credit = 4;
+    receiver.delivery_limit = 2;
     receiver.drain = true;
 
     // The previous delivery limit wraps to 2. Advancing to 0 consumes two
@@ -8067,10 +8421,7 @@ test "a peer cannot clear the debt it ran up by sending a flow" {
     try testing.expect(!receiver.attached);
 }
 
-test "a flow that does grant credit has the debt charged against it" {
-    // The other half: a peer flow is a legitimate way to establish credit, and
-    // it must go through the same charging as `issueCredit` rather than
-    // resetting the count and forgiving what was already taken.
+test "a peer flow cannot grant receiver credit or clear overrun debt" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -8120,8 +8471,13 @@ test "a flow that does grant credit has the debt charged against it" {
     while (i < 3) : (i += 1) _ = try receiver.receive(10_000);
     try testing.expectEqual(@as(u32, 3), receiver.overrun);
 
-    while (receiver.credit == 0) _ = try fixture.session.pump(10_000);
-    // Ten asserted by the peer, three already taken, so seven are usable.
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 3), receiver.overrun);
+
+    // Only the local receiver can authorize more deliveries. Its ten-credit
+    // request pays the three-delivery debt and emits the remaining seven.
+    try receiver.issueCredit(10);
     try testing.expectEqual(@as(u32, 7), receiver.credit);
     try testing.expectEqual(@as(u32, 0), receiver.overrun);
 }
@@ -8313,14 +8669,7 @@ test "disabled overrun detachment saturates debt instead of overflowing" {
     try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
 }
 
-test "a flow that names a delivery count has the debt charged against it too" {
-    // The branch above it. A flow carrying `delivery-count` is rebased onto
-    // this endpoint's own count before the credit is taken, and that rebase
-    // sits between the peer's number and the charge -- which is exactly where
-    // a grant can be established without the debt being charged against it.
-    // The sibling test covers the count-less branch, and the lagging-flow test
-    // covers the clamp, but neither can see this one: with the clamp in place
-    // a lagging flow grants zero, and zero is charged the same either way.
+test "a peer flow with delivery count cannot grant receiver credit" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -8345,8 +8694,8 @@ test "a flow that names a delivery count has the debt charged against it too" {
             .more = false,
         }, "event");
     }
-    // Names the count this endpoint has itself reached, so the rebase is a
-    // no-op and the whole ten survives the clamp.
+    // Even an internally consistent peer delivery-count and link-credit pair
+    // cannot create authorization that this receiver never emitted.
     try peer.push(0, .{ .flow = .{
         .next_incoming_id = 0,
         .incoming_window = 100,
@@ -8374,9 +8723,109 @@ test "a flow that names a delivery count has the debt charged against it too" {
     try testing.expectEqual(@as(u32, 3), receiver.overrun);
     try testing.expectEqual(@as(u32, 3), receiver.delivery_count);
 
-    while (receiver.credit == 0) _ = try fixture.session.pump(10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 3), receiver.overrun);
+
+    try receiver.issueCredit(10);
     try testing.expectEqual(@as(u32, 7), receiver.credit);
     try testing.expectEqual(@as(u32, 0), receiver.overrun);
+}
+
+test "hostile receiver flows cannot mint credit across delivery-count wrap" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .prefetch = 0,
+        .max_overrun = 1,
+        .max_buffered_bytes = null,
+    }, 10_000);
+
+    // A local one-credit grant wraps its exclusive delivery limit to zero.
+    receiver.delivery_count = std.math.maxInt(u32);
+    try receiver.issueCredit(1);
+    try testing.expectEqual(@as(u32, 0), receiver.delivery_limit);
+    mem.clearWritten();
+
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "a",
+        .settled = true,
+    }, "");
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+
+    // One raced transfer consumes the configured overrun allowance. Its
+    // preceding Flow claims fresh credit, but cannot enlarge local authority.
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 1,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 1,
+        .delivery_tag = "b",
+        .settled = true,
+    }, "");
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.overrun);
+
+    const ready_len = receiver.ready.items.len;
+    const ready_capacity = receiver.ready.capacity;
+    for (2..6) |id| {
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1000,
+            .next_outgoing_id = @intCast(id),
+            .outgoing_window = 1000,
+            .handle = 0,
+            .delivery_count = @intCast(id - 1),
+            .link_credit = 1,
+        } });
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = @intCast(id),
+            .delivery_tag = "hostile",
+            .settled = true,
+        }, "");
+    }
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectError(error.CreditExceeded, fixture.session.pump(10_000));
+    for (0..6) |_| _ = try fixture.session.pump(10_000);
+
+    try testing.expect(receiver.poisoned);
+    try testing.expectEqual(ready_len, receiver.ready.items.len);
+    try testing.expectEqual(ready_capacity, receiver.ready.capacity);
+    try testing.expectEqual(@as(u32, 1), receiver.overrun);
 }
 
 test "abandoning collects a verdict stranded behind an undecided delivery" {

--- a/link.zig
+++ b/link.zig
@@ -97,6 +97,13 @@ fn remainingToDeliveryLimit(limit: u32, count: u32) u32 {
     return if (remaining > 0) @intCast(remaining) else 0;
 }
 
+fn senderSettleModesCompatible(
+    actual: perf.SenderSettleMode,
+    desired: perf.SenderSettleMode,
+) bool {
+    return actual == .mixed or desired == .mixed or actual == desired;
+}
+
 pub const Session = struct {
     allocator: Allocator,
     driver: *Driver,
@@ -557,9 +564,14 @@ pub const Session = struct {
         // Match by link name: the peer echoes it and picks its own handle.
         for (self.senders.items) |s| {
             if (s.awaiting_attach and !s.poisoned and std.mem.eql(u8, s.name, a.name)) {
+                // The sender declares the actual mode. A receiver's field is
+                // only its desired preference; omission decodes as mixed and
+                // must not silently rewrite settled into unsettled or vice
+                // versa.
+                if (!senderSettleModesCompatible(s.snd_settle_mode, a.snd_settle_mode))
+                    return error.MalformedFrame;
                 s.remote_handle = a.handle;
                 s.max_message_size = a.max_message_size;
-                s.snd_settle_mode = a.snd_settle_mode;
                 s.rcv_settle_mode = a.rcv_settle_mode;
                 if (a.initial_delivery_count) |c| s.delivery_count = c;
                 s.attached = true;
@@ -589,6 +601,7 @@ pub const Session = struct {
                 try self.driver.sendPerformative(.amqp, self.channel, .{
                     .detach = .{ .handle = s.handle, .closed = true },
                 });
+                s.detach_sent = true;
             }
             return;
         }
@@ -606,6 +619,7 @@ pub const Session = struct {
                 try self.driver.sendPerformative(.amqp, self.channel, .{
                     .detach = .{ .handle = r.handle, .closed = true },
                 });
+                r.detach_sent = true;
             }
         }
     }
@@ -716,9 +730,9 @@ pub const SenderOptions = struct {
     /// The entity the messages go to, such as `eh` or `eh/Partitions/3`.
     target_address: []const u8,
     source_address: ?[]const u8 = null,
-    /// Desired sender settlement mode. The receiver's Attach selects the
-    /// actual mode: settled deliveries complete once emitted and retain no
-    /// in-flight entry; mixed and unsettled deliveries await disposition.
+    /// Actual sender settlement mode. The receiver's Attach carries only its
+    /// desired preference: mixed/omitted accepts this selection, while a
+    /// conflicting fixed preference rejects the Attach.
     snd_settle_mode: perf.SenderSettleMode = .mixed,
     rcv_settle_mode: perf.ReceiverSettleMode = .first,
     desired_capabilities: ?[]const []const u8 = null,
@@ -819,7 +833,7 @@ pub const Sender = struct {
     credit: u32 = 0,
     drain: bool = false,
     delivery_count: u32 = 0,
-    /// Sender settlement mode selected by the remote receiver's Attach.
+    /// Authoritative sender settlement mode selected locally.
     snd_settle_mode: perf.SenderSettleMode = .mixed,
     /// Receiver settlement mode selected by the remote receiver's Attach.
     rcv_settle_mode: perf.ReceiverSettleMode = .first,
@@ -1297,6 +1311,8 @@ pub const Sender = struct {
         self.attached = false;
         self.awaiting_attach = false;
         self.poisoned = true;
+        if (self.detach_sent or self.session.ended) return;
+        self.detach_sent = true;
         self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .detach = .{
                 .handle = self.handle,
@@ -1306,7 +1322,10 @@ pub const Sender = struct {
                     .description = "outbound delivery did not reach its final transfer",
                 },
             },
-        }) catch {};
+        }) catch {
+            self.session.driver.invalidate();
+            self.session.terminate();
+        };
     }
 
     /// Wait for the oldest delivery still in flight to settle and retire it.
@@ -2981,6 +3000,112 @@ test "a session-window timeout after the first frame poisons the sender" {
     try testing.expectEqual(before, mem.written().len);
 }
 
+test "partial send does not duplicate terminal Detach or emit after End" {
+    const Terminal = enum { detach, end };
+    inline for (std.meta.tags(Terminal)) |terminal| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try peer.pushHeader(&frame.amqp_header);
+        try peer.push(0, .{ .open = .{
+            .container_id = "service-bus",
+            .max_frame_size = 512,
+            .channel_max = 255,
+        } });
+        try peer.push(0, .{ .begin = .{
+            .remote_channel = 0,
+            .next_outgoing_id = 1,
+            .incoming_window = 1,
+            .outgoing_window = 1000,
+        } });
+        try peer.push(0, .{ .attach = .{
+            .name = "producer",
+            .handle = 0,
+            .role = .receiver,
+            .initial_delivery_count = 0,
+        } });
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1,
+            .next_outgoing_id = 1,
+            .outgoing_window = 1000,
+            .handle = 0,
+            .delivery_count = 0,
+            .link_credit = 5,
+        } });
+        switch (terminal) {
+            .detach => try peer.push(0, .{ .detach = .{
+                .handle = 0,
+                .closed = true,
+            } }),
+            .end => try peer.push(0, .{ .end = .{} }),
+        }
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+        const sender = try openSender(&fixture.session, .{
+            .name = "producer",
+            .target_address = "eh",
+        }, 10_000);
+
+        const big = try allocator.alloc(u8, 1500);
+        defer allocator.free(big);
+        @memset(big, 'x');
+
+        mem.clearWritten();
+        const result = sender.sendBytesAsync(big, .{}, 10_000);
+        switch (terminal) {
+            .detach => try testing.expectError(error.LinkDetached, result),
+            .end => try testing.expectError(error.RemoteClosed, result),
+        }
+        try testing.expect(sender.poisoned);
+        try testing.expectEqual(@as(usize, 0), sender.inFlight());
+        switch (terminal) {
+            .detach => {
+                try testing.expect(sender.detach_sent);
+                try testing.expect(!fixture.session.ended);
+            },
+            .end => try testing.expect(fixture.session.ended),
+        }
+
+        var frames = try EmittedFrames.parse(allocator, mem.written());
+        defer frames.deinit();
+        try testing.expectEqual(@as(usize, 2), frames.bodies.items.len);
+        try testing.expectEqual(
+            perf.descriptor.transfer,
+            perf.peekDescriptor(frames.bodies.items[0]).?,
+        );
+        var transfer = try perf.decode(allocator, frames.bodies.items[0]);
+        defer transfer.deinit();
+        try testing.expect(transfer.performative.transfer.more);
+        try testing.expectEqual(
+            if (terminal == .detach) perf.descriptor.detach else perf.descriptor.end,
+            perf.peekDescriptor(frames.bodies.items[1]).?,
+        );
+        const detaches = try frames.of(allocator, perf.descriptor.detach);
+        defer allocator.free(detaches);
+        const ends = try frames.of(allocator, perf.descriptor.end);
+        defer allocator.free(ends);
+        try testing.expectEqual(
+            @as(usize, if (terminal == .detach) 1 else 0),
+            detaches.len,
+        );
+        try testing.expectEqual(
+            @as(usize, if (terminal == .end) 1 else 0),
+            ends.len,
+        );
+
+        const written = mem.written().len;
+        try testing.expectError(error.LinkDetached, sender.sendBytesAsync("reuse", .{}, 10_000));
+        try testing.expectEqual(written, mem.written().len);
+    }
+}
+
 test "a socket failure after the first frame poisons the sender" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
@@ -3898,15 +4023,15 @@ test "negotiated settled sender completes sync and async sends on emission" {
     }
 }
 
-test "remote receiver Attach selects the actual sender settlement mode" {
+test "an omitted receiver preference preserves local settled mode" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
     var clock: connection.ManualClock = .{};
     const peer = Peer{ .allocator = allocator, .mem = &mem };
 
-    // The local sender requests settled, but the receiver answers with the
-    // default mixed mode. Transfers must follow the negotiated response.
+    // The receiver omits its preference, which decodes as mixed. That accepts
+    // rather than overwrites the sender's authoritative settled mode.
     try scriptSenderAttach(peer, 1);
     var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
     defer driver.deinit();
@@ -3919,10 +4044,62 @@ test "remote receiver Attach selects the actual sender settlement mode" {
         .snd_settle_mode = .settled,
     }, 10_000);
     _ = try fixture.session.pump(10_000);
-    try testing.expectEqual(perf.SenderSettleMode.mixed, sender.snd_settle_mode);
+    try testing.expectEqual(perf.SenderSettleMode.settled, sender.snd_settle_mode);
 
     mem.clearWritten();
     const token = try sender.sendBytesAsync("mixed", .{}, 10_000);
+    try testing.expectEqual(@as(u32, 0), token.id);
+    try testing.expectEqual(@as(usize, 0), sender.inFlight());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const transfers = try frames.of(allocator, perf.descriptor.transfer);
+    defer allocator.free(transfers);
+    try testing.expectEqual(@as(usize, 1), transfers.len);
+    var decoded = try perf.decode(allocator, transfers[0]);
+    defer decoded.deinit();
+    try testing.expect(decoded.performative.transfer.settled orelse false);
+    try testing.expectError(error.NoDeliveryInFlight, sender.awaitSettlement(10_000));
+}
+
+test "an omitted receiver preference does not pre-settle an unsettled sender" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 1,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+        .snd_settle_mode = .unsettled,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(perf.SenderSettleMode.unsettled, sender.snd_settle_mode);
+
+    mem.clearWritten();
+    _ = try sender.sendBytesAsync("unsettled", .{}, 10_000);
     try testing.expectEqual(@as(usize, 1), sender.inFlight());
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
@@ -3933,15 +4110,52 @@ test "remote receiver Attach selects the actual sender settlement mode" {
     var decoded = try perf.decode(allocator, transfers[0]);
     defer decoded.deinit();
     try testing.expect(!(decoded.performative.transfer.settled orelse false));
+}
 
-    try peer.push(0, .{ .disposition = .{
-        .role = .receiver,
-        .first = token.id,
-        .settled = true,
-        .state = .accepted,
-    } });
-    const settlement = try sender.awaitSettlement(10_000);
-    try testing.expectEqual(Outcome.accepted, settlement.outcome);
+test "a conflicting fixed receiver settlement preference rejects Attach" {
+    const Case = struct {
+        local: perf.SenderSettleMode,
+        remote: perf.SenderSettleMode,
+    };
+    const cases = [_]Case{
+        .{ .local = .settled, .remote = .unsettled },
+        .{ .local = .unsettled, .remote = .settled },
+    };
+    for (cases) |case| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        try peer.push(0, .{ .attach = .{
+            .name = "producer",
+            .handle = 0,
+            .role = .receiver,
+            .snd_settle_mode = case.remote,
+            .initial_delivery_count = 0,
+        } });
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        try testing.expectError(error.MalformedFrame, openSender(&fixture.session, .{
+            .name = "producer",
+            .target_address = "entity",
+            .snd_settle_mode = case.local,
+        }, 10_000));
+        try testing.expectEqual(connection.State.err, driver.state);
+        try testing.expect(fixture.session.ended);
+
+        var frames = try EmittedFrames.parse(allocator, mem.written());
+        defer frames.deinit();
+        const transfers = try frames.of(allocator, perf.descriptor.transfer);
+        defer allocator.free(transfers);
+        try testing.expectEqual(@as(usize, 0), transfers.len);
+    }
 }
 
 test "settled sender emission failure poisons without retaining in-flight state" {

--- a/link.zig
+++ b/link.zig
@@ -47,6 +47,8 @@ pub const LinkError = connection.ConnectionError || error{
     InvalidReceiverOptions,
     /// An unsettled delivery id was reused before its terminal disposition.
     DuplicateDeliveryId,
+    /// Unsettled deliveries reached `ReceiverOptions.max_unsettled_deliveries`.
+    SettlementLimitExceeded,
 };
 
 /// Set on a receiver so Event Hubs can name the owner in its error text.
@@ -283,9 +285,21 @@ pub const Session = struct {
         self.invalidateLinks();
     }
 
-    fn reserveIncomingDelivery(self: *Session, receiver: *Receiver, id: u32) LinkError!void {
+    fn reserveIncomingDelivery(
+        self: *Session,
+        receiver: *Receiver,
+        id: u32,
+        settle_mode: perf.ReceiverSettleMode,
+    ) LinkError!void {
         if (self.incoming_deliveries.contains(id)) return error.DuplicateDeliveryId;
-        try receiver.unsettled_ids.append(self.allocator, id);
+        try receiver.unsettled_ids.ensureTotalCapacityPrecise(
+            self.allocator,
+            receiver.unsettled_ids.items.len + 1,
+        );
+        receiver.unsettled_ids.appendAssumeCapacity(.{
+            .id = id,
+            .settle_mode = settle_mode,
+        });
         errdefer _ = receiver.unsettled_ids.pop();
         try self.incoming_deliveries.put(self.allocator, id, receiver);
     }
@@ -293,22 +307,20 @@ pub const Session = struct {
     fn releaseIncomingDelivery(self: *Session, receiver: *Receiver, id: u32) void {
         if (self.incoming_deliveries.get(id) != receiver) return;
         _ = self.incoming_deliveries.remove(id);
-        receiver.removePendingSettlement(id);
         for (receiver.unsettled_ids.items, 0..) |active, i| {
-            if (active != id) continue;
+            if (active.id != id) continue;
             _ = receiver.unsettled_ids.swapRemove(i);
             return;
         }
     }
 
     fn releaseReceiverDeliveries(self: *Session, receiver: *Receiver) void {
-        for (receiver.unsettled_ids.items) |id| {
-            if (self.incoming_deliveries.get(id) == receiver) {
-                _ = self.incoming_deliveries.remove(id);
+        for (receiver.unsettled_ids.items) |active| {
+            if (self.incoming_deliveries.get(active.id) == receiver) {
+                _ = self.incoming_deliveries.remove(active.id);
             }
         }
         receiver.unsettled_ids.clearRetainingCapacity();
-        receiver.pending_settlement_ids.clearRetainingCapacity();
     }
 
     fn releaseIncomingRange(self: *Session, receiver: *Receiver, first: u32, last: u32) void {
@@ -317,10 +329,9 @@ pub const Session = struct {
         var i = receiver.unsettled_ids.items.len;
         while (i > 0) {
             i -= 1;
-            const id = receiver.unsettled_ids.items[i];
+            const id = receiver.unsettled_ids.items[i].id;
             if (id -% first > span) continue;
             _ = self.incoming_deliveries.remove(id);
-            receiver.removePendingSettlement(id);
             _ = receiver.unsettled_ids.swapRemove(i);
         }
     }
@@ -425,6 +436,7 @@ pub const Session = struct {
         const last = d.last orelse d.first;
         if (d.role == .receiver) {
             // A disposition from the receiving side settles what we sent.
+            try self.acknowledgeReceiverDisposition(d.first, last, d.settled, d.state);
             for (self.senders.items) |s| {
                 s.applyDisposition(d.first, last, d.state) catch |err| {
                     // The disposition frame is consumed and cannot be replayed.
@@ -446,7 +458,84 @@ pub const Session = struct {
         if (!d.settled) return;
         for (self.receivers.items) |receiver| {
             if (receiver.rcv_settle_mode == .second) {
-                receiver.acknowledgeSettlementRange(d.first, last);
+                try receiver.acknowledgeSettlementRange(d.first, last);
+            }
+        }
+    }
+
+    fn acknowledgeReceiverDisposition(
+        self: *Session,
+        first: u32,
+        last: u32,
+        settled: bool,
+        state: ?perf.DeliveryState,
+    ) LinkError!void {
+        if (settled) return;
+        const span = last -% first;
+        if (span >= 1 << 31) return;
+
+        var cursor: ?u32 = null;
+        var run_first: u32 = 0;
+        var run_last: u32 = 0;
+        var have_run = false;
+        while (true) {
+            var next_id: ?u32 = null;
+            var next_offset: u32 = 0;
+            for (self.senders.items) |sender| {
+                if (sender.rcv_settle_mode != .second) continue;
+                for (0..sender.in_flight_len) |i| {
+                    const entry = sender.entryAt(i);
+                    if (entry.second_ack_sent) continue;
+                    const offset = entry.id -% first;
+                    if (offset > span) continue;
+                    if (cursor) |after| {
+                        if (offset <= after) continue;
+                    }
+                    if (next_id == null or offset < next_offset) {
+                        next_id = entry.id;
+                        next_offset = offset;
+                    }
+                }
+            }
+
+            const id = next_id orelse {
+                if (have_run) try self.emitSenderSettlementAck(run_first, run_last, state);
+                return;
+            };
+            if (!have_run) {
+                run_first = id;
+                run_last = id;
+                have_run = true;
+            } else if (next_offset == cursor.? + 1) {
+                run_last = id;
+            } else {
+                try self.emitSenderSettlementAck(run_first, run_last, state);
+                run_first = id;
+                run_last = id;
+            }
+            cursor = next_offset;
+        }
+    }
+
+    fn emitSenderSettlementAck(
+        self: *Session,
+        first: u32,
+        last: u32,
+        state: ?perf.DeliveryState,
+    ) LinkError!void {
+        try self.driver.sendPerformative(.amqp, self.channel, .{ .disposition = .{
+            .role = .sender,
+            .first = first,
+            .last = last,
+            .settled = true,
+            .state = state,
+        } });
+        const span = last -% first;
+        for (self.senders.items) |sender| {
+            if (sender.rcv_settle_mode != .second) continue;
+            for (0..sender.in_flight_len) |i| {
+                const entry = sender.entryAt(i);
+                if (entry.id -% first <= span) entry.second_ack_sent = true;
             }
         }
     }
@@ -457,6 +546,7 @@ pub const Session = struct {
             if (s.awaiting_attach and !s.poisoned and std.mem.eql(u8, s.name, a.name)) {
                 s.remote_handle = a.handle;
                 s.max_message_size = a.max_message_size;
+                s.rcv_settle_mode = a.rcv_settle_mode;
                 if (a.initial_delivery_count) |c| s.delivery_count = c;
                 s.attached = true;
                 s.awaiting_attach = false;
@@ -467,7 +557,6 @@ pub const Session = struct {
             if (r.awaiting_attach and !r.poisoned and std.mem.eql(u8, r.name, a.name)) {
                 r.remote_handle = a.handle;
                 r.peer_max_message_size = a.max_message_size;
-                r.rcv_settle_mode = a.rcv_settle_mode;
                 r.attached = true;
                 r.awaiting_attach = false;
                 return;
@@ -670,6 +759,7 @@ const InFlight = struct {
     id: u32,
     outcome: ?Outcome = null,
     rejection: ?Rejection = null,
+    second_ack_sent: bool = false,
 };
 
 pub const Sender = struct {
@@ -686,6 +776,8 @@ pub const Sender = struct {
     credit: u32 = 0,
     drain: bool = false,
     delivery_count: u32 = 0,
+    /// Receiver settlement mode selected by the remote receiver's Attach.
+    rcv_settle_mode: perf.ReceiverSettleMode = .first,
     /// Peer's `max-message-size`; null or 0 means unlimited.
     max_message_size: ?u64 = null,
 
@@ -1249,6 +1341,7 @@ pub fn openSender(
         .name = name,
         .handle = session.allocateHandle(),
         .in_flight = in_flight,
+        .rcv_settle_mode = options.rcv_settle_mode,
     };
 
     try session.senders.append(session.allocator, sender);
@@ -1335,6 +1428,14 @@ pub const ReceiverOptions = struct {
     /// retention above this layer.
     /// A zero-byte finite budget is invalid.
     max_buffered_bytes: ?u64 = default_max_buffered_bytes,
+    /// Maximum unsettled delivery ids retained while the application decides
+    /// an outcome or mode second waits for the sender's acknowledgment.
+    ///
+    /// This is independent of payload bytes: handing a delivery to the caller
+    /// releases its aggregate-byte reservation, but its id remains live until
+    /// settlement. Credit never authorizes more unsettled deliveries than the
+    /// remaining slots.
+    max_unsettled_deliveries: u32 = default_max_unsettled_deliveries,
 };
 
 /// The floor for a derived `max_overrun`, so a receiver driving credit by
@@ -1359,6 +1460,9 @@ pub const default_max_message_size: u64 = 128 * 1024 * 1024;
 /// deeper delivery window by setting both receiver limits explicitly.
 pub const default_max_buffered_bytes: u64 = 256 * 1024 * 1024;
 
+/// Default bound on unsettled delivery-id bookkeeping per receiver.
+pub const default_max_unsettled_deliveries: u32 = 1024;
+
 /// §2.7.3: an absent *or zero* `max-message-size` means no limit.
 fn normalizeMaxMessageSize(size: ?u64) ?u64 {
     const n = size orelse return null;
@@ -1380,6 +1484,12 @@ pub const Delivery = struct {
     tag: []const u8,
     payload: []const u8,
     settled: bool,
+};
+
+const IncomingUnsettled = struct {
+    id: u32,
+    settle_mode: perf.ReceiverSettleMode,
+    disposition_sent: bool = false,
 };
 
 pub const Receiver = struct {
@@ -1409,7 +1519,7 @@ pub const Receiver = struct {
     /// actually enforced, and `ReceiverOptions.max_message_size` for what null
     /// means.
     max_message_size: ?u64 = null,
-    /// Receiver settlement mode negotiated in the attach exchange.
+    /// Receiver settlement mode selected by this local receiver's Attach.
     rcv_settle_mode: perf.ReceiverSettleMode = .first,
     /// What the peer declared in its own `attach`, recorded but not enforced;
     /// `maxMessageSize` says why. It is the largest message the *peer*
@@ -1426,12 +1536,12 @@ pub const Receiver = struct {
     partial_id: ?u32 = null,
     partial_tag: std.ArrayList(u8) = .empty,
     partial_settled: bool = false,
+    partial_rcv_settle_mode: perf.ReceiverSettleMode = .first,
     /// Unsettled ids owned by this link, mirrored in the session-wide map so
     /// reuse is rejected across every receiver on the channel.
-    unsettled_ids: std.ArrayList(u32) = .empty,
-    /// Delivery ids for which mode second has emitted its first, unsettled
-    /// disposition and is awaiting the sender-role settled acknowledgment.
-    pending_settlement_ids: std.ArrayList(u32) = .empty,
+    unsettled_ids: std.ArrayList(IncomingUnsettled) = .empty,
+    /// Maximum unsettled ids retained independently of payload bytes.
+    max_unsettled_deliveries: u32 = default_max_unsettled_deliveries,
     /// Completed deliveries not yet handed to the caller.
     ///
     /// Drained with a head cursor rather than by removing the front element:
@@ -1453,7 +1563,6 @@ pub const Receiver = struct {
         self.partial.deinit(self.allocator);
         self.partial_tag.deinit(self.allocator);
         self.unsettled_ids.deinit(self.allocator);
-        self.pending_settlement_ids.deinit(self.allocator);
         // Everything before `ready_head` was already handed out, so its
         // buffers belong to `current` and are freed by `releaseCurrent`.
         for (self.ready.items[self.ready_head..]) |d| {
@@ -1475,51 +1584,19 @@ pub const Receiver = struct {
         self.buffered_bytes -|= @intCast(bytes);
     }
 
-    fn removePendingSettlement(self: *Receiver, id: u32) void {
-        for (self.pending_settlement_ids.items, 0..) |pending, i| {
-            if (pending != id) continue;
-            _ = self.pending_settlement_ids.swapRemove(i);
-            return;
-        }
-    }
-
-    fn markPendingSettlementRange(
-        self: *Receiver,
-        first: u32,
-        last: u32,
-    ) Allocator.Error!usize {
-        const old_len = self.pending_settlement_ids.items.len;
-        const span = last -% first;
-        if (span >= 1 << 31) return old_len;
-
-        var additional: usize = 0;
-        for (self.unsettled_ids.items) |id| {
-            if (id -% first > span) continue;
-            if (std.mem.indexOfScalar(u32, self.pending_settlement_ids.items, id) == null) {
-                additional += 1;
-            }
-        }
-        try self.pending_settlement_ids.ensureUnusedCapacity(self.allocator, additional);
-        for (self.unsettled_ids.items) |id| {
-            if (id -% first > span) continue;
-            if (std.mem.indexOfScalar(u32, self.pending_settlement_ids.items, id) == null) {
-                self.pending_settlement_ids.appendAssumeCapacity(id);
-            }
-        }
-        return old_len;
-    }
-
-    fn acknowledgeSettlementRange(self: *Receiver, first: u32, last: u32) void {
+    fn acknowledgeSettlementRange(self: *Receiver, first: u32, last: u32) LinkError!void {
         const span = last -% first;
         if (span >= 1 << 31) return;
-        var i = self.pending_settlement_ids.items.len;
+        const before = self.unsettled_ids.items.len;
+        var i = self.unsettled_ids.items.len;
         while (i > 0) {
             i -= 1;
-            const id = self.pending_settlement_ids.items[i];
-            if (id -% first > span) continue;
-            _ = self.pending_settlement_ids.swapRemove(i);
-            self.session.releaseIncomingDelivery(self, id);
+            const active = self.unsettled_ids.items[i];
+            if (!active.disposition_sent or active.settle_mode != .second) continue;
+            if (active.id -% first > span) continue;
+            self.session.releaseIncomingDelivery(self, active.id);
         }
+        if (self.unsettled_ids.items.len != before) try self.replenish();
     }
 
     fn bufferWouldOverflow(self: *const Receiver, bytes: usize) bool {
@@ -1537,6 +1614,7 @@ pub const Receiver = struct {
         self.partial_tag.clearRetainingCapacity();
         self.partial_id = null;
         self.partial_settled = false;
+        self.partial_rcv_settle_mode = self.rcv_settle_mode;
     }
 
     fn clearPartialAndFree(self: *Receiver) void {
@@ -1548,6 +1626,7 @@ pub const Receiver = struct {
         self.partial_tag.clearAndFree(self.allocator);
         self.partial_id = null;
         self.partial_settled = false;
+        self.partial_rcv_settle_mode = self.rcv_settle_mode;
     }
 
     /// A consumed transfer cannot be replayed. Any failure incorporating it
@@ -1671,6 +1750,12 @@ pub const Receiver = struct {
                     return error.MalformedFrame;
                 }
             }
+            if (t.rcv_settle_mode) |mode| {
+                if (mode != self.partial_rcv_settle_mode) {
+                    self.poisonAfterConsumedTransfer();
+                    return error.MalformedFrame;
+                }
+            }
             // Settlement may be asserted on any transfer in the delivery.
             // Once true it is terminal and remains true when later frames
             // omit the field.
@@ -1699,11 +1784,18 @@ pub const Receiver = struct {
                 self.refuseDuplicateDelivery();
                 return error.DuplicateDeliveryId;
             }
+            const settle_mode = self.effectiveReceiverSettleMode(t.rcv_settle_mode) catch |err| {
+                self.poisonAfterConsumedTransfer();
+                return err;
+            };
             if (t.aborted) return;
 
             const settled = t.settled orelse false;
             if (!settled) {
-                self.session.reserveIncomingDelivery(self, id) catch |err| {
+                if (self.unsettled_ids.items.len >= self.max_unsettled_deliveries) {
+                    try self.refuseSettlementLimit();
+                }
+                self.session.reserveIncomingDelivery(self, id, settle_mode) catch |err| {
                     if (err == error.DuplicateDeliveryId) {
                         self.refuseDuplicateDelivery();
                     }
@@ -1737,6 +1829,7 @@ pub const Receiver = struct {
 
             self.partial_id = t.delivery_id.?;
             self.partial_settled = settled;
+            self.partial_rcv_settle_mode = settle_mode;
             if (!self.partialReservationFits()) try self.refuseBufferLimit();
             if (t.delivery_tag) |tag| {
                 self.partial_tag.appendSlice(self.allocator, tag) catch |err| {
@@ -1806,15 +1899,39 @@ pub const Receiver = struct {
         return normalizeMaxMessageSize(self.max_message_size);
     }
 
+    fn effectiveReceiverSettleMode(
+        self: *const Receiver,
+        transfer_mode: ?perf.ReceiverSettleMode,
+    ) LinkError!perf.ReceiverSettleMode {
+        const mode = transfer_mode orelse self.rcv_settle_mode;
+        // A sender may ask a mode-second receiver to settle a particular
+        // delivery on first disposition. It cannot make a mode-first receiver
+        // retain state for a second phase the receiver never negotiated.
+        if (self.rcv_settle_mode == .first and mode == .second) {
+            return error.MalformedFrame;
+        }
+        return mode;
+    }
+
     /// Aggregate payload bytes currently waiting in this receiver.
     pub fn bufferedBytes(self: *const Receiver) u64 {
         return self.buffered_bytes;
     }
 
+    fn pendingSettlementCount(self: *const Receiver) usize {
+        var count: usize = 0;
+        for (self.unsettled_ids.items) |active| {
+            if (active.disposition_sent) count += 1;
+        }
+        return count;
+    }
+
     /// Maximum credit that can be outstanding without letting a conforming
     /// sender exceed the aggregate payload budget.
     fn byteCreditCapacity(self: *const Receiver) u32 {
-        const limit = self.max_buffered_bytes orelse return std.math.maxInt(u32);
+        const slots = self.max_unsettled_deliveries -|
+            @as(u32, @intCast(self.unsettled_ids.items.len));
+        const limit = self.max_buffered_bytes orelse return slots;
         // With no per-message bound, one delivery may consume the whole
         // aggregate budget. If the configured message limit is larger than
         // the aggregate budget, the aggregate limit remains authoritative.
@@ -1823,7 +1940,8 @@ pub const Receiver = struct {
         const reserved = self.reservedBufferedBytes(reservation);
         if (reserved >= limit) return 0;
         const free = limit - reserved;
-        return @intCast(@min(free / reservation, std.math.maxInt(u32)));
+        const bytes: u32 = @intCast(@min(free / reservation, std.math.maxInt(u32)));
+        return @min(bytes, slots);
     }
 
     /// Ready deliveries consume their actual size. An in-progress delivery
@@ -1857,11 +1975,11 @@ pub const Receiver = struct {
     }
 
     fn reserveIncomingCapacity(self: *Receiver, count: u32) Allocator.Error!void {
-        // Keep the common 300-credit window allocation-free per delivery
-        // without letting one caller-requested maxInt credit force a huge
-        // eager allocation.
-        const reserve_count = @min(count, 4096);
-        try self.unsettled_ids.ensureUnusedCapacity(self.allocator, @intCast(reserve_count));
+        const remaining = self.max_unsettled_deliveries -|
+            @as(u32, @intCast(self.unsettled_ids.items.len));
+        const reserve_count = @min(count, remaining);
+        const total = self.unsettled_ids.items.len + @as(usize, reserve_count);
+        try self.unsettled_ids.ensureTotalCapacityPrecise(self.allocator, total);
         try self.session.incoming_deliveries.ensureUnusedCapacity(self.allocator, reserve_count);
     }
 
@@ -1986,6 +2104,25 @@ pub const Receiver = struct {
         return error.BufferLimitExceeded;
     }
 
+    fn refuseSettlementLimit(self: *Receiver) LinkError!void {
+        self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
+        self.clearPartialAndFree();
+        self.session.releaseReceiverDeliveries(self);
+        try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{
+                .handle = self.handle,
+                .closed = true,
+                .err = .{
+                    .condition = "amqp:resource-limit-exceeded",
+                    .description = "receiver unsettled delivery limit exhausted",
+                },
+            },
+        });
+        return error.SettlementLimitExceeded;
+    }
+
     fn refuseDuplicateDelivery(self: *Receiver) void {
         self.attached = false;
         self.awaiting_attach = false;
@@ -2100,28 +2237,131 @@ pub const Receiver = struct {
     ) LinkError!void {
         if (self.session.ended or self.poisoned or !self.attached or self.detach_sent)
             return error.LinkDetached;
-        const pending_len = if (self.rcv_settle_mode == .second)
-            try self.markPendingSettlementRange(first, last)
-        else
-            0;
+
+        const span = last -% first;
+        if (span >= 1 << 31) return error.InvalidState;
+        var has_active = false;
+        for (self.unsettled_ids.items) |active| {
+            if (active.id -% first <= span) {
+                has_active = true;
+                break;
+            }
+        }
+
+        var emitted = false;
+        var cursor: ?u32 = null;
+        var run_first: u32 = 0;
+        var run_last: u32 = 0;
+        var run_mode: perf.ReceiverSettleMode = .first;
+        var have_run = false;
+
+        while (true) {
+            var next: ?IncomingUnsettled = null;
+            var next_offset: u32 = 0;
+            for (self.unsettled_ids.items) |active| {
+                const offset = active.id -% first;
+                if (offset > span) continue;
+                if (active.settle_mode == .second and active.disposition_sent) continue;
+                if (cursor) |after| {
+                    if (offset <= after) continue;
+                }
+                if (next == null or offset < next_offset) {
+                    next = active;
+                    next_offset = offset;
+                }
+            }
+
+            const active = next orelse {
+                if (have_run) {
+                    try self.emitSettlementRun(
+                        run_first,
+                        run_last,
+                        run_mode,
+                        state,
+                        emitted,
+                    );
+                } else if (!has_active) {
+                    // Preserve the API's historical ability to disposition an
+                    // explicit range even when those ids were pre-settled or
+                    // are no longer retained locally.
+                    try self.emitSettlementRun(
+                        first,
+                        last,
+                        self.rcv_settle_mode,
+                        state,
+                        false,
+                    );
+                }
+                return;
+            };
+
+            if (!have_run) {
+                run_first = active.id;
+                run_last = active.id;
+                run_mode = active.settle_mode;
+                have_run = true;
+            } else if (next_offset == cursor.? + 1 and active.settle_mode == run_mode) {
+                run_last = active.id;
+            } else {
+                try self.emitSettlementRun(
+                    run_first,
+                    run_last,
+                    run_mode,
+                    state,
+                    emitted,
+                );
+                emitted = true;
+                run_first = active.id;
+                run_last = active.id;
+                run_mode = active.settle_mode;
+            }
+            cursor = next_offset;
+        }
+    }
+
+    fn emitSettlementRun(
+        self: *Receiver,
+        first: u32,
+        last: u32,
+        mode: perf.ReceiverSettleMode,
+        state: perf.DeliveryState,
+        emitted_before: bool,
+    ) LinkError!void {
+        if (mode == .second) self.setDispositionSent(first, last, true);
         self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .disposition = .{
                 .role = .receiver,
                 .first = first,
                 .last = last,
-                .settled = self.rcv_settle_mode == .first,
+                .settled = mode == .first,
                 .state = state,
             },
         }) catch |err| {
-            if (self.session.driver.state == .err) {
+            if (mode == .second and !emitted_before and self.session.driver.state != .err) {
+                self.setDispositionSent(first, last, false);
+            }
+            if (emitted_before or self.session.driver.state == .err) {
+                if (self.session.driver.state != .err) self.session.driver.invalidate();
                 self.session.terminate();
-            } else if (self.rcv_settle_mode == .second) {
-                self.pending_settlement_ids.shrinkRetainingCapacity(pending_len);
             }
             return err;
         };
-        if (self.rcv_settle_mode == .first) {
+
+        if (mode == .first) {
             self.session.releaseIncomingRange(self, first, last);
+            self.replenish() catch |err| {
+                self.session.driver.invalidate();
+                self.session.terminate();
+                return err;
+            };
+        }
+    }
+
+    fn setDispositionSent(self: *Receiver, first: u32, last: u32, sent: bool) void {
+        const span = last -% first;
+        for (self.unsettled_ids.items) |*active| {
+            if (active.settle_mode != .second or active.id -% first > span) continue;
+            active.disposition_sent = sent;
         }
     }
 
@@ -2244,6 +2484,7 @@ pub fn openReceiver(
         options.max_message_size,
         options.max_buffered_bytes,
     );
+    if (options.max_unsettled_deliveries == 0) return error.InvalidReceiverOptions;
 
     const receiver = try session.allocator.create(Receiver);
     errdefer session.allocator.destroy(receiver);
@@ -2262,9 +2503,9 @@ pub fn openReceiver(
         .max_message_size = max_message_size,
         .max_buffered_bytes = options.max_buffered_bytes,
         .rcv_settle_mode = options.rcv_settle_mode,
+        .max_unsettled_deliveries = options.max_unsettled_deliveries,
     };
     errdefer receiver.unsettled_ids.deinit(session.allocator);
-    errdefer receiver.pending_settlement_ids.deinit(session.allocator);
 
     try session.receivers.append(session.allocator, receiver);
     errdefer _ = session.receivers.pop();
@@ -2330,6 +2571,11 @@ fn expectReceiverAccounting(receiver: *const Receiver) !void {
             @as(u128, receiver.credit) * @as(u128, message_size);
         try testing.expect(authorised <= budget);
     }
+    try testing.expect(
+        receiver.unsettled_ids.items.len + @as(usize, receiver.credit) <=
+            receiver.max_unsettled_deliveries,
+    );
+    try testing.expect(receiver.unsettled_ids.capacity <= receiver.max_unsettled_deliveries);
 }
 
 test "a sender attaches and reports the peer's max-message-size" {
@@ -4054,6 +4300,156 @@ test "one disposition settles every delivery a pipelining sender put on the wire
     try testing.expectEqual(@as(usize, 0), sender.inFlight());
 }
 
+test "sender acknowledges mode-second receiver dispositions exactly once" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .rcv_settle_mode = .second,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 2,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+        .max_in_flight = 2,
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(perf.ReceiverSettleMode.second, sender.rcv_settle_mode);
+
+    _ = try sender.sendBytesAsync("a", .{}, 10_000);
+    _ = try sender.sendBytesAsync("b", .{}, 10_000);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 1,
+        .settled = false,
+        .state = .accepted,
+    } });
+
+    mem.clearWritten();
+    _ = try fixture.session.pump(10_000);
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const dispositions = try frames.of(allocator, perf.descriptor.disposition);
+    defer allocator.free(dispositions);
+    try testing.expectEqual(@as(usize, 1), dispositions.len);
+    var decoded = try perf.decode(allocator, dispositions[0]);
+    defer decoded.deinit();
+    const ack = decoded.performative.disposition;
+    try testing.expectEqual(perf.Role.sender, ack.role);
+    try testing.expectEqual(@as(u32, 0), ack.first);
+    try testing.expectEqual(@as(?u32, 1), ack.last);
+    try testing.expect(ack.settled);
+
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 1,
+        .settled = false,
+        .state = .accepted,
+    } });
+    mem.clearWritten();
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+
+    _ = try sender.awaitSettlement(10_000);
+    _ = try sender.awaitSettlement(10_000);
+
+    // A mode-second receiver may also settle its disposition itself; that
+    // terminal form needs no sender-side second phase.
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 2,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 2,
+        .link_credit = 1,
+    } });
+    _ = try fixture.session.pump(10_000);
+    _ = try sender.sendBytesAsync("c", .{}, 10_000);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 2,
+        .settled = true,
+        .state = .accepted,
+    } });
+    mem.clearWritten();
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+    _ = try sender.awaitSettlement(10_000);
+}
+
+test "failed sender second-phase acknowledgment terminalizes the session" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .rcv_settle_mode = .second,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 1,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+    }, 10_000);
+    _ = try fixture.session.pump(10_000);
+    _ = try sender.sendBytesAsync("a", .{}, 10_000);
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .settled = false,
+        .state = .accepted,
+    } });
+
+    mem.fail_write = true;
+    try testing.expectError(error.WriteFailed, fixture.session.pump(10_000));
+    try testing.expect(fixture.session.ended);
+    try testing.expect(sender.poisoned);
+    try testing.expectEqual(connection.State.err, driver.state);
+}
+
 test "a pipelining sender attributes a rejection to the delivery it names" {
     // The middle delivery is refused and the two around it are accepted. A
     // sender holding one outcome for the whole link cannot say which of the
@@ -5415,13 +5811,17 @@ test "receiver settle mode second retains ids through timeout until sender ackno
     const peer = Peer{ .allocator = allocator, .mem = &mem };
 
     try scriptHandshake(peer, 65536);
-    try peer.push(0, .{ .attach = .{
-        .name = "consumer",
-        .handle = 0,
-        .role = .sender,
-        .rcv_settle_mode = .second,
-        .initial_delivery_count = 0,
-    } });
+    try peer.push(0, .{
+        .attach = .{
+            .name = "consumer",
+            .handle = 0,
+            .role = .sender,
+            // The remote sender's preference does not override the mode selected
+            // by the local receiver in its Attach.
+            .rcv_settle_mode = .first,
+            .initial_delivery_count = 0,
+        },
+    });
     for (10..12) |id| {
         try peer.pushTransfer(0, .{
             .handle = 0,
@@ -5468,7 +5868,7 @@ test "receiver settle mode second retains ids through timeout until sender ackno
     try receiver.settleRange(10, 11, .accepted);
     try testing.expect(fixture.session.incoming_deliveries.contains(10));
     try testing.expect(fixture.session.incoming_deliveries.contains(11));
-    try testing.expectEqual(@as(usize, 2), receiver.pending_settlement_ids.items.len);
+    try testing.expectEqual(@as(usize, 2), receiver.pendingSettlementCount());
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
@@ -5494,7 +5894,7 @@ test "receiver settle mode second retains ids through timeout until sender ackno
     _ = try fixture.session.pump(clock.millis + 10);
     try testing.expect(fixture.session.incoming_deliveries.contains(10));
     try testing.expect(fixture.session.incoming_deliveries.contains(11));
-    try testing.expectEqual(@as(usize, 2), receiver.pending_settlement_ids.items.len);
+    try testing.expectEqual(@as(usize, 2), receiver.pendingSettlementCount());
 
     try peer.push(0, .{ .disposition = .{
         .role = .sender,
@@ -5505,7 +5905,124 @@ test "receiver settle mode second retains ids through timeout until sender ackno
     } });
     _ = try fixture.session.pump(clock.millis + 10);
     try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
-    try testing.expectEqual(@as(usize, 0), receiver.pending_settlement_ids.items.len);
+    try testing.expectEqual(@as(usize, 0), receiver.pendingSettlementCount());
+}
+
+test "mixed per-transfer receiver settlement modes split disposition ranges" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .rcv_settle_mode = .first,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 40,
+        .delivery_tag = "a",
+    }, "a");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 41,
+        .delivery_tag = "b",
+        .rcv_settle_mode = .first,
+    }, "b");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 42,
+        .delivery_tag = "c",
+    }, "c");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .second,
+        .prefetch = 3,
+        .max_message_size = 8,
+        .max_buffered_bytes = 24,
+    }, 10_000);
+
+    for (0..3) |_| _ = try receiver.receive(10_000);
+    mem.clearWritten();
+    try receiver.settleRange(40, 42, .accepted);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const dispositions = try frames.of(allocator, perf.descriptor.disposition);
+    defer allocator.free(dispositions);
+    try testing.expectEqual(@as(usize, 3), dispositions.len);
+    for (dispositions, 0..) |body, i| {
+        var decoded = try perf.decode(allocator, body);
+        defer decoded.deinit();
+        const d = decoded.performative.disposition;
+        try testing.expectEqual(@as(u32, 40 + @as(u32, @intCast(i))), d.first);
+        try testing.expectEqual(d.first, d.last.?);
+        try testing.expectEqual(i == 1, d.settled);
+    }
+    try testing.expect(fixture.session.incoming_deliveries.contains(40));
+    try testing.expect(!fixture.session.incoming_deliveries.contains(41));
+    try testing.expect(fixture.session.incoming_deliveries.contains(42));
+    try testing.expectEqual(@as(usize, 2), receiver.pendingSettlementCount());
+
+    try peer.push(0, .{ .disposition = .{
+        .role = .sender,
+        .first = 40,
+        .last = 42,
+        .settled = true,
+        .state = .accepted,
+    } });
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+}
+
+test "a transfer cannot upgrade a mode-first receiver to mode second" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 50,
+        .delivery_tag = "t",
+        .rcv_settle_mode = .second,
+    }, "event");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .first,
+        .prefetch = 1,
+        .max_message_size = 8,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+
+    try testing.expectError(error.MalformedFrame, fixture.session.pump(10_000));
+    try testing.expect(receiver.poisoned);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
 }
 
 test "failed second-mode disposition terminalizes and releases active ids" {
@@ -5549,7 +6066,7 @@ test "failed second-mode disposition terminalizes and releases active ids" {
     try testing.expect(fixture.session.ended);
     try testing.expect(receiver.poisoned);
     try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
-    try testing.expectEqual(@as(usize, 0), receiver.pending_settlement_ids.items.len);
+    try testing.expectEqual(@as(usize, 0), receiver.pendingSettlementCount());
 }
 
 test "deinit releases ids awaiting second-mode settlement acknowledgment" {
@@ -5592,6 +6109,100 @@ test "deinit releases ids awaiting second-mode settlement acknowledgment" {
     try testing.expect(fixture.session.incoming_deliveries.contains(30));
     fixture.session.closeReceiver(receiver, clock.millis + 5);
     try testing.expectEqual(@as(usize, 0), fixture.session.receivers.items.len);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+}
+
+test "settlement slots bound withheld mode-second acknowledgments and replenish on release" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    for (0..4) |id| {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = @intCast(id),
+            .delivery_tag = "t",
+        }, "event");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .second,
+        .prefetch = 0,
+        .max_message_size = 8,
+        .max_buffered_bytes = 32,
+        .max_unsettled_deliveries = 4,
+    }, 10_000);
+    try receiver.issueCredit(100);
+    try testing.expectEqual(@as(u32, 4), receiver.credit);
+
+    for (0..4) |_| {
+        const delivery = try receiver.receive(10_000);
+        try receiver.accept(delivery);
+    }
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 4), receiver.unsettled_ids.items.len);
+    try testing.expectEqual(@as(usize, 4), receiver.pendingSettlementCount());
+
+    for (0..20) |cycle| {
+        const released: u32 = @intCast(cycle * 2);
+        try peer.push(0, .{ .disposition = .{
+            .role = .sender,
+            .first = released,
+            .last = released + 1,
+            .settled = true,
+            .state = .accepted,
+        } });
+        _ = try fixture.session.pump(10_000);
+        try testing.expectEqual(@as(u32, 2), receiver.credit);
+        try testing.expectEqual(@as(usize, 2), receiver.unsettled_ids.items.len);
+
+        const next: u32 = @intCast(4 + cycle * 2);
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = next,
+            .delivery_tag = "t",
+        }, "event");
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = next + 1,
+            .delivery_tag = "t",
+        }, "event");
+        for (0..2) |_| {
+            const delivery = try receiver.receive(10_000);
+            try receiver.accept(delivery);
+        }
+        try testing.expectEqual(@as(u32, 0), receiver.credit);
+        try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+        try testing.expectEqual(@as(usize, 4), receiver.unsettled_ids.items.len);
+        try testing.expectEqual(@as(usize, 4), receiver.pendingSettlementCount());
+        try testing.expect(receiver.unsettled_ids.capacity <= 4);
+    }
+
+    // A peer that ignores the withheld credit cannot grow the bounded id set.
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 44,
+        .delivery_tag = "t",
+    }, "event");
+    try testing.expectError(error.SettlementLimitExceeded, fixture.session.pump(10_000));
+    try testing.expect(receiver.poisoned);
+    try testing.expectEqual(@as(usize, 0), receiver.unsettled_ids.items.len);
     try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
 }
 
@@ -7716,6 +8327,12 @@ test "a finite aggregate budget is also the advertised per-message ceiling" {
     defer driver.deinit();
     var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
     defer fixture.deinit();
+
+    try testing.expectError(error.InvalidReceiverOptions, openReceiver(&fixture.session, .{
+        .name = "invalid",
+        .source_address = "partition/0",
+        .max_unsettled_deliveries = 0,
+    }, 10_000));
 
     mem.clearWritten();
     const receiver = try openReceiver(&fixture.session, .{

--- a/link.zig
+++ b/link.zig
@@ -385,9 +385,21 @@ pub const Session = struct {
             const credit = f.link_credit orelse r.credit;
             if (f.drain) {
                 // A drain response advances the sender's count over whatever
-                // credit went unused, so its count is authoritative.
-                if (f.delivery_count) |their_count| r.delivery_count = their_count;
-                r.grant(credit);
+                // credit went unused, so its count is authoritative. Link
+                // credit is optional; when omitted, derive what remains from
+                // the delivery limit established by our previous grant.
+                if (f.delivery_count) |their_count| {
+                    const prior_limit = r.delivery_count +% r.credit;
+                    const remaining: i32 = @bitCast(prior_limit -% their_count);
+                    r.delivery_count = their_count;
+                    r.grant(f.link_credit orelse
+                        if (remaining > 0)
+                            @min(r.credit, @as(u32, @intCast(remaining)))
+                        else
+                            0);
+                } else {
+                    r.grant(credit);
+                }
             } else if (f.delivery_count) |their_count| {
                 // Serial arithmetic (RFC 1982). A flow whose count lags the
                 // transfers already on the wire — an ordinary crossing, not a
@@ -1777,16 +1789,21 @@ pub const Receiver = struct {
                     return error.MalformedFrame;
                 }
             }
-            if (t.rcv_settle_mode) |mode| {
-                if (mode != self.partial_rcv_settle_mode) {
-                    self.poisonAfterConsumedTransfer();
-                    return error.MalformedFrame;
-                }
-            }
             // Settlement may be asserted on any transfer in the delivery.
             // Once true it is terminal and remains true when later frames
-            // omit the field.
-            if (t.settled orelse false) {
+            // omit the field. Receiver-settle-mode is ignored for a
+            // sender-settled delivery, including the frame that first makes
+            // the cumulative settlement true.
+            const settled = self.partial_settled or (t.settled orelse false);
+            if (!settled) {
+                if (t.rcv_settle_mode) |mode| {
+                    if (mode != self.partial_rcv_settle_mode) {
+                        self.poisonAfterConsumedTransfer();
+                        return error.MalformedFrame;
+                    }
+                }
+            }
+            if (settled) {
                 if (!self.partial_settled) {
                     self.partial_settled = true;
                     self.session.releaseIncomingDelivery(self, partial_id);
@@ -1811,13 +1828,15 @@ pub const Receiver = struct {
                 self.refuseDuplicateDelivery();
                 return error.DuplicateDeliveryId;
             }
-            const settle_mode = self.effectiveReceiverSettleMode(t.rcv_settle_mode) catch |err| {
-                self.poisonAfterConsumedTransfer();
-                return err;
-            };
-            if (t.aborted) return;
-
             const settled = t.settled orelse false;
+            const settle_mode = if (settled)
+                self.rcv_settle_mode
+            else
+                self.effectiveReceiverSettleMode(t.rcv_settle_mode) catch |err| {
+                    self.poisonAfterConsumedTransfer();
+                    return err;
+                };
+            if (t.aborted) return;
             if (!settled) {
                 if (self.unsettled_ids.items.len >= self.max_unsettled_deliveries) {
                     try self.refuseSettlementLimit();
@@ -4686,14 +4705,14 @@ test "a sender keeps one delivery in flight unless asked for more" {
     );
 }
 
-test "a send that never reaches a verdict leaves the sender usable" {
+test "a zero-byte settlement timeout leaves the sender usable" {
     // A timed-out send used to leave nothing behind. Keeping its ring entry
     // would wedge a default sender: every later send would find the window
     // full and fail with an error no existing caller handles.
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
-    var clock: connection.ManualClock = .{};
+    var clock: connection.ManualClock = .{ .auto_advance_ms = 1 };
     const peer = Peer{ .allocator = allocator, .mem = &mem };
 
     try scriptSenderAttach(peer, 10);
@@ -4708,8 +4727,10 @@ test "a send that never reaches a verdict leaves the sender usable" {
         .target_address = "eh",
     }, 10_000);
 
-    // Nothing is scripted to answer the first send, so it fails.
-    try testing.expectError(error.ConnectionClosed, sender.sendBytes("one", 10_000));
+    // Nothing is scripted to answer the first send, but zero-byte timeout is
+    // intentionally retryable and abandons only this in-flight entry.
+    mem.starve = true;
+    try testing.expectError(error.Timeout, sender.sendBytes("one", clock.millis + 10));
     try testing.expectEqual(@as(usize, 0), sender.inFlight());
 
     try peer.push(0, .{ .disposition = .{
@@ -4719,7 +4740,7 @@ test "a send that never reaches a verdict leaves the sender usable" {
         .settled = true,
         .state = .accepted,
     } });
-    try sender.sendBytes("two", 10_000);
+    try sender.sendBytes("two", clock.millis + 10_000);
 }
 
 test "a blocking send refuses to run alongside pipelined deliveries" {
@@ -5380,6 +5401,106 @@ test "body-buffer OOM after a frame header invalidates the session and sender" {
     try testing.expect(!sender.attached);
     try testing.expectError(error.LinkDetached, sender.sendBytes("no reuse", 10_000));
     try testing.expectEqual(@as(usize, 0), sender.inFlight());
+}
+
+const TerminalReadFailure = enum { eof, read_failed };
+
+fn terminalReadFailureInvalidatesSession(failure: TerminalReadFailure) !void {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 1,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const sender = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "entity",
+    }, 10_000);
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .prefetch = 0,
+    }, 10_000);
+
+    // A zero-byte deadline remains retryable.
+    mem.starve = true;
+    try testing.expectError(error.Timeout, fixture.session.pump(0));
+    try testing.expectEqual(connection.State.opened, driver.state);
+    try testing.expect(!fixture.session.ended);
+    try testing.expect(sender.attached);
+    try testing.expect(receiver.attached);
+
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 2,
+    } });
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 2), sender.credit);
+
+    mem.starve = false;
+    mem.fail_read = failure == .read_failed;
+    mem.clearWritten();
+    const result = fixture.session.pump(10_000);
+    mem.fail_read = false;
+    switch (failure) {
+        .eof => try testing.expectError(error.ConnectionClosed, result),
+        .read_failed => try testing.expectError(error.ReadFailed, result),
+    }
+
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expect(fixture.session.ended);
+    try testing.expect(sender.poisoned);
+    try testing.expect(!sender.attached);
+    try testing.expect(receiver.poisoned);
+    try testing.expect(!receiver.attached);
+
+    const writes = mem.write_count;
+    try testing.expectError(error.LinkDetached, sender.sendBytes("blocked", 10_000));
+    try testing.expectError(error.LinkDetached, receiver.issueCredit(1));
+    try testing.expectEqual(writes, mem.write_count);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+}
+
+test "zero-byte EOF terminalizes every link in the session" {
+    try terminalReadFailureInvalidatesSession(.eof);
+}
+
+test "zero-byte read failure terminalizes every link in the session" {
+    try terminalReadFailureInvalidatesSession(.read_failed);
 }
 
 test "remote Close error-copy OOM invalidates the consumed control frame" {
@@ -6054,7 +6175,101 @@ test "mixed per-transfer receiver settlement modes split disposition ranges" {
     try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
 }
 
-test "a transfer cannot upgrade a mode-first receiver to mode second" {
+test "an initially sender-settled delivery ignores mode on its continuations" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 50,
+        .delivery_tag = "t",
+        .settled = true,
+        .rcv_settle_mode = .second,
+        .more = true,
+    }, "ev");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 50,
+        .rcv_settle_mode = .second,
+    }, "ent");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .first,
+        .prefetch = 1,
+        .max_message_size = 8,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("event", delivery.payload);
+    try testing.expect(delivery.settled);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+}
+
+test "a sender-settled final continuation ignores receiver settle mode" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 51,
+        .delivery_tag = "t",
+        .more = true,
+        .rcv_settle_mode = .first,
+    }, "ev");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 51,
+        .settled = true,
+        .rcv_settle_mode = .second,
+    }, "ent");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .first,
+        .prefetch = 1,
+        .max_message_size = 8,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("event", delivery.payload);
+    try testing.expect(delivery.settled);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+}
+
+test "an unsettled initial transfer cannot upgrade a mode-first receiver" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -6089,6 +6304,51 @@ test "a transfer cannot upgrade a mode-first receiver to mode second" {
     }, 10_000);
 
     try testing.expectError(error.MalformedFrame, fixture.session.pump(10_000));
+    try testing.expect(receiver.poisoned);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+}
+
+test "an unsettled continuation cannot upgrade a mode-first receiver" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 52,
+        .delivery_tag = "t",
+        .more = true,
+        .rcv_settle_mode = .first,
+    }, "ev");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 52,
+        .rcv_settle_mode = .second,
+    }, "ent");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .first,
+        .prefetch = 1,
+        .max_message_size = 8,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+
+    try testing.expectError(error.MalformedFrame, receiver.receive(10_000));
     try testing.expect(receiver.poisoned);
     try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
 }
@@ -6923,7 +7183,6 @@ test "draining a receiver waits for the sender to consume the outstanding credit
         .outgoing_window = 1000,
         .handle = 0,
         .delivery_count = 5,
-        .link_credit = 0,
         .drain = true,
     } });
 
@@ -6946,6 +7205,65 @@ test "draining a receiver waits for the sender to consume the outstanding credit
     try receiver.drainCredit(10_000);
     try testing.expectEqual(@as(u32, 0), receiver.credit);
     try testing.expect(!receiver.drain);
+}
+
+test "omitted drain credit derives remaining across delivery-count wrap" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "drainable",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "drainable",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_buffered_bytes = null,
+    }, 10_000);
+    receiver.delivery_count = std.math.maxInt(u32) - 1;
+    receiver.credit = 4;
+    receiver.drain = true;
+
+    // The previous delivery limit wraps to 2. Advancing to 0 consumes two
+    // credits and leaves two, even though link-credit is omitted.
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .drain = true,
+    } });
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 2), receiver.credit);
+
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 2,
+        .drain = true,
+    } });
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
 }
 
 test "closing a sender detaches it and drops it from the session" {

--- a/link.zig
+++ b/link.zig
@@ -623,6 +623,33 @@ pub const Session = struct {
 
     /// Emit a session `flow`, optionally carrying link credit.
     fn sendFlow(self: *Session, link: ?*Receiver) LinkError!void {
+        return self.sendFlowWithLinkState(
+            link,
+            if (link) |r| r.credit else null,
+            if (link) |r| r.drain else false,
+        );
+    }
+
+    /// Emit a receiver flow using prospective credit that is not committed to
+    /// the receiver until the complete frame has reached the transport.
+    fn sendFlowWithCredit(
+        self: *Session,
+        link: ?*Receiver,
+        prospective_credit: ?u32,
+    ) LinkError!void {
+        return self.sendFlowWithLinkState(
+            link,
+            prospective_credit,
+            if (link) |r| r.drain else false,
+        );
+    }
+
+    fn sendFlowWithLinkState(
+        self: *Session,
+        link: ?*Receiver,
+        prospective_credit: ?u32,
+        prospective_drain: bool,
+    ) LinkError!void {
         var f = perf.Flow{
             .next_incoming_id = self.next_incoming_id,
             .incoming_window = self.incoming_window,
@@ -631,9 +658,9 @@ pub const Session = struct {
         };
         if (link) |r| {
             f.handle = r.handle;
-            f.link_credit = r.credit;
+            f.link_credit = prospective_credit orelse r.credit;
             f.delivery_count = r.delivery_count;
-            f.drain = r.drain;
+            f.drain = prospective_drain;
         }
         try self.driver.sendPerformative(.amqp, self.channel, .{ .flow = f });
     }
@@ -1969,9 +1996,11 @@ pub const Receiver = struct {
         if (self.poisoned or !self.attached or self.detach_sent or self.session.ended)
             return error.LinkDetached;
         try self.reserveIncomingCapacity(count);
-        self.deferred_credit +|= count;
-        self.grantDeferredCredit();
-        try self.session.sendFlow(self);
+        var prospective = self.creditState();
+        prospective.deferred_credit +|= count;
+        self.grantDeferredCredit(&prospective);
+        try self.session.sendFlowWithCredit(self, prospective.credit);
+        self.commitCreditState(prospective);
     }
 
     fn reserveIncomingCapacity(self: *Receiver, count: u32) Allocator.Error!void {
@@ -1983,12 +2012,32 @@ pub const Receiver = struct {
         try self.session.incoming_deliveries.ensureUnusedCapacity(self.allocator, reserve_count);
     }
 
-    fn grantDeferredCredit(self: *Receiver) void {
+    const CreditState = struct {
+        credit: u32,
+        deferred_credit: u32,
+        overrun: u32,
+    };
+
+    fn creditState(self: *const Receiver) CreditState {
+        return .{
+            .credit = self.credit,
+            .deferred_credit = self.deferred_credit,
+            .overrun = self.overrun,
+        };
+    }
+
+    fn commitCreditState(self: *Receiver, state: CreditState) void {
+        self.credit = state.credit;
+        self.deferred_credit = state.deferred_credit;
+        self.overrun = state.overrun;
+    }
+
+    fn grantDeferredCredit(self: *const Receiver, state: *CreditState) void {
         const capacity = self.byteCreditCapacity();
-        if (self.credit >= capacity or self.deferred_credit == 0) return;
-        const issued = @min(self.deferred_credit, capacity - self.credit);
-        self.deferred_credit -= issued;
-        self.grant(self.credit + issued);
+        if (state.credit >= capacity or state.deferred_credit == 0) return;
+        const issued = @min(state.deferred_credit, capacity - state.credit);
+        state.deferred_credit -= issued;
+        self.grantCreditState(state, state.credit + issued);
     }
 
     /// Set credit to `amount`, charging any outstanding overrun against it.
@@ -1998,31 +2047,46 @@ pub const Receiver = struct {
     /// credit onto this endpoint's delivery count: a peer must not be able to
     /// clear the debt it ran up simply by asserting a new window.
     fn grant(self: *Receiver, amount: u32) void {
+        var state = self.creditState();
+        self.grantCreditState(&state, amount);
+        self.commitCreditState(state);
+    }
+
+    fn grantCreditState(self: *const Receiver, state: *CreditState, amount: u32) void {
         const bounded = @min(amount, self.byteCreditCapacity());
-        const charged = @min(self.overrun, bounded);
-        self.overrun -= charged;
-        self.credit = bounded - charged;
+        const charged = @min(state.overrun, bounded);
+        state.overrun -= charged;
+        state.credit = bounded - charged;
     }
 
     /// Top prefetch credit back up once half of it has been consumed, so a
     /// prefetching receiver never stalls waiting for the caller.
     fn replenish(self: *Receiver) LinkError!void {
-        if (self.deferred_credit != 0) {
-            const before = self.credit;
-            self.grantDeferredCredit();
-            if (self.credit != before) {
-                try self.session.sendFlow(self);
+        var prospective = self.creditState();
+        if (prospective.deferred_credit != 0) {
+            const before = prospective.credit;
+            self.grantDeferredCredit(&prospective);
+            if (prospective.credit != before) {
+                try self.session.sendFlowWithCredit(self, prospective.credit);
+                self.commitCreditState(prospective);
                 return;
             }
         }
-        if (self.prefetch == 0) return;
+        if (self.prefetch == 0) {
+            self.commitCreditState(prospective);
+            return;
+        }
         const target = @min(self.prefetch, self.byteCreditCapacity());
-        if (target == 0) return;
+        if (target == 0) {
+            self.commitCreditState(prospective);
+            return;
+        }
         // A one- or two-delivery byte window has no useful half-window: using
         // its last credit avoids a flow write before every second delivery.
-        if (self.credit > 0 and
-            (target <= 2 or self.credit > target / 2))
+        if (prospective.credit > 0 and
+            (target <= 2 or prospective.credit > target / 2))
         {
+            self.commitCreditState(prospective);
             return;
         }
         // A peer that ran past its last grant is granted that much less now,
@@ -2030,15 +2094,19 @@ pub const Receiver = struct {
         // enough past and the charge cancels the window entirely, which is
         // what "stop granting credit" means here; keep going and
         // `refuseOverrun` ends the link.
-        const before = self.credit;
-        self.grant(self.prefetch);
+        const before = prospective.credit;
+        self.grantCreditState(&prospective, self.prefetch);
         // No flow when the charge cancelled the whole window. A peer only gets
         // here by ignoring credit already, so announcing zero to it buys
         // nothing and would put a frame on the wire per `receive` for as long
         // as it misbehaves. A peer merely racing a flow is usually charged
         // less than a window and is still told its reduced credit below.
-        if (self.credit == 0 or self.credit == before) return;
-        try self.session.sendFlow(self);
+        if (prospective.credit == 0 or prospective.credit == before) {
+            self.commitCreditState(prospective);
+            return;
+        }
+        try self.session.sendFlowWithCredit(self, prospective.credit);
+        self.commitCreditState(prospective);
     }
 
     /// Charge overrun debt as buffered deliveries are released, but defer a
@@ -2377,8 +2445,8 @@ pub const Receiver = struct {
     pub fn drainCredit(self: *Receiver, deadline_ms: i64) LinkError!void {
         if (self.session.ended or self.poisoned or !self.attached or self.detach_sent)
             return error.LinkDetached;
+        try self.session.sendFlowWithLinkState(self, self.credit, true);
         self.drain = true;
-        try self.session.sendFlow(self);
         // The sender answers a drain by advancing its delivery count over the
         // outstanding credit (§2.6.7), so wait until that lands rather than
         // leaving the link in a half-drained state.
@@ -6393,6 +6461,225 @@ test "the attach flow issues the requested prefetch credit" {
     var decoded = try perf.decode(allocator, flows[0]);
     defer decoded.deinit();
     try testing.expectEqual(@as(u32, 250), decoded.performative.flow.link_credit.?);
+}
+
+const CreditFlowPath = enum {
+    issue,
+    deferred_replenish,
+    prefetch_replenish,
+};
+
+const CreditFlowFailure = enum {
+    encode_oom,
+    pre_write,
+    partial_write,
+    flush,
+};
+
+fn invokeCreditFlow(receiver: *Receiver, path: CreditFlowPath) LinkError!void {
+    switch (path) {
+        .issue => try receiver.issueCredit(4),
+        .deferred_replenish, .prefetch_replenish => try receiver.replenish(),
+    }
+}
+
+fn creditFlowFailureIsTransactional(path: CreditFlowPath, failure: CreditFlowFailure) !void {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh",
+        .prefetch = 0,
+        .max_buffered_bytes = null,
+    }, 10_000);
+
+    switch (path) {
+        .issue => {},
+        .deferred_replenish => receiver.deferred_credit = 4,
+        .prefetch_replenish => receiver.prefetch = 4,
+    }
+    // Exercise debt as part of the transaction, and prove the Flow advertises
+    // the unchanged delivery-count paired with the newly committed credit.
+    receiver.overrun = 1;
+    receiver.delivery_count = 7;
+    const before = receiver.creditState();
+    mem.clearWritten();
+
+    var switching = SwitchAllocator{ .child = allocator };
+    const writes_before = mem.write_count;
+    switch (failure) {
+        .encode_oom => {
+            driver.allocator = switching.allocator();
+            switching.failing = true;
+        },
+        .pre_write => mem.fail_write = true,
+        .partial_write => mem.fail_write_after = writes_before + 1,
+        .flush => mem.fail_flush = true,
+    }
+
+    const result = invokeCreditFlow(receiver, path);
+    switching.failing = false;
+    driver.allocator = allocator;
+    mem.fail_write = false;
+    mem.fail_write_after = null;
+    mem.fail_flush = false;
+
+    switch (failure) {
+        .encode_oom => try testing.expectError(error.OutOfMemory, result),
+        .pre_write, .partial_write, .flush => try testing.expectError(error.WriteFailed, result),
+    }
+
+    try testing.expectEqual(before.credit, receiver.credit);
+    try testing.expectEqual(before.deferred_credit, receiver.deferred_credit);
+    try testing.expectEqual(before.overrun, receiver.overrun);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+    try testing.expectEqual(@as(usize, 0), mem.pending.items.len);
+
+    if (failure == .encode_oom) {
+        try testing.expectEqual(connection.State.opened, driver.state);
+        try testing.expect(!mem.closed);
+        try invokeCreditFlow(receiver, path);
+
+        try testing.expectEqual(@as(u32, 3), receiver.credit);
+        try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+        try testing.expectEqual(@as(u32, 0), receiver.overrun);
+
+        var frames = try EmittedFrames.parse(allocator, mem.written());
+        defer frames.deinit();
+        const flows = try frames.of(allocator, perf.descriptor.flow);
+        defer allocator.free(flows);
+        try testing.expectEqual(@as(usize, 1), flows.len);
+        var decoded = try perf.decode(allocator, flows[0]);
+        defer decoded.deinit();
+        const flow = decoded.performative.flow;
+        try testing.expectEqual(receiver.handle, flow.handle.?);
+        try testing.expectEqual(receiver.credit, flow.link_credit.?);
+        try testing.expectEqual(receiver.delivery_count, flow.delivery_count.?);
+        return;
+    }
+
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    const successful_writes: usize = switch (failure) {
+        .pre_write => 0,
+        .partial_write => 1,
+        .flush => 2,
+        .encode_oom => unreachable,
+    };
+    try testing.expectEqual(
+        writes_before + successful_writes,
+        mem.write_count,
+    );
+    try testing.expectError(error.ConnectionClosed, invokeCreditFlow(receiver, path));
+    try testing.expectEqual(before.credit, receiver.credit);
+    try testing.expectEqual(before.deferred_credit, receiver.deferred_credit);
+    try testing.expectEqual(before.overrun, receiver.overrun);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+}
+
+test "issueCredit commits only a completely emitted Flow" {
+    inline for (std.meta.tags(CreditFlowFailure)) |failure| {
+        try creditFlowFailureIsTransactional(.issue, failure);
+    }
+}
+
+test "deferred replenishment commits only a completely emitted Flow" {
+    inline for (std.meta.tags(CreditFlowFailure)) |failure| {
+        try creditFlowFailureIsTransactional(.deferred_replenish, failure);
+    }
+}
+
+test "prefetch replenishment commits only a completely emitted Flow" {
+    inline for (std.meta.tags(CreditFlowFailure)) |failure| {
+        try creditFlowFailureIsTransactional(.prefetch_replenish, failure);
+    }
+}
+
+test "drain state commits only after its Flow is emitted" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "eh",
+        .prefetch = 0,
+        .max_buffered_bytes = null,
+    }, 10_000);
+    receiver.credit = 4;
+    receiver.delivery_count = 7;
+    mem.clearWritten();
+
+    var switching = SwitchAllocator{ .child = allocator, .failing = true };
+    driver.allocator = switching.allocator();
+    try testing.expectError(error.OutOfMemory, receiver.drainCredit(10_000));
+    switching.failing = false;
+    driver.allocator = allocator;
+
+    try testing.expect(!receiver.drain);
+    try testing.expectEqual(@as(u32, 4), receiver.credit);
+    try testing.expectEqual(@as(u32, 7), receiver.delivery_count);
+    try testing.expectEqual(connection.State.opened, driver.state);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 11,
+        .link_credit = 0,
+        .drain = true,
+    } });
+    try receiver.drainCredit(10_000);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    const flow = decoded.performative.flow;
+    try testing.expectEqual(@as(?u32, 4), flow.link_credit);
+    try testing.expectEqual(@as(?u32, 7), flow.delivery_count);
+    try testing.expect(flow.drain);
+    try testing.expect(!receiver.drain);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 11), receiver.delivery_count);
 }
 
 test "a detach surfaces the condition that stole the link" {

--- a/link.zig
+++ b/link.zig
@@ -293,6 +293,7 @@ pub const Session = struct {
     fn releaseIncomingDelivery(self: *Session, receiver: *Receiver, id: u32) void {
         if (self.incoming_deliveries.get(id) != receiver) return;
         _ = self.incoming_deliveries.remove(id);
+        receiver.removePendingSettlement(id);
         for (receiver.unsettled_ids.items, 0..) |active, i| {
             if (active != id) continue;
             _ = receiver.unsettled_ids.swapRemove(i);
@@ -307,6 +308,7 @@ pub const Session = struct {
             }
         }
         receiver.unsettled_ids.clearRetainingCapacity();
+        receiver.pending_settlement_ids.clearRetainingCapacity();
     }
 
     fn releaseIncomingRange(self: *Session, receiver: *Receiver, first: u32, last: u32) void {
@@ -318,6 +320,7 @@ pub const Session = struct {
             const id = receiver.unsettled_ids.items[i];
             if (id -% first > span) continue;
             _ = self.incoming_deliveries.remove(id);
+            receiver.removePendingSettlement(id);
             _ = receiver.unsettled_ids.swapRemove(i);
         }
     }
@@ -419,20 +422,32 @@ pub const Session = struct {
     }
 
     fn applyDisposition(self: *Session, d: perf.Disposition) LinkError!void {
-        // A disposition from the receiving side settles what we sent.
-        if (d.role != .receiver) return;
         const last = d.last orelse d.first;
-        for (self.senders.items) |s| {
-            s.applyDisposition(d.first, last, d.state) catch |err| {
-                // The disposition frame is consumed and cannot be replayed.
-                // Ensure every id in its range has a terminal outcome before
-                // the session is invalidated, including entries on senders we
-                // had not reached yet.
-                for (self.senders.items) |sender| {
-                    sender.terminalizeDispositionRange(d.first, last, d.state);
-                }
-                return err;
-            };
+        if (d.role == .receiver) {
+            // A disposition from the receiving side settles what we sent.
+            for (self.senders.items) |s| {
+                s.applyDisposition(d.first, last, d.state) catch |err| {
+                    // The disposition frame is consumed and cannot be replayed.
+                    // Ensure every id in its range has a terminal outcome before
+                    // the session is invalidated, including entries on senders we
+                    // had not reached yet.
+                    for (self.senders.items) |sender| {
+                        sender.terminalizeDispositionRange(d.first, last, d.state);
+                    }
+                    return err;
+                };
+            }
+            return;
+        }
+
+        // In receiver-settle-mode second, our first disposition is not
+        // terminal. The peer, acting as sender, settles it with a second
+        // disposition; only that acknowledgement releases the active ids.
+        if (!d.settled) return;
+        for (self.receivers.items) |receiver| {
+            if (receiver.rcv_settle_mode == .second) {
+                receiver.acknowledgeSettlementRange(d.first, last);
+            }
         }
     }
 
@@ -452,6 +467,7 @@ pub const Session = struct {
             if (r.awaiting_attach and !r.poisoned and std.mem.eql(u8, r.name, a.name)) {
                 r.remote_handle = a.handle;
                 r.peer_max_message_size = a.max_message_size;
+                r.rcv_settle_mode = a.rcv_settle_mode;
                 r.attached = true;
                 r.awaiting_attach = false;
                 return;
@@ -1250,6 +1266,10 @@ pub fn openSender(
         .desired_capabilities = options.desired_capabilities,
         .properties = options.properties,
     } });
+    errdefer {
+        session.driver.invalidate();
+        session.terminate();
+    }
 
     while (!sender.attached) {
         if (sender.detach_error != null) return error.LinkDetached;
@@ -1310,9 +1330,11 @@ pub const ReceiverOptions = struct {
     /// bounded separately by `max_message_size` and remains valid until the
     /// next successful `receive`.
     ///
-    /// Null explicitly disables the aggregate bound.
+    /// Null explicitly disables the aggregate bound. The default is finite;
+    /// callers choosing null also choose responsibility for bounding total
+    /// retention above this layer.
     /// A zero-byte finite budget is invalid.
-    max_buffered_bytes: ?u64 = null,
+    max_buffered_bytes: ?u64 = default_max_buffered_bytes,
 };
 
 /// The floor for a derived `max_overrun`, so a receiver driving credit by
@@ -1330,12 +1352,11 @@ const min_overrun_allowance: u32 = 64;
 ///
 pub const default_max_message_size: u64 = 128 * 1024 * 1024;
 
-/// Recommended opt-in aggregate ceiling for payload bytes retained by one
-/// receiver.
+/// Default aggregate ceiling for payload bytes retained by one receiver.
 ///
-/// The default is unbounded so the legacy 300-credit window never authorizes
-/// traffic the receiver would then reject. Set this value explicitly when a
-/// smaller, byte-reserved window is acceptable.
+/// With the default 128 MiB per-message limit this authorizes two deliveries
+/// at a time. Services with smaller known message limits can safely retain a
+/// deeper delivery window by setting both receiver limits explicitly.
 pub const default_max_buffered_bytes: u64 = 256 * 1024 * 1024;
 
 /// §2.7.3: an absent *or zero* `max-message-size` means no limit.
@@ -1388,6 +1409,8 @@ pub const Receiver = struct {
     /// actually enforced, and `ReceiverOptions.max_message_size` for what null
     /// means.
     max_message_size: ?u64 = null,
+    /// Receiver settlement mode negotiated in the attach exchange.
+    rcv_settle_mode: perf.ReceiverSettleMode = .first,
     /// What the peer declared in its own `attach`, recorded but not enforced;
     /// `maxMessageSize` says why. It is the largest message the *peer*
     /// supports, which is a bound on a sender rather than on us.
@@ -1406,6 +1429,9 @@ pub const Receiver = struct {
     /// Unsettled ids owned by this link, mirrored in the session-wide map so
     /// reuse is rejected across every receiver on the channel.
     unsettled_ids: std.ArrayList(u32) = .empty,
+    /// Delivery ids for which mode second has emitted its first, unsettled
+    /// disposition and is awaiting the sender-role settled acknowledgment.
+    pending_settlement_ids: std.ArrayList(u32) = .empty,
     /// Completed deliveries not yet handed to the caller.
     ///
     /// Drained with a head cursor rather than by removing the front element:
@@ -1427,6 +1453,7 @@ pub const Receiver = struct {
         self.partial.deinit(self.allocator);
         self.partial_tag.deinit(self.allocator);
         self.unsettled_ids.deinit(self.allocator);
+        self.pending_settlement_ids.deinit(self.allocator);
         // Everything before `ready_head` was already handed out, so its
         // buffers belong to `current` and are freed by `releaseCurrent`.
         for (self.ready.items[self.ready_head..]) |d| {
@@ -1446,6 +1473,53 @@ pub const Receiver = struct {
 
     fn releaseBuffered(self: *Receiver, bytes: usize) void {
         self.buffered_bytes -|= @intCast(bytes);
+    }
+
+    fn removePendingSettlement(self: *Receiver, id: u32) void {
+        for (self.pending_settlement_ids.items, 0..) |pending, i| {
+            if (pending != id) continue;
+            _ = self.pending_settlement_ids.swapRemove(i);
+            return;
+        }
+    }
+
+    fn markPendingSettlementRange(
+        self: *Receiver,
+        first: u32,
+        last: u32,
+    ) Allocator.Error!usize {
+        const old_len = self.pending_settlement_ids.items.len;
+        const span = last -% first;
+        if (span >= 1 << 31) return old_len;
+
+        var additional: usize = 0;
+        for (self.unsettled_ids.items) |id| {
+            if (id -% first > span) continue;
+            if (std.mem.indexOfScalar(u32, self.pending_settlement_ids.items, id) == null) {
+                additional += 1;
+            }
+        }
+        try self.pending_settlement_ids.ensureUnusedCapacity(self.allocator, additional);
+        for (self.unsettled_ids.items) |id| {
+            if (id -% first > span) continue;
+            if (std.mem.indexOfScalar(u32, self.pending_settlement_ids.items, id) == null) {
+                self.pending_settlement_ids.appendAssumeCapacity(id);
+            }
+        }
+        return old_len;
+    }
+
+    fn acknowledgeSettlementRange(self: *Receiver, first: u32, last: u32) void {
+        const span = last -% first;
+        if (span >= 1 << 31) return;
+        var i = self.pending_settlement_ids.items.len;
+        while (i > 0) {
+            i -= 1;
+            const id = self.pending_settlement_ids.items[i];
+            if (id -% first > span) continue;
+            _ = self.pending_settlement_ids.swapRemove(i);
+            self.session.releaseIncomingDelivery(self, id);
+        }
     }
 
     fn bufferWouldOverflow(self: *const Receiver, bytes: usize) bool {
@@ -2026,16 +2100,29 @@ pub const Receiver = struct {
     ) LinkError!void {
         if (self.session.ended or self.poisoned or !self.attached or self.detach_sent)
             return error.LinkDetached;
-        try self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+        const pending_len = if (self.rcv_settle_mode == .second)
+            try self.markPendingSettlementRange(first, last)
+        else
+            0;
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
             .disposition = .{
                 .role = .receiver,
                 .first = first,
                 .last = last,
-                .settled = true,
+                .settled = self.rcv_settle_mode == .first,
                 .state = state,
             },
-        });
-        self.session.releaseIncomingRange(self, first, last);
+        }) catch |err| {
+            if (self.session.driver.state == .err) {
+                self.session.terminate();
+            } else if (self.rcv_settle_mode == .second) {
+                self.pending_settlement_ids.shrinkRetainingCapacity(pending_len);
+            }
+            return err;
+        };
+        if (self.rcv_settle_mode == .first) {
+            self.session.releaseIncomingRange(self, first, last);
+        }
     }
 
     pub fn accept(self: *Receiver, delivery: Delivery) LinkError!void {
@@ -2174,8 +2261,10 @@ pub fn openReceiver(
             @max(options.prefetch, min_overrun_allowance),
         .max_message_size = max_message_size,
         .max_buffered_bytes = options.max_buffered_bytes,
+        .rcv_settle_mode = options.rcv_settle_mode,
     };
     errdefer receiver.unsettled_ids.deinit(session.allocator);
+    errdefer receiver.pending_settlement_ids.deinit(session.allocator);
 
     try session.receivers.append(session.allocator, receiver);
     errdefer _ = session.receivers.pop();
@@ -2195,6 +2284,10 @@ pub fn openReceiver(
         .desired_capabilities = options.desired_capabilities,
         .properties = options.properties,
     } });
+    errdefer {
+        session.driver.invalidate();
+        session.terminate();
+    }
 
     while (!receiver.attached) {
         if (receiver.detach_error != null) return error.LinkDetached;
@@ -2880,6 +2973,70 @@ test "Detach acknowledgement timeout blocks transfer flow disposition and retry 
                 try testing.expectEqual(written, mem.written().len);
             },
         }
+    }
+}
+
+test "Attach timeout terminalizes the session before a stale response can bind a replacement" {
+    const Kind = enum { sender, receiver };
+    inline for (std.meta.tags(Kind)) |kind| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{ .auto_advance_ms = 1 };
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        mem.starve = true;
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        mem.clearWritten();
+        const deadline = clock.millis + 10;
+        switch (kind) {
+            .sender => try testing.expectError(error.Timeout, openSender(&fixture.session, .{
+                .name = "link",
+                .target_address = "entity",
+            }, deadline)),
+            .receiver => try testing.expectError(error.Timeout, openReceiver(&fixture.session, .{
+                .name = "link",
+                .source_address = "entity",
+            }, deadline)),
+        }
+        try testing.expect(fixture.session.ended);
+        try testing.expectEqual(connection.State.err, driver.state);
+        try testing.expect(mem.closed);
+        const written = mem.written().len;
+        try testing.expect(written > 0);
+
+        // Even if the old response arrives later, the closed stream cannot
+        // route it by name into a replacement object.
+        try peer.push(0, .{ .attach = .{
+            .name = "link",
+            .handle = 77,
+            .role = if (kind == .sender) .receiver else .sender,
+            .initial_delivery_count = 0,
+        } });
+        try testing.expectError(error.LinkDetached, fixture.session.pump(deadline + 10));
+        switch (kind) {
+            .sender => try testing.expectError(
+                error.ConnectionClosed,
+                openSender(&fixture.session, .{
+                    .name = "link",
+                    .target_address = "entity",
+                }, deadline + 10),
+            ),
+            .receiver => try testing.expectError(
+                error.ConnectionClosed,
+                openReceiver(&fixture.session, .{
+                    .name = "link",
+                    .source_address = "entity",
+                }, deadline + 10),
+            ),
+        }
+        try testing.expectEqual(written, mem.written().len);
     }
 }
 
@@ -5247,6 +5404,195 @@ test "a batch settles a contiguous run in one disposition" {
     // thing. At the default 300-deep prefetch that is 300.
     try testing.expectEqual(@as(usize, 1), ranges.len);
     try testing.expectEqual([2]u32{ 0, 7 }, ranges[0]);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+}
+
+test "receiver settle mode second retains ids through timeout until sender acknowledgment" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{ .auto_advance_ms = 1 };
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .rcv_settle_mode = .second,
+        .initial_delivery_count = 0,
+    } });
+    for (10..12) |id| {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = @intCast(id),
+            .delivery_tag = "t",
+        }, "event");
+    }
+    mem.starve = true;
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .second,
+        .prefetch = 2,
+        .max_message_size = 1024,
+        .max_buffered_bytes = 2048,
+    }, 10_000);
+    try testing.expectEqual(perf.ReceiverSettleMode.second, receiver.rcv_settle_mode);
+
+    for (0..2) |_| _ = try fixture.session.pump(10_000);
+    _ = try receiver.receive(10_000);
+    _ = try receiver.receive(10_000);
+    try testing.expect(fixture.session.incoming_deliveries.contains(10));
+    try testing.expect(fixture.session.incoming_deliveries.contains(11));
+
+    // A sender-role disposition is not our second-phase acknowledgment until
+    // this receiver has actually emitted its first disposition.
+    try peer.push(0, .{ .disposition = .{
+        .role = .sender,
+        .first = 10,
+        .last = 11,
+        .settled = true,
+        .state = .accepted,
+    } });
+    _ = try fixture.session.pump(clock.millis + 10);
+    try testing.expect(fixture.session.incoming_deliveries.contains(10));
+    try testing.expect(fixture.session.incoming_deliveries.contains(11));
+
+    mem.clearWritten();
+    try receiver.settleRange(10, 11, .accepted);
+    try testing.expect(fixture.session.incoming_deliveries.contains(10));
+    try testing.expect(fixture.session.incoming_deliveries.contains(11));
+    try testing.expectEqual(@as(usize, 2), receiver.pending_settlement_ids.items.len);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const dispositions = try frames.of(allocator, perf.descriptor.disposition);
+    defer allocator.free(dispositions);
+    try testing.expectEqual(@as(usize, 1), dispositions.len);
+    var decoded = try perf.decode(allocator, dispositions[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(perf.Role.receiver, decoded.performative.disposition.role);
+    try testing.expect(!decoded.performative.disposition.settled);
+
+    try testing.expectError(error.Timeout, fixture.session.pump(clock.millis + 5));
+    try testing.expect(fixture.session.incoming_deliveries.contains(10));
+    try testing.expect(fixture.session.incoming_deliveries.contains(11));
+
+    try peer.push(0, .{ .disposition = .{
+        .role = .sender,
+        .first = 10,
+        .last = 11,
+        .settled = false,
+        .state = .accepted,
+    } });
+    _ = try fixture.session.pump(clock.millis + 10);
+    try testing.expect(fixture.session.incoming_deliveries.contains(10));
+    try testing.expect(fixture.session.incoming_deliveries.contains(11));
+    try testing.expectEqual(@as(usize, 2), receiver.pending_settlement_ids.items.len);
+
+    try peer.push(0, .{ .disposition = .{
+        .role = .sender,
+        .first = 10,
+        .last = 11,
+        .settled = true,
+        .state = .accepted,
+    } });
+    _ = try fixture.session.pump(clock.millis + 10);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+    try testing.expectEqual(@as(usize, 0), receiver.pending_settlement_ids.items.len);
+}
+
+test "failed second-mode disposition terminalizes and releases active ids" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .rcv_settle_mode = .second,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 20,
+        .delivery_tag = "t",
+    }, "event");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .second,
+        .prefetch = 1,
+        .max_message_size = 1024,
+        .max_buffered_bytes = 1024,
+    }, 10_000);
+
+    _ = try receiver.receive(10_000);
+    try testing.expect(fixture.session.incoming_deliveries.contains(20));
+    mem.fail_write = true;
+    try testing.expectError(error.WriteFailed, receiver.settleRange(20, 20, .accepted));
+    try testing.expect(fixture.session.ended);
+    try testing.expect(receiver.poisoned);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
+    try testing.expectEqual(@as(usize, 0), receiver.pending_settlement_ids.items.len);
+}
+
+test "deinit releases ids awaiting second-mode settlement acknowledgment" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{ .auto_advance_ms = 1 };
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .rcv_settle_mode = .second,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 30,
+        .delivery_tag = "t",
+    }, "event");
+    mem.starve = true;
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "entity",
+        .rcv_settle_mode = .second,
+        .prefetch = 1,
+        .max_message_size = 1024,
+        .max_buffered_bytes = 1024,
+    }, 10_000);
+
+    const delivery = try receiver.receive(10_000);
+    try receiver.accept(delivery);
+    try testing.expect(fixture.session.incoming_deliveries.contains(30));
+    fixture.session.closeReceiver(receiver, clock.millis + 5);
+    try testing.expectEqual(@as(usize, 0), fixture.session.receivers.items.len);
+    try testing.expectEqual(@as(usize, 0), fixture.session.incoming_deliveries.count());
 }
 
 test "a batch does not settle across a gap in delivery ids" {
@@ -7264,7 +7610,7 @@ test "a null max-message-size declares and enforces no limit" {
     try testing.expectEqual(@as(?u64, null), decoded.performative.attach.max_message_size);
 }
 
-test "the default receiver accepts every delivery in its granted credit window" {
+test "the default receiver derives granted credit from its finite byte budget" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -7278,7 +7624,7 @@ test "the default receiver accepts every delivery in its granted credit window" 
         .role = .sender,
         .initial_delivery_count = 0,
     } });
-    for (0..300) |i| {
+    for (0..2) |i| {
         try peer.pushTransfer(0, .{
             .handle = 0,
             .delivery_id = @intCast(i),
@@ -7293,16 +7639,17 @@ test "the default receiver accepts every delivery in its granted credit window" 
     defer fixture.deinit();
 
     mem.clearWritten();
-    // Per-message safety remains on by default. Aggregate retention is opt-in
-    // because a finite budget smaller than the full granted window would
-    // authorize legal traffic and then detach the conforming sender for it.
     const receiver = try openReceiver(&fixture.session, .{
         .name = "consumer",
         .source_address = "eh/ConsumerGroups/$default/Partitions/0",
     }, 10_000);
     try testing.expectEqual(default_max_message_size, receiver.maxMessageSize().?);
-    try testing.expectEqual(@as(?u64, null), receiver.max_buffered_bytes);
-    try testing.expectEqual(@as(u32, 300), receiver.credit);
+    try testing.expectEqual(
+        @as(?u64, default_max_buffered_bytes),
+        receiver.max_buffered_bytes,
+    );
+    try testing.expectEqual(@as(u32, 2), receiver.credit);
+    try testing.expectEqual(@as(u32, 298), receiver.deferred_credit);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
@@ -7317,13 +7664,14 @@ test "the default receiver accepts every delivery in its granted credit window" 
     try testing.expectEqual(@as(usize, 1), flows.len);
     var flow = try perf.decode(allocator, flows[0]);
     defer flow.deinit();
-    try testing.expectEqual(@as(u32, 300), flow.performative.flow.link_credit.?);
+    try testing.expectEqual(@as(u32, 2), flow.performative.flow.link_credit.?);
 
-    for (0..300) |_| _ = try fixture.session.pump(10_000);
+    for (0..2) |_| _ = try fixture.session.pump(10_000);
     try testing.expect(receiver.attached);
     try testing.expectEqual(@as(u32, 0), receiver.credit);
-    try testing.expectEqual(@as(u64, 1500), receiver.bufferedBytes());
-    try testing.expectEqual(@as(usize, 300), receiver.ready.items.len);
+    try testing.expectEqual(@as(u64, 10), receiver.bufferedBytes());
+    try testing.expectEqual(@as(usize, 2), receiver.ready.items.len);
+    try expectReceiverAccounting(receiver);
 }
 
 test "a finite aggregate budget is also the advertised per-message ceiling" {

--- a/root.zig
+++ b/root.zig
@@ -55,6 +55,7 @@ pub const DecidedDelivery = link.DecidedDelivery;
 pub const Receiver = link.Receiver;
 pub const ReceiverOptions = link.ReceiverOptions;
 pub const default_max_message_size = link.default_max_message_size;
+pub const default_max_buffered_bytes = link.default_max_buffered_bytes;
 pub const Delivery = link.Delivery;
 pub const Rejection = link.Rejection;
 pub const SettleBatch = link.SettleBatch;

--- a/root.zig
+++ b/root.zig
@@ -56,6 +56,7 @@ pub const Receiver = link.Receiver;
 pub const ReceiverOptions = link.ReceiverOptions;
 pub const default_max_message_size = link.default_max_message_size;
 pub const default_max_buffered_bytes = link.default_max_buffered_bytes;
+pub const default_max_unsettled_deliveries = link.default_max_unsettled_deliveries;
 pub const Delivery = link.Delivery;
 pub const Rejection = link.Rejection;
 pub const SettleBatch = link.SettleBatch;

--- a/transport.zig
+++ b/transport.zig
@@ -180,6 +180,8 @@ pub const MemoryTransport = struct {
     closed: bool = false,
     /// Set by tests to make the next `write` fail.
     fail_write: bool = false,
+    /// Set by tests to make the next `read` fail terminally.
+    fail_read: bool = false,
     /// Set by tests to fail without publishing the pending writes.
     fail_flush: bool = false,
     /// Number of successful writes. Tests can fail a later write precisely,
@@ -228,6 +230,7 @@ pub const MemoryTransport = struct {
         const self: *MemoryTransport = @ptrCast(@alignCast(ptr));
         if (self.pending.items.len != 0) self.reads_with_pending_writes += 1;
         if (self.closed) return error.ConnectionClosed;
+        if (self.fail_read) return error.ReadFailed;
         const remaining = self.inbound.items.len - self.inbound_pos;
         if (remaining == 0) return if (self.starve) 0 else error.ConnectionClosed;
         var n = @min(remaining, buffer.len);

--- a/transport.zig
+++ b/transport.zig
@@ -180,6 +180,10 @@ pub const MemoryTransport = struct {
     closed: bool = false,
     /// Set by tests to make the next `write` fail.
     fail_write: bool = false,
+    /// Number of successful writes. Tests can fail a later write precisely,
+    /// after an earlier frame has already reached the wire.
+    write_count: usize = 0,
+    fail_write_after: ?usize = null,
 
     pub fn init(allocator: Allocator) MemoryTransport {
         return .{ .allocator = allocator };
@@ -234,8 +238,13 @@ pub const MemoryTransport = struct {
     fn memWrite(ptr: *anyopaque, bytes: []const u8) TransportError!void {
         const self: *MemoryTransport = @ptrCast(@alignCast(ptr));
         if (self.closed) return error.ConnectionClosed;
-        if (self.fail_write) return error.WriteFailed;
+        if (self.fail_write or
+            (self.fail_write_after != null and self.write_count >= self.fail_write_after.?))
+        {
+            return error.WriteFailed;
+        }
         try self.pending.appendSlice(self.allocator, bytes);
+        self.write_count += 1;
     }
 
     fn memFlush(ptr: *anyopaque) TransportError!void {

--- a/transport.zig
+++ b/transport.zig
@@ -180,6 +180,8 @@ pub const MemoryTransport = struct {
     closed: bool = false,
     /// Set by tests to make the next `write` fail.
     fail_write: bool = false,
+    /// Set by tests to fail without publishing the pending writes.
+    fail_flush: bool = false,
     /// Number of successful writes. Tests can fail a later write precisely,
     /// after an earlier frame has already reached the wire.
     write_count: usize = 0,
@@ -250,6 +252,7 @@ pub const MemoryTransport = struct {
     fn memFlush(ptr: *anyopaque) TransportError!void {
         const self: *MemoryTransport = @ptrCast(@alignCast(ptr));
         if (self.closed) return error.ConnectionClosed;
+        if (self.fail_flush) return error.WriteFailed;
         try self.outbound.appendSlice(self.allocator, self.pending.items);
         self.pending.clearRetainingCapacity();
     }
@@ -257,6 +260,7 @@ pub const MemoryTransport = struct {
     fn memClose(ptr: *anyopaque) void {
         const self: *MemoryTransport = @ptrCast(@alignCast(ptr));
         self.closed = true;
+        self.pending.clearRetainingCapacity();
     }
 };
 


### PR DESCRIPTION
## Summary

Release `azure_sdk_amqp` 0.5.0 from the accumulated post-v0.4.0 work already merged to `sdk/amqp`. The package version remains 0.5.0; its fingerprint, publish paths, Zig floor, and immutable `uamqp` dependency are unchanged.

This release gives Event Hubs and Service Bus a tagged AMQP revision to pin, unblocking their sealed package releases.

## Release-range audit

Audited `azure_sdk_amqp/v0.4.0..bd5330d983ca75a56771a085659ec1136c9a81f6`: #323, #326, #328, #329, #333, #335, #336, #344, #346, #348, and #349.

The range combines sender pipelining and recovery, session flow-control corrections, receive-path allocation work, credit enforcement, and receiver message bounds. Event Hubs and Service Bus already repinned through `bd5330d98` in #350/#351.

Manifest audit:

- `.paths` exactly matches the registered `azure_sdk_amqp` publish set
- no local-path dependencies
- `uamqp` remains pinned by full commit URL and hash to `7fe05747b219fa105d3d36dcf6eaebfe15d61d0e`, tagged `v0.3.0`
- fingerprint remains `0xe0a2f9e77f72407d`

## Audit blockers resolved

- Receiver payload retention is bounded by configurable `max_buffered_bytes`, with a finite 256 MiB default; ready bytes, a full-size reservation for any in-progress delivery, and outstanding credit share one overflow-safe invariant. Explicit null is the opt-out.
- Delivery count and credit are charged exactly once on the initial transfer. Continuations may omit or repeat the original delivery id without recharging; aborted continuations are discarded, while only a different id before completion terminally detaches the link.
- Any allocation failure after a transfer is consumed clears partial state and terminally poisons the receiver, preventing a later continuation from producing truncated data.
- Sender poison is terminal. Late attach/flow frames cannot reactivate it, same-name replacement is rejected until the old object is removed, and all send paths refuse reuse.
- A finite aggregate budget is advertised and enforced as the effective per-message maximum when the configured message limit is larger, null, or zero; zero aggregate budgets are rejected.
- Credit-overrun debt saturates at `maxInt(u32)` when detachment is explicitly disabled.
- Model/invariant tests cover partial plus ready byte accounting and reservations, omitted/repeated/different continuation ids, abort, interleaving attempts, injected OOM and retry, late attach/flow, replacement links, effective limits, and near-overflow debt.
- Any header, body, or flush failure during frame emission closes the transport and terminally poisons the sending link, discarding pending bytes so a later operation cannot flush a corrupt partial frame.

Multi-frame outbound failure handling remains: once an opening frame succeeds, link credit/delivery count are consumed; a later failure poisons the sender and creates no phantom settlement entry. Opening-frame emission failures leave credit/count untouched but close the connection and poison the sender.

## Final compatibility and stream-invariant review

- Credit is always derived from the finite byte budget and effective per-message maximum. Deferred manual credit is reissued as capacity returns, while service packages must choose explicit service-specific limits and clamp their requested prefetch to a safe window.
- Any failure after an inbound frame header byte is consumed terminally closes the driver and invalidates every link on the session; injected body-buffer OOM proves unread body bytes and senders cannot be reused.
- Unsettled inbound delivery ids are tracked across every receiver on the session until settlement, abort, detach, error, or deinit. Same- and cross-link duplicates are rejected, equal active continuations remain valid, and settled ids may be reused.
- Disposition rejection allocation failure terminalizes every matching in-flight entry before invalidating the session, including the unvisited tail of a multi-delivery range.
- Protocol header, frame header/body, heartbeat, and flush failures all close and discard the dirty transport; terminal drivers reject retry.

## Final control-state and credit review

- Aggregate buffering defaults to 256 MiB. With the default 128 MiB message maximum, no more than two deliveries are granted at once; every grant remains covered by worst-case byte reservation. Explicit null is an intentional unbounded opt-out.
- Every initial transfer checks the session-wide active delivery-id set, including aborted and pre-settled transfers; only unsettled ids are inserted and held through terminal settlement.
- Every consumed SASL/Open/Begin/End/Close and connection-pump control is guarded: decode or apply failure invalidates retry state, links, driver, and transport.
- Remote End responds and terminalizes the session and links. Remote Close responds and terminalizes the connection. Remote Detach responds and terminally poisons the named link. Later sender/receiver calls emit nothing.

## Final teardown-state review

- A successfully emitted local Close, End, or closing Detach immediately blocks later protocol output at its connection, session, or link scope. Acknowledgement timeout cannot leave the object writable, retries emit no duplicate terminal frame, and Close timeout closes the transport.
- Close is recognized globally before registered-channel/session routing, including valid nonzero negotiated channels, then acknowledged and terminalized.
- `settled = true` on any delivery continuation is cumulative, survives later omission, is returned on the completed delivery, and releases the session-wide active delivery id.
- Because resumable link state is intentionally discarded, remote `Detach(closed = false)` is answered truthfully with `closed = true`; late Attach cannot revive the poisoned object.

## Pending-control, bounded-default, and settlement review

- SASL/AMQP protocol-header, Begin, and End waits become terminal immediately after a successfully emitted control if the acknowledgment times out with zero bytes consumed. Retry cannot duplicate the control.
- Sender and receiver Attach failures after emission invalidate the session/transport before the half-attached object is destroyed, preventing a delayed name-only response from activating a replacement.
- The receiver aggregate default is finite at 256 MiB. Credit is derived from the aggregate budget and effective message maximum, so the default 128 MiB maximum grants two deliveries rather than authorizing 37.5 GiB.
- The local receiver settlement mode is preserved from `ReceiverOptions` and is not overwritten by the remote sender's Attach preference. Mode first emits `settled = true` and releases immediately; mode second emits `settled = false`, tracks only locally dispositioned ids, and releases them only on the sender-role settled acknowledgment. Timeout, premature acknowledgment, ranges, dirty emission failure, and deinitialization are covered.


## Merge-gate settlement ownership and Open review

- The receiver preserves its locally selected settlement mode. On a mode-second link, each initial Transfer may reduce that delivery to mode first; continuations preserve the effective mode, and mixed settlement ranges are split into correct contiguous first/second dispositions.
- The sender records the remote receiver's actual mode. In mode second, a receiver-role `settled = false` disposition is answered exactly once with the required sender-role `settled = true` range before in-flight entries are retired; already-settled dispositions need no second phase.
- `max_unsettled_deliveries` adds a finite settlement-slot bound, defaulting to 1024. Initial and replenished prefetch/manual credit are capped by both byte capacity and remaining slots. Mode-first settlement and mode-second acknowledgment release slots and replenish deferred credit; a credit-ignoring peer cannot grow retained state beyond the bound.
- Explicit settlement of pre-settled fixture deliveries retains the historical requested-range behavior, while active mode-second IDs suppress duplicate dispositions.
- After AMQP protocol-header exchange, every Open encode, allocation, decode/apply, or acknowledgment failure invalidates and closes the driver. Open cannot be retried or duplicated after the peer has advanced.
- Tests cover local/remote mode disagreement, mixed per-transfer overrides, all sender second-phase forms, acknowledgment write failure, repeated hostile settlement-slot cycles, release/replenishment, zero slot validation, and zero-byte/OOM/malformed Open failures.


## Transactional receiver Flow review

- `issueCredit` and both deferred/manual and prefetch replenishment paths compute prospective credit, deferred request, and overrun debt without mutating the receiver. Those counters commit only after the complete `Flow` frame is encoded, written, and flushed.
- Encode OOM leaves the connection and counters unchanged, so retry emits exactly one grant. Header-write, body-write, and flush failures leave counters uncommitted and terminalize the dirty stream; retry emits nothing.
- Flow delivery-count is captured consistently with the prospective grant. Drain intent follows the same emission transaction and cannot become locally active before the peer is told.
- Matrix tests cover all three credit paths under encode OOM, pre-write failure, partial-write failure, and flush failure, including nonzero overrun debt, exact retry grants, unchanged delivery-count, cleared pending bytes, and terminal dirty-stream behavior.


## Final drain, terminal-read, and pre-settlement review

- A drain response may omit optional `link-credit`. Remaining receiver credit is derived from the prior delivery limit and reported `delivery-count` with RFC 1982 wrap arithmetic, clamped so stale reports cannot increase authorization; a completed drain now reaches zero instead of timing out.
- `receiveFrame` invalidates the driver on EOF, `ConnectionClosed`, `ReadFailed`, and every other terminal zero-byte read error. `Session.pump` then terminalizes every sender and receiver; later operations emit nothing. Only a zero-byte `Timeout` remains retryable, while timeout after any consumed frame byte is terminal.
- Sender-settled Transfers ignore `rcv-settle-mode`, including when settlement becomes true on a final continuation and on later continuations after an initially settled frame. Unsettled initial frames and continuations still reject an illegal mode-second upgrade on a mode-first receiver.
- Tests cover omitted drain credit, partial drain progress and delivery-count wrap, retryable zero-byte timeout versus terminal EOF/read failure, all-link invalidation/no later writes, initial/final cumulative settlement, and illegal unsettled upgrades.


## Final Flow authority and sender-settlement review

- Receiver credit is locally authoritative. Each successfully emitted receiver `Flow` records an exclusive delivery limit; incoming sender Flow may reconcile/reduce remaining credit but can neither enlarge it nor pay overrun debt. Serial reconciliation is wrap-safe and capped below the undefined RFC 1982 half-range.
- Hostile repeated `Flow(link-credit = 1)` plus empty pre-settled Transfers cannot grow the ready queue or tag allocations beyond the configured overrun allowance, including across delivery-count wrap.
- The local sender's `SenderOptions.snd_settle_mode` is the authoritative actual mode. For a locally initiated sender, every remote receiver Attach value is advisory, including an opposite fixed preference, and cannot rewrite the local choice or invalidate the session. Settled mode emits `settled = true` on every Transfer frame and completes synchronous/asynchronous sends immediately after emission without in-flight retention; mixed/unsettled modes retain existing disposition behavior. Dirty emission failure remains terminal with no phantom entry.
- Abandoning or timing out an undecided receiver-settle-mode-second delivery now emits a closing Detach before discarding its bounded id state. If Detach cannot be emitted, the connection is invalidated. Late first-phase dispositions need no acknowledgment because the peer was already told the link is terminal; reuse is rejected.
- Tests cover hostile Flow authority with wrap, local debt-charging grants, sender-settled sync/async and emission failure, remote mode selection, mode-second timeout/explicit abandon, single Detach emission, late disposition, and no reuse/unbounded tombstones.

## Final sender Attach and partial-terminal review

- The sender's locally selected `snd-settle-mode` is preserved as the actual mode. Remote omission, mixed, and opposite fixed preferences are valid advisory responses and cannot silently pre-settle/unsettle Transfers or damage the session.
- Partial-delivery cleanup is idempotent and scope-aware. A remote Detach during continuation-window wait produces exactly one Detach response; a remote End produces exactly one End and no later Detach. Both paths poison the incomplete sender, retain no phantom in-flight entry, and reject reuse without emission.
- The sender response path only matches an unpoisoned link awaiting its locally initiated `openSender` Attach, so receiver-role advisory semantics are not confused with a peer-initiated sender selection. Tests cover omitted preferences, both opposite fixed preferences, actual Transfer settlement behavior, survival/use of an unrelated link, first-frame partial delivery followed by remote Detach or End, exact frame order/count, and no-reuse behavior.

## Validation

- `zig fmt --check .`
- `zig build --summary all`
- Debug: 239/239
- ReleaseSafe: 239/239
- ReleaseFast: 239/239
- 20 repeated/randomized 239-test Debug runs
- Event Hubs full suite against the AMQP worktree: 216/216 with temporary, uncommitted `receiver.zig` options: clamp requested prefetch to 8, `max_message_size = 32 MiB`, and `max_buffered_bytes = 256 MiB`
- Service Bus full suite against the AMQP worktree: 120/120 with temporary, uncommitted changes: clamp prefetch to 8, `max_message_size = 128 MiB`, `max_buffered_bytes = 1 GiB`; update the credit expectation from 300 to 8 and allocation bounds for amortized refill flows; plus the known fixture correction `scriptCbsReplyAt(h.peer(), allocator, 2, 1, 2)`
- package version, fingerprint, dependency pin, and diff validation
- computed release tag: `azure_sdk_amqp/v0.5.0`

Both downstream worktrees were restored clean after validation. The temporary service limits, prefetch clamps, Service Bus allocation-test adjustment, and CBS fixture correction must be made permanent in their repin PRs.

No AMQP-package examples, benchmarks, or live-test steps are defined. Cross-platform package CI passed the fixed Linux, macOS, and Windows contexts at `e95bd18ddb522b4678fc7353178540eef92ec0c3`.








