### PR TITLE
Register Key Vault 0.2.0 shared modules

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -384,6 +384,8 @@ pub const all = [_]Package{
             "build.zig",
             "build.zig.zon",
             "root.zig",
+            "pipeline.zig",
+            "test_support.zig",
             "secrets",
             "keys",
             "certificates",


### PR DESCRIPTION
Unblocks publication of `azure_sdk_keyvault/v0.2.0` after #441.

- synchronize `eng/packages.zig` with the exact package manifest path set
- publish `pipeline.zig` and `test_support.zig` used by the reviewed package tests/runtime state

Validation:
- `zig fmt --check eng/packages.zig`
- `zig build package-check --summary all`
- `zig build package-history-check --summary all`