### PR TITLE
Migrate azure_sdk_testing to Core 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ playback HTTP transports.
 Transport descriptors are copied by value while their contexts are borrowed.
 Keep playback/recording transport values, wrapped transport contexts, crypto
 provider contexts, and any open operations alive for the full lifetime stated
-by their API documentation. These testing transports are caller-serialized.
+by their API documentation. Playback is caller-serialized. Recording attempt
+reservation/finalization is internally synchronized; callers must still
+synchronize borrowed `getExchanges` slices and policy contexts.
 
 Construct a runtime with independently selected dependencies:
 
@@ -32,7 +34,9 @@ duplicates are preserved.
 stable outcome stage and error category for transport/send, open, response-body,
 and finish failures; playback reproduces the failure at that stage without
 persisting backend-specific error identities. Version 2 successful-response
-recordings remain readable. Accepted request and response bodies are
+recordings remain readable. The stable cancellation category replays as
+Core's terminal `OperationCancelled` error so retry policy behavior does not
+diverge. Accepted request and response bodies are
 represented losslessly as base64 with an explicit encoding field. Every
 non-empty body is rejected by default and requires an explicit caller
 body-policy decision. Approved textual and binary bodies, including NUL and
@@ -54,11 +58,13 @@ observed before that terminal event. A body failure retains its partial bytes
 and replays the error after those bytes; a finish failure replays only from
 `finish`.
 
-Request metadata and exchange capacity are allocated before dispatch.
-Bookkeeping allocation failure after dispatch or deinitializing an open
-operation without a terminal event poisons the recorder. `isComplete` then
-returns false, subsequent dispatch is rejected, and `toJson` returns
-`IncompleteRecording` rather than silently emitting a divergent sequence.
+Request metadata and an ordered slot are allocated before dispatch. Each
+attempt finalizes its own ticket, so overlapping operations remain in dispatch
+order even when they complete out of order. Active unresolved slots make
+`isComplete` false and `toJson` returns `IncompleteRecording`. Bookkeeping
+allocation failure after dispatch or deinitializing an open operation without
+a terminal event additionally poisons the recorder and rejects subsequent
+dispatch rather than silently emitting a divergent sequence.
 
 A redirect allocation failure still consumed a real transport attempt. A
 later caller retry therefore requires the next recorded attempt, just as live
@@ -88,11 +94,13 @@ fully redacted.
 Credential source URL headers such as `x-ms-copy-source` remain fully redacted.
 URL sanitization parses the URI reference from its start, percent-decodes path
 and query components through a bounded recursive decoder, and recursively
-sanitizes URI-valued parameters. Nested URIs are re-encoded with their
-host/path/nonsensitive fields preserved and exact while only nested credential
-fields are redacted. Credential-bearing paths are rejected. Safe fragments
-are preserved in recorded URL headers; Core strips them when constructing the
-redirected HTTP request. Recognized sensitive Location fragments are stripped
+sanitizes URI-valued parameters. Safe nested URIs retain the caller's original
+encoding exactly. When nested credentials require redaction, the nested URI is
+re-encoded with its host/path/nonsensitive fields preserved and exact while
+only credential fields are redacted. Credential-bearing paths are rejected.
+Safe fragments are preserved in recorded URL headers; Core strips them when
+constructing the redirected HTTP request. Recognized sensitive Location
+fragments are stripped
 while preserving the replayable pre-fragment target; malformed location
 fragments fail closed. Relative redirects such as
 `/callback?return=https://...` remain replayable when their decoded values are

--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ recorded request header. Additional live request headers are allowed so
 volatile telemetry can be omitted from recordings. Response header order and
 duplicates are preserved.
 
-`RecordingTransport.toJson` emits version 2 recordings. Accepted request and
-response bodies are represented losslessly as base64 with an explicit encoding
-field. Every non-empty body is rejected by default and requires an explicit
-caller body-policy decision. Approved textual and binary bodies, including NUL
-and non-UTF-8 data, then round-trip exactly through `parseJson`. Parsed
-recordings can be passed directly to playback:
+`RecordingTransport.toJson` emits version 3 recordings. Version 3 records a
+stable outcome stage and error category for transport/send, open, response-body,
+and finish failures; playback reproduces the failure at that stage without
+persisting backend-specific error identities. Version 2 successful-response
+recordings remain readable. Accepted request and response bodies are
+represented losslessly as base64 with an explicit encoding field. Every
+non-empty body is rejected by default and requires an explicit caller
+body-policy decision. Approved textual and binary bodies, including NUL and
+non-UTF-8 data, then round-trip exactly through `parseJson`. Parsed recordings
+can be passed directly to playback:
 
 ```zig
 var parsed = try testing.parseJson(allocator, json);
@@ -46,7 +50,15 @@ pipeline transaction. Redirect and retry responses are recorded and replayed
 in the order observed. Buffered responses are recorded when the inner
 transport returns them. Streaming responses are recorded when the operation
 finishes, is aborted, or is cancelled, including only response body bytes
-observed before that terminal event.
+observed before that terminal event. A body failure retains its partial bytes
+and replays the error after those bytes; a finish failure replays only from
+`finish`.
+
+Request metadata and exchange capacity are allocated before dispatch.
+Bookkeeping allocation failure after dispatch or deinitializing an open
+operation without a terminal event poisons the recorder. `isComplete` then
+returns false, subsequent dispatch is rejected, and `toJson` returns
+`IncompleteRecording` rather than silently emitting a divergent sequence.
 
 A redirect allocation failure still consumed a real transport attempt. A
 later caller retry therefore requires the next recorded attempt, just as live
@@ -71,15 +83,18 @@ requirements.
 `Location`, `Content-Location`, `Operation-Location`, and
 `Azure-AsyncOperation` retain their origin/path and nonsensitive query fields;
 only recognized credential query values are replaced. This keeps redirect and
-LRO URLs replayable. Malformed or unsafe location values are fully redacted.
+LRO URLs replayable. Malformed or unsafe non-fragment location values are
+fully redacted.
 Credential source URL headers such as `x-ms-copy-source` remain fully redacted.
 URL sanitization parses the URI reference from its start, percent-decodes path
-and query components through a bounded recursive decoder, recursively inspects
-URI-valued parameters, redacts recognized credential names and
-credential-shaped values, and rejects credential-bearing paths or fragments.
-Safe fragments are preserved in recorded URL headers; Core strips them when
-constructing the redirected HTTP request. Unsafe or malformed location
-fragments cause full header redaction. Relative redirects such as
+and query components through a bounded recursive decoder, and recursively
+sanitizes URI-valued parameters. Nested URIs are re-encoded with their
+host/path/nonsensitive fields preserved and exact while only nested credential
+fields are redacted. Credential-bearing paths are rejected. Safe fragments
+are preserved in recorded URL headers; Core strips them when constructing the
+redirected HTTP request. Recognized sensitive Location fragments are stripped
+while preserving the replayable pre-fragment target; malformed location
+fragments fail closed. Relative redirects such as
 `/callback?return=https://...` remain replayable when their decoded values are
 safe. Safe network-path references such as `//example.test/final` and pathless
 absolute references such as `https://example.test?mode=one` are preserved;
@@ -186,11 +201,13 @@ legal preambles, epilogues, and nested multipart parts are inspected, while
 invalid close suffixes, missing closes, and malformed multipart structures fail
 closed. Policy contexts are borrowed through `toJson`.
 
-Playback consumes one exchange for each successful raw transport invocation.
-Buffered attempts advance after response allocation succeeds; streaming
-attempts advance after operation allocation succeeds. Outer pipeline redirect
-allocation, retry, backoff, and cancellation behavior does not roll back an
-already completed raw attempt.
+Playback consumes one exchange for each raw transport invocation, including
+recorded failures. Buffered attempts advance after either a recorded transport
+error is returned or response allocation succeeds. Streaming attempts advance
+after either a recorded open error is returned or operation allocation
+succeeds. Body and finish outcomes then replay from the operation. Outer
+pipeline redirect allocation, retry, backoff, and cancellation behavior does
+not roll back an already completed raw attempt.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ duplicates are preserved.
 
 `RecordingTransport.toJson` emits version 2 recordings. Accepted request and
 response bodies are represented losslessly as base64 with an explicit encoding
-field, so approved binary bodies and empty, NUL-containing, non-UTF-8, and
-normal UTF-8 bodies can round-trip through `parseJson`. NUL-containing,
-non-UTF-8, encoded, and binary bodies are rejected by default as opaque; they
-must first be approved by the caller policy described below. Parsed recordings
-can be passed directly to playback:
+field. Every non-empty body is rejected by default and requires an explicit
+caller body-policy decision. Approved textual and binary bodies, including NUL
+and non-UTF-8 data, then round-trip exactly through `parseJson`. Parsed
+recordings can be passed directly to playback:
 
 ```zig
 var parsed = try testing.parseJson(allocator, json);
@@ -54,9 +53,12 @@ nonsensitive query fields such as App Configuration's `key` filter and all
 other nonsensitive URL components, headers, and bodies remain exact-match
 requirements.
 
-Header names are checked case-insensitively using conservative Azure credential
-patterns, including metadata suffixes such as `password`, `pwd`,
-`private-key`, and `connection-string`. Applications can add redactions or
+Header names are checked case-insensitively. The default preserves only a
+known-safe standard/Azure header allowlist, after inspecting every value for
+signed URLs, JWTs, connection strings, and other recognized credentials.
+Unknown application and metadata headers are redacted. Credential-shaped names,
+including metadata suffixes such as `password`, `pwd`, `private-key`, and
+`connection-string`, are also redacted. Applications can add redactions or
 explicitly preserve a known-safe false positive with an exchange-aware header
 policy:
 
@@ -89,15 +91,18 @@ text cannot activate these schema rules, so App Configuration key/value
 documents and paths containing words such as `vault/secrets` remain recordable
 and exact.
 
-The default threat model accepts structurally inspected safe JSON, form, and
-plain-text bodies. A declared JSON content type always requires successful JSON
-parsing. Unicode BOMs, NUL-bearing data, UTF-16/32 charsets, non-identity
-content encodings, binary MIME types, non-UTF-8 bodies, multipart bodies, XML
-bodies, and malformed JSON are rejected unless the relevant opaque structure
-is explicitly approved. This prevents DER/PKCS#12, compressed or wide-character
-secret documents, and unknown containers from being base64-obscured under a
-false sanitization guarantee. A caller that knows a specific rejected
-opaque/XML/multipart exchange is safe can opt in with an exchange-aware policy:
+The default body contract is deny-by-default: every non-empty body is rejected
+with `BodyPolicyRequired` unless `bodyPolicyFn` classifies that exact exchange.
+Before default rejection, the recorder still detects known plaintext and
+structured credentials and returns `SensitiveBodyRequiresSanitization`.
+Returning `inspect` explicitly opts a recognized textual content type into
+built-in structural checks. A declared JSON content type must parse
+successfully. Only untyped UTF-8 text,
+`text/*`, JSON, XML, form URL encoding, JavaScript/ECMAScript, and GraphQL are
+recognized as textual; PDF, CBOR, PKCS7, protobuf, arbitrary vendor/container
+types, Unicode BOMs, NUL-bearing data, UTF-16/32 charsets, non-identity content
+encodings, and non-UTF-8 bodies are opaque. Returning `allow_opaque` is the
+explicit trust boundary for a caller-verified opaque body:
 
 ```zig
 fn bodyPolicy(
@@ -105,7 +110,9 @@ fn bodyPolicy(
     body: testing.BodySafetyContext,
 ) testing.BodyPolicyDecision {
     _ = context;
-    return if (isKnownSafeBinaryEndpoint(body.url)) .allow_opaque else .inspect;
+    if (isKnownSafeAppConfigurationExchange(body)) return .inspect;
+    if (isKnownSafeBinaryEndpoint(body.url)) return .allow_opaque;
+    return .reject_sensitive;
 }
 
 var recording = testing.RecordingTransport.initWithOptions(
@@ -118,10 +125,12 @@ var recording = testing.RecordingTransport.initWithOptions(
 );
 ```
 
-The callback may also return `reject_sensitive` for application-specific
-schemas. Private-key markers cannot be bypassed by `allow_opaque`; callers that
-approve otherwise opaque encodings take responsibility for their decoded
-contents. Policy contexts are borrowed through `toJson`.
+`inspect` does not sanitize or rewrite bodies; it persists only bodies that pass
+the built-in checks, and playback continues to match request bodies exactly.
+`reject_sensitive` rejects application-specific schemas. Private-key markers
+and detectable plaintext credentials cannot be bypassed by `allow_opaque`;
+callers that approve otherwise opaque encodings take responsibility for their
+decoded contents. Policy contexts are borrowed through `toJson`.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Transport descriptors are copied by value while their contexts are borrowed.
 Keep playback/recording transport values, wrapped transport contexts, crypto
 provider contexts, and any open operations alive for the full lifetime stated
 by their API documentation. Playback is caller-serialized. Recording attempt
-reservation/finalization is internally synchronized; callers must still
-synchronize borrowed `getExchanges` slices and policy contexts.
+reservation/finalization and every recorder-owned allocation/free are
+internally synchronized, so the allocator supplied to `RecordingTransport`
+need not itself support concurrent calls. Callers must still synchronize
+borrowed `getExchanges` slices, policy contexts, and `toJson` lifecycle access.
 
 Construct a runtime with independently selected dependencies:
 
@@ -81,6 +83,12 @@ Established vendor signing fields such as `X-Amz-Signature`,
 same treatment, including nested and multiply encoded URLs.
 Each redacted header carries a structured `redacted` flag, so playback
 wildcards only values that recording explicitly classified as credentials.
+Sanitized request URLs and location-style headers additionally carry an
+internal structured redaction template. Playback never infers wildcard
+positions from the literal text `REDACTED`, so caller data containing that
+text remains exact even beside a generated credential wildcard. Older version
+3 files without templates and version 2 files are matched conservatively as
+exact URL text.
 Those structured redactions match a caller-supplied live credential, while
 nonsensitive query fields such as App Configuration's `key` filter and all
 other nonsensitive URL components, headers, and bodies remain exact-match
@@ -97,7 +105,9 @@ and query components through a bounded recursive decoder, and recursively
 sanitizes URI-valued parameters. Safe nested URIs retain the caller's original
 encoding exactly. When nested credentials require redaction, the nested URI is
 re-encoded with its host/path/nonsensitive fields preserved and exact while
-only credential fields are redacted. Credential-bearing paths are rejected.
+only credential fields are redacted; outer percent-encoding depth is retained,
+so paths such as `/a%252Fb` and `/a%2Fb` cannot collapse into one match.
+Credential-bearing paths are rejected.
 Safe fragments are preserved in recorded URL headers; Core strips them when
 constructing the redirected HTTP request. Recognized sensitive Location
 fragments are stripped
@@ -207,7 +217,9 @@ JWTs, and parseable structured part payloads. Declared multipart boundaries are
 parsed from `Content-Type` and recognized only as exact MIME delimiter lines;
 legal preambles, epilogues, and nested multipart parts are inspected, while
 invalid close suffixes, missing closes, and malformed multipart structures fail
-closed. Policy contexts are borrowed through `toJson`.
+closed. Mixed structured content in preambles or epilogues that cannot be
+classified in full also fails closed. Policy contexts are borrowed through
+`toJson`.
 
 Playback consumes one exchange for each raw transport invocation, including
 recorded failures. Buffered attempts advance after either a recorded transport

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ requirements.
 only recognized credential query values are replaced. This keeps redirect and
 LRO URLs replayable. Malformed or unsafe location values are fully redacted.
 Credential source URL headers such as `x-ms-copy-source` remain fully redacted.
+URL sanitization parses the URI reference from its start, percent-decodes path
+and query components for inspection, redacts recognized credential names and
+credential-shaped values, and rejects credential-bearing paths or fragments.
+Request URL fragments are rejected; unsafe location fragments cause full
+header redaction. Relative redirects such as `/callback?return=https://...`
+remain replayable when their decoded values are safe.
 
 Header names are checked case-insensitively. The default preserves only a
 known-safe standard/Azure header allowlist, after inspecting every value for
@@ -143,8 +149,15 @@ and detectable plaintext credentials cannot be bypassed by `allow_opaque`;
 callers that approve otherwise opaque encodings take responsibility for their
 decoded contents. Multipart bodies are also scanned before opaque allowance,
 including form-data names, embedded HTTP authorization headers, signed URLs,
-JWTs, and parseable structured part payloads. Policy contexts are borrowed
-through `toJson`.
+JWTs, and parseable structured part payloads. Declared multipart boundaries are
+parsed from `Content-Type`; legal preambles and nested multipart parts are
+supported, while malformed multipart structures fail closed. Policy contexts
+are borrowed through `toJson`.
+
+Playback matches without consuming an exchange. It advances the caller-
+serialized index only after the response or streaming operation has been
+allocated successfully, so allocation failures can be retried against the same
+recording.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,37 @@ remain exact-match requirements.
 Credential-bearing JSON fields are detected structurally and
 case-insensitively, including nested list-keys results, connection strings,
 API keys, tokens, passwords, SAS URIs, and common Azure key fields. Form,
-connection-string, XML, and private-key bodies receive conservative checks.
-Sensitive bodies and malformed JSON-like bodies are rejected explicitly
-instead of being base64-obscured under a false sanitization guarantee.
+connection-string, multipart field names, XML elements/attributes, and common
+private-key envelopes receive conservative checks. Key Vault secret endpoints
+treat root `value` fields as sensitive, while App Configuration key/value
+documents remain recordable and exact.
+
+The default threat model accepts structurally inspected safe JSON, form, and
+plain-text bodies, but rejects opaque non-UTF-8 bodies, multipart bodies, XML
+bodies, and malformed JSON-like bodies. This prevents DER/PKCS#12, UTF-16
+secret documents, and unknown containers from being base64-obscured under a
+false sanitization guarantee. A caller that knows a specific rejected
+opaque/XML/multipart exchange is safe can opt in with an exchange-aware policy:
+
+```zig
+fn bodyPolicy(
+    context: ?*anyopaque,
+    body: testing.BodySafetyContext,
+) testing.BodyPolicyDecision {
+    _ = context;
+    return if (isKnownSafeBinaryEndpoint(body.url)) .allow_opaque else .inspect;
+}
+
+var recording = testing.RecordingTransport.initWithOptions(
+    allocator,
+    transport,
+    .{ .bodyPolicyFn = &bodyPolicy },
+);
+```
+
+The callback may also return `reject_sensitive` for application-specific
+schemas. Built-in recognized credential fields and private-key markers cannot
+be bypassed by `allow_opaque`. Policy contexts are borrowed through `toJson`.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ and finish failures; playback reproduces the failure at that stage without
 persisting backend-specific error identities. Version 2 successful-response
 recordings remain readable. The stable cancellation category replays as
 Core's terminal `OperationCancelled` error so retry policy behavior does not
-diverge. Accepted request and response bodies are
+diverge. URL and header metadata stays readable as JSON strings when it is
+valid UTF-8; arbitrary byte sequences such as HTTP obs-text are represented
+losslessly with the same explicit base64 encoding object and remain
+exact-match data. Accepted request and response bodies are
 represented losslessly as base64 with an explicit encoding field. Every
 non-empty body is rejected by default and requires an explicit caller
 body-policy decision. Approved textual and binary bodies, including NUL and
@@ -218,8 +221,12 @@ parsed from `Content-Type` and recognized only as exact MIME delimiter lines;
 legal preambles, epilogues, and nested multipart parts are inspected, while
 invalid close suffixes, missing closes, and malformed multipart structures fail
 closed. Mixed structured content in preambles or epilogues that cannot be
-classified in full also fails closed. Policy contexts are borrowed through
-`toJson`.
+classified in full also fails closed. Folded MIME/application-HTTP headers are
+unsupported and fail closed before disposition fields or embedded
+authorization can be hidden across continuation lines. XML-looking bodies
+must be consumed as one well-formed document; mismatched tags, malformed
+prefixes, extra roots, and trailing mixed structures are rejected. Policy
+contexts are borrowed through `toJson`.
 
 Playback consumes one exchange for each raw transport invocation, including
 recorded failures. Buffered attempts advance after either a recorded transport
@@ -227,7 +234,11 @@ error is returned or response allocation succeeds. Streaming attempts advance
 after either a recorded open error is returned or operation allocation
 succeeds. Body and finish outcomes then replay from the operation. Outer
 pipeline redirect allocation, retry, backoff, and cancellation behavior does
-not roll back an already completed raw attempt.
+not roll back an already completed raw attempt. If a cooperative upload reader
+cancels exactly after producing the prefix recorded for a cancelled open
+attempt, playback validates and consumes that attempt before returning
+`OperationCancelled`; preflight cancellation and cancellation against a
+non-cancelled recording leave the attempt unconsumed.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,27 @@ const runtime = testing.initHttpRuntime(
 Playback validates method, exact URL, body presence/content, and every
 recorded request header. Additional live request headers are allowed so
 volatile telemetry can be omitted from recordings. Response header order and
-duplicates are preserved. Recording JSON redacts recognized sensitive headers
-and URL query values, and refuses to serialize bodies containing recognized
-credential fields rather than emitting them unsanitized.
+duplicates are preserved.
+
+`RecordingTransport.toJson` emits version 2 recordings. Request and response
+bodies are always represented as base64 with an explicit encoding field, so
+empty, NUL-containing, non-UTF-8, and normal UTF-8 bodies round-trip losslessly
+through `parseJson`. Parsed recordings can be passed directly to playback:
+
+```zig
+var parsed = try testing.parseJson(allocator, json);
+defer parsed.deinit();
+var playback = testing.PlaybackTransport.init(allocator, parsed.asSlice());
+```
+
+Recording JSON replaces recognized authorization, token, secret, key, cookie,
+and SAS-bearing header values with `REDACTED`. Credential URL headers such as
+`x-ms-copy-source` are fully redacted; recognized secret query parameters in
+request URLs and location-style headers are value-redacted. During playback,
+those structured redactions match a caller-supplied live credential, while
+all nonsensitive URL components, headers, and bodies remain exact-match
+requirements. Credential-bearing bodies are rejected instead of being emitted
+under a false sanitization guarantee.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ recorded request header. Additional live request headers are allowed so
 volatile telemetry can be omitted from recordings. Response header order and
 duplicates are preserved.
 
-`RecordingTransport.toJson` emits version 2 recordings. Request and response
-bodies are always represented as base64 with an explicit encoding field, so
-empty, NUL-containing, non-UTF-8, and normal UTF-8 bodies round-trip losslessly
-through `parseJson`. Parsed recordings can be passed directly to playback:
+`RecordingTransport.toJson` emits version 2 recordings. Accepted request and
+response bodies are represented losslessly as base64 with an explicit encoding
+field, so approved binary bodies and empty, NUL-containing, non-UTF-8, and
+normal UTF-8 bodies can round-trip through `parseJson`. NUL-containing,
+non-UTF-8, encoded, and binary bodies are rejected by default as opaque; they
+must first be approved by the caller policy described below. Parsed recordings
+can be passed directly to playback:
 
 ```zig
 var parsed = try testing.parseJson(allocator, json);
@@ -44,22 +47,54 @@ and SAS-bearing header values with `REDACTED`. Credential URL headers such as
 `x-ms-copy-source`, `x-ms-rename-source`, and
 `x-ms-file-rename-source` are fully redacted; recognized credential-specific
 query parameters in request URLs and location-style headers are value-redacted.
-During playback, those structured redactions match a caller-supplied live
-credential, while nonsensitive query fields such as App Configuration's
-`key` filter and all other nonsensitive URL components, headers, and bodies
-remain exact-match requirements.
+Each redacted header carries a structured `redacted` flag, so playback
+wildcards only values that recording explicitly classified as credentials.
+Those structured redactions match a caller-supplied live credential, while
+nonsensitive query fields such as App Configuration's `key` filter and all
+other nonsensitive URL components, headers, and bodies remain exact-match
+requirements.
+
+Header names are checked case-insensitively using conservative Azure credential
+patterns, including metadata suffixes such as `password`, `pwd`,
+`private-key`, and `connection-string`. Applications can add redactions or
+explicitly preserve a known-safe false positive with an exchange-aware header
+policy:
+
+```zig
+fn headerPolicy(
+    context: ?*anyopaque,
+    header: testing.HeaderSafetyContext,
+) testing.HeaderPolicyDecision {
+    _ = context;
+    if (isApplicationCredential(header.name)) return .redact;
+    if (isKnownSafeMetadataLabel(header.name)) return .preserve;
+    return .inspect;
+}
+```
+
+`preserve` bypasses a conservative built-in classification and therefore
+asserts that the persisted value is not a credential. Policy contexts are
+borrowed through `toJson`.
 
 Credential-bearing JSON fields are detected structurally and
 case-insensitively, including nested list-keys results, connection strings,
 API keys, tokens, passwords, SAS URIs, and common Azure key fields. Form,
 connection-string, multipart field names, XML elements/attributes, and common
-private-key envelopes receive conservative checks. Key Vault secret endpoints
-treat root `value` fields as sensitive, while App Configuration key/value
-documents remain recordable and exact.
+private-key envelopes receive conservative checks. String scalars are scanned
+recursively for signed URLs/SAS parameters, connection strings, private-key
+containers, and JWT-shaped identity tokens. Key Vault secret, certificate, and
+JWK rules apply only to parsed trusted Azure vault hosts and matching resource
+paths; Kusto rules likewise use trusted service host suffixes. Arbitrary URL
+text cannot activate these schema rules, so App Configuration key/value
+documents and paths containing words such as `vault/secrets` remain recordable
+and exact.
 
 The default threat model accepts structurally inspected safe JSON, form, and
-plain-text bodies, but rejects opaque non-UTF-8 bodies, multipart bodies, XML
-bodies, and malformed JSON-like bodies. This prevents DER/PKCS#12, UTF-16
+plain-text bodies. A declared JSON content type always requires successful JSON
+parsing. Unicode BOMs, NUL-bearing data, UTF-16/32 charsets, non-identity
+content encodings, binary MIME types, non-UTF-8 bodies, multipart bodies, XML
+bodies, and malformed JSON are rejected unless the relevant opaque structure
+is explicitly approved. This prevents DER/PKCS#12, compressed or wide-character
 secret documents, and unknown containers from being base64-obscured under a
 false sanitization guarantee. A caller that knows a specific rejected
 opaque/XML/multipart exchange is safe can opt in with an exchange-aware policy:
@@ -76,13 +111,17 @@ fn bodyPolicy(
 var recording = testing.RecordingTransport.initWithOptions(
     allocator,
     transport,
-    .{ .bodyPolicyFn = &bodyPolicy },
+    .{
+        .bodyPolicyFn = &bodyPolicy,
+        .headerPolicyFn = &headerPolicy,
+    },
 );
 ```
 
 The callback may also return `reject_sensitive` for application-specific
-schemas. Built-in recognized credential fields and private-key markers cannot
-be bypassed by `allow_opaque`. Policy contexts are borrowed through `toJson`.
+schemas. Private-key markers cannot be bypassed by `allow_opaque`; callers that
+approve otherwise opaque encodings take responsibility for their decoded
+contents. Policy contexts are borrowed through `toJson`.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ nonsensitive query fields such as App Configuration's `key` filter and all
 other nonsensitive URL components, headers, and bodies remain exact-match
 requirements.
 
+`Location`, `Content-Location`, `Operation-Location`, and
+`Azure-AsyncOperation` retain their origin/path and nonsensitive query fields;
+only recognized credential query values are replaced. This keeps redirect and
+LRO URLs replayable. Malformed or unsafe location values are fully redacted.
+Credential source URL headers such as `x-ms-copy-source` remain fully redacted.
+
 Header names are checked case-insensitively. The default preserves only a
 known-safe standard/Azure header allowlist, after inspecting every value for
 signed URLs, JWTs, connection strings, and other recognized credentials.
@@ -61,6 +67,11 @@ including metadata suffixes such as `password`, `pwd`, `private-key`, and
 `connection-string`, are also redacted. Applications can add redactions or
 explicitly preserve a known-safe false positive with an exchange-aware header
 policy:
+
+Volatile request headers—including request/correlation IDs, `date`,
+`x-ms-date`, `traceparent`, and `tracestate`—are structurally redacted by
+default so freshly generated Core pipeline values wildcard during playback.
+Returning `preserve` from the header policy makes a selected value exact.
 
 ```zig
 fn headerPolicy(
@@ -130,7 +141,10 @@ the built-in checks, and playback continues to match request bodies exactly.
 `reject_sensitive` rejects application-specific schemas. Private-key markers
 and detectable plaintext credentials cannot be bypassed by `allow_opaque`;
 callers that approve otherwise opaque encodings take responsibility for their
-decoded contents. Policy contexts are borrowed through `toJson`.
+decoded contents. Multipart bodies are also scanned before opaque allowance,
+including form-data names, embedded HTTP authorization headers, signed URLs,
+JWTs, and parseable structured part payloads. Policy contexts are borrowed
+through `toJson`.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,26 @@ defer parsed.deinit();
 var playback = testing.PlaybackTransport.init(allocator, parsed.asSlice());
 ```
 
-Recording stages a complete redirect/retry chain before publishing any of its
-exchanges. Buffered chains commit only when their final nonretry response is
-returned; a retryable final response remains tentative until it is accepted or
-the original request restarts. Streaming chains commit only after the final
-operation finishes. Intermediate redirect aborts remain tentative, while
-redirect allocation failure, retry restart from the original request,
-operation failure, abort, or cancellation discards the whole tentative chain.
+Each exchange represents one raw HTTP transport invocation, not a logical
+pipeline transaction. Redirect and retry responses are recorded and replayed
+in the order observed. Buffered responses are recorded when the inner
+transport returns them. Streaming responses are recorded when the operation
+finishes, is aborted, or is cancelled, including only response body bytes
+observed before that terminal event.
+
+A redirect allocation failure still consumed a real transport attempt. A
+later caller retry therefore requires the next recorded attempt, just as live
+recording would. A terminal retryable result must include every raw attempt
+produced by the selected retry configuration.
 
 Recording JSON replaces recognized authorization, token, secret, key, cookie,
 and SAS-bearing header values with `REDACTED`. Credential URL headers such as
 `x-ms-copy-source`, `x-ms-rename-source`, and
 `x-ms-file-rename-source` are fully redacted; recognized credential-specific
 query parameters in request URLs and location-style headers are value-redacted.
+Established vendor signing fields such as `X-Amz-Signature`,
+`X-Amz-Credential`, `X-Amz-Security-Token`, and `X-Goog-Signature` receive the
+same treatment, including nested and multiply encoded URLs.
 Each redacted header carries a structured `redacted` flag, so playback
 wildcards only values that recording explicitly classified as credentials.
 Those structured redactions match a caller-supplied live credential, while
@@ -126,9 +133,11 @@ hosts and the matching action. Managed HSM host rules include every supported
 sovereign suffix, including `managedhsm.microsoftazure.de`. Endpoint path
 segments and query names/values are canonicalized with the same bounded
 recursive decoder before schema classification; malformed or over-depth
-endpoint encodings fail closed. Arbitrary URL text cannot activate these
-schema rules, so App Configuration key/value documents and paths containing
-words such as `vault/secrets` remain recordable and exact.
+endpoint encodings fail closed. Endpoint hosts are parsed canonically,
+percent-decoded, and normalized by removing a terminal DNS root dot; malformed
+and userinfo-bearing authorities fail closed. Arbitrary URL text cannot
+activate these schema rules, so App Configuration key/value documents and
+paths containing words such as `vault/secrets` remain recordable and exact.
 
 The default body contract is deny-by-default: every non-empty body is rejected
 with `BodyPolicyRequired` unless `bodyPolicyFn` classifies that exact exchange.
@@ -177,13 +186,11 @@ legal preambles, epilogues, and nested multipart parts are inspected, while
 invalid close suffixes, missing closes, and malformed multipart structures fail
 closed. Policy contexts are borrowed through `toJson`.
 
-Playback matches without consuming an exchange. It advances the caller-
-serialized index only after a nonredirect buffered response succeeds or a
-final streaming operation finishes successfully. Redirect chains remain a
-single tentative transaction until their final response/operation commits, so
-allocation failure at any Core redirect-resolution/request-construction step
-can retry the original request. Aborted, cancelled, or failed streaming
-operations remain retryable.
+Playback consumes one exchange for each successful raw transport invocation.
+Buffered attempts advance after response allocation succeeds; streaming
+attempts advance after operation allocation succeeds. Outer pipeline redirect
+allocation, retry, backoff, and cancellation behavior does not roll back an
+already completed raw attempt.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,34 @@
 # azure_sdk_testing
 
-Testing helpers for Azure SDK packages, including playback-oriented HTTP
-transport support.
+Testing helpers for Azure SDK packages, including full-contract recording and
+playback HTTP transports.
 
-- Source: `sdk/core/testing`
-- Release branch: `sdk/core_testing`
-- Initial version: `0.1.0`
-- Internal dependency: `azure_sdk_core`
+- Source: repository root on the `sdk/testing` package branch
+- Release branch: `sdk/testing`
+- Version: `0.2.0`
+- Internal dependency: `azure_sdk_core` 0.3.0 at
+  `bc77bcacbb64af935ca53d60bf8a351c9592bc41`
+
+Transport descriptors are copied by value while their contexts are borrowed.
+Keep playback/recording transport values, wrapped transport contexts, crypto
+provider contexts, and any open operations alive for the full lifetime stated
+by their API documentation. These testing transports are caller-serialized.
+
+Construct a runtime with independently selected dependencies:
+
+```zig
+const runtime = testing.initHttpRuntime(
+    playback.asTransport(),
+    crypto_provider,
+);
+```
+
+Playback validates method, exact URL, body presence/content, and every
+recorded request header. Additional live request headers are allowed so
+volatile telemetry can be omitted from recordings. Response header order and
+duplicates are preserved. Recording JSON redacts recognized sensitive headers
+and URL query values, and refuses to serialize bodies containing recognized
+credential fields rather than emitting them unsanitized.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,20 @@ var playback = testing.PlaybackTransport.init(allocator, parsed.asSlice());
 
 Recording JSON replaces recognized authorization, token, secret, key, cookie,
 and SAS-bearing header values with `REDACTED`. Credential URL headers such as
-`x-ms-copy-source` are fully redacted; recognized secret query parameters in
-request URLs and location-style headers are value-redacted. During playback,
-those structured redactions match a caller-supplied live credential, while
-all nonsensitive URL components, headers, and bodies remain exact-match
-requirements. Credential-bearing bodies are rejected instead of being emitted
-under a false sanitization guarantee.
+`x-ms-copy-source`, `x-ms-rename-source`, and
+`x-ms-file-rename-source` are fully redacted; recognized credential-specific
+query parameters in request URLs and location-style headers are value-redacted.
+During playback, those structured redactions match a caller-supplied live
+credential, while nonsensitive query fields such as App Configuration's
+`key` filter and all other nonsensitive URL components, headers, and bodies
+remain exact-match requirements.
+
+Credential-bearing JSON fields are detected structurally and
+case-insensitively, including nested list-keys results, connection strings,
+API keys, tokens, passwords, SAS URIs, and common Azure key fields. Form,
+connection-string, XML, and private-key bodies receive conservative checks.
+Sensitive bodies and malformed JSON-like bodies are rejected explicitly
+instead of being base64-obscured under a false sanitization guarantee.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,15 @@ only recognized credential query values are replaced. This keeps redirect and
 LRO URLs replayable. Malformed or unsafe location values are fully redacted.
 Credential source URL headers such as `x-ms-copy-source` remain fully redacted.
 URL sanitization parses the URI reference from its start, percent-decodes path
-and query components for inspection, redacts recognized credential names and
+and query components through a bounded recursive decoder, recursively inspects
+URI-valued parameters, redacts recognized credential names and
 credential-shaped values, and rejects credential-bearing paths or fragments.
-Request URL fragments are rejected; unsafe location fragments cause full
-header redaction. Relative redirects such as `/callback?return=https://...`
-remain replayable when their decoded values are safe.
+Safe fragments are preserved in recorded URL headers; Core strips them when
+constructing the redirected HTTP request. Unsafe or malformed location
+fragments cause full header redaction. Relative redirects such as
+`/callback?return=https://...` remain replayable when their decoded values are
+safe. Decode depth and size are bounded, and malformed or over-depth encodings
+fail closed.
 
 Header names are checked case-insensitively. The default preserves only a
 known-safe standard/Azure header allowlist, after inspecting every value for
@@ -103,10 +107,14 @@ private-key envelopes receive conservative checks. String scalars are scanned
 recursively for signed URLs/SAS parameters, connection strings, private-key
 containers, and JWT-shaped identity tokens. Key Vault secret, certificate, and
 JWK rules apply only to parsed trusted Azure vault hosts and matching resource
-paths; Kusto rules likewise use trusted service host suffixes. Arbitrary URL
-text cannot activate these schema rules, so App Configuration key/value
-documents and paths containing words such as `vault/secrets` remain recordable
-and exact.
+paths; Kusto rules likewise use trusted service host suffixes. ARM
+list/regenerate credential schemas—including Batch, AI Search, Event Grid,
+Cognitive Services, Cosmos DB, and Container Registry—apply only to the
+explicit public, US Government, China, and German management hosts. Storage
+User Delegation Key XML is recognized only on trusted sovereign Blob service
+hosts and the matching action. Arbitrary URL text cannot activate these schema
+rules, so App Configuration key/value documents and paths containing words
+such as `vault/secrets` remain recordable and exact.
 
 The default body contract is deny-by-default: every non-empty body is rejected
 with `BodyPolicyRequired` unless `bodyPolicyFn` classifies that exact exchange.
@@ -150,14 +158,18 @@ callers that approve otherwise opaque encodings take responsibility for their
 decoded contents. Multipart bodies are also scanned before opaque allowance,
 including form-data names, embedded HTTP authorization headers, signed URLs,
 JWTs, and parseable structured part payloads. Declared multipart boundaries are
-parsed from `Content-Type`; legal preambles and nested multipart parts are
-supported, while malformed multipart structures fail closed. Policy contexts
-are borrowed through `toJson`.
+parsed from `Content-Type` and recognized only as exact MIME delimiter lines;
+legal preambles, epilogues, and nested multipart parts are inspected, while
+invalid close suffixes, missing closes, and malformed multipart structures fail
+closed. Policy contexts are borrowed through `toJson`.
 
 Playback matches without consuming an exchange. It advances the caller-
-serialized index only after the response or streaming operation has been
-allocated successfully, so allocation failures can be retried against the same
-recording.
+serialized index only after a nonredirect buffered response succeeds or a
+final streaming operation finishes successfully. Redirect chains remain a
+single tentative transaction until their final response/operation commits, so
+allocation failure at any Core redirect-resolution/request-construction step
+can retry the original request. Aborted, cancelled, or failed streaming
+operations remain retryable.
 
 Run its independent tests from this directory:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ defer parsed.deinit();
 var playback = testing.PlaybackTransport.init(allocator, parsed.asSlice());
 ```
 
+Recording stages a complete redirect/retry chain before publishing any of its
+exchanges. Buffered chains commit only when their final nonretry response is
+returned; a retryable final response remains tentative until it is accepted or
+the original request restarts. Streaming chains commit only after the final
+operation finishes. Intermediate redirect aborts remain tentative, while
+redirect allocation failure, retry restart from the original request,
+operation failure, abort, or cancellation discards the whole tentative chain.
+
 Recording JSON replaces recognized authorization, token, secret, key, cookie,
 and SAS-bearing header values with `REDACTED`. Credential URL headers such as
 `x-ms-copy-source`, `x-ms-rename-source`, and
@@ -66,8 +74,10 @@ Safe fragments are preserved in recorded URL headers; Core strips them when
 constructing the redirected HTTP request. Unsafe or malformed location
 fragments cause full header redaction. Relative redirects such as
 `/callback?return=https://...` remain replayable when their decoded values are
-safe. Decode depth and size are bounded, and malformed or over-depth encodings
-fail closed.
+safe. Safe network-path references such as `//example.test/final` and pathless
+absolute references such as `https://example.test?mode=one` are preserved;
+userinfo and credential-bearing authorities are rejected. Decode depth and
+size are bounded, and malformed or over-depth encodings fail closed.
 
 Header names are checked case-insensitively. The default preserves only a
 known-safe standard/Azure header allowlist, after inspecting every value for
@@ -112,9 +122,13 @@ list/regenerate credential schemas—including Batch, AI Search, Event Grid,
 Cognitive Services, Cosmos DB, and Container Registry—apply only to the
 explicit public, US Government, China, and German management hosts. Storage
 User Delegation Key XML is recognized only on trusted sovereign Blob service
-hosts and the matching action. Arbitrary URL text cannot activate these schema
-rules, so App Configuration key/value documents and paths containing words
-such as `vault/secrets` remain recordable and exact.
+hosts and the matching action. Managed HSM host rules include every supported
+sovereign suffix, including `managedhsm.microsoftazure.de`. Endpoint path
+segments and query names/values are canonicalized with the same bounded
+recursive decoder before schema classification; malformed or over-depth
+endpoint encodings fail closed. Arbitrary URL text cannot activate these
+schema rules, so App Configuration key/value documents and paths containing
+words such as `vault/secrets` remain recordable and exact.
 
 The default body contract is deny-by-default: every non-empty body is rejected
 with `BodyPolicyRequired` unless `bodyPolicyFn` classifies that exact exchange.
@@ -176,3 +190,6 @@ Run its independent tests from this directory:
 ```bash
 zig build test --summary all
 ```
+
+The test target runs both Core raw-transport and pipeline conformance contracts,
+plus Core allocation-failure fixtures.

--- a/build.zig
+++ b/build.zig
@@ -9,8 +9,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const core_mod = core_dep.module("azure_sdk_core");
+    const http_conformance_mod = core_dep.module("azure_sdk_core_http_conformance");
 
-    _ = b.addModule("azure_sdk_testing", .{
+    const testing_mod = b.addModule("azure_sdk_testing", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .optimize = optimize,
@@ -29,6 +30,22 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    const conformance_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("conformance_test.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "azure_sdk_core", .module = core_mod },
+                .{ .name = "azure_sdk_testing", .module = testing_mod },
+                .{
+                    .name = "azure_sdk_core_http_conformance",
+                    .module = http_conformance_mod,
+                },
+            },
+        }),
+    });
     const test_step = b.step("test", "Run Core Testing tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
+    test_step.dependOn(&b.addRunArtifact(conformance_tests).step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .azure_sdk_testing,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0xedf330a9407b1b45,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
         },
     },
     .paths = .{
@@ -14,6 +14,7 @@
         "build.zig",
         "build.zig.zon",
         "root.zig",
+        "conformance_test.zig",
         "README.md",
         "LICENSE.txt",
     },

--- a/conformance_test.zig
+++ b/conformance_test.zig
@@ -9,19 +9,126 @@ const State = struct {
     response_headers: []testing.HeaderPair,
     recordings: [1]testing.RecordedExchange,
     playback: testing.PlaybackTransport,
+    observed_body: std.ArrayList(u8) = .empty,
+    request_count: usize = 0,
+
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &send,
+        .open = &open,
+    };
 
     fn finish(_: *anyopaque) !void {}
 
     fn observe(context: *anyopaque) conformance.Observation {
         const self: *State = @ptrCast(@alignCast(context));
-        return .{ .request_count = self.playback.index };
+        return .{
+            .request_count = self.request_count,
+            .body = self.observed_body.items,
+            .body_length = self.observed_body.items.len,
+            .finish_count = self.playback.finish_count,
+            .abort_count = self.playback.abort_count,
+            .cancel_count = self.playback.cancel_count,
+            .deinit_count = self.playback.deinit_count,
+        };
+    }
+
+    fn asTransport(self: *State) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn send(
+        context: *anyopaque,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const self: *State = @ptrCast(@alignCast(context));
+        const transport = self.playback.asTransport();
+        const response = try transport.vtable.send(
+            transport.context,
+            request,
+        );
+        self.request_count += 1;
+        if (request.body) |body| {
+            try self.observed_body.appendSlice(self.allocator, body);
+        }
+        return response;
+    }
+
+    fn open(
+        context: *anyopaque,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *State = @ptrCast(@alignCast(context));
+        const transport = self.playback.asTransport();
+        const open_fn = transport.vtable.open.?;
+        var wrapped_options = options;
+        var observer: ObservingReader = undefined;
+        if (options.body) |body| {
+            observer.init(self, body.reader);
+            wrapped_options.body.?.reader = &observer.interface;
+        }
+        const operation = try open_fn(
+            transport.context,
+            request,
+            wrapped_options,
+        );
+        self.request_count += 1;
+        return operation;
     }
 
     fn destroy(context: *anyopaque) void {
         const self: *State = @ptrCast(@alignCast(context));
+        self.observed_body.deinit(self.allocator);
         self.allocator.free(self.response_headers);
         self.allocator.free(self.url);
         self.allocator.destroy(self);
+    }
+};
+
+const ObservingReader = struct {
+    interface: std.Io.Reader,
+    source: *std.Io.Reader,
+    state: *State,
+    buffer: [64]u8 = undefined,
+    scratch: [4096]u8 = undefined,
+
+    fn init(
+        self: *ObservingReader,
+        state: *State,
+        source: *std.Io.Reader,
+    ) void {
+        self.* = .{
+            .interface = undefined,
+            .source = source,
+            .state = state,
+        };
+        self.interface = .{
+            .vtable = &.{ .stream = &stream },
+            .buffer = &self.buffer,
+            .seek = 0,
+            .end = 0,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *ObservingReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        const length = limit.minInt(self.scratch.len);
+        if (length == 0) return 0;
+        const count = self.source.readSliceShort(
+            self.scratch[0..length],
+        ) catch return error.ReadFailed;
+        if (count == 0) return error.EndOfStream;
+        self.state.observed_body.appendSlice(
+            self.state.allocator,
+            self.scratch[0..count],
+        ) catch return error.ReadFailed;
+        try writer.writeAll(self.scratch[0..count]);
+        return count;
     }
 };
 
@@ -31,6 +138,16 @@ fn createBackend(
     _: std.Io,
     options: conformance.BackendOptions,
 ) !conformance.BackendInstance {
+    const streaming = std.mem.eql(
+        u8,
+        options.response.body,
+        "stream-response",
+    );
+    const buffered = std.mem.eql(
+        u8,
+        options.response.body,
+        "buffered-response",
+    );
     const state = try allocator.create(State);
     errdefer allocator.destroy(state);
     const url = try allocator.dupe(u8, "https://example.com/conformance");
@@ -48,14 +165,15 @@ fn createBackend(
         .url = url,
         .response_headers = response_headers,
         .recordings = .{.{
-            .request_method = .GET,
+            .request_method = if (streaming) .POST else .GET,
             .request_url = url,
-            .request_headers = &.{
+            .request_headers = if (buffered) &.{
                 .{
                     .name = "User-Agent",
                     .value = "azsdk-zig-conformance/0.3.0",
                 },
-            },
+            } else &.{},
+            .request_body = if (streaming) "stream-upload" else null,
             .response_status = options.response.status_code,
             .response_body = options.response.body,
             .response_headers = response_headers,
@@ -67,7 +185,7 @@ fn createBackend(
         &state.recordings,
     );
     return .{
-        .transport = state.playback.asTransport(),
+        .transport = state.asTransport(),
         .url = state.url,
         .context = state,
         .finishFn = &State.finish,
@@ -92,6 +210,14 @@ fn playbackFactory() conformance.BackendFactory {
 
 test "playback participates in compatible Core pipeline conformance" {
     try conformance.runPipelineContracts(
+        std.testing.allocator,
+        std.testing.io,
+        playbackFactory(),
+    );
+}
+
+test "playback satisfies Core raw transport conformance" {
+    try conformance.runRawTransportContracts(
         std.testing.allocator,
         std.testing.io,
         playbackFactory(),

--- a/conformance_test.zig
+++ b/conformance_test.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const core = @import("azure_sdk_core");
+const testing = @import("azure_sdk_testing");
+const conformance = @import("azure_sdk_core_http_conformance");
+
+const State = struct {
+    allocator: std.mem.Allocator,
+    url: []u8,
+    response_headers: []testing.HeaderPair,
+    recordings: [1]testing.RecordedExchange,
+    playback: testing.PlaybackTransport,
+
+    fn finish(_: *anyopaque) !void {}
+
+    fn observe(context: *anyopaque) conformance.Observation {
+        const self: *State = @ptrCast(@alignCast(context));
+        return .{ .request_count = self.playback.index };
+    }
+
+    fn destroy(context: *anyopaque) void {
+        const self: *State = @ptrCast(@alignCast(context));
+        self.allocator.free(self.response_headers);
+        self.allocator.free(self.url);
+        self.allocator.destroy(self);
+    }
+};
+
+fn createBackend(
+    _: ?*anyopaque,
+    allocator: std.mem.Allocator,
+    _: std.Io,
+    options: conformance.BackendOptions,
+) !conformance.BackendInstance {
+    const state = try allocator.create(State);
+    errdefer allocator.destroy(state);
+    const url = try allocator.dupe(u8, "https://example.com/conformance");
+    errdefer allocator.free(url);
+    const response_headers = try allocator.alloc(
+        testing.HeaderPair,
+        options.response.headers.len,
+    );
+    errdefer allocator.free(response_headers);
+    for (options.response.headers, response_headers) |header, *pair| {
+        pair.* = .{ .name = header.name, .value = header.value };
+    }
+    state.* = .{
+        .allocator = allocator,
+        .url = url,
+        .response_headers = response_headers,
+        .recordings = .{.{
+            .request_method = .GET,
+            .request_url = url,
+            .request_headers = &.{
+                .{
+                    .name = "User-Agent",
+                    .value = "azsdk-zig-conformance/0.3.0",
+                },
+            },
+            .response_status = options.response.status_code,
+            .response_body = options.response.body,
+            .response_headers = response_headers,
+        }},
+        .playback = undefined,
+    };
+    state.playback = testing.PlaybackTransport.init(
+        allocator,
+        &state.recordings,
+    );
+    return .{
+        .transport = state.playback.asTransport(),
+        .url = state.url,
+        .context = state,
+        .finishFn = &State.finish,
+        .observeFn = &State.observe,
+        .deinitFn = &State.destroy,
+    };
+}
+
+fn playbackFactory() conformance.BackendFactory {
+    return .{
+        .name = "azure_sdk_testing.PlaybackTransport",
+        .capabilities = .{
+            .streaming = true,
+            .ordered_duplicate_response_headers = true,
+            .request_framing_validation = true,
+            .cancellation = .cooperative_upload,
+            .lifecycle_observable = true,
+        },
+        .createFn = &createBackend,
+    };
+}
+
+test "playback participates in compatible Core pipeline conformance" {
+    try conformance.runPipelineContracts(
+        std.testing.allocator,
+        std.testing.io,
+        playbackFactory(),
+    );
+}
+
+test "Core exported allocation conformance remains leak-free" {
+    try conformance.runAllocationFailureContracts();
+}

--- a/root.zig
+++ b/root.zig
@@ -342,9 +342,11 @@ pub const RecordingTransport = struct {
     /// Serialize version 2 recordings with lossless base64 bodies while
     /// redacting sensitive header values and sensitive URL query parameters.
     ///
-    /// Recognized credential-bearing body fields cause
-    /// `error.SensitiveBodyRequiresSanitization`; bodies are never silently
-    /// emitted under a false sanitization guarantee.
+    /// Structurally recognized credential-bearing JSON, form, connection
+    /// string, XML, and private-key bodies cause
+    /// `error.SensitiveBodyRequiresSanitization`. Malformed JSON-like bodies
+    /// cause `error.UnsupportedBodySanitization`; neither is silently emitted
+    /// under a false sanitization guarantee.
     pub fn toJson(
         self: *const RecordingTransport,
         allocator: std.mem.Allocator,
@@ -369,8 +371,8 @@ pub const RecordingTransport = struct {
             .{recording_format_version},
         );
         for (self.exchanges.items, 0..) |exchange, index| {
-            try ensureBodySafe(exchange.request_body);
-            try ensureBodySafe(exchange.response_body);
+            try ensureBodySafe(allocator, exchange.request_body);
+            try ensureBodySafe(allocator, exchange.response_body);
             if (index != 0) try writer.writeAll(",");
             try writer.writeAll("\n  {\"request_method\":");
             try writeJsonString(writer, methodToString(exchange.request_method));
@@ -1260,6 +1262,7 @@ const explicitly_sensitive_headers = [_][]const u8{
     "x-ms-authorization-auxiliary",
     "x-ms-copy-source-authorization",
     "x-ms-source-authorization",
+    "x-ms-file-rename-source-authorization",
     "cookie",
     "set-cookie",
     "x-ms-client-secret",
@@ -1280,6 +1283,8 @@ const explicitly_sensitive_headers = [_][]const u8{
 const fully_redacted_url_headers = [_][]const u8{
     "x-ms-copy-source",
     "x-ms-copy-source-url",
+    "x-ms-rename-source",
+    "x-ms-file-rename-source",
 };
 
 const sanitized_url_headers = [_][]const u8{
@@ -1287,38 +1292,72 @@ const sanitized_url_headers = [_][]const u8{
     "content-location",
     "operation-location",
     "azure-asyncoperation",
-    "x-ms-rename-source",
 };
 
 const sensitive_body_fields = [_][]const u8{
-    "access_token",
     "accesstoken",
-    "refresh_token",
     "refreshtoken",
-    "client_secret",
     "clientsecret",
-    "client_assertion",
     "clientassertion",
     "password",
-    "shared_access_signature",
+    "secret",
+    "credential",
+    "credentials",
+    "applicationsecret",
+    "apikey",
+    "connectionstring",
+    "aliassecondaryconnectionstring",
+    "primaryconnectionstring",
+    "secondaryconnectionstring",
+    "primarykey",
+    "secondarykey",
+    "accountkey",
+    "sharedaccesskey",
     "sharedaccesssignature",
+    "sshpassword",
+    "adminpassword",
+    "administratorloginpassword",
+    "runaspassword",
+    "accesssas",
+    "websiteauthencryptionkey",
+    "decryptionkey",
+    "privatekey",
+    "certificatepassword",
+    "sasuri",
+    "containerurl",
+    "containeruri",
+    "inputdatauri",
+    "outputdatauri",
+    "urlsource",
+    "token",
+    "aegsaskey",
+    "aegsastoken",
+    "authorization",
+};
+
+const sensitive_body_containers = [_][]const u8{
+    "keys",
+    "listkeys",
+    "accesskeys",
+    "secrets",
+    "connectionstrings",
 };
 
 const sensitive_query_fields = [_][]const u8{
     "sig",
     "signature",
-    "token",
     "access_token",
     "refresh_token",
     "client_secret",
     "client_assertion",
     "password",
     "api_key",
+    "api-key",
     "subscription-key",
     "aeg-sas-key",
     "aeg-sas-token",
-    "key",
-    "secret",
+    "account-key",
+    "shared-access-key",
     "code",
 };
 
@@ -1347,12 +1386,185 @@ pub fn isSensitiveHeader(name: []const u8) bool {
     return isFullyRedactedUrlHeader(name);
 }
 
-fn ensureBodySafe(body: ?[]const u8) !void {
+fn ensureBodySafe(
+    allocator: std.mem.Allocator,
+    body: ?[]const u8,
+) !void {
     const bytes = body orelse return;
-    for (sensitive_body_fields) |field| {
-        if (containsIgnoreCase(bytes, field))
+    if (!std.unicode.utf8ValidateSlice(bytes)) return;
+    if (looksLikeStructuredJson(bytes)) {
+        const parsed = std.json.parseFromSlice(
+            std.json.Value,
+            allocator,
+            bytes,
+            .{},
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.UnsupportedBodySanitization,
+        };
+        defer parsed.deinit();
+        if (jsonContainsSensitiveField(parsed.value))
             return error.SensitiveBodyRequiresSanitization;
     }
+    if (containsSensitiveAssignment(bytes) or
+        containsSensitiveXmlElement(bytes) or
+        containsIgnoreCase(bytes, "-----BEGIN PRIVATE KEY-----"))
+    {
+        return error.SensitiveBodyRequiresSanitization;
+    }
+}
+
+fn looksLikeStructuredJson(body: []const u8) bool {
+    const trimmed = std.mem.trim(u8, body, " \t\r\n");
+    return trimmed.len != 0 and (trimmed[0] == '{' or trimmed[0] == '[');
+}
+
+fn jsonContainsSensitiveField(value: std.json.Value) bool {
+    return jsonContainsSensitiveFieldInContext(value, false);
+}
+
+fn jsonContainsSensitiveFieldInContext(
+    value: std.json.Value,
+    sensitive_container: bool,
+) bool {
+    switch (value) {
+        .object => |object| {
+            var iterator = object.iterator();
+            while (iterator.next()) |entry| {
+                if (isSensitiveBodyField(entry.key_ptr.*) or
+                    (sensitive_container and
+                        normalizedFieldEquals(entry.key_ptr.*, "value")) or
+                    jsonContainsSensitiveFieldInContext(
+                        entry.value_ptr.*,
+                        sensitive_container or
+                            isSensitiveBodyContainer(entry.key_ptr.*),
+                    ))
+                {
+                    return true;
+                }
+            }
+        },
+        .array => |array| {
+            for (array.items) |item| {
+                if (jsonContainsSensitiveFieldInContext(
+                    item,
+                    sensitive_container,
+                )) return true;
+            }
+        },
+        else => {},
+    }
+    return false;
+}
+
+fn isSensitiveBodyContainer(name: []const u8) bool {
+    for (sensitive_body_containers) |field| {
+        if (normalizedFieldEquals(name, field)) return true;
+    }
+    return false;
+}
+
+fn isSensitiveBodyField(name: []const u8) bool {
+    for (sensitive_body_fields) |field| {
+        if (normalizedFieldEquals(name, field)) return true;
+    }
+    return false;
+}
+
+fn normalizedFieldEquals(name: []const u8, normalized: []const u8) bool {
+    var normalized_index: usize = 0;
+    var index: usize = 0;
+    while (index < name.len) : (index += 1) {
+        const byte = name[index];
+        if (!std.ascii.isAlphanumeric(byte)) continue;
+        if (normalized_index >= normalized.len or
+            std.ascii.toLower(byte) != normalized[normalized_index])
+        {
+            return false;
+        }
+        normalized_index += 1;
+    }
+    return normalized_index == normalized.len;
+}
+
+fn containsSensitiveAssignment(body: []const u8) bool {
+    var start: usize = 0;
+    var index: usize = 0;
+    while (index <= body.len) : (index += 1) {
+        if (index != body.len and
+            body[index] != '&' and
+            body[index] != ';' and
+            body[index] != ',' and
+            body[index] != '\n' and
+            body[index] != '\r')
+        {
+            continue;
+        }
+        const field = body[start..index];
+        start = index + 1;
+        const equals = std.mem.indexOfScalar(u8, field, '=') orelse continue;
+        var name = std.mem.trim(u8, field[0..equals], " \t\"'{}[]");
+        if (std.mem.lastIndexOfScalar(u8, name, ':')) |colon| {
+            name = name[colon + 1 ..];
+        }
+        var decoded_buffer: [256]u8 = undefined;
+        const decoded = percentDecodeFieldName(name, &decoded_buffer) orelse
+            continue;
+        if (isSensitiveBodyField(decoded)) return true;
+    }
+    return false;
+}
+
+fn percentDecodeFieldName(
+    encoded: []const u8,
+    buffer: []u8,
+) ?[]const u8 {
+    var input_index: usize = 0;
+    var output_index: usize = 0;
+    while (input_index < encoded.len) {
+        if (output_index >= buffer.len) return null;
+        if (encoded[input_index] == '%' and input_index + 2 < encoded.len) {
+            const high = std.fmt.charToDigit(encoded[input_index + 1], 16) catch
+                return null;
+            const low = std.fmt.charToDigit(encoded[input_index + 2], 16) catch
+                return null;
+            buffer[output_index] = high * 16 + low;
+            input_index += 3;
+        } else {
+            buffer[output_index] = encoded[input_index];
+            input_index += 1;
+        }
+        output_index += 1;
+    }
+    return buffer[0..output_index];
+}
+
+fn containsSensitiveXmlElement(body: []const u8) bool {
+    var index: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, body, index, '<')) |open| {
+        index = open + 1;
+        if (index >= body.len) break;
+        if (body[index] == '/' or body[index] == '?' or body[index] == '!') {
+            index += 1;
+        }
+        const name_start = index;
+        while (index < body.len and
+            body[index] != '>' and
+            body[index] != '/' and
+            body[index] != ' ' and
+            body[index] != '\t' and
+            body[index] != '\r' and
+            body[index] != '\n')
+        {
+            index += 1;
+        }
+        var name = body[name_start..index];
+        if (std.mem.lastIndexOfScalar(u8, name, ':')) |colon| {
+            name = name[colon + 1 ..];
+        }
+        if (isSensitiveBodyField(name)) return true;
+    }
+    return false;
 }
 
 fn writeHeaders(
@@ -1945,6 +2157,8 @@ test "sensitive Azure headers are classified case-insensitively" {
         "x-ms-encryption-key",
         "X-MS-SOURCE-ENCRYPTION-KEY-SHA256",
         "X-MS-COPY-SOURCE",
+        "X-MS-FILE-RENAME-SOURCE",
+        "x-ms-file-rename-source-authorization",
         "OCP-APIM-SUBSCRIPTION-KEY",
         "x-functions-key",
         "X-Auth-Token",
@@ -2017,6 +2231,113 @@ test "Event Grid key and SAS token redactions roundtrip" {
     try live.setHeader("AEG-SAS-TOKEN", "live-header-token");
     var replayed = try playback.asTransport().send(&live);
     replayed.deinit();
+}
+
+test "Azure Files rename source URL redactions roundtrip" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        202,
+        "accepted",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .PUT,
+        "https://account.file.core.windows.net/share/destination",
+    );
+    defer request.deinit();
+    try request.setHeader(
+        "X-Ms-FiLe-ReNaMe-SoUrCe",
+        "https://account.file.core.windows.net/share/source?sig=file-rename-secret&sv=2026-01-01",
+    );
+    try request.setHeader(
+        "x-ms-file-rename-source-authorization",
+        "Bearer file-rename-auth-secret",
+    );
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "file-rename-secret") == null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "file-rename-auth-secret") == null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "account.file.core.windows.net/share/source") == null,
+    );
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .PUT,
+        "https://account.file.core.windows.net/share/destination",
+    );
+    defer live.deinit();
+    try live.setHeader(
+        "x-ms-file-rename-source",
+        "https://rotated.file.core.windows.net/other/source?sig=rotated-key",
+    );
+    try live.setHeader(
+        "X-MS-FILE-RENAME-SOURCE-AUTHORIZATION",
+        "Bearer rotated-auth-key",
+    );
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
+}
+
+test "App Configuration key query remains exact" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "setting",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://config.azconfig.io/kv?key=prod*&api-version=1.0",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "key=prod*") != null);
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var different = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://config.azconfig.io/kv?key=dev*&api-version=1.0",
+    );
+    defer different.deinit();
+    try std.testing.expectError(
+        error.UrlMismatch,
+        playback.asTransport().send(&different),
+    );
 }
 
 test "authenticated recording JSON roundtrips with structured redactions" {
@@ -2245,11 +2566,11 @@ test "recording JSON base64 bodies roundtrip arbitrary bytes" {
     }
 }
 
-test "recording JSON refuses recognized credential bodies" {
+fn expectSensitiveResponseBodyRejected(body: []const u8) !void {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
         200,
-        "{\"access_token\":\"secret\"}",
+        body,
     );
     defer mock.deinit();
     var recorder = RecordingTransport.init(
@@ -2268,6 +2589,132 @@ test "recording JSON refuses recognized credential bodies" {
     try std.testing.expectError(
         error.SensitiveBodyRequiresSanitization,
         recorder.toJson(std.testing.allocator),
+    );
+}
+
+fn expectSensitiveRequestBodyRejected(body: []const u8) !void {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "{\"message\":\"safe\"}",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/request",
+    );
+    defer request.deinit();
+    request.body = body;
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    try std.testing.expectError(
+        error.SensitiveBodyRequiresSanitization,
+        recorder.toJson(std.testing.allocator),
+    );
+}
+
+test "recording JSON rejects structural JSON form XML and connection secrets" {
+    for ([_][]const u8{
+        "{\"primaryKey\":\"primary-value\"}",
+        "{\"listKeys\":{\"Secondary_Key\":{\"value\":\"secondary-value\"}}}",
+        "{\"keys\":[{\"name\":\"primary\",\"value\":\"nested-key-value\"}]}",
+        "{\"List-Keys\":{\"value\":\"nested-list-key-value\"}}",
+        "{\"result\":{\"connectionString\":\"Endpoint=x;SharedAccessKey=y\"}}",
+        "{\"outer\":[{\"Api-Key\":{\"value\":\"api-value\"}}]}",
+        "{\"applicationSecret\":\"application-value\"}",
+        "client_secret=form-value&grant_type=client_credentials",
+        "Endpoint=https://example;AccountKey=account-value",
+        "<ListKeys><PrimaryKey>xml-value</PrimaryKey></ListKeys>",
+        "<ns:Credentials><ns:Value>nested-value</ns:Value></ns:Credentials>",
+        "-----BEGIN PRIVATE KEY-----\nprivate-value\n-----END PRIVATE KEY-----",
+    }) |body| {
+        try expectSensitiveResponseBodyRejected(body);
+    }
+    try expectSensitiveRequestBodyRejected(
+        "{\"outer\":{\"CLIENT-ASSERTION\":{\"value\":\"request-value\"}}}",
+    );
+}
+
+test "recording JSON rejects malformed structured bodies explicitly" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "{\"primaryKey\":\"unterminated\"",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/malformed",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    try std.testing.expectError(
+        error.UnsupportedBodySanitization,
+        recorder.toJson(std.testing.allocator),
+    );
+}
+
+test "recording JSON decodes safe structured bodies losslessly" {
+    const request_body =
+        "{\"key\":\"prod*\",\"value\":\"nonsensitive\",\"nested\":{\"kind\":\"filter\"}}";
+    const response_body =
+        "{\"items\":[{\"key\":\"prod\",\"value\":\"enabled\"}]}";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        response_body,
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/safe",
+    );
+    defer request.deinit();
+    request.body = request_body;
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 1), parsed.asSlice().len);
+    try std.testing.expectEqualSlices(
+        u8,
+        request_body,
+        parsed.asSlice()[0].request_body.?,
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        response_body,
+        parsed.asSlice()[0].response_body,
+    );
+    try ensureBodySafe(
+        std.testing.allocator,
+        parsed.asSlice()[0].request_body,
+    );
+    try ensureBodySafe(
+        std.testing.allocator,
+        parsed.asSlice()[0].response_body,
     );
 }
 
@@ -2339,7 +2786,7 @@ fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
         200,
-        "\x00response\xff",
+        "{\"message\":\"response\"}",
     );
     defer mock.deinit();
     var recorder = RecordingTransport.init(
@@ -2353,7 +2800,7 @@ fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
         "https://example.com/items?sig=secret&version=1",
     );
     defer request.deinit();
-    request.body = "\xffrequest\x00";
+    request.body = "{\"message\":\"request\"}";
     try request.setHeader("Authorization", "Bearer secret");
     var response = try recorder.asTransport().send(&request);
     response.deinit();

--- a/root.zig
+++ b/root.zig
@@ -1,187 +1,1117 @@
-///! Azure SDK Test Framework — mock transport, recording/playback, helpers.
-///!
-///! Built on `std.testing` with Azure-specific utilities.
-///!
-///! Supports two test modes (controlled by `AZURE_TEST_MODE` env var):
-///!   - `record`   — runs live requests, records exchanges to JSON files
-///!   - `playback` — replays previously recorded exchanges (default)
+//! Azure SDK testing helpers for recording and playback.
+//!
+//! `PlaybackTransport` and `RecordingTransport` expose copyable Core 0.3
+//! transport descriptors whose opaque contexts borrow the transport values.
+//! The values and any wrapped backend contexts must outlive every descriptor
+//! copy and open operation. Both transports are caller-serialized.
 const std = @import("std");
 const core = @import("azure_sdk_core");
-
-// ──────────────────── Recorded Exchange ────────────────────
-
-/// A recorded HTTP exchange for recording and playback.
-pub const RecordedExchange = struct {
-    request_method: core.http.Method,
-    request_url: []const u8,
-    request_headers: ?[]const HeaderPair = null,
-    request_body: ?[]const u8 = null,
-    response_status: u16,
-    response_body: []const u8,
-    response_headers: ?[]const HeaderPair = null,
-};
 
 pub const HeaderPair = struct {
     name: []const u8,
     value: []const u8,
 };
 
-// ──────────────────── Playback Transport ───────────────────
+/// A borrowed HTTP exchange used by playback.
+///
+/// Method, URL, and body are matched exactly, including whether a body is
+/// present. Every request header listed here must occur with the same value;
+/// additional live headers are allowed. Response headers retain wire order
+/// and duplicate values.
+pub const RecordedExchange = struct {
+    request_method: core.http.Method,
+    request_url: []const u8,
+    request_headers: []const HeaderPair = &.{},
+    request_body: ?[]const u8 = null,
+    response_status: u16,
+    response_body: []const u8,
+    response_headers: []const HeaderPair = &.{},
+};
 
-/// Playback transport — replays a sequence of recorded exchanges in order.
+/// An allocator-owned exchange captured by `RecordingTransport`.
+pub const OwnedExchange = struct {
+    request_method: core.http.Method,
+    request_url: []u8,
+    request_headers: []HeaderPair,
+    request_body: ?[]u8,
+    response_status: u16,
+    response_body: []u8,
+    response_headers: []HeaderPair,
+
+    fn deinit(self: *OwnedExchange, allocator: std.mem.Allocator) void {
+        allocator.free(self.request_url);
+        deinitHeaderPairs(allocator, self.request_headers);
+        if (self.request_body) |body| allocator.free(body);
+        allocator.free(self.response_body);
+        deinitHeaderPairs(allocator, self.response_headers);
+        self.* = undefined;
+    }
+};
+
+/// Construct the canonical Core runtime while selecting transport and crypto
+/// independently. Both descriptors are copied and borrow their contexts.
+pub fn initHttpRuntime(
+    transport: core.http.HttpTransport,
+    crypto_provider: core.crypto.CryptoProvider,
+) core.http.HttpRuntime {
+    return core.http.HttpRuntime.init(transport, crypto_provider);
+}
+
+/// Caller-serialized playback transport.
+///
+/// The returned descriptor borrows this value. Keep it alive until all
+/// descriptor copies and open operations are deinitialized.
 pub const PlaybackTransport = struct {
     recordings: []const RecordedExchange,
     index: usize = 0,
     allocator: std.mem.Allocator,
-    transport: core.http.HttpTransport,
+    open_count: usize = 0,
+    finish_count: usize = 0,
+    abort_count: usize = 0,
+    cancel_count: usize = 0,
+    deinit_count: usize = 0,
 
-    pub fn init(allocator: std.mem.Allocator, recordings: []const RecordedExchange) PlaybackTransport {
-        return .{
-            .recordings = recordings,
-            .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl },
-        };
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &sendImpl,
+        .open = &openImpl,
+    };
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        recordings: []const RecordedExchange,
+    ) PlaybackTransport {
+        return .{ .recordings = recordings, .allocator = allocator };
     }
 
-    pub fn asTransport(self: *PlaybackTransport) *core.http.HttpTransport {
-        return &self.transport;
+    pub fn asTransport(self: *PlaybackTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
-    fn sendImpl(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *PlaybackTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn next(self: *PlaybackTransport) !RecordedExchange {
         if (self.index >= self.recordings.len) return error.NoMoreRecordings;
+        return self.recordings[self.index];
+    }
 
-        const rec = self.recordings[self.index];
+    fn matchAndAdvance(
+        self: *PlaybackTransport,
+        request: *const core.http.Request,
+        body: ?[]const u8,
+    ) !RecordedExchange {
+        const exchange = try self.next();
+        try matchRequest(exchange, request, body);
         self.index += 1;
+        return exchange;
+    }
 
-        if (rec.request_method != request.method) return error.MethodMismatch;
+    fn sendImpl(
+        context: *anyopaque,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const self: *PlaybackTransport = @ptrCast(@alignCast(context));
+        const exchange = try self.matchAndAdvance(request, request.body);
+        return responseFromExchange(self.allocator, exchange);
+    }
 
-        const body_copy = try self.allocator.dupe(u8, rec.response_body);
-        const headers = std.StringHashMap([]const u8).init(self.allocator);
-        return .{
-            .status_code = rec.response_status,
-            .headers = headers,
-            .body = body_copy,
-            .allocator = self.allocator,
-        };
+    fn openImpl(
+        context: *anyopaque,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *PlaybackTransport = @ptrCast(@alignCast(context));
+        if (options.body != null and request.body != null)
+            return error.MultipleRequestBodies;
+        try checkCancelled(options.cancellation);
+        try validateRequestFraming(request, options);
+
+        var captured: ?[]u8 = null;
+        defer if (captured) |body| self.allocator.free(body);
+        const body: ?[]const u8 = if (options.body) |streaming| blk: {
+            captured = try readRequestBody(
+                self.allocator,
+                streaming,
+                options.cancellation,
+            );
+            break :blk captured.?;
+        } else request.body;
+
+        const exchange = try self.matchAndAdvance(request, body);
+        const operation = try PlaybackOperation.create(self, exchange);
+        self.open_count += 1;
+        return operation;
     }
 };
 
-// ──────────────────── Recording Transport ─────────────────
-
-/// Recording transport — wraps a real transport, forwards requests,
-/// and captures all exchanges for later serialization.
-pub const RecordingTransport = struct {
-    inner: *core.http.HttpTransport,
-    exchanges: std.ArrayList(OwnedExchange),
+const PlaybackOperation = struct {
+    operation: core.http.HttpOperation,
     allocator: std.mem.Allocator,
-    transport: core.http.HttpTransport,
+    owner: *PlaybackTransport,
+    response_body: []u8,
+    reader_impl: std.Io.Reader,
 
-    const OwnedExchange = struct {
-        request_method: core.http.Method,
-        request_url: []u8,
-        response_status: u16,
-        response_body: []u8,
-    };
+    fn create(
+        owner: *PlaybackTransport,
+        exchange: RecordedExchange,
+    ) !*core.http.HttpOperation {
+        const self = try owner.allocator.create(PlaybackOperation);
+        errdefer owner.allocator.destroy(self);
+        const body = try owner.allocator.dupe(u8, exchange.response_body);
+        errdefer owner.allocator.free(body);
+        var header_set = try responseHeaderSet(
+            owner.allocator,
+            exchange.response_headers,
+        );
+        errdefer header_set.deinit(owner.allocator);
 
-    pub fn init(allocator: std.mem.Allocator, inner: *core.http.HttpTransport) RecordingTransport {
-        return .{
-            .inner = inner,
-            .exchanges = .empty,
-            .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl },
+        self.* = .{
+            .operation = undefined,
+            .allocator = owner.allocator,
+            .owner = owner,
+            .response_body = body,
+            .reader_impl = std.Io.Reader.fixed(body),
         };
+        self.operation = .{
+            .status_code = exchange.response_status,
+            .headers = header_set.map,
+            .response_headers = header_set.ordered,
+            .body_reader = &self.reader_impl,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &cancelImpl,
+            .deinitFn = &deinitImpl,
+        };
+        return &self.operation;
     }
 
-    pub fn asTransport(self: *RecordingTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn finishImpl(operation: *core.http.HttpOperation) !void {
+        const self: *PlaybackOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        _ = try self.reader_impl.discardRemaining();
+        self.owner.finish_count += 1;
+    }
+
+    fn abortImpl(operation: *core.http.HttpOperation) void {
+        const self: *PlaybackOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.abort_count += 1;
+    }
+
+    fn cancelImpl(operation: *core.http.HttpOperation) void {
+        const self: *PlaybackOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.cancel_count += 1;
+    }
+
+    fn deinitImpl(operation: *core.http.HttpOperation) void {
+        const self: *PlaybackOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.owner.deinit_count += 1;
+        deinitResponseStorage(
+            self.allocator,
+            &self.operation.headers,
+            &self.operation.response_headers,
+        );
+        self.allocator.free(self.response_body);
+        self.allocator.destroy(self);
+    }
+};
+
+/// Caller-serialized recording transport wrapping a full Core descriptor.
+///
+/// The inner descriptor is copied by value. Its context, this recording
+/// transport, and the recording allocator must outlive every open operation.
+/// `deinit` does not deinitialize the borrowed inner transport.
+pub const RecordingTransport = struct {
+    inner: core.http.HttpTransport,
+    exchanges: std.ArrayList(OwnedExchange) = .empty,
+    allocator: std.mem.Allocator,
+
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &sendImpl,
+        .open = &openImpl,
+    };
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        inner: core.http.HttpTransport,
+    ) RecordingTransport {
+        return .{ .inner = inner, .allocator = allocator };
+    }
+
+    pub fn asTransport(self: *RecordingTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
     }
 
     pub fn deinit(self: *RecordingTransport) void {
-        for (self.exchanges.items) |ex| {
-            self.allocator.free(ex.request_url);
-            self.allocator.free(ex.response_body);
+        for (self.exchanges.items) |*exchange| {
+            exchange.deinit(self.allocator);
         }
         self.exchanges.deinit(self.allocator);
+        self.* = undefined;
     }
 
-    /// Get the recorded exchanges as a slice.
     pub fn getExchanges(self: *const RecordingTransport) []const OwnedExchange {
         return self.exchanges.items;
     }
 
-    /// Serialize all recorded exchanges to a JSON string.
-    pub fn toJson(self: *const RecordingTransport, allocator: std.mem.Allocator) ![]u8 {
-        var aw: std.Io.Writer.Allocating = .init(allocator);
-        errdefer aw.deinit();
-        const writer = &aw.writer;
+    /// Serialize recordings while redacting sensitive header values and
+    /// sensitive URL query parameters.
+    ///
+    /// Recognized credential-bearing body fields cause
+    /// `error.SensitiveBodyRequiresSanitization`; bodies are never silently
+    /// emitted under a false sanitization guarantee.
+    pub fn toJson(
+        self: *const RecordingTransport,
+        allocator: std.mem.Allocator,
+    ) ![]u8 {
+        var output: std.Io.Writer.Allocating = .init(allocator);
+        errdefer output.deinit();
+        const writer = &output.writer;
         try writer.writeAll("[");
-        for (self.exchanges.items, 0..) |ex, i| {
-            if (i > 0) try writer.writeAll(",");
-            try writer.writeAll("\n  {");
-            try writer.writeAll("\"method\":\"");
-            try writer.writeAll(methodToString(ex.request_method));
-            try writer.writeAll("\",\"url\":");
-            try writeJsonString(writer, ex.request_url);
-            try writer.writeAll(",\"status\":");
-            try writer.print("{d}", .{ex.response_status});
-            try writer.writeAll(",\"body\":");
-            try writeJsonString(writer, sanitizeBody(ex.response_body));
+        for (self.exchanges.items, 0..) |exchange, index| {
+            try ensureBodySafe(exchange.request_body);
+            try ensureBodySafe(exchange.response_body);
+            if (index != 0) try writer.writeAll(",");
+            try writer.writeAll("\n  {\"request_method\":");
+            try writeJsonString(writer, methodToString(exchange.request_method));
+            try writer.writeAll(",\"request_url\":");
+            try writeSanitizedUrl(writer, allocator, exchange.request_url);
+            try writer.writeAll(",\"request_headers\":");
+            try writeHeaders(writer, exchange.request_headers);
+            try writer.writeAll(",\"request_body\":");
+            try writeOptionalJsonString(writer, exchange.request_body);
+            try writer.writeAll(",\"response_status\":");
+            try writer.print("{d}", .{exchange.response_status});
+            try writer.writeAll(",\"response_headers\":");
+            try writeHeaders(writer, exchange.response_headers);
+            try writer.writeAll(",\"response_body\":");
+            try writeJsonString(writer, exchange.response_body);
             try writer.writeAll("}");
         }
         try writer.writeAll("\n]\n");
-        return aw.toOwnedSlice();
+        return output.toOwnedSlice();
     }
 
-    fn sendImpl(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *RecordingTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn sendImpl(
+        context: *anyopaque,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        var response = try self.inner.vtable.send(self.inner.context, request);
+        errdefer response.deinit();
+        var exchange = try ownedExchangeFromResponse(
+            self.allocator,
+            request,
+            request.body,
+            &response,
+            response.body,
+        );
+        errdefer exchange.deinit(self.allocator);
+        try self.exchanges.append(self.allocator, exchange);
+        return response;
+    }
 
-        // Forward to inner transport.
-        const resp = try self.inner.send(request);
+    fn openImpl(
+        context: *anyopaque,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        if (options.body != null and request.body != null)
+            return error.MultipleRequestBodies;
+        try checkCancelled(options.cancellation);
 
-        // Record the exchange.
-        try self.exchanges.append(self.allocator, .{
-            .request_method = request.method,
-            .request_url = try self.allocator.dupe(u8, request.url),
-            .response_status = resp.status_code,
-            .response_body = try self.allocator.dupe(u8, resp.body),
-        });
+        var pending = try PendingRequest.init(
+            self.allocator,
+            request,
+            request.body,
+        );
+        errdefer pending.deinit(self.allocator);
 
-        return resp;
+        const open_fn = self.inner.vtable.open orelse
+            return error.WrappedTransportDoesNotSupportOpen;
+        var inner_options = options;
+        var request_capture: CapturingReader = undefined;
+        var has_capture = false;
+        if (options.body) |streaming| {
+            request_capture.init(
+                self.allocator,
+                streaming.reader,
+                null,
+            );
+            has_capture = true;
+            inner_options.body.?.reader = &request_capture.interface;
+        }
+        defer if (has_capture) request_capture.deinit();
+
+        const inner_operation = open_fn(
+            self.inner.context,
+            request,
+            inner_options,
+        ) catch |err| {
+            if (has_capture) {
+                if (request_capture.failure) |failure| return failure;
+            }
+            return err;
+        };
+        errdefer {
+            inner_operation.abort();
+            inner_operation.deinit();
+        }
+
+        if (has_capture) {
+            pending.body = try request_capture.toOwnedSlice();
+        }
+        return RecordingOperation.create(
+            self,
+            inner_operation,
+            pending,
+            recordsRedirect(request, options, inner_operation),
+        );
     }
 };
 
-// ──────────────────── Sanitization ────────────────────────
+const PendingRequest = struct {
+    method: core.http.Method,
+    url: []u8,
+    headers: []HeaderPair,
+    body: ?[]u8,
 
-/// List of header names whose values should be redacted in recordings.
+    fn init(
+        allocator: std.mem.Allocator,
+        request: *const core.http.Request,
+        body: ?[]const u8,
+    ) !PendingRequest {
+        const url = try allocator.dupe(u8, request.url);
+        errdefer allocator.free(url);
+        const headers = try cloneRequestHeaders(allocator, &request.headers);
+        errdefer deinitHeaderPairs(allocator, headers);
+        const owned_body = if (body) |bytes|
+            try allocator.dupe(u8, bytes)
+        else
+            null;
+        return .{
+            .method = request.method,
+            .url = url,
+            .headers = headers,
+            .body = owned_body,
+        };
+    }
+
+    fn deinit(self: *PendingRequest, allocator: std.mem.Allocator) void {
+        allocator.free(self.url);
+        deinitHeaderPairs(allocator, self.headers);
+        if (self.body) |body| allocator.free(body);
+        self.* = undefined;
+    }
+};
+
+const RecordingOperation = struct {
+    operation: core.http.HttpOperation,
+    allocator: std.mem.Allocator,
+    owner: *RecordingTransport,
+    inner: *core.http.HttpOperation,
+    pending: ?PendingRequest,
+    redirect_exchange: ?OwnedExchange,
+    response_reader: CapturingReader,
+
+    fn create(
+        owner: *RecordingTransport,
+        inner: *core.http.HttpOperation,
+        pending_value: PendingRequest,
+        record_redirect: bool,
+    ) !*core.http.HttpOperation {
+        const self = try owner.allocator.create(RecordingOperation);
+        errdefer owner.allocator.destroy(self);
+        var header_set = try cloneOperationHeaders(owner.allocator, inner);
+        errdefer header_set.deinit(owner.allocator);
+        const inner_reader = try inner.reader();
+        var redirect_headers: ?[]HeaderPair = null;
+        errdefer if (redirect_headers) |headers|
+            deinitHeaderPairs(owner.allocator, headers);
+        var redirect_body: ?[]u8 = null;
+        errdefer if (redirect_body) |body| owner.allocator.free(body);
+        if (record_redirect) {
+            try owner.exchanges.ensureUnusedCapacity(owner.allocator, 1);
+            redirect_headers = try cloneResponseHeaders(
+                owner.allocator,
+                &inner.headers,
+                &inner.response_headers,
+            );
+            redirect_body = try owner.allocator.dupe(u8, "");
+        }
+
+        self.* = .{
+            .operation = undefined,
+            .allocator = owner.allocator,
+            .owner = owner,
+            .inner = inner,
+            .pending = if (record_redirect) null else pending_value,
+            .redirect_exchange = if (record_redirect) .{
+                .request_method = pending_value.method,
+                .request_url = pending_value.url,
+                .request_headers = pending_value.headers,
+                .request_body = pending_value.body,
+                .response_status = inner.status_code,
+                .response_body = redirect_body.?,
+                .response_headers = redirect_headers.?,
+            } else null,
+            .response_reader = undefined,
+        };
+        self.response_reader.init(owner.allocator, inner_reader, inner);
+        self.operation = .{
+            .status_code = inner.status_code,
+            .headers = header_set.map,
+            .response_headers = header_set.ordered,
+            .body_reader = &self.response_reader.interface,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &cancelImpl,
+            .deinitFn = &deinitImpl,
+            .bodyErrorFn = &bodyErrorImpl,
+        };
+        return &self.operation;
+    }
+
+    fn finishImpl(operation: *core.http.HttpOperation) !void {
+        const self: *RecordingOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        _ = self.response_reader.interface.discardRemaining() catch |err| {
+            if (self.response_reader.failure) |failure| return failure;
+            if (self.inner.bodyError()) |failure| return failure;
+            return err;
+        };
+        try self.inner.finish();
+        if (self.response_reader.failure) |failure| return failure;
+
+        const body = try self.response_reader.toOwnedSlice();
+        const response_headers = cloneResponseHeaders(
+            self.allocator,
+            &self.operation.headers,
+            &self.operation.response_headers,
+        ) catch |err| {
+            self.allocator.free(body);
+            return err;
+        };
+        const pending = self.pending orelse {
+            self.allocator.free(body);
+            deinitHeaderPairs(self.allocator, response_headers);
+            return error.RecordingAlreadyFinalized;
+        };
+        self.pending = null;
+        var exchange = OwnedExchange{
+            .request_method = pending.method,
+            .request_url = pending.url,
+            .request_headers = pending.headers,
+            .request_body = pending.body,
+            .response_status = self.operation.status_code,
+            .response_body = body,
+            .response_headers = response_headers,
+        };
+        self.owner.exchanges.append(self.allocator, exchange) catch |err| {
+            exchange.deinit(self.allocator);
+            return err;
+        };
+    }
+
+    fn abortImpl(operation: *core.http.HttpOperation) void {
+        const self: *RecordingOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.inner.abort();
+        if (self.redirect_exchange) |exchange| {
+            self.owner.exchanges.appendAssumeCapacity(exchange);
+            self.redirect_exchange = null;
+        }
+    }
+
+    fn cancelImpl(operation: *core.http.HttpOperation) void {
+        const self: *RecordingOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.inner.cancel();
+    }
+
+    fn bodyErrorImpl(operation: *const core.http.HttpOperation) ?anyerror {
+        const self: *const RecordingOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        if (self.response_reader.failure) |failure| return failure;
+        return self.inner.bodyError();
+    }
+
+    fn deinitImpl(operation: *core.http.HttpOperation) void {
+        const self: *RecordingOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.inner.deinit();
+        if (self.pending) |*pending| pending.deinit(self.allocator);
+        if (self.redirect_exchange) |*exchange| {
+            exchange.deinit(self.allocator);
+        }
+        self.response_reader.deinit();
+        deinitResponseStorage(
+            self.allocator,
+            &self.operation.headers,
+            &self.operation.response_headers,
+        );
+        self.allocator.destroy(self);
+    }
+};
+
+fn recordsRedirect(
+    request: *const core.http.Request,
+    options: core.http.OpenOptions,
+    operation: *const core.http.HttpOperation,
+) bool {
+    if (request.redirect_policy == .not_allowed or
+        operation.getHeader("Location") == null)
+    {
+        return false;
+    }
+    return switch (operation.status_code) {
+        301, 302 => request.method == .POST or options.isReplayable(),
+        303 => true,
+        307, 308 => options.isReplayable(),
+        else => false,
+    };
+}
+
+const CapturingReader = struct {
+    interface: std.Io.Reader,
+    source: *std.Io.Reader,
+    captured: std.Io.Writer.Allocating,
+    source_operation: ?*core.http.HttpOperation,
+    failure: ?anyerror = null,
+    reader_buffer: [64]u8 = undefined,
+    scratch: [4096]u8 = undefined,
+
+    fn init(
+        self: *CapturingReader,
+        allocator: std.mem.Allocator,
+        source: *std.Io.Reader,
+        source_operation: ?*core.http.HttpOperation,
+    ) void {
+        self.* = .{
+            .interface = undefined,
+            .source = source,
+            .captured = .init(allocator),
+            .source_operation = source_operation,
+        };
+        self.interface = .{
+            .vtable = &.{ .stream = &stream },
+            .buffer = &self.reader_buffer,
+            .seek = 0,
+            .end = 0,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *CapturingReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        const length = limit.minInt(self.scratch.len);
+        if (length == 0) return 0;
+        const count = self.source.readSliceShort(self.scratch[0..length]) catch |err| {
+            self.failure = if (self.source_operation) |operation|
+                operation.bodyError() orelse err
+            else
+                err;
+            return error.ReadFailed;
+        };
+        if (count == 0) return error.EndOfStream;
+        self.captured.writer.writeAll(self.scratch[0..count]) catch {
+            self.failure = error.OutOfMemory;
+            return error.ReadFailed;
+        };
+        try writer.writeAll(self.scratch[0..count]);
+        return count;
+    }
+
+    fn toOwnedSlice(self: *CapturingReader) ![]u8 {
+        const result = try self.captured.toOwnedSlice();
+        self.captured = .init(self.captured.allocator);
+        return result;
+    }
+
+    fn deinit(self: *CapturingReader) void {
+        self.captured.deinit();
+    }
+};
+
+const ResponseHeaderSet = struct {
+    map: std.StringHashMap([]const u8),
+    ordered: core.http.ResponseHeaders,
+
+    fn deinit(self: *ResponseHeaderSet, allocator: std.mem.Allocator) void {
+        deinitOwnedHeaderMap(allocator, &self.map);
+        self.ordered.deinit();
+    }
+};
+
+fn responseFromExchange(
+    allocator: std.mem.Allocator,
+    exchange: RecordedExchange,
+) !core.http.Response {
+    const body = try allocator.dupe(u8, exchange.response_body);
+    errdefer allocator.free(body);
+    var header_set = try responseHeaderSet(allocator, exchange.response_headers);
+    errdefer header_set.deinit(allocator);
+    return .{
+        .status_code = exchange.response_status,
+        .headers = header_set.map,
+        .body = body,
+        .allocator = allocator,
+        .response_headers = header_set.ordered,
+    };
+}
+
+fn responseHeaderSet(
+    allocator: std.mem.Allocator,
+    headers: []const HeaderPair,
+) !ResponseHeaderSet {
+    var result = ResponseHeaderSet{
+        .map = std.StringHashMap([]const u8).init(allocator),
+        .ordered = core.http.ResponseHeaders.init(allocator),
+    };
+    errdefer result.deinit(allocator);
+    for (headers) |header| {
+        try result.ordered.append(header.name, header.value);
+        try putOwnedHeader(allocator, &result.map, header.name, header.value);
+    }
+    return result;
+}
+
+fn cloneOperationHeaders(
+    allocator: std.mem.Allocator,
+    operation: *const core.http.HttpOperation,
+) !ResponseHeaderSet {
+    const pairs = try cloneResponseHeaders(
+        allocator,
+        &operation.headers,
+        &operation.response_headers,
+    );
+    defer deinitHeaderPairs(allocator, pairs);
+    return responseHeaderSet(allocator, pairs);
+}
+
+fn cloneResponseHeaders(
+    allocator: std.mem.Allocator,
+    map: *const std.StringHashMap([]const u8),
+    ordered: *const core.http.ResponseHeaders,
+) ![]HeaderPair {
+    if (ordered.entries.items.len != 0) {
+        const result = try allocator.alloc(HeaderPair, ordered.entries.items.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (result[0..initialized]) |header| {
+                allocator.free(header.name);
+                allocator.free(header.value);
+            }
+            allocator.free(result);
+        }
+        for (ordered.entries.items, result) |header, *pair| {
+            pair.* = .{
+                .name = try allocator.dupe(u8, header.name),
+                .value = undefined,
+            };
+            errdefer allocator.free(pair.name);
+            pair.value = try allocator.dupe(u8, header.value);
+            initialized += 1;
+        }
+        return result;
+    }
+
+    const result = try allocator.alloc(HeaderPair, map.count());
+    var initialized: usize = 0;
+    errdefer {
+        for (result[0..initialized]) |header| {
+            allocator.free(header.name);
+            allocator.free(header.value);
+        }
+        allocator.free(result);
+    }
+    var iterator = map.iterator();
+    while (iterator.next()) |entry| {
+        result[initialized] = .{
+            .name = try allocator.dupe(u8, entry.key_ptr.*),
+            .value = undefined,
+        };
+        errdefer allocator.free(result[initialized].name);
+        result[initialized].value = try allocator.dupe(u8, entry.value_ptr.*);
+        initialized += 1;
+    }
+    return result;
+}
+
+fn ownedExchangeFromResponse(
+    allocator: std.mem.Allocator,
+    request: *const core.http.Request,
+    request_body: ?[]const u8,
+    response: *const core.http.Response,
+    response_body: []const u8,
+) !OwnedExchange {
+    var pending = try PendingRequest.init(allocator, request, request_body);
+    errdefer pending.deinit(allocator);
+    const body = try allocator.dupe(u8, response_body);
+    errdefer allocator.free(body);
+    const headers = try cloneResponseHeaders(
+        allocator,
+        &response.headers,
+        &response.response_headers,
+    );
+    return .{
+        .request_method = pending.method,
+        .request_url = pending.url,
+        .request_headers = pending.headers,
+        .request_body = pending.body,
+        .response_status = response.status_code,
+        .response_body = body,
+        .response_headers = headers,
+    };
+}
+
+fn matchRequest(
+    exchange: RecordedExchange,
+    request: *const core.http.Request,
+    body: ?[]const u8,
+) !void {
+    if (exchange.request_method != request.method) return error.MethodMismatch;
+    if (!std.mem.eql(u8, exchange.request_url, request.url))
+        return error.UrlMismatch;
+    if ((exchange.request_body == null) != (body == null))
+        return error.BodyMismatch;
+    if (exchange.request_body) |expected| {
+        if (!std.mem.eql(u8, expected, body.?)) return error.BodyMismatch;
+    }
+    for (exchange.request_headers) |expected| {
+        const actual = getHeader(&request.headers, expected.name) orelse
+            return error.HeaderMismatch;
+        if (!std.mem.eql(u8, expected.value, actual))
+            return error.HeaderMismatch;
+    }
+}
+
+fn validateRequestFraming(
+    request: *const core.http.Request,
+    options: core.http.OpenOptions,
+) !void {
+    const content_length = getHeader(&request.headers, "Content-Length");
+    const transfer_encoding = getHeader(&request.headers, "Transfer-Encoding");
+    const framing: union(enum) {
+        none,
+        content_length: u64,
+        chunked,
+    } = if (options.body) |body|
+        if (body.content_length) |length|
+            .{ .content_length = length }
+        else
+            .chunked
+    else if (request.body) |body|
+        .{ .content_length = body.len }
+    else if (request.method.toStd().requestHasBody())
+        .{ .content_length = 0 }
+    else
+        .none;
+
+    switch (framing) {
+        .content_length => |length| {
+            if (transfer_encoding != null) return error.ConflictingRequestFraming;
+            if (content_length) |value| {
+                const parsed = std.fmt.parseInt(u64, std.mem.trim(u8, value, " \t"), 10) catch
+                    return error.ConflictingRequestFraming;
+                if (parsed != length) return error.ConflictingRequestFraming;
+            }
+        },
+        .chunked => {
+            if (content_length != null) return error.ConflictingRequestFraming;
+            if (transfer_encoding) |value| {
+                if (!std.ascii.eqlIgnoreCase(
+                    std.mem.trim(u8, value, " \t"),
+                    "chunked",
+                )) return error.ConflictingRequestFraming;
+            }
+        },
+        .none => if (content_length != null or transfer_encoding != null)
+            return error.ConflictingRequestFraming,
+    }
+}
+
+fn readRequestBody(
+    allocator: std.mem.Allocator,
+    body: core.http.StreamingRequestBody,
+    cancellation: ?*const core.http.CancellationToken,
+) ![]u8 {
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    var buffer: [4096]u8 = undefined;
+    if (body.content_length) |length| {
+        var remaining = length;
+        while (remaining != 0) {
+            try checkCancelled(cancellation);
+            const read_length: usize = @intCast(@min(remaining, buffer.len));
+            const count = try body.reader.readSliceShort(buffer[0..read_length]);
+            try checkCancelled(cancellation);
+            if (count == 0) return error.RequestBodyTooShort;
+            try output.writer.writeAll(buffer[0..count]);
+            remaining -= count;
+        }
+        var extra: [1]u8 = undefined;
+        if (try body.reader.readSliceShort(&extra) != 0)
+            return error.RequestBodyTooLong;
+    } else {
+        while (true) {
+            try checkCancelled(cancellation);
+            const count = try body.reader.readSliceShort(&buffer);
+            try checkCancelled(cancellation);
+            if (count == 0) break;
+            try output.writer.writeAll(buffer[0..count]);
+        }
+    }
+    return output.toOwnedSlice();
+}
+
+fn checkCancelled(token: ?*const core.http.CancellationToken) !void {
+    if (token) |value| {
+        if (value.isCancelled()) return error.OperationCancelled;
+    }
+}
+
+fn cloneRequestHeaders(
+    allocator: std.mem.Allocator,
+    headers: *const std.StringHashMap([]const u8),
+) ![]HeaderPair {
+    const result = try allocator.alloc(HeaderPair, headers.count());
+    var initialized: usize = 0;
+    errdefer {
+        for (result[0..initialized]) |header| {
+            allocator.free(header.name);
+            allocator.free(header.value);
+        }
+        allocator.free(result);
+    }
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        result[initialized] = .{
+            .name = try allocator.dupe(u8, entry.key_ptr.*),
+            .value = undefined,
+        };
+        errdefer allocator.free(result[initialized].name);
+        result[initialized].value = try allocator.dupe(u8, entry.value_ptr.*);
+        initialized += 1;
+    }
+    return result;
+}
+
+fn deinitHeaderPairs(
+    allocator: std.mem.Allocator,
+    headers: []const HeaderPair,
+) void {
+    for (headers) |header| {
+        allocator.free(header.name);
+        allocator.free(header.value);
+    }
+    allocator.free(headers);
+}
+
+fn getHeader(
+    headers: *const std.StringHashMap([]const u8),
+    name: []const u8,
+) ?[]const u8 {
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, name))
+            return entry.value_ptr.*;
+    }
+    return null;
+}
+
+fn putOwnedHeader(
+    allocator: std.mem.Allocator,
+    headers: *std.StringHashMap([]const u8),
+    name: []const u8,
+    value: []const u8,
+) !void {
+    const owned_value = try allocator.dupe(u8, value);
+    errdefer allocator.free(owned_value);
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, name)) {
+            allocator.free(entry.value_ptr.*);
+            entry.value_ptr.* = owned_value;
+            return;
+        }
+    }
+    const owned_name = try allocator.dupe(u8, name);
+    errdefer allocator.free(owned_name);
+    try headers.put(owned_name, owned_value);
+}
+
+fn deinitOwnedHeaderMap(
+    allocator: std.mem.Allocator,
+    headers: *std.StringHashMap([]const u8),
+) void {
+    var iterator = headers.iterator();
+    while (iterator.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+        allocator.free(entry.value_ptr.*);
+    }
+    headers.deinit();
+}
+
+fn deinitResponseStorage(
+    allocator: std.mem.Allocator,
+    headers: *std.StringHashMap([]const u8),
+    ordered: *core.http.ResponseHeaders,
+) void {
+    ordered.deinit();
+    deinitOwnedHeaderMap(allocator, headers);
+}
+
 const sensitive_headers = [_][]const u8{
     "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
     "x-ms-client-secret",
     "ocp-apim-subscription-key",
     "api-key",
 };
 
-/// Replace sensitive values in a body string.
-/// Currently redacts `access_token` values in JSON.
-fn sanitizeBody(body: []const u8) []const u8 {
-    // Light-touch: don't modify body in-place. Full sanitization
-    // would require JSON-aware rewriting. For now, return as-is;
-    // callers should avoid recording in production environments.
-    return body;
-}
+const sensitive_body_fields = [_][]const u8{
+    "access_token",
+    "accesstoken",
+    "refresh_token",
+    "refreshtoken",
+    "client_secret",
+    "clientsecret",
+    "client_assertion",
+    "clientassertion",
+    "password",
+    "shared_access_signature",
+    "sharedaccesssignature",
+};
 
-/// Check if a header name is sensitive (case-insensitive).
+const sensitive_query_fields = [_][]const u8{
+    "sig",
+    "signature",
+    "token",
+    "access_token",
+    "key",
+    "secret",
+    "code",
+};
+
 pub fn isSensitiveHeader(name: []const u8) bool {
-    for (sensitive_headers) |h| {
-        if (eqlIgnoreCase(name, h)) return true;
+    for (sensitive_headers) |sensitive| {
+        if (std.ascii.eqlIgnoreCase(name, sensitive)) return true;
     }
     return false;
 }
 
-// ──────────────────── JSON Helpers ─────────────────────────
+fn ensureBodySafe(body: ?[]const u8) !void {
+    const bytes = body orelse return;
+    for (sensitive_body_fields) |field| {
+        if (containsIgnoreCase(bytes, field))
+            return error.SensitiveBodyRequiresSanitization;
+    }
+}
 
-fn methodToString(m: core.http.Method) []const u8 {
-    return switch (m) {
+fn writeHeaders(
+    writer: *std.Io.Writer,
+    headers: []const HeaderPair,
+) !void {
+    try writer.writeByte('[');
+    for (headers, 0..) |header, index| {
+        if (index != 0) try writer.writeByte(',');
+        try writer.writeAll("{\"name\":");
+        try writeJsonString(writer, header.name);
+        try writer.writeAll(",\"value\":");
+        try writeJsonString(
+            writer,
+            if (isSensitiveHeader(header.name)) "REDACTED" else header.value,
+        );
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+}
+
+fn writeSanitizedUrl(
+    writer: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    url: []const u8,
+) !void {
+    const scheme = std.mem.indexOf(u8, url, "://");
+    if (scheme) |index| {
+        const authority_start = index + 3;
+        const authority_end = std.mem.indexOfScalarPos(
+            u8,
+            url,
+            authority_start,
+            '/',
+        ) orelse std.mem.indexOfScalarPos(
+            u8,
+            url,
+            authority_start,
+            '?',
+        ) orelse url.len;
+        if (std.mem.indexOfScalar(
+            u8,
+            url[authority_start..authority_end],
+            '@',
+        ) != null) return error.SensitiveUrlRequiresSanitization;
+    }
+
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+    const question = std.mem.indexOfScalar(u8, url, '?') orelse {
+        return writeJsonString(writer, url);
+    };
+    try output.writer.writeAll(url[0 .. question + 1]);
+    const fragment = std.mem.indexOfScalarPos(u8, url, question + 1, '#') orelse
+        url.len;
+    var first = true;
+    var iterator = std.mem.splitScalar(u8, url[question + 1 .. fragment], '&');
+    while (iterator.next()) |parameter| {
+        if (!first) try output.writer.writeByte('&');
+        first = false;
+        const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse {
+            try output.writer.writeAll(parameter);
+            continue;
+        };
+        const name = parameter[0..equals];
+        try output.writer.writeAll(name);
+        try output.writer.writeByte('=');
+        try output.writer.writeAll(
+            if (isSensitiveQueryField(name))
+                "REDACTED"
+            else
+                parameter[equals + 1 ..],
+        );
+    }
+    try output.writer.writeAll(url[fragment..]);
+    try writeJsonString(writer, output.writer.buffered());
+}
+
+fn isSensitiveQueryField(name: []const u8) bool {
+    for (sensitive_query_fields) |sensitive| {
+        if (std.ascii.eqlIgnoreCase(name, sensitive)) return true;
+    }
+    return false;
+}
+
+fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len > haystack.len) return false;
+    var index: usize = 0;
+    while (index + needle.len <= haystack.len) : (index += 1) {
+        if (std.ascii.eqlIgnoreCase(
+            haystack[index .. index + needle.len],
+            needle,
+        )) return true;
+    }
+    return false;
+}
+
+fn methodToString(method: core.http.Method) []const u8 {
+    return switch (method) {
         .GET => "GET",
         .POST => "POST",
         .PUT => "PUT",
@@ -192,150 +1122,649 @@ fn methodToString(m: core.http.Method) []const u8 {
     };
 }
 
-fn writeJsonString(writer: anytype, s: []const u8) !void {
+fn writeOptionalJsonString(
+    writer: *std.Io.Writer,
+    value: ?[]const u8,
+) !void {
+    if (value) |bytes| {
+        try writeJsonString(writer, bytes);
+    } else {
+        try writer.writeAll("null");
+    }
+}
+
+fn writeJsonString(writer: *std.Io.Writer, value: []const u8) !void {
     try writer.writeByte('"');
-    for (s) |c| {
-        switch (c) {
+    for (value) |byte| {
+        switch (byte) {
             '"' => try writer.writeAll("\\\""),
             '\\' => try writer.writeAll("\\\\"),
             '\n' => try writer.writeAll("\\n"),
             '\r' => try writer.writeAll("\\r"),
             '\t' => try writer.writeAll("\\t"),
-            else => {
-                if (c < 0x20) {
-                    const hex = "0123456789abcdef";
-                    try writer.writeAll("\\u00");
-                    try writer.writeByte(hex[c >> 4]);
-                    try writer.writeByte(hex[c & 0x0f]);
-                } else {
-                    try writer.writeByte(c);
-                }
+            else => if (byte < 0x20) {
+                const hex = "0123456789abcdef";
+                try writer.writeAll("\\u00");
+                try writer.writeByte(hex[byte >> 4]);
+                try writer.writeByte(hex[byte & 0x0f]);
+            } else {
+                try writer.writeByte(byte);
             },
         }
     }
     try writer.writeByte('"');
 }
 
-fn eqlIgnoreCase(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |ca, cb| {
-        if (std.ascii.toLower(ca) != std.ascii.toLower(cb)) return false;
-    }
-    return true;
+pub fn expectSuccess(response: core.http.Response) !void {
+    if (!response.isSuccess()) return error.UnexpectedStatus;
 }
 
-// ──────────────────── Test Helpers ─────────────────────────
-
-/// Assert a response is successful (2xx).
-pub fn expectSuccess(resp: core.http.Response) !void {
-    if (!resp.isSuccess()) {
-        std.log.err("Expected 2xx but got {d}", .{resp.status_code});
-        return error.UnexpectedStatus;
-    }
+pub fn expectStatus(response: core.http.Response, expected: u16) !void {
+    try std.testing.expectEqual(expected, response.status_code);
 }
 
-/// Assert a response has a specific status code.
-pub fn expectStatus(resp: core.http.Response, expected: u16) !void {
-    try std.testing.expectEqual(expected, resp.status_code);
+test "playback validates request and preserves duplicate response headers" {
+    const recordings = [_]RecordedExchange{.{
+        .request_method = .POST,
+        .request_url = "https://example.com/items",
+        .request_headers = &.{.{ .name = "Content-Type", .value = "application/json" }},
+        .request_body = "{}",
+        .response_status = 201,
+        .response_body = "created",
+        .response_headers = &.{
+            .{ .name = "X-Value", .value = "first" },
+            .{ .name = "x-value", .value = "second" },
+        },
+    }};
+    var playback = PlaybackTransport.init(std.testing.allocator, &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/items",
+    );
+    defer request.deinit();
+    request.body = "{}";
+    try request.setHeader("Content-Type", "application/json");
+    try request.setHeader("User-Agent", "volatile");
+
+    var response = try playback.asTransport().send(&request);
+    defer response.deinit();
+    const values = try response.getHeaderValues(std.testing.allocator, "X-VALUE");
+    defer std.testing.allocator.free(values);
+    try std.testing.expectEqual(@as(usize, 2), values.len);
+    try std.testing.expectEqualStrings("first", values[0]);
+    try std.testing.expectEqualStrings("second", values[1]);
 }
 
-// ─────────────────────── Tests ───────────────────────
+test "playback supports streaming upload and response lifecycle" {
+    const recordings = [_]RecordedExchange{.{
+        .request_method = .PUT,
+        .request_url = "https://example.com/stream",
+        .request_body = "streaming",
+        .response_status = 200,
+        .response_body = "response",
+    }};
+    var playback = PlaybackTransport.init(std.testing.allocator, &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .PUT,
+        "https://example.com/stream",
+    );
+    defer request.deinit();
+    var source = std.Io.Reader.fixed("streaming");
+    var operation = try playback.asTransport().open(&request, .{
+        .body = core.http.StreamingRequestBody.knownLength(&source, 9),
+    });
+    const response = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(response);
+    try std.testing.expectEqualStrings("response", response);
+    try operation.finish();
+    operation.deinit();
+    try std.testing.expectEqual(@as(usize, 1), playback.finish_count);
+    try std.testing.expectEqual(@as(usize, 1), playback.deinit_count);
+}
 
-test "PlaybackTransport replays recordings" {
-    const allocator = std.testing.allocator;
+test "playback preserves abort and cancellation semantics" {
     const recordings = [_]RecordedExchange{
-        .{ .request_method = .GET, .request_url = "/secrets/s1", .response_status = 200, .response_body = "{\"value\":\"v1\"}" },
-        .{ .request_method = .PUT, .request_url = "/secrets/s2", .response_status = 200, .response_body = "{\"value\":\"v2\"}" },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.com/abort",
+            .response_status = 200,
+            .response_body = "abort",
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.com/cancel",
+            .response_status = 200,
+            .response_body = "cancel",
+        },
     };
-    var playback = PlaybackTransport.init(allocator, &recordings);
+    var playback = PlaybackTransport.init(std.testing.allocator, &recordings);
+    var abort_request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/abort",
+    );
+    defer abort_request.deinit();
+    var aborted = try playback.asTransport().open(&abort_request, .{});
+    aborted.abort();
+    aborted.deinit();
 
-    var req1 = core.http.Request.init(allocator, .GET, "/secrets/s1");
-    defer req1.deinit();
-    var resp1 = try playback.asTransport().send(&req1);
-    defer resp1.deinit();
-    try std.testing.expectEqual(@as(u16, 200), resp1.status_code);
-
-    var req2 = core.http.Request.init(allocator, .PUT, "/secrets/s2");
-    defer req2.deinit();
-    var resp2 = try playback.asTransport().send(&req2);
-    defer resp2.deinit();
-    try std.testing.expectEqualStrings("{\"value\":\"v2\"}", resp2.body);
+    var cancel_request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/cancel",
+    );
+    defer cancel_request.deinit();
+    var cancelled = try playback.asTransport().open(&cancel_request, .{});
+    cancelled.cancel();
+    cancelled.deinit();
+    try std.testing.expectEqual(@as(usize, 1), playback.abort_count);
+    try std.testing.expectEqual(@as(usize, 1), playback.cancel_count);
+    try std.testing.expectEqual(@as(usize, 2), playback.deinit_count);
 }
 
-test "PlaybackTransport detects method mismatch" {
-    const allocator = std.testing.allocator;
+test "playback follows redirects and cleans intermediate operations" {
     const recordings = [_]RecordedExchange{
-        .{ .request_method = .POST, .request_url = "/x", .response_status = 200, .response_body = "{}" },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.com/start",
+            .response_status = 302,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/final" },
+            },
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.com/final",
+            .response_status = 200,
+            .response_body = "done",
+        },
     };
-    var playback = PlaybackTransport.init(allocator, &recordings);
-    var req = core.http.Request.init(allocator, .GET, "/x");
-    defer req.deinit();
-    try std.testing.expectError(error.MethodMismatch, playback.asTransport().send(&req));
+    var playback = PlaybackTransport.init(std.testing.allocator, &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/start",
+    );
+    defer request.deinit();
+    var operation = try playback.asTransport().open(&request, .{});
+    const body = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("done", body);
+    try operation.finish();
+    operation.deinit();
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
+    try std.testing.expectEqual(@as(usize, 1), playback.abort_count);
+    try std.testing.expectEqual(@as(usize, 1), playback.finish_count);
+    try std.testing.expectEqual(@as(usize, 2), playback.deinit_count);
 }
 
-test "expectSuccess" {
-    var resp = core.http.Response{
-        .status_code = 200,
-        .headers = std.StringHashMap([]const u8).init(std.testing.allocator),
-        .body = try std.testing.allocator.dupe(u8, "ok"),
-        .allocator = std.testing.allocator,
+test "playback cancellation does not consume a recording" {
+    const recordings = [_]RecordedExchange{.{
+        .request_method = .POST,
+        .request_url = "https://example.com/cancel",
+        .request_body = "part",
+        .response_status = 200,
+        .response_body = "",
+    }};
+    var playback = PlaybackTransport.init(std.testing.allocator, &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/cancel",
+    );
+    defer request.deinit();
+    var token = core.http.CancellationToken{};
+    const CancellingReader = struct {
+        interface: std.Io.Reader,
+        token: *core.http.CancellationToken,
+        emitted: bool = false,
+
+        fn init(value: *@This(), cancellation: *core.http.CancellationToken) void {
+            value.* = .{
+                .interface = .{
+                    .vtable = &.{ .stream = &stream },
+                    .buffer = &.{},
+                    .seek = 0,
+                    .end = 0,
+                },
+                .token = cancellation,
+            };
+        }
+
+        fn stream(
+            interface: *std.Io.Reader,
+            writer: *std.Io.Writer,
+            limit: std.Io.Limit,
+        ) std.Io.Reader.StreamError!usize {
+            const self: *@This() =
+                @alignCast(@fieldParentPtr("interface", interface));
+            if (self.emitted) return error.EndOfStream;
+            const bytes = limit.sliceConst("part");
+            try writer.writeAll(bytes);
+            self.emitted = true;
+            self.token.cancel();
+            return bytes.len;
+        }
     };
-    defer resp.deinit();
-    try expectSuccess(resp);
+    var source: CancellingReader = undefined;
+    source.init(&token);
+    try std.testing.expectError(
+        error.OperationCancelled,
+        playback.asTransport().open(&request, .{
+            .body = core.http.StreamingRequestBody.chunked(&source.interface),
+            .cancellation = &token,
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), playback.index);
 }
 
-test "RecordingTransport captures exchanges" {
-    const allocator = std.testing.allocator;
+test "playback detects URL body and header mismatches without advancing" {
+    const recordings = [_]RecordedExchange{.{
+        .request_method = .POST,
+        .request_url = "https://example.com/expected",
+        .request_headers = &.{.{ .name = "X-Expected", .value = "yes" }},
+        .request_body = "expected",
+        .response_status = 200,
+        .response_body = "",
+    }};
+    var playback = PlaybackTransport.init(std.testing.allocator, &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/wrong",
+    );
+    defer request.deinit();
+    request.body = "expected";
+    try std.testing.expectError(
+        error.UrlMismatch,
+        playback.asTransport().send(&request),
+    );
+    request.url = "https://example.com/expected";
+    request.body = "wrong";
+    try std.testing.expectError(
+        error.BodyMismatch,
+        playback.asTransport().send(&request),
+    );
+    request.body = "expected";
+    try std.testing.expectError(
+        error.HeaderMismatch,
+        playback.asTransport().send(&request),
+    );
+    try std.testing.expectEqual(@as(usize, 0), playback.index);
+}
 
-    // Inner mock transport.
-    var mock = core.http.MockTransport.init(allocator, 200, "{\"secret\":\"value\"}");
+test "recording wraps streaming operations and copies descriptor by value" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        202,
+        "stream-response",
+    );
     defer mock.deinit();
-
-    var recorder = RecordingTransport.init(allocator, mock.asTransport());
+    mock.response_headers_list = &.{
+        .{ .name = "X-Duplicate", .value = "first" },
+        .{ .name = "x-duplicate", .value = "second" },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
     defer recorder.deinit();
+    const copied = recorder.asTransport();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/record",
+    );
+    defer request.deinit();
+    var source = std.Io.Reader.fixed("stream-request");
+    var operation = try copied.open(&request, .{
+        .body = core.http.StreamingRequestBody.chunked(&source),
+    });
+    var first: [6]u8 = undefined;
+    try (try operation.reader()).readSliceAll(&first);
+    try operation.finish();
+    operation.deinit();
 
-    var req = core.http.Request.init(allocator, .GET, "https://vault.azure.net/secrets/s1");
-    defer req.deinit();
-    var resp = try recorder.asTransport().send(&req);
-    defer resp.deinit();
-
-    try std.testing.expectEqual(@as(u16, 200), resp.status_code);
-    try std.testing.expectEqualStrings("{\"secret\":\"value\"}", resp.body);
-
-    // Verify the exchange was recorded.
     const exchanges = recorder.getExchanges();
     try std.testing.expectEqual(@as(usize, 1), exchanges.len);
-    try std.testing.expectEqual(core.http.Method.GET, exchanges[0].request_method);
-    try std.testing.expect(std.mem.find(u8, exchanges[0].request_url, "secrets/s1") != null);
+    try std.testing.expectEqualStrings("stream-request", exchanges[0].request_body.?);
+    try std.testing.expectEqualStrings("stream-response", exchanges[0].response_body);
+    try std.testing.expectEqual(@as(usize, 2), exchanges[0].response_headers.len);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_finish_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_deinit_count);
 }
 
-test "RecordingTransport toJson" {
-    const allocator = std.testing.allocator;
-
-    var mock = core.http.MockTransport.init(allocator, 201, "{\"id\":\"123\"}");
+test "recording forwards abort and cancel without recording partial responses" {
+    var mock = core.http.MockTransport.init(std.testing.allocator, 200, "body");
     defer mock.deinit();
-
-    var recorder = RecordingTransport.init(allocator, mock.asTransport());
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
     defer recorder.deinit();
 
-    var req = core.http.Request.init(allocator, .POST, "https://example.com/items");
-    defer req.deinit();
-    var resp = try recorder.asTransport().send(&req);
-    defer resp.deinit();
-
-    const json = try recorder.toJson(allocator);
-    defer allocator.free(json);
-
-    // Verify JSON structure.
-    try std.testing.expect(std.mem.find(u8, json, "\"method\":\"POST\"") != null);
-    try std.testing.expect(std.mem.find(u8, json, "\"status\":201") != null);
-    try std.testing.expect(std.mem.find(u8, json, "example.com/items") != null);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/abort",
+    );
+    defer request.deinit();
+    var aborted = try recorder.asTransport().open(&request, .{});
+    aborted.abort();
+    aborted.deinit();
+    var cancelled = try recorder.asTransport().open(&request, .{});
+    cancelled.cancel();
+    cancelled.deinit();
+    try std.testing.expectEqual(@as(usize, 0), recorder.getExchanges().len);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
+    try std.testing.expectEqual(@as(usize, 1), mock.stream_cancel_count);
+    try std.testing.expectEqual(@as(usize, 2), mock.stream_deinit_count);
 }
 
-test "isSensitiveHeader" {
-    try std.testing.expect(isSensitiveHeader("Authorization"));
-    try std.testing.expect(isSensitiveHeader("authorization"));
-    try std.testing.expect(isSensitiveHeader("Api-Key"));
-    try std.testing.expect(!isSensitiveHeader("Content-Type"));
-    try std.testing.expect(!isSensitiveHeader("Accept"));
+test "recording and playback preserve streaming redirect sequences" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "ignored",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 200, .body = "done" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/start",
+    );
+    defer request.deinit();
+    var operation = try recorder.asTransport().open(&request, .{});
+    try operation.finish();
+    operation.deinit();
+    try std.testing.expectEqual(@as(usize, 2), recorder.getExchanges().len);
+
+    const owned = recorder.getExchanges();
+    var recordings: [2]RecordedExchange = undefined;
+    for (owned, &recordings) |exchange, *recording| {
+        recording.* = .{
+            .request_method = exchange.request_method,
+            .request_url = exchange.request_url,
+            .request_headers = exchange.request_headers,
+            .request_body = exchange.request_body,
+            .response_status = exchange.response_status,
+            .response_body = exchange.response_body,
+            .response_headers = exchange.response_headers,
+        };
+    }
+    var playback = PlaybackTransport.init(std.testing.allocator, &recordings);
+    var replay_request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/start",
+    );
+    defer replay_request.deinit();
+    var replay = try playback.asTransport().open(&replay_request, .{});
+    const body = try (try replay.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("done", body);
+    try replay.finish();
+    replay.deinit();
+}
+
+test "recording JSON redacts headers and URL query credentials" {
+    var mock = core.http.MockTransport.init(std.testing.allocator, 200, "ok");
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/items?sig=secret&version=1",
+    );
+    defer request.deinit();
+    try request.setHeader("Authorization", "Bearer secret");
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "REDACTED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "Bearer secret") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "sig=secret") == null);
+}
+
+test "recording JSON refuses recognized credential bodies" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "{\"access_token\":\"secret\"}",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/token",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    try std.testing.expectError(
+        error.SensitiveBodyRequiresSanitization,
+        recorder.toJson(std.testing.allocator),
+    );
+}
+
+fn playbackAllocationFixture(allocator: std.mem.Allocator) !void {
+    const recordings = [_]RecordedExchange{.{
+        .request_method = .GET,
+        .request_url = "https://example.com",
+        .response_status = 200,
+        .response_body = "response",
+        .response_headers = &.{.{ .name = "X-Test", .value = "value" }},
+    }};
+    var playback = PlaybackTransport.init(allocator, &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com",
+    );
+    defer request.deinit();
+    var operation = try playback.asTransport().open(&request, .{});
+    defer operation.deinit();
+    try operation.finish();
+}
+
+fn recordingAllocationFixture(allocator: std.mem.Allocator) !void {
+    var mock = core.http.MockTransport.init(allocator, 200, "response");
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(allocator, mock.asTransport());
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com",
+    );
+    defer request.deinit();
+    var source = std.Io.Reader.fixed("request");
+    var operation = try recorder.asTransport().open(&request, .{
+        .body = core.http.StreamingRequestBody.chunked(&source),
+    });
+    defer operation.deinit();
+    try operation.finish();
+}
+
+fn recordingRedirectAllocationFixture(allocator: std.mem.Allocator) !void {
+    var sequence = core.http.SequenceMockTransport.init(
+        allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "ignored",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 200, .body = "done" },
+        },
+    );
+    var recorder = RecordingTransport.init(allocator, sequence.asTransport());
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com/start",
+    );
+    defer request.deinit();
+    var operation = try recorder.asTransport().open(&request, .{});
+    defer operation.deinit();
+    try operation.finish();
+}
+
+test "transport allocation failures clean up" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        playbackAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        recordingAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        recordingRedirectAllocationFixture,
+        .{},
+    );
+}
+
+test "initHttpRuntime preserves selected transport and crypto provider" {
+    var playback = PlaybackTransport.init(std.testing.allocator, &.{});
+    const Spy = struct {
+        fn random(_: *anyopaque, out: []u8) !void {
+            @memset(out, 0x5a);
+        }
+        fn md5(_: *anyopaque, _: []const u8, out: *core.crypto.Md5Digest) !void {
+            @memset(out, 0x5a);
+        }
+        fn sha256(
+            _: *anyopaque,
+            _: []const u8,
+            out: *core.crypto.Sha256Digest,
+        ) !void {
+            @memset(out, 0x5a);
+        }
+        fn hmac(
+            _: *anyopaque,
+            _: []const u8,
+            _: []const u8,
+            out: *core.crypto.HmacSha256Digest,
+        ) !void {
+            @memset(out, 0x5a);
+        }
+        fn sha256Init(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+        ) !core.crypto.Sha256Operation {
+            return error.Unused;
+        }
+        const vtable: core.crypto.CryptoProvider.VTable = .{
+            .random_bytes = &random,
+            .md5 = &md5,
+            .sha256 = &sha256,
+            .hmac_sha256 = &hmac,
+            .sha256_init = &sha256Init,
+        };
+    };
+    var context: u8 = 0;
+    const provider = core.crypto.CryptoProvider{
+        .context = &context,
+        .vtable = &Spy.vtable,
+    };
+    const runtime = initHttpRuntime(playback.asTransport(), provider);
+    var bytes: [2]u8 = undefined;
+    try runtime.crypto.randomBytes(&bytes);
+    try std.testing.expectEqualSlices(u8, &.{ 0x5a, 0x5a }, &bytes);
+    try std.testing.expectEqual(
+        playback.asTransport().context,
+        runtime.transport.context,
+    );
+}
+
+test "initHttpRuntime propagates selected provider failures" {
+    var playback = PlaybackTransport.init(std.testing.allocator, &.{});
+    const Fault = struct {
+        fn failRandom(_: *anyopaque, _: []u8) !void {
+            return error.ProviderFailure;
+        }
+        fn failMd5(
+            _: *anyopaque,
+            _: []const u8,
+            _: *core.crypto.Md5Digest,
+        ) !void {
+            return error.ProviderFailure;
+        }
+        fn failSha256(
+            _: *anyopaque,
+            _: []const u8,
+            _: *core.crypto.Sha256Digest,
+        ) !void {
+            return error.ProviderFailure;
+        }
+        fn failHmac(
+            _: *anyopaque,
+            _: []const u8,
+            _: []const u8,
+            _: *core.crypto.HmacSha256Digest,
+        ) !void {
+            return error.ProviderFailure;
+        }
+        fn failSha256Init(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+        ) !core.crypto.Sha256Operation {
+            return error.ProviderFailure;
+        }
+        const vtable: core.crypto.CryptoProvider.VTable = .{
+            .random_bytes = &failRandom,
+            .md5 = &failMd5,
+            .sha256 = &failSha256,
+            .hmac_sha256 = &failHmac,
+            .sha256_init = &failSha256Init,
+        };
+    };
+    var context: u8 = 0;
+    const runtime = initHttpRuntime(playback.asTransport(), .{
+        .context = &context,
+        .vtable = &Fault.vtable,
+    });
+    var bytes: [1]u8 = undefined;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        runtime.crypto.randomBytes(&bytes),
+    );
 }

--- a/root.zig
+++ b/root.zig
@@ -71,6 +71,39 @@ pub const ParsedRecordings = struct {
     }
 };
 
+pub const BodyDirection = enum {
+    request,
+    response,
+};
+
+/// Exchange-aware input for an optional recording body policy.
+pub const BodySafetyContext = struct {
+    direction: BodyDirection,
+    method: core.http.Method,
+    url: []const u8,
+    content_type: ?[]const u8,
+    body: []const u8,
+};
+
+/// A caller body policy may add a schema-specific rejection or explicitly
+/// allow an otherwise opaque/unsupported body that the caller knows is safe.
+///
+/// Built-in recognized credentials and private-key markers are never bypassed
+/// by `allow_opaque`.
+pub const BodyPolicyDecision = enum {
+    inspect,
+    reject_sensitive,
+    allow_opaque,
+};
+
+pub const RecordingOptions = struct {
+    body_policy_context: ?*anyopaque = null,
+    bodyPolicyFn: ?*const fn (
+        context: ?*anyopaque,
+        body: BodySafetyContext,
+    ) BodyPolicyDecision = null,
+};
+
 /// Parse the versioned, lossless JSON format emitted by `toJson`.
 ///
 /// All returned strings and decoded bodies are allocator-owned. Invalid JSON,
@@ -305,11 +338,13 @@ const PlaybackOperation = struct {
 ///
 /// The inner descriptor is copied by value. Its context, this recording
 /// transport, and the recording allocator must outlive every open operation.
-/// `deinit` does not deinitialize the borrowed inner transport.
+/// A configured body-policy context is also borrowed and must outlive calls to
+/// `toJson`. `deinit` does not deinitialize either borrowed context.
 pub const RecordingTransport = struct {
     inner: core.http.HttpTransport,
     exchanges: std.ArrayList(OwnedExchange) = .empty,
     allocator: std.mem.Allocator,
+    options: RecordingOptions,
 
     const vtable: core.http.HttpTransport.VTable = .{
         .send = &sendImpl,
@@ -320,7 +355,19 @@ pub const RecordingTransport = struct {
         allocator: std.mem.Allocator,
         inner: core.http.HttpTransport,
     ) RecordingTransport {
-        return .{ .inner = inner, .allocator = allocator };
+        return initWithOptions(allocator, inner, .{});
+    }
+
+    pub fn initWithOptions(
+        allocator: std.mem.Allocator,
+        inner: core.http.HttpTransport,
+        options: RecordingOptions,
+    ) RecordingTransport {
+        return .{
+            .inner = inner,
+            .allocator = allocator,
+            .options = options,
+        };
     }
 
     pub fn asTransport(self: *RecordingTransport) core.http.HttpTransport {
@@ -371,8 +418,18 @@ pub const RecordingTransport = struct {
             .{recording_format_version},
         );
         for (self.exchanges.items, 0..) |exchange, index| {
-            try ensureBodySafe(allocator, exchange.request_body);
-            try ensureBodySafe(allocator, exchange.response_body);
+            try ensureExchangeBodySafe(
+                allocator,
+                self.options,
+                exchange,
+                .request,
+            );
+            try ensureExchangeBodySafe(
+                allocator,
+                self.options,
+                exchange,
+                .response,
+            );
             if (index != 0) try writer.writeAll(",");
             try writer.writeAll("\n  {\"request_method\":");
             try writeJsonString(writer, methodToString(exchange.request_method));
@@ -421,6 +478,9 @@ pub const RecordingTransport = struct {
         if (options.body != null and request.body != null)
             return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
+        const open_fn = self.inner.vtable.open;
+        if (open_fn == null and options.body != null)
+            return error.StreamingRequestUnsupported;
 
         var pending = try PendingRequest.init(
             self.allocator,
@@ -429,8 +489,6 @@ pub const RecordingTransport = struct {
         );
         errdefer pending.deinit(self.allocator);
 
-        const open_fn = self.inner.vtable.open orelse
-            return error.WrappedTransportDoesNotSupportOpen;
         var inner_options = options;
         var request_capture: CapturingReader = undefined;
         var has_capture = false;
@@ -445,16 +503,21 @@ pub const RecordingTransport = struct {
         }
         defer if (has_capture) request_capture.deinit();
 
-        const inner_operation = open_fn(
-            self.inner.context,
-            request,
-            inner_options,
-        ) catch |err| {
-            if (has_capture) {
-                if (request_capture.failure) |failure| return failure;
+        const inner_operation = if (open_fn) |call_open|
+            call_open(
+                self.inner.context,
+                request,
+                inner_options,
+            ) catch |err| {
+                if (has_capture) {
+                    if (request_capture.failure) |failure| return failure;
+                }
+                return err;
             }
-            return err;
-        };
+        else
+            try BufferedInnerOperation.create(
+                try self.inner.vtable.send(self.inner.context, request),
+            );
         errdefer {
             inner_operation.abort();
             inner_operation.deinit();
@@ -504,6 +567,52 @@ const PendingRequest = struct {
         deinitHeaderPairs(allocator, self.headers);
         if (self.body) |body| allocator.free(body);
         self.* = undefined;
+    }
+};
+
+const BufferedInnerOperation = struct {
+    operation: core.http.HttpOperation,
+    response: core.http.Response,
+    reader_impl: std.Io.Reader,
+
+    fn create(
+        response_value: core.http.Response,
+    ) !*core.http.HttpOperation {
+        var response = response_value;
+        errdefer response.deinit();
+        const self = try response.allocator.create(BufferedInnerOperation);
+        self.* = .{
+            .operation = undefined,
+            .response = response,
+            .reader_impl = std.Io.Reader.fixed(response.body),
+        };
+        self.operation = .{
+            .status_code = response.status_code,
+            .headers = response.headers,
+            .response_headers = response.response_headers,
+            .body_reader = &self.reader_impl,
+            .finishFn = &finishImpl,
+            .abortFn = &abortImpl,
+            .cancelFn = &abortImpl,
+            .deinitFn = &deinitImpl,
+        };
+        return &self.operation;
+    }
+
+    fn finishImpl(operation: *core.http.HttpOperation) !void {
+        const self: *BufferedInnerOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        _ = try self.reader_impl.discardRemaining();
+    }
+
+    fn abortImpl(_: *core.http.HttpOperation) void {}
+
+    fn deinitImpl(operation: *core.http.HttpOperation) void {
+        const self: *BufferedInnerOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        const allocator = self.response.allocator;
+        self.response.deinit();
+        allocator.destroy(self);
     }
 };
 
@@ -1272,6 +1381,10 @@ const explicitly_sensitive_headers = [_][]const u8{
     "x-ms-sas-token",
     "aeg-sas-key",
     "aeg-sas-token",
+    "aad-token",
+    "identity-token",
+    "lock-token",
+    "x-auth-token",
     "ocp-apim-subscription-key",
     "api-key",
     "x-api-key",
@@ -1330,6 +1443,11 @@ const sensitive_body_fields = [_][]const u8{
     "outputdatauri",
     "urlsource",
     "token",
+    "aadtoken",
+    "identitytoken",
+    "oidctoken",
+    "assertiontoken",
+    "sastoken",
     "aegsaskey",
     "aegsastoken",
     "authorization",
@@ -1370,7 +1488,10 @@ pub fn isSensitiveHeader(name: []const u8) bool {
         containsIgnoreCase(name, "credential") or
         containsIgnoreCase(name, "secret") or
         containsIgnoreCase(name, "signature") or
-        containsIgnoreCase(name, "token") or
+        containsIgnoreCase(name, "auth-token") or
+        containsIgnoreCase(name, "access-token") or
+        containsIgnoreCase(name, "refresh-token") or
+        containsIgnoreCase(name, "sas-token") or
         containsIgnoreCase(name, "encryption-key") or
         containsIgnoreCase(name, "api-key") or
         containsIgnoreCase(name, "apikey") or
@@ -1386,12 +1507,75 @@ pub fn isSensitiveHeader(name: []const u8) bool {
     return isFullyRedactedUrlHeader(name);
 }
 
+fn ensureExchangeBodySafe(
+    allocator: std.mem.Allocator,
+    options: RecordingOptions,
+    exchange: OwnedExchange,
+    direction: BodyDirection,
+) !void {
+    const body = switch (direction) {
+        .request => exchange.request_body,
+        .response => exchange.response_body,
+    };
+    const bytes = body orelse return;
+    if (bytes.len == 0) return;
+    const headers = switch (direction) {
+        .request => exchange.request_headers,
+        .response => exchange.response_headers,
+    };
+    const context = BodySafetyContext{
+        .direction = direction,
+        .method = exchange.request_method,
+        .url = exchange.request_url,
+        .content_type = getHeaderPair(headers, "Content-Type"),
+        .body = bytes,
+    };
+    const decision = if (options.bodyPolicyFn) |policy|
+        policy(options.body_policy_context, context)
+    else
+        .inspect;
+    if (decision == .reject_sensitive)
+        return error.SensitiveBodyRequiresSanitization;
+    return ensureBodySafe(
+        allocator,
+        context,
+        decision == .allow_opaque,
+    );
+}
+
 fn ensureBodySafe(
     allocator: std.mem.Allocator,
-    body: ?[]const u8,
+    context: BodySafetyContext,
+    allow_opaque: bool,
 ) !void {
-    const bytes = body orelse return;
-    if (!std.unicode.utf8ValidateSlice(bytes)) return;
+    const bytes = context.body;
+    if (containsPrivateKeyMarker(bytes))
+        return error.SensitiveBodyRequiresSanitization;
+
+    const content_type = context.content_type orelse "";
+    const multipart = containsIgnoreCase(content_type, "multipart/") or
+        (containsIgnoreCase(bytes, "content-disposition:") and
+            containsIgnoreCase(bytes, "form-data"));
+    if (multipart) {
+        if (containsSensitiveMultipartField(bytes))
+            return error.SensitiveBodyRequiresSanitization;
+        if (!allow_opaque) return error.UnsupportedBodySanitization;
+        return;
+    }
+
+    if (!std.unicode.utf8ValidateSlice(bytes)) {
+        if (!allow_opaque) return error.OpaqueBodyNotAllowed;
+        return;
+    }
+
+    const xml = containsIgnoreCase(content_type, "xml") or looksLikeXml(bytes);
+    if (xml) {
+        if (containsSensitiveXml(bytes) or containsSensitiveAssignment(bytes))
+            return error.SensitiveBodyRequiresSanitization;
+        if (!allow_opaque) return error.UnsupportedBodySanitization;
+        return;
+    }
+
     if (looksLikeStructuredJson(bytes)) {
         const parsed = std.json.parseFromSlice(
             std.json.Value,
@@ -1403,15 +1587,85 @@ fn ensureBodySafe(
             else => return error.UnsupportedBodySanitization,
         };
         defer parsed.deinit();
-        if (jsonContainsSensitiveField(parsed.value))
+        if (jsonContainsSensitiveField(parsed.value) or
+            (isKnownSecretEndpoint(context.url) and
+                jsonRootHasValueField(parsed.value)))
+        {
             return error.SensitiveBodyRequiresSanitization;
+        }
     }
     if (containsSensitiveAssignment(bytes) or
-        containsSensitiveXmlElement(bytes) or
-        containsIgnoreCase(bytes, "-----BEGIN PRIVATE KEY-----"))
+        containsSensitiveXml(bytes))
     {
         return error.SensitiveBodyRequiresSanitization;
     }
+}
+
+fn getHeaderPair(headers: []const HeaderPair, name: []const u8) ?[]const u8 {
+    for (headers) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, name)) return header.value;
+    }
+    return null;
+}
+
+fn containsPrivateKeyMarker(body: []const u8) bool {
+    return containsIgnoreCase(body, "-----BEGIN PRIVATE KEY-----") or
+        containsIgnoreCase(body, "-----BEGIN RSA PRIVATE KEY-----") or
+        containsIgnoreCase(body, "-----BEGIN EC PRIVATE KEY-----") or
+        containsIgnoreCase(body, "-----BEGIN ENCRYPTED PRIVATE KEY-----") or
+        containsIgnoreCase(body, "-----BEGIN OPENSSH PRIVATE KEY-----") or
+        (containsIgnoreCase(body, "-----BEGIN ") and
+            containsIgnoreCase(body, "PRIVATE KEY-----"));
+}
+
+fn containsSensitiveMultipartField(body: []const u8) bool {
+    var search_start: usize = 0;
+    while (indexOfIgnoreCasePos(body, search_start, "content-disposition:")) |start| {
+        const line_end = std.mem.indexOfAnyPos(
+            u8,
+            body,
+            start,
+            "\r\n",
+        ) orelse body.len;
+        var parameters = std.mem.splitScalar(u8, body[start..line_end], ';');
+        _ = parameters.next();
+        while (parameters.next()) |parameter| {
+            const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse
+                continue;
+            const name = std.mem.trim(u8, parameter[0..equals], " \t");
+            if (!std.ascii.eqlIgnoreCase(name, "name")) continue;
+            const value = std.mem.trim(
+                u8,
+                parameter[equals + 1 ..],
+                " \t\"'",
+            );
+            if (isSensitiveBodyField(value)) return true;
+        }
+        search_start = line_end;
+    }
+    return false;
+}
+
+fn looksLikeXml(body: []const u8) bool {
+    const trimmed = std.mem.trim(u8, body, " \t\r\n");
+    return trimmed.len != 0 and trimmed[0] == '<';
+}
+
+fn isKnownSecretEndpoint(url: []const u8) bool {
+    return containsIgnoreCase(url, "vault") and
+        containsIgnoreCase(url, "/secrets/");
+}
+
+fn jsonRootHasValueField(value: std.json.Value) bool {
+    const object = switch (value) {
+        .object => |result| result,
+        else => return false,
+    };
+    var iterator = object.iterator();
+    while (iterator.next()) |entry| {
+        if (normalizedFieldEquals(entry.key_ptr.*, "value")) return true;
+    }
+    return false;
 }
 
 fn looksLikeStructuredJson(body: []const u8) bool {
@@ -1468,7 +1722,16 @@ fn isSensitiveBodyField(name: []const u8) bool {
     for (sensitive_body_fields) |field| {
         if (normalizedFieldEquals(name, field)) return true;
     }
-    return false;
+    return normalizedFieldEndsWith(name, "password") or
+        normalizedFieldEndsWith(name, "secret") or
+        normalizedFieldEndsWith(name, "connectionstring") or
+        normalizedFieldEndsWith(name, "apikey") or
+        normalizedFieldEndsWith(name, "accountkey") or
+        normalizedFieldEndsWith(name, "accesskey") or
+        normalizedFieldEndsWith(name, "encryptionkey") or
+        normalizedFieldEndsWith(name, "privatekey") or
+        normalizedFieldEndsWith(name, "sharedkey") or
+        normalizedFieldEndsWith(name, "secretkey");
 }
 
 fn normalizedFieldEquals(name: []const u8, normalized: []const u8) bool {
@@ -1485,6 +1748,24 @@ fn normalizedFieldEquals(name: []const u8, normalized: []const u8) bool {
         normalized_index += 1;
     }
     return normalized_index == normalized.len;
+}
+
+fn normalizedFieldEndsWith(name: []const u8, suffix: []const u8) bool {
+    var name_index = name.len;
+    var suffix_index = suffix.len;
+    while (suffix_index != 0) {
+        while (name_index != 0 and
+            !std.ascii.isAlphanumeric(name[name_index - 1]))
+        {
+            name_index -= 1;
+        }
+        if (name_index == 0) return false;
+        name_index -= 1;
+        suffix_index -= 1;
+        if (std.ascii.toLower(name[name_index]) != suffix[suffix_index])
+            return false;
+    }
+    return true;
 }
 
 fn containsSensitiveAssignment(body: []const u8) bool {
@@ -1539,7 +1820,7 @@ fn percentDecodeFieldName(
     return buffer[0..output_index];
 }
 
-fn containsSensitiveXmlElement(body: []const u8) bool {
+fn containsSensitiveXml(body: []const u8) bool {
     var index: usize = 0;
     while (std.mem.indexOfScalarPos(u8, body, index, '<')) |open| {
         index = open + 1;
@@ -1563,6 +1844,84 @@ fn containsSensitiveXmlElement(body: []const u8) bool {
             name = name[colon + 1 ..];
         }
         if (isSensitiveBodyField(name)) return true;
+
+        while (index < body.len and body[index] != '>') {
+            while (index < body.len and
+                (body[index] == ' ' or
+                    body[index] == '\t' or
+                    body[index] == '\r' or
+                    body[index] == '\n' or
+                    body[index] == '/'))
+            {
+                index += 1;
+            }
+            if (index >= body.len or body[index] == '>') break;
+            const attribute_start = index;
+            while (index < body.len and
+                body[index] != '=' and
+                body[index] != '>' and
+                body[index] != ' ' and
+                body[index] != '\t' and
+                body[index] != '\r' and
+                body[index] != '\n')
+            {
+                index += 1;
+            }
+            var attribute_name = body[attribute_start..index];
+            if (std.mem.lastIndexOfScalar(u8, attribute_name, ':')) |colon| {
+                attribute_name = attribute_name[colon + 1 ..];
+            }
+            while (index < body.len and
+                (body[index] == ' ' or
+                    body[index] == '\t' or
+                    body[index] == '\r' or
+                    body[index] == '\n'))
+            {
+                index += 1;
+            }
+            if (index >= body.len or body[index] != '=') continue;
+            index += 1;
+            while (index < body.len and
+                (body[index] == ' ' or
+                    body[index] == '\t' or
+                    body[index] == '\r' or
+                    body[index] == '\n'))
+            {
+                index += 1;
+            }
+            if (index >= body.len) break;
+            const quote = if (body[index] == '"' or body[index] == '\'')
+                body[index]
+            else
+                0;
+            if (quote != 0) index += 1;
+            const value_start = index;
+            while (index < body.len and
+                if (quote != 0)
+                    body[index] != quote
+                else
+                    body[index] != ' ' and
+                        body[index] != '\t' and
+                        body[index] != '\r' and
+                        body[index] != '\n' and
+                        body[index] != '>')
+            {
+                index += 1;
+            }
+            const attribute_value = body[value_start..index];
+            if (isSensitiveBodyField(attribute_name) or
+                ((normalizedFieldEquals(attribute_name, "key") or
+                    normalizedFieldEquals(attribute_name, "name") or
+                    normalizedFieldEquals(attribute_name, "field") or
+                    normalizedFieldEquals(attribute_name, "property")) and
+                    isSensitiveBodyField(attribute_value)) or
+                containsSensitiveAssignment(attribute_value) or
+                containsPrivateKeyMarker(attribute_value))
+            {
+                return true;
+            }
+            if (quote != 0 and index < body.len) index += 1;
+        }
     }
     return false;
 }
@@ -1678,15 +2037,23 @@ fn isSanitizedUrlHeader(name: []const u8) bool {
 }
 
 fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
-    if (needle.len > haystack.len) return false;
-    var index: usize = 0;
+    return indexOfIgnoreCasePos(haystack, 0, needle) != null;
+}
+
+fn indexOfIgnoreCasePos(
+    haystack: []const u8,
+    start: usize,
+    needle: []const u8,
+) ?usize {
+    if (needle.len > haystack.len or start > haystack.len) return null;
+    var index = start;
     while (index + needle.len <= haystack.len) : (index += 1) {
         if (std.ascii.eqlIgnoreCase(
             haystack[index .. index + needle.len],
             needle,
-        )) return true;
+        )) return index;
     }
-    return false;
+    return null;
 }
 
 fn methodToString(method: core.http.Method) []const u8 {
@@ -1755,6 +2122,38 @@ pub fn expectSuccess(response: core.http.Response) !void {
 
 pub fn expectStatus(response: core.http.Response, expected: u16) !void {
     try std.testing.expectEqual(expected, response.status_code);
+}
+
+const BufferedOnlyTransport = struct {
+    inner: *core.http.MockTransport,
+
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &send,
+    };
+
+    fn asTransport(self: *BufferedOnlyTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn send(
+        context: *anyopaque,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const self: *BufferedOnlyTransport = @ptrCast(@alignCast(context));
+        const transport = self.inner.asTransport();
+        return transport.vtable.send(transport.context, request);
+    }
+};
+
+fn allowKnownSafeOpaqueBody(
+    _: ?*anyopaque,
+    body: BodySafetyContext,
+) BodyPolicyDecision {
+    return if (containsIgnoreCase(body.url, "example.com/invalid") or
+        containsIgnoreCase(body.url, "example.com/nul"))
+        .allow_opaque
+    else
+        .inspect;
 }
 
 test "playback validates request and preserves duplicate response headers" {
@@ -2037,6 +2436,58 @@ test "recording wraps streaming operations and copies descriptor by value" {
     try std.testing.expectEqual(@as(usize, 1), mock.stream_deinit_count);
 }
 
+test "recording preserves buffered open fallback" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "buffered-response",
+    );
+    defer mock.deinit();
+    var buffered_only = BufferedOnlyTransport{ .inner = &mock };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        buffered_only.asTransport(),
+    );
+    defer recorder.deinit();
+
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/buffered",
+    );
+    defer request.deinit();
+    request.body = "buffered-request";
+    var operation = try recorder.asTransport().open(&request, .{});
+    const response = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(response);
+    try std.testing.expectEqualStrings("buffered-response", response);
+    try operation.finish();
+    operation.deinit();
+    try std.testing.expectEqual(@as(usize, 1), recorder.getExchanges().len);
+    try std.testing.expectEqualStrings(
+        "buffered-request",
+        recorder.getExchanges()[0].request_body.?,
+    );
+
+    var streamed_request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/streamed",
+    );
+    defer streamed_request.deinit();
+    var source = std.Io.Reader.fixed("streamed");
+    try std.testing.expectError(
+        error.StreamingRequestUnsupported,
+        recorder.asTransport().open(&streamed_request, .{
+            .body = core.http.StreamingRequestBody.chunked(&source),
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
 test "recording forwards abort and cancel without recording partial responses" {
     var mock = core.http.MockTransport.init(std.testing.allocator, 200, "body");
     defer mock.deinit();
@@ -2171,6 +2622,7 @@ test "sensitive Azure headers are classified case-insensitively" {
     try std.testing.expect(!isSensitiveHeader("Content-Type"));
     try std.testing.expect(!isSensitiveHeader("x-opt-partition-key"));
     try std.testing.expect(!isSensitiveHeader("x-ms-documentdb-partitionkey"));
+    try std.testing.expect(!isSensitiveHeader("x-ms-continuation-token"));
 }
 
 test "Event Grid key and SAS token redactions roundtrip" {
@@ -2534,9 +2986,10 @@ test "recording JSON base64 bodies roundtrip arbitrary bytes" {
             .{ .status = 200, .body = response_bodies[3] },
         },
     );
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         sequence.asTransport(),
+        .{ .bodyPolicyFn = &allowKnownSafeOpaqueBody },
     );
     defer recorder.deinit();
     for (urls, request_bodies) |url, body| {
@@ -2628,6 +3081,7 @@ test "recording JSON rejects structural JSON form XML and connection secrets" {
         "{\"result\":{\"connectionString\":\"Endpoint=x;SharedAccessKey=y\"}}",
         "{\"outer\":[{\"Api-Key\":{\"value\":\"api-value\"}}]}",
         "{\"applicationSecret\":\"application-value\"}",
+        "{\"properties\":{\"vCenterPassword\":\"vcenter-value\",\"NSXT-PASSWORD\":{\"value\":\"nsxt-value\"}}}",
         "client_secret=form-value&grant_type=client_credentials",
         "Endpoint=https://example;AccountKey=account-value",
         "<ListKeys><PrimaryKey>xml-value</PrimaryKey></ListKeys>",
@@ -2639,6 +3093,197 @@ test "recording JSON rejects structural JSON form XML and connection secrets" {
     try expectSensitiveRequestBodyRejected(
         "{\"outer\":{\"CLIENT-ASSERTION\":{\"value\":\"request-value\"}}}",
     );
+}
+
+test "Key Vault root value bodies are endpoint-sensitive" {
+    {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"value\":\"response-key-vault-value\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.vault.azure.net/secrets/name?api-version=7.6",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.SensitiveBodyRequiresSanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
+    {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"id\":\"safe\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .PUT,
+            "https://example.vault.azure.net/secrets/name?api-version=7.6",
+        );
+        defer request.deinit();
+        request.body = "{\"VaLuE\":\"request-key-vault-value\"}";
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.SensitiveBodyRequiresSanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
+}
+
+test "multipart token fields and XML credential attributes are rejected" {
+    {
+        const multipart_body =
+            "--boundary\r\n" ++
+            "Content-Disposition: form-data; name=\"refreshToken\"\r\n\r\n" ++
+            "registry-refresh-value\r\n" ++
+            "--boundary\r\n" ++
+            "Content-Disposition: form-data; name=\"accessToken\"\r\n\r\n" ++
+            "registry-access-value\r\n" ++
+            "--boundary--\r\n";
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"message\":\"safe\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            "https://registry.azurecr.io/oauth2/exchange",
+        );
+        defer request.deinit();
+        request.body = multipart_body;
+        try request.setHeader(
+            "Content-Type",
+            "multipart/form-data; boundary=boundary",
+        );
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.SensitiveBodyRequiresSanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
+    {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "<settings><add key=\"Password\" value=\"xml-attribute-value\"/></settings>",
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "application/xml" },
+        };
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.com/settings",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.SensitiveBodyRequiresSanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
+}
+
+test "opaque bodies reject by default and require an explicit safe policy" {
+    const opaque_bodies = [_][]const u8{
+        "\x30\x82\xff\x00pkcs12-like",
+        "\xff\xfeP\x00a\x00s\x00s\x00w\x00o\x00r\x00d\x00",
+        "{\"message\":\"malformed\xff\"}",
+    };
+    for (opaque_bodies) |body| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            body,
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.com/opaque",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.OpaqueBodyNotAllowed,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
+}
+
+test "common private key markers cannot be allowed as opaque" {
+    for ([_][]const u8{
+        "-----BEGIN PRIVATE KEY-----\nvalue\n-----END PRIVATE KEY-----",
+        "-----BEGIN RSA PRIVATE KEY-----\nvalue\n-----END RSA PRIVATE KEY-----",
+        "-----BEGIN EC PRIVATE KEY-----\nvalue\n-----END EC PRIVATE KEY-----",
+        "-----BEGIN ENCRYPTED PRIVATE KEY-----\nvalue\n-----END ENCRYPTED PRIVATE KEY-----",
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nvalue\n-----END OPENSSH PRIVATE KEY-----",
+    }) |body| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            body,
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &allowKnownSafeOpaqueBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.com/invalid",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.SensitiveBodyRequiresSanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
 }
 
 test "recording JSON rejects malformed structured bodies explicitly" {
@@ -2671,7 +3316,7 @@ test "recording JSON decodes safe structured bodies losslessly" {
     const request_body =
         "{\"key\":\"prod*\",\"value\":\"nonsensitive\",\"nested\":{\"kind\":\"filter\"}}";
     const response_body =
-        "{\"items\":[{\"key\":\"prod\",\"value\":\"enabled\"}]}";
+        "{\"items\":[{\"key\":\"prod\",\"value\":\"enabled\"}],\"continuationToken\":\"next\"}";
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
         200,
@@ -2686,7 +3331,7 @@ test "recording JSON decodes safe structured bodies losslessly" {
     var request = core.http.Request.init(
         std.testing.allocator,
         .POST,
-        "https://example.com/safe",
+        "https://config.azconfig.io/kv?key=prod*&api-version=1.0",
     );
     defer request.deinit();
     request.body = request_body;
@@ -2708,13 +3353,31 @@ test "recording JSON decodes safe structured bodies losslessly" {
         response_body,
         parsed.asSlice()[0].response_body,
     );
-    try ensureBodySafe(
+
+    var playback = PlaybackTransport.init(
         std.testing.allocator,
-        parsed.asSlice()[0].request_body,
+        parsed.asSlice(),
     );
-    try ensureBodySafe(
+    var replay_request = core.http.Request.init(
         std.testing.allocator,
-        parsed.asSlice()[0].response_body,
+        .POST,
+        "https://config.azconfig.io/kv?key=prod*&api-version=1.0",
+    );
+    defer replay_request.deinit();
+    replay_request.body = request_body;
+    var replayed = try playback.asTransport().send(&replay_request);
+    defer replayed.deinit();
+    try std.testing.expectEqualSlices(u8, response_body, replayed.body);
+
+    var mismatch = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    replay_request.body =
+        "{\"key\":\"prod*\",\"value\":\"changed\",\"nested\":{\"kind\":\"filter\"}}";
+    try std.testing.expectError(
+        error.BodyMismatch,
+        mismatch.asTransport().send(&replay_request),
     );
 }
 
@@ -2782,6 +3445,29 @@ fn recordingRedirectAllocationFixture(allocator: std.mem.Allocator) !void {
     try operation.finish();
 }
 
+fn recordingBufferedFallbackAllocationFixture(
+    allocator: std.mem.Allocator,
+) !void {
+    var mock = core.http.MockTransport.init(allocator, 200, "response");
+    defer mock.deinit();
+    var buffered_only = BufferedOnlyTransport{ .inner = &mock };
+    var recorder = RecordingTransport.init(
+        allocator,
+        buffered_only.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/buffered",
+    );
+    defer request.deinit();
+    request.body = "request";
+    var operation = try recorder.asTransport().open(&request, .{});
+    defer operation.deinit();
+    try operation.finish();
+}
+
 fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -2831,6 +3517,11 @@ test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         recordingRedirectAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        recordingBufferedFallbackAllocationFixture,
         .{},
     );
     try std.testing.checkAllAllocationFailures(

--- a/root.zig
+++ b/root.zig
@@ -246,14 +246,13 @@ pub const PlaybackTransport = struct {
         return self.recordings[self.index];
     }
 
-    fn matchAndAdvance(
+    fn matchNext(
         self: *PlaybackTransport,
         request: *const core.http.Request,
         body: ?[]const u8,
     ) !RecordedExchange {
         const exchange = try self.next();
         try matchRequest(exchange, request, body);
-        self.index += 1;
         return exchange;
     }
 
@@ -262,8 +261,10 @@ pub const PlaybackTransport = struct {
         request: *core.http.Request,
     ) !core.http.Response {
         const self: *PlaybackTransport = @ptrCast(@alignCast(context));
-        const exchange = try self.matchAndAdvance(request, request.body);
-        return responseFromExchange(self.allocator, exchange);
+        const exchange = try self.matchNext(request, request.body);
+        const response = try responseFromExchange(self.allocator, exchange);
+        self.index += 1;
+        return response;
     }
 
     fn openImpl(
@@ -288,8 +289,9 @@ pub const PlaybackTransport = struct {
             break :blk captured.?;
         } else request.body;
 
-        const exchange = try self.matchAndAdvance(request, body);
+        const exchange = try self.matchNext(request, body);
         const operation = try PlaybackOperation.create(self, exchange);
+        self.index += 1;
         self.open_count += 1;
         return operation;
     }
@@ -1229,9 +1231,7 @@ fn hasRedactedSensitiveQuery(url: []const u8) bool {
     var iterator = std.mem.splitScalar(u8, url[question + 1 .. fragment], '&');
     while (iterator.next()) |parameter| {
         const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse continue;
-        if (isSensitiveQueryField(parameter[0..equals]) and
-            std.mem.eql(u8, parameter[equals + 1 ..], redacted_value))
-        {
+        if (std.mem.eql(u8, parameter[equals + 1 ..], redacted_value)) {
             return true;
         }
     }
@@ -1477,6 +1477,10 @@ const sensitive_body_fields = [_][]const u8{
     "secondaryconnectionstring",
     "primarykey",
     "secondarykey",
+    "primarymasterkey",
+    "secondarymasterkey",
+    "primaryreadonlymasterkey",
+    "secondaryreadonlymasterkey",
     "accountkey",
     "sharedaccesskey",
     "sharedaccesssignature",
@@ -1519,6 +1523,9 @@ const sensitive_query_fields = [_][]const u8{
     "signature",
     "access_token",
     "refresh_token",
+    "id_token",
+    "identity_token",
+    "sas_token",
     "client_secret",
     "client_assertion",
     "password",
@@ -1704,7 +1711,12 @@ fn ensureBodySafe(
         (containsIgnoreCase(bytes, "content-disposition:") and
             containsIgnoreCase(bytes, "form-data"));
     if (multipart) {
-        if (try containsSensitiveMultipartContent(allocator, bytes))
+        if (try containsSensitiveMultipartContent(
+            allocator,
+            content_type,
+            bytes,
+            0,
+        ))
             return error.SensitiveBodyRequiresSanitization;
         if (!allow_opaque) return error.UnsupportedBodySanitization;
         return;
@@ -1811,32 +1823,78 @@ fn containsSensitiveMultipartField(body: []const u8) bool {
 
 fn containsSensitiveMultipartContent(
     allocator: std.mem.Allocator,
+    content_type: []const u8,
     body: []const u8,
+    depth: usize,
 ) !bool {
+    if (depth >= 8) return error.UnsupportedBodySanitization;
     if (containsSensitiveMultipartField(body)) return true;
     if (try containsSensitiveHttpHeaderLine(allocator, body)) return true;
 
-    const first_line_end = std.mem.indexOfAny(u8, body, "\r\n") orelse
-        return false;
-    const delimiter = std.mem.trim(u8, body[0..first_line_end], " \t");
-    if (!std.mem.startsWith(u8, delimiter, "--") or delimiter.len <= 2)
-        return false;
+    const boundary = try multipartBoundary(content_type);
+    const delimiter = try std.fmt.allocPrint(allocator, "--{s}", .{boundary});
+    defer allocator.free(delimiter);
+    var delimiter_start: ?usize = null;
+    var search_start: usize = 0;
+    while (std.mem.indexOfPos(u8, body, search_start, delimiter)) |index| {
+        if (index == 0 or body[index - 1] == '\n') {
+            delimiter_start = index;
+            break;
+        }
+        search_start = index + delimiter.len;
+    }
+    const first_delimiter = delimiter_start orelse
+        return error.UnsupportedBodySanitization;
 
-    var parts = std.mem.splitSequence(u8, body, delimiter);
+    var parts = std.mem.splitSequence(u8, body[first_delimiter..], delimiter);
+    _ = parts.next();
+    var saw_part = false;
+    var saw_close = false;
     while (parts.next()) |raw_part| {
         const part = std.mem.trim(u8, raw_part, " \t\r\n");
-        if (part.len == 0 or std.mem.eql(u8, part, "--")) continue;
-        const outer_separator = findHeaderSeparator(part) orelse continue;
+        if (std.mem.startsWith(u8, part, "--")) {
+            saw_close = true;
+            break;
+        }
+        if (part.len == 0) continue;
+        saw_part = true;
+        const outer_separator = findHeaderSeparator(part) orelse
+            return error.UnsupportedBodySanitization;
+        const outer_headers = part[0..outer_separator.start];
         var payload = part[outer_separator.end..];
+        var payload_content_type = headerValueFromBlock(
+            outer_headers,
+            "Content-Type",
+        );
         if (looksLikeHttpMessage(payload)) {
             const inner_separator = findHeaderSeparator(payload) orelse
-                continue;
+                return error.UnsupportedBodySanitization;
+            const inner_headers = payload[0..inner_separator.start];
+            payload_content_type = headerValueFromBlock(
+                inner_headers,
+                "Content-Type",
+            );
             payload = payload[inner_separator.end..];
         }
         payload = std.mem.trim(u8, payload, " \t\r\n");
         if (payload.len == 0) continue;
+        if (payload_content_type) |part_type| {
+            if (containsIgnoreCase(part_type, "multipart/")) {
+                if (try containsSensitiveMultipartContent(
+                    allocator,
+                    part_type,
+                    payload,
+                    depth + 1,
+                )) return true;
+                continue;
+            }
+        }
         if (try containsSensitiveScalar(allocator, payload)) return true;
-        if (looksLikeStructuredJson(payload)) {
+        const declared_json = if (payload_content_type) |part_type|
+            isJsonContentType(part_type)
+        else
+            false;
+        if (declared_json or looksLikeStructuredJson(payload)) {
             const parsed = std.json.parseFromSlice(
                 std.json.Value,
                 allocator,
@@ -1844,7 +1902,7 @@ fn containsSensitiveMultipartContent(
                 .{},
             ) catch |err| switch (err) {
                 error.OutOfMemory => return err,
-                else => continue,
+                else => return error.UnsupportedBodySanitization,
             };
             defer parsed.deinit();
             if (try jsonContainsSensitiveField(allocator, parsed.value))
@@ -1857,7 +1915,64 @@ fn containsSensitiveMultipartContent(
             return true;
         }
     }
+    if (!saw_part or !saw_close)
+        return error.UnsupportedBodySanitization;
     return false;
+}
+
+fn multipartBoundary(content_type: []const u8) ![]const u8 {
+    var parameters = std.mem.splitScalar(u8, content_type, ';');
+    const media_type = std.mem.trim(u8, parameters.next() orelse "", " \t");
+    if (!std.ascii.startsWithIgnoreCase(media_type, "multipart/"))
+        return error.UnsupportedBodySanitization;
+    while (parameters.next()) |raw_parameter| {
+        const parameter = std.mem.trim(u8, raw_parameter, " \t");
+        const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse
+            continue;
+        const name = std.mem.trim(u8, parameter[0..equals], " \t");
+        if (!std.ascii.eqlIgnoreCase(name, "boundary")) continue;
+        const raw_value = std.mem.trim(
+            u8,
+            parameter[equals + 1 ..],
+            " \t",
+        );
+        var boundary = raw_value;
+        if (raw_value.len != 0 and
+            (raw_value[0] == '"' or raw_value[0] == '\''))
+        {
+            if (raw_value.len < 2 or
+                raw_value[raw_value.len - 1] != raw_value[0])
+            {
+                return error.UnsupportedBodySanitization;
+            }
+            boundary = raw_value[1 .. raw_value.len - 1];
+        } else if (std.mem.indexOfAny(u8, raw_value, "\"'") != null) {
+            return error.UnsupportedBodySanitization;
+        }
+        if (boundary.len == 0 or boundary.len > 70)
+            return error.UnsupportedBodySanitization;
+        for (boundary) |byte| {
+            if (byte <= 0x20 or byte >= 0x7f)
+                return error.UnsupportedBodySanitization;
+        }
+        return boundary;
+    }
+    return error.UnsupportedBodySanitization;
+}
+
+fn headerValueFromBlock(
+    headers: []const u8,
+    expected_name: []const u8,
+) ?[]const u8 {
+    var lines = std.mem.splitScalar(u8, headers, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const name = std.mem.trim(u8, line[0..colon], " \t");
+        if (std.ascii.eqlIgnoreCase(name, expected_name))
+            return std.mem.trim(u8, line[colon + 1 ..], " \t");
+    }
+    return null;
 }
 
 fn containsSensitiveHttpHeaderLine(
@@ -1882,14 +1997,15 @@ fn containsSensitiveHttpHeaderLine(
 }
 
 const HeaderSeparator = struct {
+    start: usize,
     end: usize,
 };
 
 fn findHeaderSeparator(bytes: []const u8) ?HeaderSeparator {
     if (std.mem.indexOf(u8, bytes, "\r\n\r\n")) |index|
-        return .{ .end = index + 4 };
+        return .{ .start = index, .end = index + 4 };
     if (std.mem.indexOf(u8, bytes, "\n\n")) |index|
-        return .{ .end = index + 2 };
+        return .{ .start = index, .end = index + 2 };
     return null;
 }
 
@@ -1935,6 +2051,24 @@ fn jsonContainsExchangeSensitiveSchema(
         isAzureKeyManagementPath(target.path) and
         (jsonRootHasField(value, "key1") or
             jsonRootHasField(value, "key2")))
+    {
+        return true;
+    }
+    if (isAzureManagementHost(target.host) and
+        pathHasResource(target.path, "Microsoft.DocumentDB") and
+        (pathHasResource(target.path, "listKeys") or
+            pathHasResource(target.path, "listReadOnlyKeys")) and
+        (jsonContainsField(value, "primarymasterkey") or
+            jsonContainsField(value, "secondarymasterkey") or
+            jsonContainsField(value, "primaryreadonlymasterkey") or
+            jsonContainsField(value, "secondaryreadonlymasterkey")))
+    {
+        return true;
+    }
+    if (isAzureManagementHost(target.host) and
+        pathHasResource(target.path, "Microsoft.ContainerRegistry") and
+        pathHasResource(target.path, "listCredentials") and
+        jsonContainsField(value, "passwords"))
     {
         return true;
     }
@@ -2330,6 +2464,7 @@ fn isSensitiveBodyField(name: []const u8) bool {
         normalizedFieldEndsWith(name, "connectionstring") or
         normalizedFieldEndsWith(name, "apikey") or
         normalizedFieldEndsWith(name, "accountkey") or
+        normalizedFieldEndsWith(name, "masterkey") or
         normalizedFieldEndsWith(name, "accesskey") or
         normalizedFieldEndsWith(name, "encryptionkey") or
         normalizedFieldEndsWith(name, "privatekey") or
@@ -2564,18 +2699,14 @@ fn writeHeaders(
             .redact => redact = true,
             .preserve => {},
             .inspect => if (isSanitizedUrlHeader(header.name)) {
-                if (try canSanitizeLocationHeader(allocator, header.value)) {
-                    sanitized_url = sanitizeUrlAlloc(
-                        allocator,
-                        header.value,
-                    ) catch |err| switch (err) {
-                        error.SensitiveUrlRequiresSanitization => null,
-                        else => return err,
-                    };
-                    redact = sanitized_url == null;
-                } else {
-                    redact = true;
-                }
+                sanitized_url = sanitizeUrlAlloc(
+                    allocator,
+                    header.value,
+                ) catch |err| switch (err) {
+                    error.SensitiveUrlRequiresSanitization => null,
+                    else => return err,
+                };
+                redact = sanitized_url == null;
             } else {
                 redact = try shouldRedactHeader(
                     allocator,
@@ -2598,80 +2729,6 @@ fn writeHeaders(
     try writer.writeByte(']');
 }
 
-fn canSanitizeLocationHeader(
-    allocator: std.mem.Allocator,
-    url: []const u8,
-) !bool {
-    if (url.len == 0 or
-        std.mem.indexOfAny(u8, url, "\x00\r\n") != null)
-    {
-        return false;
-    }
-    if (std.mem.indexOf(u8, url, "://")) |scheme_end| {
-        const scheme = url[0..scheme_end];
-        if (!std.ascii.eqlIgnoreCase(scheme, "https") and
-            !std.ascii.eqlIgnoreCase(scheme, "http"))
-        {
-            return false;
-        }
-        const authority_start = scheme_end + 3;
-        const authority_end = std.mem.indexOfAnyPos(
-            u8,
-            url,
-            authority_start,
-            "/?#",
-        ) orelse url.len;
-        const authority = url[authority_start..authority_end];
-        if (authority.len == 0 or
-            std.mem.indexOfScalar(u8, authority, '@') != null)
-        {
-            return false;
-        }
-    } else if (std.mem.startsWith(u8, url, "//")) {
-        return false;
-    }
-
-    const question = std.mem.indexOfScalar(u8, url, '?') orelse {
-        return !try containsSensitiveScalar(allocator, url);
-    };
-    if (try containsSensitiveScalar(allocator, url[0..question]))
-        return false;
-    const fragment = std.mem.indexOfScalarPos(
-        u8,
-        url,
-        question + 1,
-        '#',
-    ) orelse url.len;
-    var parameters = std.mem.splitScalar(
-        u8,
-        url[question + 1 .. fragment],
-        '&',
-    );
-    while (parameters.next()) |parameter| {
-        const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse {
-            if (try containsSensitiveScalar(allocator, parameter))
-                return false;
-            continue;
-        };
-        var decoded_name_buffer: [256]u8 = undefined;
-        const decoded_name = percentDecodeFieldName(
-            parameter[0..equals],
-            &decoded_name_buffer,
-        ) orelse return false;
-        if (isSensitiveQueryField(decoded_name)) continue;
-        if (try containsSensitiveScalar(
-            allocator,
-            parameter[equals + 1 ..],
-        )) return false;
-    }
-    if (fragment != url.len and
-        try containsSensitiveScalar(allocator, url[fragment + 1 ..]))
-    {
-        return false;
-    }
-    return true;
-}
-
 fn writeSanitizedUrl(
     writer: *std.Io.Writer,
     allocator: std.mem.Allocator,
@@ -2686,56 +2743,162 @@ fn sanitizeUrlAlloc(
     allocator: std.mem.Allocator,
     url: []const u8,
 ) ![]u8 {
-    const scheme = std.mem.indexOf(u8, url, "://");
-    if (scheme) |index| {
-        const authority_start = index + 3;
-        const authority_end = std.mem.indexOfScalarPos(
+    if (url.len == 0 or std.mem.indexOfAny(u8, url, "\x00\r\n") != null)
+        return error.SensitiveUrlRequiresSanitization;
+    if (std.mem.indexOfScalar(u8, url, '#') != null)
+        return error.SensitiveUrlRequiresSanitization;
+
+    const question = std.mem.indexOfScalar(u8, url, '?');
+    const reference_end = question orelse url.len;
+    var path_start: usize = 0;
+    const scheme_end_value = schemeEndAtReferenceStart(url, reference_end);
+    if (scheme_end_value) |scheme_end| {
+        const scheme = url[0..scheme_end];
+        if (!std.ascii.eqlIgnoreCase(scheme, "https") and
+            !std.ascii.eqlIgnoreCase(scheme, "http"))
+        {
+            return error.SensitiveUrlRequiresSanitization;
+        }
+        if (!std.mem.startsWith(u8, url[scheme_end + 1 ..], "//"))
+            return error.SensitiveUrlRequiresSanitization;
+        const authority_start = scheme_end + 3;
+        const slash = std.mem.indexOfScalarPos(
             u8,
             url,
             authority_start,
             '/',
-        ) orelse std.mem.indexOfScalarPos(
-            u8,
-            url,
-            authority_start,
-            '?',
-        ) orelse url.len;
-        if (std.mem.indexOfScalar(
-            u8,
-            url[authority_start..authority_end],
-            '@',
-        ) != null) return error.SensitiveUrlRequiresSanitization;
+        );
+        const authority_end = if (slash) |index|
+            @min(index, reference_end)
+        else
+            reference_end;
+        const authority = url[authority_start..authority_end];
+        if (authority.len == 0 or
+            std.mem.indexOfScalar(u8, authority, '@') != null)
+        {
+            return error.SensitiveUrlRequiresSanitization;
+        }
+        path_start = authority_end;
+    } else if (std.mem.startsWith(u8, url, "//") or
+        std.mem.indexOf(u8, url[0..reference_end], "://") != null)
+    {
+        return error.SensitiveUrlRequiresSanitization;
     }
 
+    const encoded_path = url[path_start..reference_end];
+    const decoded_path = try percentDecodeAlloc(
+        allocator,
+        encoded_path,
+        false,
+    );
+    defer allocator.free(decoded_path);
+    if (try containsSensitiveScalar(allocator, decoded_path))
+        return error.SensitiveUrlRequiresSanitization;
+
+    const query_start = question orelse return allocator.dupe(u8, url);
     var output: std.Io.Writer.Allocating = .init(allocator);
     errdefer output.deinit();
-    const question = std.mem.indexOfScalar(u8, url, '?') orelse {
-        return allocator.dupe(u8, url);
-    };
-    try output.writer.writeAll(url[0 .. question + 1]);
-    const fragment = std.mem.indexOfScalarPos(u8, url, question + 1, '#') orelse
-        url.len;
+    try output.writer.writeAll(url[0 .. query_start + 1]);
     var first = true;
-    var iterator = std.mem.splitScalar(u8, url[question + 1 .. fragment], '&');
+    var iterator = std.mem.splitScalar(u8, url[query_start + 1 ..], '&');
     while (iterator.next()) |parameter| {
         if (!first) try output.writer.writeByte('&');
         first = false;
         const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse {
-            try output.writer.writeAll(parameter);
+            const decoded = try percentDecodeAlloc(
+                allocator,
+                parameter,
+                true,
+            );
+            defer allocator.free(decoded);
+            if (isSensitiveQueryField(decoded) or
+                try containsSensitiveScalar(allocator, decoded))
+            {
+                try output.writer.writeAll(parameter);
+                try output.writer.writeAll("=");
+                try output.writer.writeAll(redacted_value);
+            } else {
+                try output.writer.writeAll(parameter);
+            }
             continue;
         };
-        const name = parameter[0..equals];
-        try output.writer.writeAll(name);
-        try output.writer.writeByte('=');
-        try output.writer.writeAll(
-            if (isSensitiveQueryField(name))
-                redacted_value
-            else
-                parameter[equals + 1 ..],
+        const encoded_name = parameter[0..equals];
+        const encoded_value = parameter[equals + 1 ..];
+        const decoded_name = try percentDecodeAlloc(
+            allocator,
+            encoded_name,
+            true,
         );
+        defer allocator.free(decoded_name);
+        const decoded_value = try percentDecodeAlloc(
+            allocator,
+            encoded_value,
+            true,
+        );
+        defer allocator.free(decoded_value);
+        const redact = isSensitiveQueryField(decoded_name) or
+            try containsSensitiveScalar(allocator, decoded_value);
+        try output.writer.writeAll(encoded_name);
+        try output.writer.writeByte('=');
+        try output.writer.writeAll(if (redact) redacted_value else encoded_value);
     }
-    try output.writer.writeAll(url[fragment..]);
     return output.toOwnedSlice();
+}
+
+fn schemeEndAtReferenceStart(url: []const u8, reference_end: usize) ?usize {
+    const colon = std.mem.indexOfScalar(u8, url[0..reference_end], ':') orelse
+        return null;
+    const first_delimiter = std.mem.indexOfAny(u8, url[0..reference_end], "/") orelse
+        reference_end;
+    if (colon > first_delimiter or colon == 0 or
+        !std.ascii.isAlphabetic(url[0]))
+    {
+        return null;
+    }
+    for (url[1..colon]) |byte| {
+        if (!std.ascii.isAlphanumeric(byte) and
+            byte != '+' and byte != '-' and byte != '.')
+        {
+            return null;
+        }
+    }
+    return colon;
+}
+
+fn percentDecodeAlloc(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+    plus_as_space: bool,
+) ![]u8 {
+    const decoded = try allocator.alloc(u8, encoded.len);
+    errdefer allocator.free(decoded);
+    var input_index: usize = 0;
+    var output_index: usize = 0;
+    while (input_index < encoded.len) {
+        if (encoded[input_index] == '%') {
+            if (input_index + 2 >= encoded.len)
+                return error.SensitiveUrlRequiresSanitization;
+            const high = std.fmt.charToDigit(
+                encoded[input_index + 1],
+                16,
+            ) catch return error.SensitiveUrlRequiresSanitization;
+            const low = std.fmt.charToDigit(
+                encoded[input_index + 2],
+                16,
+            ) catch return error.SensitiveUrlRequiresSanitization;
+            decoded[output_index] = high * 16 + low;
+            input_index += 3;
+        } else {
+            decoded[output_index] = if (plus_as_space and
+                encoded[input_index] == '+')
+                ' '
+            else
+                encoded[input_index];
+            input_index += 1;
+        }
+        output_index += 1;
+    }
+    return allocator.realloc(decoded, output_index);
 }
 
 fn isSensitiveQueryField(name: []const u8) bool {
@@ -2745,7 +2908,7 @@ fn isSensitiveQueryField(name: []const u8) bool {
     for (sensitive_query_fields) |sensitive| {
         if (std.ascii.eqlIgnoreCase(candidate, sensitive)) return true;
     }
-    return false;
+    return isSensitiveBodyField(candidate);
 }
 
 fn isFullyRedactedUrlHeader(name: []const u8) bool {
@@ -3174,6 +3337,75 @@ test "playback detects URL body and header mismatches without advancing" {
         playback.asTransport().send(&request),
     );
     try std.testing.expectEqual(@as(usize, 0), playback.index);
+}
+
+test "playback allocation failures do not consume buffered exchanges" {
+    const recordings = [_]RecordedExchange{.{
+        .request_method = .GET,
+        .request_url = "https://example.test/retry",
+        .response_status = 200,
+        .response_body = "response",
+        .response_headers = &.{
+            .{ .name = "Content-Type", .value = "text/plain" },
+        },
+    }};
+    var no_memory: [0]u8 = .{};
+    var fixed = std.heap.FixedBufferAllocator.init(&no_memory);
+    var playback = PlaybackTransport.init(fixed.allocator(), &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/retry",
+    );
+    defer request.deinit();
+    try std.testing.expectError(
+        error.OutOfMemory,
+        playback.asTransport().send(&request),
+    );
+    try std.testing.expectEqual(@as(usize, 0), playback.index);
+
+    playback.allocator = std.testing.allocator;
+    var response = try playback.asTransport().send(&request);
+    defer response.deinit();
+    try std.testing.expectEqualStrings("response", response.body);
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
+}
+
+test "playback allocation failures do not consume streaming exchanges" {
+    const recordings = [_]RecordedExchange{.{
+        .request_method = .GET,
+        .request_url = "https://example.test/retry-stream",
+        .response_status = 200,
+        .response_body = "stream-response",
+    }};
+    var no_memory: [0]u8 = .{};
+    var fixed = std.heap.FixedBufferAllocator.init(&no_memory);
+    var playback = PlaybackTransport.init(fixed.allocator(), &recordings);
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/retry-stream",
+    );
+    defer request.deinit();
+    try std.testing.expectError(
+        error.OutOfMemory,
+        playback.asTransport().open(&request, .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 0), playback.index);
+    try std.testing.expectEqual(@as(usize, 0), playback.open_count);
+
+    playback.allocator = std.testing.allocator;
+    var operation = try playback.asTransport().open(&request, .{});
+    defer operation.deinit();
+    const body = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("stream-response", body);
+    try operation.finish();
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
+    try std.testing.expectEqual(@as(usize, 1), playback.open_count);
 }
 
 test "recording wraps streaming operations and copies descriptor by value" {
@@ -3858,6 +4090,115 @@ test "App Configuration key query remains exact" {
     );
 }
 
+test "URL sanitization inspects decoded query path and fragment components" {
+    const recorded_jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
+        "." ++
+        "eyJzdWIiOiJyZWNvcmRlZCIsImV4cCI6NDEwMjQ0NDgwMH0" ++
+        "." ++
+        "c2lnbmF0dXJlLWJ5dGVzLXZhbHVl";
+    const live_jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
+        "." ++
+        "eyJzdWIiOiJsaXZlIiwiZXhwIjo0MTAyNDQ0ODAwfQ" ++
+        "." ++
+        "cm90YXRlZC1zaWduYXR1cmUtdmFsdWU";
+    const recorded_url = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "https://example.test/callback?token={s}&payload=Endpoint%3Dhttps%3A%2F%2Fexample%3BAccountKey%3Dquery-key&return=https%3A%2F%2Fsafe.example%2Fnext",
+        .{recorded_jwt},
+    );
+    defer std.testing.allocator.free(recorded_url);
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        recorded_url,
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, recorded_jwt) == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "query-key") == null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "token=REDACTED") != null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "payload=REDACTED") != null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(
+            u8,
+            json,
+            "return=https%3A%2F%2Fsafe.example%2Fnext",
+        ) != null,
+    );
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    const live_url = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "https://example.test/callback?token={s}&payload=Endpoint%3Dhttps%3A%2F%2Fexample%3BAccountKey%3Drotated-key&return=https%3A%2F%2Fsafe.example%2Fnext",
+        .{live_jwt},
+    );
+    defer std.testing.allocator.free(live_url);
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        live_url,
+    );
+    defer live.deinit();
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
+
+    for ([_][]const u8{
+        "https://example.test/callback/Bearer%20path-secret",
+        "https://example.test/callback#access_token=fragment-secret",
+    }) |unsafe_url| {
+        var unsafe_mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "",
+        );
+        defer unsafe_mock.deinit();
+        var unsafe_recorder = RecordingTransport.init(
+            std.testing.allocator,
+            unsafe_mock.asTransport(),
+        );
+        defer unsafe_recorder.deinit();
+        var unsafe_request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            unsafe_url,
+        );
+        defer unsafe_request.deinit();
+        var unsafe_response =
+            try unsafe_recorder.asTransport().send(&unsafe_request);
+        unsafe_response.deinit();
+        try expectRejectedSerializationExcludes(
+            &unsafe_recorder,
+            error.SensitiveUrlRequiresSanitization,
+            &.{ "path-secret", "fragment-secret" },
+        );
+    }
+}
+
 test "authenticated recording JSON roundtrips with structured redactions" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -4063,6 +4404,10 @@ test "location headers preserve replayable URLs and rotated SAS next exchanges" 
                         .name = "Azure-AsyncOperation",
                         .value = "/operations/1/status?sig=async-sas&api-version=1",
                     },
+                    .{
+                        .name = "Content-Location",
+                        .value = "/callback?return=https://safe.example/next&mode=one",
+                    },
                 },
             },
             .{ .status = 200, .body = "" },
@@ -4126,6 +4471,13 @@ test "location headers preserve replayable URLs and rotated SAS next exchanges" 
         getHeaderPair(
             recordings[1].response_headers,
             "Azure-AsyncOperation",
+        ).?,
+    );
+    try std.testing.expectEqualStrings(
+        "/callback?return=https://safe.example/next&mode=one",
+        getHeaderPair(
+            recordings[1].response_headers,
+            "Content-Location",
         ).?,
     );
     for (recordings[0].response_headers) |header| {
@@ -4641,6 +4993,56 @@ test "Azure key management key1 and key2 responses are rejected" {
     }
 }
 
+test "Cosmos and Container Registry credential schemas are rejected" {
+    const cases = [_]struct {
+        url: []const u8,
+        body: []const u8,
+        secrets: []const []const u8,
+    }{
+        .{
+            .url = "https://management.azure.com/subscriptions/s/resourceGroups/r/providers/Microsoft.DocumentDB/databaseAccounts/a/listKeys?api-version=2025-04-15",
+            .body = "{\"primaryMasterKey\":\"cosmos-primary\",\"secondaryMasterKey\":\"cosmos-secondary\",\"primaryReadonlyMasterKey\":\"cosmos-read-primary\",\"secondaryReadonlyMasterKey\":\"cosmos-read-secondary\"}",
+            .secrets = &.{
+                "cosmos-primary",
+                "cosmos-secondary",
+                "cosmos-read-primary",
+                "cosmos-read-secondary",
+            },
+        },
+        .{
+            .url = "https://management.azure.com/subscriptions/s/resourceGroups/r/providers/Microsoft.ContainerRegistry/registries/a/listCredentials?api-version=2025-04-01",
+            .body = "{\"username\":\"registry-user\",\"passwords\":[{\"name\":\"password\",\"value\":\"registry-password-one\"},{\"name\":\"password2\",\"value\":\"registry-password-two\"}]}",
+            .secrets = &.{ "registry-password-one", "registry-password-two" },
+        },
+    };
+    for (cases) |case| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            case.body,
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            case.url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            case.secrets,
+        );
+    }
+}
+
 test "Kusto source URIs and tabular credential scalars are rejected" {
     const jwt =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
@@ -4836,6 +5238,15 @@ test "multipart application http credentials cannot bypass allow opaque" {
         "--batch\r\nContent-Type: application/http\r\n\r\n" ++
             "GET https://storage.example/table?sv=1&sig=batch-sas HTTP/1.1\r\n\r\n" ++
             "--batch--\r\n",
+        "legal MIME preamble\r\n" ++
+            "--batch\r\nContent-Type: application/json\r\n\r\n" ++
+            "{\"accessToken\":\"nested-json-token\"}\r\n" ++
+            "--batch--\r\n",
+        "legal MIME preamble\r\n" ++
+            "--batch\r\nContent-Type: multipart/mixed; boundary=inner\r\n\r\n" ++
+            "--inner\r\nContent-Type: application/json\r\n\r\n" ++
+            "{\"refreshToken\":\"recursive-json-token\"}\r\n" ++
+            "--inner--\r\n--batch--\r\n",
         jwt_batch,
     }) |body| {
         var mock = core.http.MockTransport.init(
@@ -4874,6 +5285,7 @@ test "multipart application http credentials cannot bypass allow opaque" {
 
 test "safe multipart application http batch roundtrips explicitly" {
     const body =
+        "legal MIME preamble\r\n" ++
         "--batch\r\nContent-Type: application/http\r\n" ++
         "Content-Transfer-Encoding: binary\r\n\r\n" ++
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n" ++
@@ -4886,7 +5298,10 @@ test "safe multipart application http batch roundtrips explicitly" {
     );
     defer mock.deinit();
     mock.response_headers_list = &.{
-        .{ .name = "Content-Type", .value = "multipart/mixed; boundary=batch" },
+        .{
+            .name = "Content-Type",
+            .value = "multipart/mixed; charset=utf-8; boundary=\"batch\"",
+        },
     };
     var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
@@ -4911,6 +5326,54 @@ test "safe multipart application http batch roundtrips explicitly" {
         body,
         parsed.asSlice()[0].response_body,
     );
+}
+
+test "declared malformed multipart fails closed despite allow opaque" {
+    for ([_]struct {
+        content_type: []const u8,
+        body: []const u8,
+    }{
+        .{
+            .content_type = "multipart/mixed",
+            .body = "--batch\r\nContent-Type: text/plain\r\n\r\nsafe\r\n--batch--\r\n",
+        },
+        .{
+            .content_type = "multipart/mixed; boundary=batch",
+            .body = "--batch\r\nContent-Type: text/plain\r\n\r\nsafe\r\n",
+        },
+        .{
+            .content_type = "multipart/mixed; boundary=\"batch",
+            .body = "--batch\r\nContent-Type: text/plain\r\n\r\nsafe\r\n--batch--\r\n",
+        },
+    }) |case| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            case.body,
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = case.content_type },
+        };
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &allowOpaqueBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/multipart",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.UnsupportedBodySanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
 }
 
 test "opaque bodies reject by default and require an explicit safe policy" {
@@ -5146,7 +5609,7 @@ test "non-empty bodies require an explicit caller policy" {
 
 test "App Configuration dotted values are not mistaken for JWTs" {
     const body =
-        "{\"key\":\"endpoint\",\"key1\":\"configuration-label\",\"value\":\"service.production.contoso\"}";
+        "{\"key\":\"endpoint\",\"key1\":\"configuration-label\",\"value\":\"service.production.contoso\",\"passwords\":[{\"name\":\"password\",\"value\":\"ordinary-schema-example\"}]}";
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
         200,

--- a/root.zig
+++ b/root.zig
@@ -16,8 +16,10 @@ pub const HeaderPair = struct {
 ///
 /// Method, URL, and body are matched exactly, including whether a body is
 /// present. Every request header listed here must occur with the same value;
-/// additional live headers are allowed. Response headers retain wire order
-/// and duplicate values.
+/// additional live headers are allowed. `REDACTED` values produced by
+/// `toJson` wildcard only recognized sensitive header values and sensitive
+/// URL query values; nonsensitive fields remain exact. Response headers retain
+/// wire order and duplicate values.
 pub const RecordedExchange = struct {
     request_method: core.http.Method,
     request_url: []const u8,
@@ -47,6 +49,90 @@ pub const OwnedExchange = struct {
         self.* = undefined;
     }
 };
+
+/// Allocator-owned recordings parsed from `RecordingTransport.toJson`.
+///
+/// `asSlice` borrows this value. Keep it alive until playback and all open
+/// playback operations are finished.
+pub const ParsedRecordings = struct {
+    allocator: std.mem.Allocator,
+    owned: []OwnedExchange,
+    recordings: []RecordedExchange,
+
+    pub fn asSlice(self: *const ParsedRecordings) []const RecordedExchange {
+        return self.recordings;
+    }
+
+    pub fn deinit(self: *ParsedRecordings) void {
+        for (self.owned) |*exchange| exchange.deinit(self.allocator);
+        self.allocator.free(self.owned);
+        self.allocator.free(self.recordings);
+        self.* = undefined;
+    }
+};
+
+/// Parse the versioned, lossless JSON format emitted by `toJson`.
+///
+/// All returned strings and decoded bodies are allocator-owned. Invalid JSON,
+/// unsupported versions or encodings, and invalid base64 are distinct errors.
+pub fn parseJson(
+    allocator: std.mem.Allocator,
+    json: []const u8,
+) !ParsedRecordings {
+    const parsed = std.json.parseFromSlice(
+        std.json.Value,
+        allocator,
+        json,
+        .{},
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.InvalidRecordingJson,
+    };
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |value| value,
+        else => return error.InvalidRecordingJson,
+    };
+    const version = root.get("version") orelse return error.InvalidRecordingJson;
+    if (version != .integer or version.integer != recording_format_version)
+        return error.UnsupportedRecordingVersion;
+    const exchanges_value = root.get("exchanges") orelse
+        return error.InvalidRecordingJson;
+    const exchange_values = switch (exchanges_value) {
+        .array => |value| value.items,
+        else => return error.InvalidRecordingJson,
+    };
+
+    const owned = try allocator.alloc(OwnedExchange, exchange_values.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (owned[0..initialized]) |*exchange| exchange.deinit(allocator);
+        allocator.free(owned);
+    }
+    for (exchange_values, owned) |value, *exchange| {
+        exchange.* = try parseExchange(allocator, value);
+        initialized += 1;
+    }
+
+    const recordings = try allocator.alloc(RecordedExchange, owned.len);
+    for (owned, recordings) |exchange, *recording| {
+        recording.* = .{
+            .request_method = exchange.request_method,
+            .request_url = exchange.request_url,
+            .request_headers = exchange.request_headers,
+            .request_body = exchange.request_body,
+            .response_status = exchange.response_status,
+            .response_body = exchange.response_body,
+            .response_headers = exchange.response_headers,
+        };
+    }
+    return .{
+        .allocator = allocator,
+        .owned = owned,
+        .recordings = recordings,
+    };
+}
 
 /// Construct the canonical Core runtime while selecting transport and crypto
 /// independently. Both descriptors are copied and borrow their contexts.
@@ -253,8 +339,8 @@ pub const RecordingTransport = struct {
         return self.exchanges.items;
     }
 
-    /// Serialize recordings while redacting sensitive header values and
-    /// sensitive URL query parameters.
+    /// Serialize version 2 recordings with lossless base64 bodies while
+    /// redacting sensitive header values and sensitive URL query parameters.
     ///
     /// Recognized credential-bearing body fields cause
     /// `error.SensitiveBodyRequiresSanitization`; bodies are never silently
@@ -266,7 +352,22 @@ pub const RecordingTransport = struct {
         var output: std.Io.Writer.Allocating = .init(allocator);
         errdefer output.deinit();
         const writer = &output.writer;
-        try writer.writeAll("[");
+        self.writeJson(writer, allocator) catch |err| switch (err) {
+            error.WriteFailed => return error.OutOfMemory,
+            else => return err,
+        };
+        return output.toOwnedSlice();
+    }
+
+    fn writeJson(
+        self: *const RecordingTransport,
+        writer: *std.Io.Writer,
+        allocator: std.mem.Allocator,
+    ) !void {
+        try writer.print(
+            "{{\"version\":{d},\"exchanges\":[",
+            .{recording_format_version},
+        );
         for (self.exchanges.items, 0..) |exchange, index| {
             try ensureBodySafe(exchange.request_body);
             try ensureBodySafe(exchange.response_body);
@@ -276,19 +377,18 @@ pub const RecordingTransport = struct {
             try writer.writeAll(",\"request_url\":");
             try writeSanitizedUrl(writer, allocator, exchange.request_url);
             try writer.writeAll(",\"request_headers\":");
-            try writeHeaders(writer, exchange.request_headers);
+            try writeHeaders(writer, allocator, exchange.request_headers);
             try writer.writeAll(",\"request_body\":");
-            try writeOptionalJsonString(writer, exchange.request_body);
+            try writeOptionalBody(writer, allocator, exchange.request_body);
             try writer.writeAll(",\"response_status\":");
             try writer.print("{d}", .{exchange.response_status});
             try writer.writeAll(",\"response_headers\":");
-            try writeHeaders(writer, exchange.response_headers);
+            try writeHeaders(writer, allocator, exchange.response_headers);
             try writer.writeAll(",\"response_body\":");
-            try writeJsonString(writer, exchange.response_body);
+            try writeBody(writer, allocator, exchange.response_body);
             try writer.writeAll("}");
         }
-        try writer.writeAll("\n]\n");
-        return output.toOwnedSlice();
+        try writer.writeAll("\n]}\n");
     }
 
     fn sendImpl(
@@ -769,13 +869,148 @@ fn ownedExchangeFromResponse(
     };
 }
 
+fn parseExchange(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !OwnedExchange {
+    const object = switch (value) {
+        .object => |result| result,
+        else => return error.InvalidRecordingJson,
+    };
+    const method_value = object.get("request_method") orelse
+        return error.InvalidRecordingJson;
+    const request_url_value = object.get("request_url") orelse
+        return error.InvalidRecordingJson;
+    const request_headers_value = object.get("request_headers") orelse
+        return error.InvalidRecordingJson;
+    const request_body_value = object.get("request_body") orelse
+        return error.InvalidRecordingJson;
+    const response_status_value = object.get("response_status") orelse
+        return error.InvalidRecordingJson;
+    const response_headers_value = object.get("response_headers") orelse
+        return error.InvalidRecordingJson;
+    const response_body_value = object.get("response_body") orelse
+        return error.InvalidRecordingJson;
+
+    const method = try parseMethod(try jsonString(method_value));
+    const request_url = try allocator.dupe(u8, try jsonString(request_url_value));
+    errdefer allocator.free(request_url);
+    const request_headers = try parseHeaders(allocator, request_headers_value);
+    errdefer deinitHeaderPairs(allocator, request_headers);
+    const request_body = try parseOptionalBody(allocator, request_body_value);
+    errdefer if (request_body) |body| allocator.free(body);
+
+    const response_status_integer = switch (response_status_value) {
+        .integer => |result| result,
+        else => return error.InvalidRecordingJson,
+    };
+    if (response_status_integer < 0 or response_status_integer > 65535)
+        return error.InvalidRecordingJson;
+    const response_headers = try parseHeaders(allocator, response_headers_value);
+    errdefer deinitHeaderPairs(allocator, response_headers);
+    const response_body = try parseBody(allocator, response_body_value);
+    errdefer allocator.free(response_body);
+
+    return .{
+        .request_method = method,
+        .request_url = request_url,
+        .request_headers = request_headers,
+        .request_body = request_body,
+        .response_status = @intCast(response_status_integer),
+        .response_body = response_body,
+        .response_headers = response_headers,
+    };
+}
+
+fn parseHeaders(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) ![]HeaderPair {
+    const values = switch (value) {
+        .array => |result| result.items,
+        else => return error.InvalidRecordingJson,
+    };
+    const headers = try allocator.alloc(HeaderPair, values.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (headers[0..initialized]) |header| {
+            allocator.free(header.name);
+            allocator.free(header.value);
+        }
+        allocator.free(headers);
+    }
+    for (values, headers) |header_value, *header| {
+        const object = switch (header_value) {
+            .object => |result| result,
+            else => return error.InvalidRecordingJson,
+        };
+        const name_value = object.get("name") orelse
+            return error.InvalidRecordingJson;
+        const field_value = object.get("value") orelse
+            return error.InvalidRecordingJson;
+        header.name = try allocator.dupe(u8, try jsonString(name_value));
+        errdefer allocator.free(header.name);
+        header.value = try allocator.dupe(u8, try jsonString(field_value));
+        initialized += 1;
+    }
+    return headers;
+}
+
+fn parseOptionalBody(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !?[]u8 {
+    return switch (value) {
+        .null => null,
+        else => try parseBody(allocator, value),
+    };
+}
+
+fn parseBody(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) ![]u8 {
+    const object = switch (value) {
+        .object => |result| result,
+        else => return error.InvalidRecordingJson,
+    };
+    const encoding_value = object.get("encoding") orelse
+        return error.InvalidRecordingJson;
+    const data_value = object.get("data") orelse
+        return error.InvalidRecordingJson;
+    if (!std.mem.eql(u8, try jsonString(encoding_value), "base64"))
+        return error.UnsupportedBodyEncoding;
+    const encoded = try jsonString(data_value);
+    const length = std.base64.standard.Decoder.calcSizeForSlice(encoded) catch
+        return error.InvalidRecordingBody;
+    const decoded = try allocator.alloc(u8, length);
+    errdefer allocator.free(decoded);
+    std.base64.standard.Decoder.decode(decoded, encoded) catch
+        return error.InvalidRecordingBody;
+    return decoded;
+}
+
+fn jsonString(value: std.json.Value) ![]const u8 {
+    return switch (value) {
+        .string => |result| result,
+        else => error.InvalidRecordingJson,
+    };
+}
+
+fn parseMethod(value: []const u8) !core.http.Method {
+    inline for (std.meta.fields(core.http.Method)) |field| {
+        if (std.mem.eql(u8, value, field.name)) return @enumFromInt(field.value);
+    }
+    return error.InvalidRecordingMethod;
+}
+
 fn matchRequest(
     exchange: RecordedExchange,
     request: *const core.http.Request,
     body: ?[]const u8,
 ) !void {
     if (exchange.request_method != request.method) return error.MethodMismatch;
-    if (!std.mem.eql(u8, exchange.request_url, request.url))
+    if (!try urlMatches(request.allocator, exchange.request_url, request.url))
         return error.UrlMismatch;
     if ((exchange.request_body == null) != (body == null))
         return error.BodyMismatch;
@@ -785,9 +1020,59 @@ fn matchRequest(
     for (exchange.request_headers) |expected| {
         const actual = getHeader(&request.headers, expected.name) orelse
             return error.HeaderMismatch;
-        if (!std.mem.eql(u8, expected.value, actual))
+        if (!try headerValueMatches(
+            request.allocator,
+            expected.name,
+            expected.value,
+            actual,
+        ))
             return error.HeaderMismatch;
     }
+}
+
+fn headerValueMatches(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    expected: []const u8,
+    actual: []const u8,
+) !bool {
+    if (isSensitiveHeader(name) and
+        std.mem.eql(u8, expected, redacted_value))
+    {
+        return true;
+    }
+    if (isSanitizedUrlHeader(name)) {
+        return urlMatches(allocator, expected, actual);
+    }
+    return std.mem.eql(u8, expected, actual);
+}
+
+fn urlMatches(
+    allocator: std.mem.Allocator,
+    expected: []const u8,
+    actual: []const u8,
+) !bool {
+    if (!hasRedactedSensitiveQuery(expected))
+        return std.mem.eql(u8, expected, actual);
+    const sanitized = try sanitizeUrlAlloc(allocator, actual);
+    defer allocator.free(sanitized);
+    return std.mem.eql(u8, expected, sanitized);
+}
+
+fn hasRedactedSensitiveQuery(url: []const u8) bool {
+    const question = std.mem.indexOfScalar(u8, url, '?') orelse return false;
+    const fragment = std.mem.indexOfScalarPos(u8, url, question + 1, '#') orelse
+        url.len;
+    var iterator = std.mem.splitScalar(u8, url[question + 1 .. fragment], '&');
+    while (iterator.next()) |parameter| {
+        const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse continue;
+        if (isSensitiveQueryField(parameter[0..equals]) and
+            std.mem.eql(u8, parameter[equals + 1 ..], redacted_value))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 fn validateRequestFraming(
@@ -966,14 +1251,41 @@ fn deinitResponseStorage(
     deinitOwnedHeaderMap(allocator, headers);
 }
 
-const sensitive_headers = [_][]const u8{
+pub const redacted_value = "REDACTED";
+const recording_format_version = 2;
+
+const explicitly_sensitive_headers = [_][]const u8{
     "authorization",
     "proxy-authorization",
+    "x-ms-authorization-auxiliary",
+    "x-ms-copy-source-authorization",
+    "x-ms-source-authorization",
     "cookie",
     "set-cookie",
     "x-ms-client-secret",
+    "x-ms-client-principal",
+    "x-ms-encryption-key",
+    "x-ms-encryption-key-sha256",
+    "x-ms-sas-token",
     "ocp-apim-subscription-key",
     "api-key",
+    "x-api-key",
+    "x-functions-key",
+    "subscription-key",
+    "x-subscription-key",
+};
+
+const fully_redacted_url_headers = [_][]const u8{
+    "x-ms-copy-source",
+    "x-ms-copy-source-url",
+};
+
+const sanitized_url_headers = [_][]const u8{
+    "location",
+    "content-location",
+    "operation-location",
+    "azure-asyncoperation",
+    "x-ms-rename-source",
 };
 
 const sensitive_body_fields = [_][]const u8{
@@ -995,16 +1307,40 @@ const sensitive_query_fields = [_][]const u8{
     "signature",
     "token",
     "access_token",
+    "refresh_token",
+    "client_secret",
+    "client_assertion",
+    "password",
+    "api_key",
+    "subscription-key",
     "key",
     "secret",
     "code",
 };
 
 pub fn isSensitiveHeader(name: []const u8) bool {
-    for (sensitive_headers) |sensitive| {
+    for (explicitly_sensitive_headers) |sensitive| {
         if (std.ascii.eqlIgnoreCase(name, sensitive)) return true;
     }
-    return false;
+    if (containsIgnoreCase(name, "authorization") or
+        containsIgnoreCase(name, "authentication") or
+        containsIgnoreCase(name, "credential") or
+        containsIgnoreCase(name, "secret") or
+        containsIgnoreCase(name, "signature") or
+        containsIgnoreCase(name, "token") or
+        containsIgnoreCase(name, "encryption-key") or
+        containsIgnoreCase(name, "api-key") or
+        containsIgnoreCase(name, "apikey") or
+        containsIgnoreCase(name, "subscription-key") or
+        containsIgnoreCase(name, "functions-key") or
+        containsIgnoreCase(name, "account-key") or
+        containsIgnoreCase(name, "access-key") or
+        containsIgnoreCase(name, "secret-key") or
+        containsIgnoreCase(name, "shared-key"))
+    {
+        return true;
+    }
+    return isFullyRedactedUrlHeader(name);
 }
 
 fn ensureBodySafe(body: ?[]const u8) !void {
@@ -1017,6 +1353,7 @@ fn ensureBodySafe(body: ?[]const u8) !void {
 
 fn writeHeaders(
     writer: *std.Io.Writer,
+    allocator: std.mem.Allocator,
     headers: []const HeaderPair,
 ) !void {
     try writer.writeByte('[');
@@ -1025,10 +1362,13 @@ fn writeHeaders(
         try writer.writeAll("{\"name\":");
         try writeJsonString(writer, header.name);
         try writer.writeAll(",\"value\":");
-        try writeJsonString(
-            writer,
-            if (isSensitiveHeader(header.name)) "REDACTED" else header.value,
-        );
+        if (isSensitiveHeader(header.name)) {
+            try writeJsonString(writer, redacted_value);
+        } else if (isSanitizedUrlHeader(header.name)) {
+            try writeSanitizedUrl(writer, allocator, header.value);
+        } else {
+            try writeJsonString(writer, header.value);
+        }
         try writer.writeByte('}');
     }
     try writer.writeByte(']');
@@ -1039,6 +1379,15 @@ fn writeSanitizedUrl(
     allocator: std.mem.Allocator,
     url: []const u8,
 ) !void {
+    const sanitized = try sanitizeUrlAlloc(allocator, url);
+    defer allocator.free(sanitized);
+    try writeJsonString(writer, sanitized);
+}
+
+fn sanitizeUrlAlloc(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+) ![]u8 {
     const scheme = std.mem.indexOf(u8, url, "://");
     if (scheme) |index| {
         const authority_start = index + 3;
@@ -1061,9 +1410,9 @@ fn writeSanitizedUrl(
     }
 
     var output: std.Io.Writer.Allocating = .init(allocator);
-    defer output.deinit();
+    errdefer output.deinit();
     const question = std.mem.indexOfScalar(u8, url, '?') orelse {
-        return writeJsonString(writer, url);
+        return allocator.dupe(u8, url);
     };
     try output.writer.writeAll(url[0 .. question + 1]);
     const fragment = std.mem.indexOfScalarPos(u8, url, question + 1, '#') orelse
@@ -1082,18 +1431,32 @@ fn writeSanitizedUrl(
         try output.writer.writeByte('=');
         try output.writer.writeAll(
             if (isSensitiveQueryField(name))
-                "REDACTED"
+                redacted_value
             else
                 parameter[equals + 1 ..],
         );
     }
     try output.writer.writeAll(url[fragment..]);
-    try writeJsonString(writer, output.writer.buffered());
+    return output.toOwnedSlice();
 }
 
 fn isSensitiveQueryField(name: []const u8) bool {
     for (sensitive_query_fields) |sensitive| {
         if (std.ascii.eqlIgnoreCase(name, sensitive)) return true;
+    }
+    return false;
+}
+
+fn isFullyRedactedUrlHeader(name: []const u8) bool {
+    for (fully_redacted_url_headers) |header| {
+        if (std.ascii.eqlIgnoreCase(name, header)) return true;
+    }
+    return false;
+}
+
+fn isSanitizedUrlHeader(name: []const u8) bool {
+    for (sanitized_url_headers) |header| {
+        if (std.ascii.eqlIgnoreCase(name, header)) return true;
     }
     return false;
 }
@@ -1122,15 +1485,30 @@ fn methodToString(method: core.http.Method) []const u8 {
     };
 }
 
-fn writeOptionalJsonString(
+fn writeOptionalBody(
     writer: *std.Io.Writer,
+    allocator: std.mem.Allocator,
     value: ?[]const u8,
 ) !void {
     if (value) |bytes| {
-        try writeJsonString(writer, bytes);
+        try writeBody(writer, allocator, bytes);
     } else {
         try writer.writeAll("null");
     }
+}
+
+fn writeBody(
+    writer: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !void {
+    const encoded_length = std.base64.standard.Encoder.calcSize(value.len);
+    const encoded = try allocator.alloc(u8, encoded_length);
+    defer allocator.free(encoded);
+    const result = std.base64.standard.Encoder.encode(encoded, value);
+    try writer.writeAll("{\"encoding\":\"base64\",\"data\":");
+    try writeJsonString(writer, result);
+    try writer.writeByte('}');
 }
 
 fn writeJsonString(writer: *std.Io.Writer, value: []const u8) !void {
@@ -1554,6 +1932,253 @@ test "recording JSON redacts headers and URL query credentials" {
     try std.testing.expect(std.mem.indexOf(u8, json, "sig=secret") == null);
 }
 
+test "sensitive Azure headers are classified case-insensitively" {
+    for ([_][]const u8{
+        "Authorization",
+        "X-MS-AUTHORIZATION-AUXILIARY",
+        "x-ms-copy-source-authorization",
+        "X-MS-SOURCE-AUTHORIZATION",
+        "x-ms-encryption-key",
+        "X-MS-SOURCE-ENCRYPTION-KEY-SHA256",
+        "X-MS-COPY-SOURCE",
+        "OCP-APIM-SUBSCRIPTION-KEY",
+        "x-functions-key",
+        "X-Auth-Token",
+        "Set-Cookie",
+    }) |name| {
+        try std.testing.expect(isSensitiveHeader(name));
+    }
+    try std.testing.expect(!isSensitiveHeader("Content-Type"));
+    try std.testing.expect(!isSensitiveHeader("x-opt-partition-key"));
+    try std.testing.expect(!isSensitiveHeader("x-ms-documentdb-partitionkey"));
+}
+
+test "authenticated recording JSON roundtrips with structured redactions" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "response",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Set-Cookie", .value = "session=response-cookie-secret" },
+        .{ .name = "X-MS-ENCRYPTION-KEY", .value = "response-key-secret" },
+        .{
+            .name = "x-ms-copy-source-authorization",
+            .value = "Bearer response-copy-auth-secret",
+        },
+        .{
+            .name = "Location",
+            .value = "https://example.com/next?sig=response-sas-secret&next=1",
+        },
+        .{
+            .name = "x-ms-copy-source",
+            .value = "https://storage.example/source?sig=response-copy-secret",
+        },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/items?sig=request-sas-secret&version=1",
+    );
+    defer request.deinit();
+    request.body = "safe request";
+    try request.setHeader("Authorization", "Bearer bearer-secret");
+    try request.setHeader("X-MS-ENCRYPTION-KEY", "encryption-secret");
+    try request.setHeader(
+        "x-ms-source-encryption-key",
+        "source-encryption-secret",
+    );
+    try request.setHeader(
+        "x-ms-source-encryption-key-sha256",
+        "source-encryption-hash",
+    );
+    try request.setHeader(
+        "x-ms-source-authorization",
+        "Bearer source-auth-secret",
+    );
+    try request.setHeader(
+        "x-Ms-CoPy-SoUrCe-AuThOrIzAtIoN",
+        "Bearer copy-auth-secret",
+    );
+    try request.setHeader(
+        "X-MS-COPY-SOURCE",
+        "https://storage.example/source?sig=copy-sas-secret&sp=r",
+    );
+    try request.setHeader(
+        "Ocp-Apim-Subscription-Key",
+        "subscription-secret",
+    );
+    try request.setHeader("x-functions-key", "function-secret");
+    try request.setHeader("X-Stable", "stable-value");
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    for ([_][]const u8{
+        "request-sas-secret",
+        "bearer-secret",
+        "encryption-secret",
+        "copy-auth-secret",
+        "copy-sas-secret",
+        "subscription-secret",
+        "function-secret",
+        "response-cookie-secret",
+        "response-key-secret",
+        "response-copy-auth-secret",
+        "response-sas-secret",
+        "response-copy-secret",
+        "source-encryption-secret",
+        "source-encryption-hash",
+        "source-auth-secret",
+    }) |secret| {
+        try std.testing.expect(std.mem.indexOf(u8, json, secret) == null);
+    }
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "https://storage.example/source") == null,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, json, "sp=r") == null);
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/items?sig=different-sas&version=1",
+    );
+    defer live.deinit();
+    live.body = "safe request";
+    try live.setHeader("Authorization", "Bearer different-bearer");
+    try live.setHeader("x-ms-encryption-key", "different-key");
+    try live.setHeader(
+        "X-MS-SOURCE-ENCRYPTION-KEY",
+        "different-source-key",
+    );
+    try live.setHeader(
+        "X-MS-SOURCE-ENCRYPTION-KEY-SHA256",
+        "different-source-key-hash",
+    );
+    try live.setHeader(
+        "X-MS-SOURCE-AUTHORIZATION",
+        "Bearer different-source-auth",
+    );
+    try live.setHeader(
+        "X-MS-COPY-SOURCE-AUTHORIZATION",
+        "Bearer different-copy-auth",
+    );
+    try live.setHeader(
+        "x-ms-copy-source",
+        "https://elsewhere.example/object?sig=different-copy-sas",
+    );
+    try live.setHeader("ocp-apim-subscription-key", "different-subscription");
+    try live.setHeader("X-FUNCTIONS-KEY", "different-function-key");
+    try live.setHeader("X-Stable", "stable-value");
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
+
+    var header_mismatch = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    try live.setHeader("X-Stable", "changed");
+    try std.testing.expectError(
+        error.HeaderMismatch,
+        header_mismatch.asTransport().send(&live),
+    );
+
+    var url_mismatch = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    try live.setHeader("X-Stable", "stable-value");
+    live.url = "https://example.com/items?sig=different-sas&version=2";
+    try std.testing.expectError(
+        error.UrlMismatch,
+        url_mismatch.asTransport().send(&live),
+    );
+
+    var body_mismatch = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    live.url = "https://example.com/items?sig=different-sas&version=1";
+    live.body = "changed request";
+    try std.testing.expectError(
+        error.BodyMismatch,
+        body_mismatch.asTransport().send(&live),
+    );
+}
+
+test "recording JSON base64 bodies roundtrip arbitrary bytes" {
+    const urls = [_][]const u8{
+        "https://example.com/invalid",
+        "https://example.com/nul",
+        "https://example.com/empty",
+        "https://example.com/utf8",
+    };
+    const request_bodies = [_][]const u8{
+        "\xff\xfe\x80",
+        "\x00request\x00",
+        "",
+        "snowman: \xe2\x98\x83",
+    };
+    const response_bodies = [_][]const u8{
+        "\x80\xff\x00",
+        "response\x00body",
+        "",
+        "lambda: \xce\xbb",
+    };
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{ .status = 200, .body = response_bodies[0] },
+            .{ .status = 200, .body = response_bodies[1] },
+            .{ .status = 200, .body = response_bodies[2] },
+            .{ .status = 200, .body = response_bodies[3] },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    for (urls, request_bodies) |url, body| {
+        var request = core.http.Request.init(std.testing.allocator, .POST, url);
+        defer request.deinit();
+        request.body = body;
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+    }
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(json));
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    for (urls, request_bodies, response_bodies) |url, request_body, expected| {
+        var request = core.http.Request.init(std.testing.allocator, .POST, url);
+        defer request.deinit();
+        request.body = request_body;
+        var response = try playback.asTransport().send(&request);
+        defer response.deinit();
+        try std.testing.expectEqualSlices(u8, expected, response.body);
+    }
+}
+
 test "recording JSON refuses recognized credential bodies" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -1644,6 +2269,41 @@ fn recordingRedirectAllocationFixture(allocator: std.mem.Allocator) !void {
     try operation.finish();
 }
 
+fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "\x00response\xff",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.com/items?sig=secret&version=1",
+    );
+    defer request.deinit();
+    request.body = "\xffrequest\x00";
+    try request.setHeader("Authorization", "Bearer secret");
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(allocator);
+    allocator.free(json);
+}
+
+const allocation_fixture_json =
+    \\{"version":2,"exchanges":[{"request_method":"POST","request_url":"https://example.com","request_headers":[],"request_body":{"encoding":"base64","data":"cmVxdWVzdA=="},"response_status":200,"response_headers":[],"response_body":{"encoding":"base64","data":"cmVzcG9uc2U="}}]}
+;
+
+fn parsingAllocationFixture(allocator: std.mem.Allocator) !void {
+    var parsed = try parseJson(allocator, allocation_fixture_json);
+    parsed.deinit();
+}
+
 test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
@@ -1659,6 +2319,40 @@ test "transport allocation failures clean up" {
         std.testing.allocator,
         recordingRedirectAllocationFixture,
         .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        serializationAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parsingAllocationFixture,
+        .{},
+    );
+}
+
+test "recording parser reports version encoding and base64 errors" {
+    try std.testing.expectError(
+        error.UnsupportedRecordingVersion,
+        parseJson(
+            std.testing.allocator,
+            "{\"version\":1,\"exchanges\":[]}",
+        ),
+    );
+    try std.testing.expectError(
+        error.UnsupportedBodyEncoding,
+        parseJson(
+            std.testing.allocator,
+            "{\"version\":2,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"raw\",\"data\":\"value\"}}]}",
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidRecordingBody,
+        parseJson(
+            std.testing.allocator,
+            "{\"version\":2,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"base64\",\"data\":\"***\"}}]}",
+        ),
     );
 }
 

--- a/root.zig
+++ b/root.zig
@@ -4,8 +4,9 @@
 //! transport descriptors whose opaque contexts borrow the transport values.
 //! The values and any wrapped backend contexts must outlive every descriptor
 //! copy and open operation. Playback is caller-serialized. Recording attempt
-//! ordering/finalization is synchronized; borrowed slices and policy contexts
-//! still require caller synchronization.
+//! ordering/finalization and recorder-owned allocation are synchronized;
+//! borrowed slices, policy contexts, and lifecycle calls still require caller
+//! synchronization.
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
@@ -13,6 +14,7 @@ pub const HeaderPair = struct {
     name: []const u8,
     value: []const u8,
     redacted: bool = false,
+    url_redaction_template: ?[]const u8 = null,
 };
 
 /// Stable failure stages represented by a raw transport attempt.
@@ -47,13 +49,15 @@ pub const RecordedErrorCategory = enum {
 /// Method, URL, and body are matched exactly, including whether a body is
 /// present. Every request header listed here must occur with the same value;
 /// additional live headers are allowed. `REDACTED` values produced by
-/// `toJson` wildcard only recognized sensitive header values and sensitive
-/// URL query values; nonsensitive fields remain exact. Response headers retain
-/// wire order and duplicate values. `outcome` replays stable failure
-/// categories at transport, open, response-body, or finish stages.
+/// `toJson` wildcard only recognized sensitive header values and explicit URL
+/// redaction-template positions; literal `REDACTED` values and nonsensitive
+/// fields remain exact. Response headers retain wire order and duplicate
+/// values. `outcome` replays stable failure categories at transport, open,
+/// response-body, or finish stages.
 pub const RecordedExchange = struct {
     request_method: core.http.Method,
     request_url: []const u8,
+    request_url_redaction_template: ?[]const u8 = null,
     request_headers: []const HeaderPair = &.{},
     request_body: ?[]const u8 = null,
     response_status: u16 = 0,
@@ -67,6 +71,7 @@ pub const RecordedExchange = struct {
 pub const OwnedExchange = struct {
     request_method: core.http.Method,
     request_url: []u8,
+    request_url_redaction_template: ?[]u8 = null,
     request_headers: []HeaderPair,
     request_body: ?[]u8,
     response_status: u16,
@@ -79,6 +84,8 @@ pub const OwnedExchange = struct {
 
     fn deinit(self: *OwnedExchange, allocator: std.mem.Allocator) void {
         allocator.free(self.request_url);
+        if (self.request_url_redaction_template) |template|
+            allocator.free(template);
         deinitHeaderPairs(allocator, self.request_headers);
         if (self.request_body) |body| allocator.free(body);
         allocator.free(self.response_body_allocation orelse self.response_body);
@@ -229,6 +236,7 @@ pub fn parseJson(
         recording.* = .{
             .request_method = exchange.request_method,
             .request_url = exchange.request_url,
+            .request_url_redaction_template = exchange.request_url_redaction_template,
             .request_headers = exchange.request_headers,
             .request_body = exchange.request_body,
             .response_status = exchange.response_status,
@@ -635,15 +643,18 @@ const RecordingMutex = struct {
 /// `toJson`. Each exchange is one completed raw transport attempt, including
 /// redirect, retry, and stable staged failure outcomes. Post-dispatch
 /// bookkeeping failure poisons serialization rather than omitting an attempt.
-/// Attempt ordering and finalization are internally synchronized. Borrowed
-/// slices from `getExchanges` still require caller synchronization. `deinit`
-/// does not deinitialize either borrowed context.
+/// Attempt ordering, finalization, and all recorder-owned allocator calls are
+/// internally synchronized, so the supplied allocator need not be
+/// thread-safe. Borrowed slices from `getExchanges`, policy contexts, and
+/// lifecycle calls still require caller synchronization. `deinit` does not
+/// deinitialize either borrowed context.
 pub const RecordingTransport = struct {
     inner: core.http.HttpTransport,
     exchanges: std.ArrayList(OwnedExchange) = .empty,
     allocator: std.mem.Allocator,
     options: RecordingOptions,
     mutex: RecordingMutex = .{},
+    allocator_mutex: RecordingMutex = .{},
     poisoned: bool = false,
 
     const vtable: core.http.HttpTransport.VTable = .{
@@ -675,10 +686,11 @@ pub const RecordingTransport = struct {
     }
 
     pub fn deinit(self: *RecordingTransport) void {
+        const allocator = self.synchronizedAllocator();
         for (self.exchanges.items) |*exchange| {
-            exchange.deinit(self.allocator);
+            exchange.deinit(allocator);
         }
-        self.exchanges.deinit(self.allocator);
+        self.exchanges.deinit(allocator);
         self.* = undefined;
     }
 
@@ -686,6 +698,92 @@ pub const RecordingTransport = struct {
     /// `resolved == false`; do not retain this slice across concurrent calls.
     pub fn getExchanges(self: *const RecordingTransport) []const OwnedExchange {
         return self.exchanges.items;
+    }
+
+    fn synchronizedAllocator(self: *RecordingTransport) std.mem.Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &synchronized_allocator_vtable,
+        };
+    }
+
+    const synchronized_allocator_vtable: std.mem.Allocator.VTable = .{
+        .alloc = &synchronizedAlloc,
+        .resize = &synchronizedResize,
+        .remap = &synchronizedRemap,
+        .free = &synchronizedFree,
+    };
+
+    fn synchronizedAlloc(
+        context: *anyopaque,
+        len: usize,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        self.allocator_mutex.lock();
+        defer self.allocator_mutex.unlock();
+        return self.allocator.vtable.alloc(
+            self.allocator.ptr,
+            len,
+            alignment,
+            return_address,
+        );
+    }
+
+    fn synchronizedResize(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) bool {
+        const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        self.allocator_mutex.lock();
+        defer self.allocator_mutex.unlock();
+        return self.allocator.vtable.resize(
+            self.allocator.ptr,
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        );
+    }
+
+    fn synchronizedRemap(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        self.allocator_mutex.lock();
+        defer self.allocator_mutex.unlock();
+        return self.allocator.vtable.remap(
+            self.allocator.ptr,
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        );
+    }
+
+    fn synchronizedFree(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) void {
+        const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        self.allocator_mutex.lock();
+        defer self.allocator_mutex.unlock();
+        self.allocator.vtable.free(
+            self.allocator.ptr,
+            memory,
+            alignment,
+            return_address,
+        );
     }
 
     /// False when post-dispatch bookkeeping failed or an open operation was
@@ -719,7 +817,10 @@ pub const RecordingTransport = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         if (self.poisoned) return error.IncompleteRecording;
-        try self.exchanges.ensureUnusedCapacity(self.allocator, 1);
+        try self.exchanges.ensureUnusedCapacity(
+            self.synchronizedAllocator(),
+            1,
+        );
         const ticket = self.exchanges.items.len;
         self.exchanges.appendAssumeCapacity(pending.intoSlot());
         return ticket;
@@ -764,8 +865,9 @@ pub const RecordingTransport = struct {
         defer self.mutex.unlock();
         const slot = &self.exchanges.items[ticket];
         std.debug.assert(!slot.resolved);
-        self.allocator.free(slot.response_body);
-        deinitHeaderPairs(self.allocator, slot.response_headers);
+        const allocator = self.synchronizedAllocator();
+        allocator.free(slot.response_body);
+        deinitHeaderPairs(allocator, slot.response_headers);
         slot.response_status = response.status;
         slot.response_body = response.body;
         slot.response_body_allocation = response.body_allocation;
@@ -790,6 +892,8 @@ pub const RecordingTransport = struct {
     /// `.inspect` explicitly opts supported text into built-in checks;
     /// `.allow_opaque` is the caller's trust boundary for known-safe opaque
     /// content.
+    /// Generated URL wildcard locations are serialized as explicit templates;
+    /// literal `REDACTED` URL values remain exact-match data.
     ///
     /// Structurally recognized credential-bearing JSON, form, connection
     /// string, XML, and private-key bodies cause
@@ -800,10 +904,16 @@ pub const RecordingTransport = struct {
         self: *const RecordingTransport,
         allocator: std.mem.Allocator,
     ) ![]u8 {
-        var output: std.Io.Writer.Allocating = .init(allocator);
+        const mutable = @constCast(self);
+        const output_allocator = if (allocator.ptr == self.allocator.ptr and
+            allocator.vtable == self.allocator.vtable)
+            mutable.synchronizedAllocator()
+        else
+            allocator;
+        var output: std.Io.Writer.Allocating = .init(output_allocator);
         errdefer output.deinit();
         const writer = &output.writer;
-        self.writeJson(writer, allocator) catch |err| switch (err) {
+        self.writeJson(writer, output_allocator) catch |err| switch (err) {
             error.WriteFailed => return error.OutOfMemory,
             else => return err,
         };
@@ -850,7 +960,31 @@ pub const RecordingTransport = struct {
             try writer.writeAll("\n  {\"request_method\":");
             try writeJsonString(writer, methodToString(exchange.request_method));
             try writer.writeAll(",\"request_url\":");
-            try writeSanitizedUrl(writer, allocator, exchange.request_url);
+            const sanitized_request_url = try sanitizeUrlAlloc(
+                allocator,
+                exchange.request_url,
+            );
+            defer allocator.free(sanitized_request_url);
+            try writeJsonString(writer, sanitized_request_url);
+            try writer.writeAll(",\"request_url_redaction_template\":");
+            if (!std.mem.eql(
+                u8,
+                exchange.request_url,
+                sanitized_request_url,
+            )) {
+                const template = try sanitizeUrlAllocWithMarker(
+                    allocator,
+                    exchange.request_url,
+                    "\x00",
+                );
+                defer allocator.free(template);
+                if (std.mem.indexOfScalar(u8, template, 0) != null)
+                    try writeJsonString(writer, template)
+                else
+                    try writer.writeAll("null");
+            } else {
+                try writer.writeAll("null");
+            }
             try writer.writeAll(",\"request_headers\":");
             try writeHeaders(
                 writer,
@@ -894,13 +1028,14 @@ pub const RecordingTransport = struct {
     ) !core.http.Response {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
         try self.ensureCanDispatch();
+        const allocator = self.synchronizedAllocator();
         var pending = try PendingRequest.init(
-            self.allocator,
+            allocator,
             request,
             request.body,
         );
         var pending_owned = true;
-        defer if (pending_owned) pending.deinit(self.allocator);
+        defer if (pending_owned) pending.deinit(allocator);
         const ticket = try self.reserveAttempt(&pending);
         pending_owned = false;
 
@@ -917,7 +1052,7 @@ pub const RecordingTransport = struct {
         };
         errdefer response.deinit();
         const owned_response = ownedResponseFromResponse(
-            self.allocator,
+            allocator,
             &response,
             response.body,
         ) catch |err| {
@@ -935,6 +1070,7 @@ pub const RecordingTransport = struct {
     ) !*core.http.HttpOperation {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
         try self.ensureCanDispatch();
+        const allocator = self.synchronizedAllocator();
         if (options.body != null and request.body != null)
             return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
@@ -943,12 +1079,12 @@ pub const RecordingTransport = struct {
             return error.StreamingRequestUnsupported;
 
         var pending = try PendingRequest.init(
-            self.allocator,
+            allocator,
             request,
             request.body,
         );
         var pending_owned = true;
-        defer if (pending_owned) pending.deinit(self.allocator);
+        defer if (pending_owned) pending.deinit(allocator);
         const ticket = try self.reserveAttempt(&pending);
         pending_owned = false;
 
@@ -957,7 +1093,7 @@ pub const RecordingTransport = struct {
         var has_capture = false;
         if (options.body) |streaming| {
             request_capture.init(
-                self.allocator,
+                allocator,
                 streaming.reader,
                 null,
             );
@@ -1175,28 +1311,29 @@ const RecordingOperation = struct {
         inner: *core.http.HttpOperation,
         ticket: usize,
     ) !*core.http.HttpOperation {
-        const self = try owner.allocator.create(RecordingOperation);
-        errdefer owner.allocator.destroy(self);
-        var header_set = try cloneOperationHeaders(owner.allocator, inner);
-        errdefer header_set.deinit(owner.allocator);
+        const allocator = owner.synchronizedAllocator();
+        const self = try allocator.create(RecordingOperation);
+        errdefer allocator.destroy(self);
+        var header_set = try cloneOperationHeaders(allocator, inner);
+        errdefer header_set.deinit(allocator);
         const inner_reader = try inner.reader();
         const attempt_headers = try cloneResponseHeaders(
-            owner.allocator,
+            allocator,
             &inner.headers,
             &inner.response_headers,
         );
-        errdefer deinitHeaderPairs(owner.allocator, attempt_headers);
+        errdefer deinitHeaderPairs(allocator, attempt_headers);
 
         self.* = .{
             .operation = undefined,
-            .allocator = owner.allocator,
+            .allocator = allocator,
             .owner = owner,
             .inner = inner,
             .ticket = ticket,
             .attempt_headers = attempt_headers,
             .response_reader = undefined,
         };
-        self.response_reader.init(owner.allocator, inner_reader, inner);
+        self.response_reader.init(allocator, inner_reader, inner);
         self.operation = .{
             .status_code = inner.status_code,
             .headers = header_set.map,
@@ -1583,6 +1720,17 @@ fn parseExchange(
         return error.InvalidRecordingJson;
     const request_url_value = object.get("request_url") orelse
         return error.InvalidRecordingJson;
+    const request_url_redaction_template: ?[]u8 =
+        if (format_version == 2 or
+        object.get("request_url_redaction_template") == null)
+            null
+        else switch (object.get("request_url_redaction_template").?) {
+            .null => null,
+            .string => |template| try allocator.dupe(u8, template),
+            else => return error.InvalidRecordingJson,
+        };
+    errdefer if (request_url_redaction_template) |template|
+        allocator.free(template);
     const request_headers_value = object.get("request_headers") orelse
         return error.InvalidRecordingJson;
     const request_body_value = object.get("request_body") orelse
@@ -1590,6 +1738,8 @@ fn parseExchange(
     const method = try parseMethod(try jsonString(method_value));
     const request_url = try allocator.dupe(u8, try jsonString(request_url_value));
     errdefer allocator.free(request_url);
+    if (request_url_redaction_template) |template|
+        try validateUrlRedactionTemplate(request_url, template);
     const request_headers = try parseHeaders(allocator, request_headers_value);
     errdefer deinitHeaderPairs(allocator, request_headers);
     const request_body = try parseOptionalBody(allocator, request_body_value);
@@ -1618,6 +1768,7 @@ fn parseExchange(
         return .{
             .request_method = method,
             .request_url = request_url,
+            .request_url_redaction_template = request_url_redaction_template,
             .request_headers = request_headers,
             .request_body = request_body,
             .response_status = 0,
@@ -1648,6 +1799,7 @@ fn parseExchange(
     return .{
         .request_method = method,
         .request_url = request_url,
+        .request_url_redaction_template = request_url_redaction_template,
         .request_headers = request_headers,
         .request_body = request_body,
         .response_status = @intCast(response_status_integer),
@@ -1692,6 +1844,8 @@ fn parseHeaders(
         for (headers[0..initialized]) |header| {
             allocator.free(header.name);
             allocator.free(header.value);
+            if (header.url_redaction_template) |template|
+                allocator.free(template);
         }
         allocator.free(headers);
     }
@@ -1709,10 +1863,25 @@ fn parseHeaders(
             .bool => |result| result,
             else => return error.InvalidRecordingJson,
         } else false;
+        const url_redaction_template: ?[]u8 =
+            if (object.get("url_redaction_template")) |template_value|
+                switch (template_value) {
+                    .null => null,
+                    .string => |template| try allocator.dupe(u8, template),
+                    else => return error.InvalidRecordingJson,
+                }
+            else
+                null;
+        errdefer if (url_redaction_template) |template|
+            allocator.free(template);
         header.name = try allocator.dupe(u8, try jsonString(name_value));
         errdefer allocator.free(header.name);
         header.value = try allocator.dupe(u8, try jsonString(field_value));
+        errdefer allocator.free(header.value);
         header.redacted = redacted;
+        header.url_redaction_template = url_redaction_template;
+        if (url_redaction_template) |template|
+            try validateUrlRedactionTemplate(header.value, template);
         initialized += 1;
     }
     return headers;
@@ -1759,6 +1928,44 @@ fn jsonString(value: std.json.Value) ![]const u8 {
     };
 }
 
+fn validateUrlRedactionTemplate(
+    visible: []const u8,
+    template: []const u8,
+) !void {
+    var template_offset: usize = 0;
+    var visible_offset: usize = 0;
+    var found_marker = false;
+    while (std.mem.indexOfScalarPos(
+        u8,
+        template,
+        template_offset,
+        0,
+    )) |marker_offset| {
+        found_marker = true;
+        const literal = template[template_offset..marker_offset];
+        if (!std.mem.startsWith(u8, visible[visible_offset..], literal))
+            return error.InvalidRecordingJson;
+        visible_offset += literal.len;
+        if (!std.mem.startsWith(
+            u8,
+            visible[visible_offset..],
+            redacted_value,
+        ))
+            return error.InvalidRecordingJson;
+        visible_offset += redacted_value.len;
+        template_offset = marker_offset + 1;
+    }
+    if (!found_marker or
+        !std.mem.eql(
+            u8,
+            visible[visible_offset..],
+            template[template_offset..],
+        ))
+    {
+        return error.InvalidRecordingJson;
+    }
+}
+
 fn parseMethod(value: []const u8) !core.http.Method {
     inline for (std.meta.fields(core.http.Method)) |field| {
         if (std.mem.eql(u8, value, field.name)) return @enumFromInt(field.value);
@@ -1772,7 +1979,12 @@ fn matchRequest(
     body: ?[]const u8,
 ) !void {
     if (exchange.request_method != request.method) return error.MethodMismatch;
-    if (!try urlMatches(request.allocator, exchange.request_url, request.url))
+    if (!try urlMatches(
+        request.allocator,
+        exchange.request_url,
+        request.url,
+        exchange.request_url_redaction_template,
+    ))
         return error.UrlMismatch;
     if ((exchange.request_body == null) != (body == null))
         return error.BodyMismatch;
@@ -1798,9 +2010,15 @@ fn headerValueMatches(
 ) !bool {
     if (expected.redacted) return true;
     if (isSanitizedUrlHeader(expected.name)) {
-        const sanitized = try sanitizeLocationUrlAlloc(allocator, actual);
+        const template = expected.url_redaction_template orelse
+            return std.mem.eql(u8, expected.value, actual);
+        const sanitized = try sanitizeLocationUrlAllocWithMarker(
+            allocator,
+            actual,
+            "\x00",
+        );
         defer allocator.free(sanitized);
-        return std.mem.eql(u8, expected.value, sanitized);
+        return std.mem.eql(u8, template, sanitized);
     }
     return std.mem.eql(u8, expected.value, actual);
 }
@@ -1809,54 +2027,17 @@ fn urlMatches(
     allocator: std.mem.Allocator,
     expected: []const u8,
     actual: []const u8,
+    redaction_template: ?[]const u8,
 ) !bool {
-    if (!try hasRedactedSensitiveQuery(allocator, expected, 0))
+    const template = redaction_template orelse
         return std.mem.eql(u8, expected, actual);
-    const sanitized = try sanitizeUrlAlloc(allocator, actual);
+    const sanitized = try sanitizeUrlAllocWithMarker(
+        allocator,
+        actual,
+        "\x00",
+    );
     defer allocator.free(sanitized);
-    return std.mem.eql(u8, expected, sanitized);
-}
-
-fn hasRedactedSensitiveQuery(
-    allocator: std.mem.Allocator,
-    url: []const u8,
-    nesting: usize,
-) !bool {
-    if (nesting > max_nested_url_depth) return false;
-    const question = std.mem.indexOfScalar(u8, url, '?') orelse return false;
-    const fragment = std.mem.indexOfScalarPos(u8, url, question + 1, '#') orelse
-        url.len;
-    var iterator = std.mem.splitScalar(u8, url[question + 1 .. fragment], '&');
-    while (iterator.next()) |parameter| {
-        const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse continue;
-        if (std.mem.eql(u8, parameter[equals + 1 ..], redacted_value)) {
-            return true;
-        }
-        var decoded = try allocator.dupe(u8, parameter[equals + 1 ..]);
-        defer allocator.free(decoded);
-        var decode_count: usize = 0;
-        while (decode_count < max_url_decode_depth) : (decode_count += 1) {
-            const next = try percentDecodeAlloc(
-                allocator,
-                decoded,
-                decode_count == 0,
-            );
-            const changed = !std.mem.eql(u8, decoded, next);
-            allocator.free(decoded);
-            decoded = next;
-            if (!changed) break;
-        }
-        if (looksLikeNestedUriReference(decoded) and
-            try hasRedactedSensitiveQuery(
-                allocator,
-                decoded,
-                nesting + 1,
-            ))
-        {
-            return true;
-        }
-    }
-    return false;
+    return std.mem.eql(u8, template, sanitized);
 }
 
 fn validateRequestFraming(
@@ -1994,6 +2175,8 @@ fn deinitHeaderPairs(
     for (headers) |header| {
         allocator.free(header.name);
         allocator.free(header.value);
+        if (header.url_redaction_template) |template|
+            allocator.free(template);
     }
     allocator.free(headers);
 }
@@ -2572,6 +2755,11 @@ fn containsSensitiveLoosePayload(
     const payload = std.mem.trim(u8, raw_payload, " \t\r\n");
     if (payload.len == 0) return false;
     if (try containsSensitiveScalar(allocator, payload)) return true;
+    if (try containsSensitiveXml(allocator, payload) or
+        try containsSensitiveAssignment(allocator, payload))
+    {
+        return true;
+    }
     if (looksLikeStructuredJson(payload)) {
         const parsed = std.json.parseFromSlice(
             std.json.Value,
@@ -2585,13 +2773,11 @@ fn containsSensitiveLoosePayload(
         defer parsed.deinit();
         if (try jsonContainsSensitiveField(allocator, parsed.value))
             return true;
+        return false;
     }
-    if (looksLikeXml(payload) and
-        (try containsSensitiveXml(allocator, payload) or
-            try containsSensitiveAssignment(allocator, payload)))
-    {
-        return true;
-    }
+    if (looksLikeXml(payload)) return false;
+    if (std.mem.indexOfAny(u8, payload, "{}[]<>") != null)
+        return error.UnsupportedBodySanitization;
     return false;
 }
 
@@ -3583,6 +3769,9 @@ fn writeHeaders(
             .inspect;
         var sanitized_url: ?[]u8 = null;
         defer if (sanitized_url) |url| allocator.free(url);
+        var sanitized_template: ?[]u8 = null;
+        defer if (sanitized_template) |template|
+            allocator.free(template);
         var redact = header.redacted;
         if (!redact) switch (decision) {
             .redact => redact = true,
@@ -3596,6 +3785,21 @@ fn writeHeaders(
                     else => return err,
                 };
                 redact = sanitized_url == null;
+                if (sanitized_url) |url| {
+                    if (!std.mem.eql(u8, header.value, url)) {
+                        const template =
+                            try sanitizeLocationUrlAllocWithMarker(
+                                allocator,
+                                header.value,
+                                "\x00",
+                            );
+                        if (std.mem.indexOfScalar(u8, template, 0) != null) {
+                            sanitized_template = template;
+                        } else {
+                            allocator.free(template);
+                        }
+                    }
+                }
             } else {
                 redact = try shouldRedactHeader(
                     allocator,
@@ -3613,31 +3817,50 @@ fn writeHeaders(
             try writeJsonString(writer, header.value);
         }
         try writer.print(",\"redacted\":{}", .{redact});
+        try writer.writeAll(",\"url_redaction_template\":");
+        if (!redact) {
+            if (sanitized_template) |template|
+                try writeJsonString(writer, template)
+            else
+                try writer.writeAll("null");
+        } else {
+            try writer.writeAll("null");
+        }
         try writer.writeByte('}');
     }
     try writer.writeByte(']');
-}
-
-fn writeSanitizedUrl(
-    writer: *std.Io.Writer,
-    allocator: std.mem.Allocator,
-    url: []const u8,
-) !void {
-    const sanitized = try sanitizeUrlAlloc(allocator, url);
-    defer allocator.free(sanitized);
-    try writeJsonString(writer, sanitized);
 }
 
 fn sanitizeUrlAlloc(
     allocator: std.mem.Allocator,
     url: []const u8,
 ) ![]u8 {
-    return sanitizeUrlAllocDepth(allocator, url, 0);
+    return sanitizeUrlAllocWithMarker(allocator, url, redacted_value);
+}
+
+fn sanitizeUrlAllocWithMarker(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    marker: []const u8,
+) ![]u8 {
+    return sanitizeUrlAllocDepth(allocator, url, 0, marker);
 }
 
 fn sanitizeLocationUrlAlloc(
     allocator: std.mem.Allocator,
     url: []const u8,
+) ![]u8 {
+    return sanitizeLocationUrlAllocWithMarker(
+        allocator,
+        url,
+        redacted_value,
+    );
+}
+
+fn sanitizeLocationUrlAllocWithMarker(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    marker: []const u8,
 ) ![]u8 {
     if (std.mem.indexOfScalar(u8, url, '#')) |fragment| {
         if (try encodedComponentIsSensitive(
@@ -3647,10 +3870,14 @@ fn sanitizeLocationUrlAlloc(
             true,
             0,
         )) {
-            return sanitizeUrlAlloc(allocator, url[0..fragment]);
+            return sanitizeUrlAllocWithMarker(
+                allocator,
+                url[0..fragment],
+                marker,
+            );
         }
     }
-    return sanitizeUrlAlloc(allocator, url);
+    return sanitizeUrlAllocWithMarker(allocator, url, marker);
 }
 
 const max_url_decode_depth = 3;
@@ -3698,6 +3925,7 @@ fn sanitizeUrlAllocDepth(
     allocator: std.mem.Allocator,
     url: []const u8,
     nesting: usize,
+    marker: []const u8,
 ) anyerror![]u8 {
     if (nesting > max_nested_url_depth or
         url.len == 0 or
@@ -3802,7 +4030,7 @@ fn sanitizeUrlAllocDepth(
             )) {
                 try output.writer.writeAll(parameter);
                 try output.writer.writeAll("=");
-                try output.writer.writeAll(redacted_value);
+                try output.writer.writeAll(marker);
             } else {
                 try output.writer.writeAll(parameter);
             }
@@ -3817,12 +4045,13 @@ fn sanitizeUrlAllocDepth(
         try output.writer.writeAll(encoded_name);
         try output.writer.writeByte('=');
         if (redact_name) {
-            try output.writer.writeAll(redacted_value);
+            try output.writer.writeAll(marker);
         } else {
             const sanitized_value = try sanitizeQueryValueAlloc(
                 allocator,
                 encoded_value,
                 nesting,
+                marker,
             );
             defer allocator.free(sanitized_value);
             try output.writer.writeAll(sanitized_value);
@@ -3838,58 +4067,89 @@ fn sanitizeQueryValueAlloc(
     allocator: std.mem.Allocator,
     encoded: []const u8,
     nesting: usize,
+    marker: []const u8,
 ) ![]u8 {
     if (encoded.len > max_sanitized_url_length)
-        return allocator.dupe(u8, redacted_value);
+        return allocator.dupe(u8, marker);
     var current = try allocator.dupe(u8, encoded);
     defer allocator.free(current);
-    var decode_count: usize = 0;
-    while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+    var decoded_layers: usize = 0;
+    while (true) {
+        if (looksLikeNestedUriReference(current)) {
+            if (nesting >= max_nested_url_depth)
+                return allocator.dupe(u8, marker);
+            const sanitized_nested = sanitizeUrlAllocDepth(
+                allocator,
+                current,
+                nesting + 1,
+                marker,
+            ) catch |err| switch (err) {
+                error.SensitiveUrlRequiresSanitization => {
+                    return allocator.dupe(u8, marker);
+                },
+                else => return err,
+            };
+            defer allocator.free(sanitized_nested);
+            if (std.mem.eql(u8, current, sanitized_nested))
+                return allocator.dupe(u8, encoded);
+            var result = try allocator.dupe(u8, sanitized_nested);
+            errdefer allocator.free(result);
+            for (0..decoded_layers) |_| {
+                const next = try percentEncodeQueryValueAlloc(
+                    allocator,
+                    result,
+                    marker,
+                );
+                allocator.free(result);
+                result = next;
+            }
+            return result;
+        }
+        if (decoded_layers == max_url_decode_depth) break;
         const decoded = try percentDecodeAlloc(
             allocator,
             current,
-            decode_count == 0,
+            false,
         );
         const changed = !std.mem.eql(u8, current, decoded);
         allocator.free(current);
         current = decoded;
         if (!changed) break;
+        decoded_layers += 1;
     }
     if (containsPercentEscape(current))
-        return allocator.dupe(u8, redacted_value);
-
-    if (looksLikeNestedUriReference(current)) {
-        if (nesting >= max_nested_url_depth)
-            return allocator.dupe(u8, redacted_value);
-        const sanitized_nested = sanitizeUrlAllocDepth(
-            allocator,
-            current,
-            nesting + 1,
-        ) catch |err| switch (err) {
-            error.SensitiveUrlRequiresSanitization => {
-                return allocator.dupe(u8, redacted_value);
-            },
-            else => return err,
-        };
-        defer allocator.free(sanitized_nested);
-        if (std.mem.eql(u8, current, sanitized_nested))
-            return allocator.dupe(u8, encoded);
-        return percentEncodeQueryValueAlloc(allocator, sanitized_nested);
-    }
-
+        return allocator.dupe(u8, marker);
     if (try containsSensitiveScalar(allocator, current))
-        return allocator.dupe(u8, redacted_value);
+        return allocator.dupe(u8, marker);
+    if (std.mem.indexOfScalar(u8, current, '+') != null) {
+        const form_value = try allocator.dupe(u8, current);
+        defer allocator.free(form_value);
+        std.mem.replaceScalar(u8, form_value, '+', ' ');
+        if (try containsSensitiveScalar(allocator, form_value))
+            return allocator.dupe(u8, marker);
+    }
     return allocator.dupe(u8, encoded);
 }
 
 fn percentEncodeQueryValueAlloc(
     allocator: std.mem.Allocator,
     value: []const u8,
+    marker: []const u8,
 ) ![]u8 {
     var output: std.Io.Writer.Allocating = .init(allocator);
     errdefer output.deinit();
     const hex = "0123456789ABCDEF";
-    for (value) |byte| {
+    var index: usize = 0;
+    while (index < value.len) {
+        if (marker.len != 0 and
+            std.mem.startsWith(u8, value[index..], marker))
+        {
+            try output.writer.writeAll(marker);
+            index += marker.len;
+            continue;
+        }
+        const byte = value[index];
+        index += 1;
         if (std.ascii.isAlphanumeric(byte) or
             byte == '-' or byte == '.' or byte == '_' or byte == '~')
         {
@@ -3976,6 +4236,7 @@ fn encodedComponentIsSensitive(
                 allocator,
                 current,
                 nesting + 1,
+                redacted_value,
             ) catch |err| switch (err) {
                 error.SensitiveUrlRequiresSanitization => return true,
                 else => return err,
@@ -4212,6 +4473,136 @@ const BufferedOnlyTransport = struct {
         const self: *BufferedOnlyTransport = @ptrCast(@alignCast(context));
         const transport = self.inner.asTransport();
         return transport.vtable.send(transport.context, request);
+    }
+};
+
+const GuardedAllocator = struct {
+    child: std.mem.Allocator,
+    active: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    overlap: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = &alloc,
+        .resize = &resize,
+        .remap = &remap,
+        .free = &free,
+    };
+
+    fn allocator(self: *GuardedAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    fn enter(self: *GuardedAllocator) void {
+        if (self.active.swap(true, .acquire))
+            self.overlap.store(true, .release);
+        for (0..10_000) |_| std.atomic.spinLoopHint();
+    }
+
+    fn leave(self: *GuardedAllocator) void {
+        self.active.store(false, .release);
+    }
+
+    fn alloc(
+        context: *anyopaque,
+        len: usize,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        return self.child.rawAlloc(len, alignment, return_address);
+    }
+
+    fn resize(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) bool {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        return self.child.rawResize(
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        );
+    }
+
+    fn remap(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        return self.child.rawRemap(
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        );
+    }
+
+    fn free(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) void {
+        const self: *GuardedAllocator = @ptrCast(@alignCast(context));
+        self.enter();
+        defer self.leave();
+        self.child.rawFree(memory, alignment, return_address);
+    }
+};
+
+const ThreadSafeEmptyTransport = struct {
+    const vtable: core.http.HttpTransport.VTable = .{ .send = &send };
+
+    fn asTransport(self: *ThreadSafeEmptyTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn send(
+        _: *anyopaque,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const body = try request.allocator.alloc(u8, 0);
+        return .{
+            .status_code = 200,
+            .headers = std.StringHashMap([]const u8).init(request.allocator),
+            .body = body,
+            .allocator = request.allocator,
+            .response_headers = core.http.ResponseHeaders.init(request.allocator),
+        };
+    }
+};
+
+const ConcurrentRecorderWorker = struct {
+    recorder: *RecordingTransport,
+    start: *std.atomic.Value(bool),
+    failed: *std.atomic.Value(bool),
+
+    fn run(self: *ConcurrentRecorderWorker) void {
+        while (!self.start.load(.acquire)) std.atomic.spinLoopHint();
+        var request = core.http.Request.init(
+            std.heap.page_allocator,
+            .GET,
+            "https://example.test/concurrent",
+        );
+        defer request.deinit();
+        var response = self.recorder.asTransport().send(&request) catch {
+            self.failed.store(true, .release);
+            return;
+        };
+        response.deinit();
     }
 };
 
@@ -5065,6 +5456,51 @@ test "overlapping attempts retain dispatch order and block serialization" {
         request_c.url,
         parsed.asSlice()[2].request_url,
     );
+}
+
+test "recorder serializes backing allocator across threads" {
+    const worker_count = 12;
+    var guarded = GuardedAllocator{ .child = std.heap.page_allocator };
+    var inner = ThreadSafeEmptyTransport{};
+    var recorder = RecordingTransport.init(
+        guarded.allocator(),
+        inner.asTransport(),
+    );
+    var recorder_owned = true;
+    errdefer if (recorder_owned) recorder.deinit();
+    var start = std.atomic.Value(bool).init(false);
+    var failed = std.atomic.Value(bool).init(false);
+    var workers: [worker_count]ConcurrentRecorderWorker = undefined;
+    var threads: [worker_count]std.Thread = undefined;
+    var spawned: usize = 0;
+    errdefer {
+        start.store(true, .release);
+        for (threads[0..spawned]) |thread| thread.join();
+    }
+    for (&workers, &threads) |*worker, *thread| {
+        worker.* = .{
+            .recorder = &recorder,
+            .start = &start,
+            .failed = &failed,
+        };
+        thread.* = try std.Thread.spawn(.{}, ConcurrentRecorderWorker.run, .{
+            worker,
+        });
+        spawned += 1;
+    }
+    start.store(true, .release);
+    for (threads) |thread| thread.join();
+    spawned = 0;
+
+    try std.testing.expect(!failed.load(.acquire));
+    try std.testing.expect(recorder.isComplete());
+    try std.testing.expectEqual(
+        @as(usize, worker_count),
+        recorder.getExchanges().len,
+    );
+    recorder.deinit();
+    recorder_owned = false;
+    try std.testing.expect(!guarded.overlap.load(.acquire));
 }
 
 test "recording preserves buffered open fallback" {
@@ -6969,6 +7405,202 @@ test "nested signed URI preserves exact host path and nonsensitive fields" {
             std.testing.allocator,
             .GET,
             mismatch_url,
+        );
+        defer mismatch.deinit();
+        try std.testing.expectError(
+            error.UrlMismatch,
+            mismatch_playback.asTransport().send(&mismatch),
+        );
+    }
+}
+
+test "nested URI redaction preserves outer encoding depth" {
+    const recorded =
+        "https://example.test/callback?return=" ++
+        "https%3A%2F%2Fstorage.example%2Fa%25252Fb%3F" ++
+        "sig%3Drecorded-secret";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        recorded,
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var rotated = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/callback?return=" ++
+            "https%3A%2F%2Fstorage.example%2Fa%25252Fb%3F" ++
+            "sig%3Drotated-secret",
+    );
+    defer rotated.deinit();
+    var replayed = try playback.asTransport().send(&rotated);
+    replayed.deinit();
+
+    var mismatch_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var mismatch = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/callback?return=" ++
+            "https%3A%2F%2Fstorage.example%2Fa%252Fb%3F" ++
+            "sig%3Drotated-secret",
+    );
+    defer mismatch.deinit();
+    try std.testing.expectError(
+        error.UrlMismatch,
+        mismatch_playback.asTransport().send(&mismatch),
+    );
+}
+
+test "literal redaction marker remains exact beside credential wildcard" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/item?mode=REDACTED&sig=recorded-secret",
+    );
+    defer request.deinit();
+    try request.setHeader(
+        "Operation-Location",
+        "https://next.example/item?mode=REDACTED&sig=recorded-header",
+    );
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var rotated = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/item?mode=REDACTED&sig=rotated-secret",
+    );
+    defer rotated.deinit();
+    try rotated.setHeader(
+        "Operation-Location",
+        "https://next.example/item?mode=REDACTED&sig=rotated-header",
+    );
+    var replayed = try playback.asTransport().send(&rotated);
+    replayed.deinit();
+
+    var mismatch_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var mismatch = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/item?mode=Bearer%20live-secret&sig=rotated-secret",
+    );
+    defer mismatch.deinit();
+    try mismatch.setHeader(
+        "Operation-Location",
+        "https://next.example/item?mode=Bearer%20live-secret&sig=rotated-header",
+    );
+    try std.testing.expectError(
+        error.UrlMismatch,
+        mismatch_playback.asTransport().send(&mismatch),
+    );
+
+    var header_mismatch_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var header_mismatch = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/item?mode=REDACTED&sig=rotated-secret",
+    );
+    defer header_mismatch.deinit();
+    try header_mismatch.setHeader(
+        "Operation-Location",
+        "https://next.example/item?mode=Bearer%20live-secret&sig=rotated-header",
+    );
+    try std.testing.expectError(
+        error.HeaderMismatch,
+        header_mismatch_playback.asTransport().send(&header_mismatch),
+    );
+}
+
+test "legacy recordings never infer URL wildcards from marker text" {
+    const recordings = [_][]const u8{
+        "{\"version\":2,\"exchanges\":[{" ++
+            "\"request_method\":\"GET\"," ++
+            "\"request_url\":\"https://example.test/item?mode=REDACTED\"," ++
+            "\"request_headers\":[],\"request_body\":null," ++
+            "\"response_status\":200,\"response_headers\":[]," ++
+            "\"response_body\":{\"encoding\":\"base64\",\"data\":\"\"}}]}",
+        "{\"version\":3,\"exchanges\":[{" ++
+            "\"request_method\":\"GET\"," ++
+            "\"request_url\":\"https://example.test/item?mode=REDACTED\"," ++
+            "\"request_headers\":[],\"request_body\":null," ++
+            "\"outcome\":\"response\",\"response_status\":200," ++
+            "\"response_headers\":[]," ++
+            "\"response_body\":{\"encoding\":\"base64\",\"data\":\"\"}}]}",
+    };
+    for (recordings) |json| {
+        var parsed = try parseJson(std.testing.allocator, json);
+        defer parsed.deinit();
+        var exact_playback = PlaybackTransport.init(
+            std.testing.allocator,
+            parsed.asSlice(),
+        );
+        var exact = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/item?mode=REDACTED",
+        );
+        defer exact.deinit();
+        var response = try exact_playback.asTransport().send(&exact);
+        response.deinit();
+
+        var mismatch_playback = PlaybackTransport.init(
+            std.testing.allocator,
+            parsed.asSlice(),
+        );
+        var mismatch = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/item?mode=Bearer%20live-secret",
         );
         defer mismatch.deinit();
         try std.testing.expectError(
@@ -9132,6 +9764,62 @@ test "multipart application http credentials cannot bypass allow opaque" {
     }
 }
 
+test "multipart preamble and epilogue structures fail closed" {
+    const cases = [_]struct {
+        body: []const u8,
+        secret: []const u8,
+        expected_error: anyerror,
+    }{
+        .{
+            .body = "notice\r\n{\"clientSecret\":\"preamble-secret\"}\r\n" ++
+                "--batch\r\nContent-Type: text/plain\r\n\r\nsafe\r\n" ++
+                "--batch--\r\n",
+            .secret = "preamble-secret",
+            .expected_error = error.SensitiveBodyRequiresSanitization,
+        },
+        .{
+            .body = "--batch\r\nContent-Type: text/plain\r\n\r\nsafe\r\n" ++
+                "--batch--\r\nnotice\r\n" ++
+                "<add key=\"Password\" value=\"epilogue-secret\"/>",
+            .secret = "epilogue-secret",
+            .expected_error = error.SensitiveBodyRequiresSanitization,
+        },
+    };
+    for (cases) |case| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            case.body,
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{
+                .name = "Content-Type",
+                .value = "multipart/mixed; boundary=batch",
+            },
+        };
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &allowOpaqueBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/multipart-envelope",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            case.expected_error,
+            &.{case.secret},
+        );
+    }
+}
+
 test "safe multipart application http batch roundtrips explicitly" {
     const body =
         "legal MIME preamble\r\n" ++
@@ -9863,13 +10551,42 @@ fn parsingAllocationFixture(allocator: std.mem.Allocator) !void {
 
 const failure_allocation_fixture_json =
     \\{"version":3,"exchanges":[
-    \\{"request_method":"GET","request_url":"https://example.com/open","request_headers":[],"request_body":null,"outcome":"open_error","error_category":"connection"},
-    \\{"request_method":"GET","request_url":"https://example.com/body","request_headers":[],"request_body":null,"outcome":"body_error","error_category":"io","response_status":200,"response_headers":[],"response_body":{"encoding":"base64","data":"cGFydGlhbA=="}}
+    \\{"request_method":"GET","request_url":"https://example.com/open","request_url_redacted":false,"request_headers":[],"request_body":null,"outcome":"open_error","error_category":"connection"},
+    \\{"request_method":"GET","request_url":"https://example.com/body","request_url_redacted":false,"request_headers":[],"request_body":null,"outcome":"body_error","error_category":"io","response_status":200,"response_headers":[],"response_body":{"encoding":"base64","data":"cGFydGlhbA=="}}
     \\]}
 ;
 
 fn failureParsingAllocationFixture(allocator: std.mem.Allocator) !void {
     var parsed = try parseJson(allocator, failure_allocation_fixture_json);
+    parsed.deinit();
+}
+
+const redaction_template_allocation_fixture_json =
+    \\{"version":3,"exchanges":[{
+    \\"request_method":"GET",
+    \\"request_url":"https://example.test/item?sig=REDACTED",
+    \\"request_url_redaction_template":"https://example.test/item?sig=\u0000",
+    \\"request_headers":[{
+    \\"name":"Operation-Location",
+    \\"value":"https://next.example/item?sig=REDACTED",
+    \\"redacted":false,
+    \\"url_redaction_template":"https://next.example/item?sig=\u0000"
+    \\}],
+    \\"request_body":null,
+    \\"outcome":"response",
+    \\"response_status":200,
+    \\"response_headers":[],
+    \\"response_body":{"encoding":"base64","data":""}
+    \\}]}
+;
+
+fn redactionTemplateParsingAllocationFixture(
+    allocator: std.mem.Allocator,
+) !void {
+    var parsed = try parseJson(
+        allocator,
+        redaction_template_allocation_fixture_json,
+    );
     parsed.deinit();
 }
 
@@ -9922,6 +10639,11 @@ test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         failureParsingAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        redactionTemplateParsingAllocationFixture,
         .{},
     );
 }
@@ -10083,21 +10805,21 @@ test "recording parser reports version encoding and base64 errors" {
         error.InvalidRecordingOutcome,
         parseJson(
             std.testing.allocator,
-            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"outcome\":\"backend_specific\"}]}",
+            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_url_redacted\":false,\"request_headers\":[],\"request_body\":null,\"outcome\":\"backend_specific\"}]}",
         ),
     );
     try std.testing.expectError(
         error.InvalidRecordingJson,
         parseJson(
             std.testing.allocator,
-            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"outcome\":\"transport_error\"}]}",
+            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_url_redacted\":false,\"request_headers\":[],\"request_body\":null,\"outcome\":\"transport_error\"}]}",
         ),
     );
     try std.testing.expectError(
         error.InvalidRecordingJson,
         parseJson(
             std.testing.allocator,
-            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"outcome\":\"response\",\"error_category\":\"unknown\",\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"base64\",\"data\":\"\"}}]}",
+            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_url_redacted\":false,\"request_headers\":[],\"request_body\":null,\"outcome\":\"response\",\"error_category\":\"unknown\",\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"base64\",\"data\":\"\"}}]}",
         ),
     );
 }

--- a/root.zig
+++ b/root.zig
@@ -10,6 +10,7 @@ const core = @import("azure_sdk_core");
 pub const HeaderPair = struct {
     name: []const u8,
     value: []const u8,
+    redacted: bool = false,
 };
 
 /// A borrowed HTTP exchange used by playback.
@@ -82,6 +83,7 @@ pub const BodySafetyContext = struct {
     method: core.http.Method,
     url: []const u8,
     content_type: ?[]const u8,
+    content_encoding: ?[]const u8,
     body: []const u8,
 };
 
@@ -96,12 +98,40 @@ pub const BodyPolicyDecision = enum {
     allow_opaque,
 };
 
+/// Exchange-aware input for an optional recording header policy.
+pub const HeaderSafetyContext = struct {
+    direction: BodyDirection,
+    method: core.http.Method,
+    url: []const u8,
+    name: []const u8,
+    value: []const u8,
+};
+
+/// Header policy decisions are serialized into structured matching metadata.
+///
+/// `preserve` is an explicit escape hatch for application headers that the
+/// built-in conservative name rules classify as sensitive. The caller is
+/// responsible for proving that the value is safe to persist.
+pub const HeaderPolicyDecision = enum {
+    inspect,
+    redact,
+    preserve,
+};
+
+/// Recording safety policy callbacks and their borrowed contexts.
+///
+/// Callback contexts must outlive every `toJson` call on the transport.
 pub const RecordingOptions = struct {
     body_policy_context: ?*anyopaque = null,
     bodyPolicyFn: ?*const fn (
         context: ?*anyopaque,
         body: BodySafetyContext,
     ) BodyPolicyDecision = null,
+    header_policy_context: ?*anyopaque = null,
+    headerPolicyFn: ?*const fn (
+        context: ?*anyopaque,
+        header: HeaderSafetyContext,
+    ) HeaderPolicyDecision = null,
 };
 
 /// Parse the versioned, lossless JSON format emitted by `toJson`.
@@ -392,8 +422,8 @@ pub const RecordingTransport = struct {
     /// Structurally recognized credential-bearing JSON, form, connection
     /// string, XML, and private-key bodies cause
     /// `error.SensitiveBodyRequiresSanitization`. Malformed JSON-like bodies
-    /// cause `error.UnsupportedBodySanitization`; neither is silently emitted
-    /// under a false sanitization guarantee.
+    /// and unapproved opaque encodings cause an explicit error; neither is
+    /// silently emitted under a false sanitization guarantee.
     pub fn toJson(
         self: *const RecordingTransport,
         allocator: std.mem.Allocator,
@@ -436,13 +466,25 @@ pub const RecordingTransport = struct {
             try writer.writeAll(",\"request_url\":");
             try writeSanitizedUrl(writer, allocator, exchange.request_url);
             try writer.writeAll(",\"request_headers\":");
-            try writeHeaders(writer, allocator, exchange.request_headers);
+            try writeHeaders(
+                writer,
+                allocator,
+                self.options,
+                exchange,
+                .request,
+            );
             try writer.writeAll(",\"request_body\":");
             try writeOptionalBody(writer, allocator, exchange.request_body);
             try writer.writeAll(",\"response_status\":");
             try writer.print("{d}", .{exchange.response_status});
             try writer.writeAll(",\"response_headers\":");
-            try writeHeaders(writer, allocator, exchange.response_headers);
+            try writeHeaders(
+                writer,
+                allocator,
+                self.options,
+                exchange,
+                .response,
+            );
             try writer.writeAll(",\"response_body\":");
             try writeBody(writer, allocator, exchange.response_body);
             try writer.writeAll("}");
@@ -1059,9 +1101,15 @@ fn parseHeaders(
             return error.InvalidRecordingJson;
         const field_value = object.get("value") orelse
             return error.InvalidRecordingJson;
+        const redacted_value_json = object.get("redacted");
+        const redacted = if (redacted_value_json) |flag| switch (flag) {
+            .bool => |result| result,
+            else => return error.InvalidRecordingJson,
+        } else false;
         header.name = try allocator.dupe(u8, try jsonString(name_value));
         errdefer allocator.free(header.name);
         header.value = try allocator.dupe(u8, try jsonString(field_value));
+        header.redacted = redacted;
         initialized += 1;
     }
     return headers;
@@ -1133,8 +1181,7 @@ fn matchRequest(
             return error.HeaderMismatch;
         if (!try headerValueMatches(
             request.allocator,
-            expected.name,
-            expected.value,
+            expected,
             actual,
         ))
             return error.HeaderMismatch;
@@ -1143,19 +1190,14 @@ fn matchRequest(
 
 fn headerValueMatches(
     allocator: std.mem.Allocator,
-    name: []const u8,
-    expected: []const u8,
+    expected: HeaderPair,
     actual: []const u8,
 ) !bool {
-    if (isSensitiveHeader(name) and
-        std.mem.eql(u8, expected, redacted_value))
-    {
-        return true;
+    if (expected.redacted) return true;
+    if (isSanitizedUrlHeader(expected.name)) {
+        return urlMatches(allocator, expected.value, actual);
     }
-    if (isSanitizedUrlHeader(name)) {
-        return urlMatches(allocator, expected, actual);
-    }
-    return std.mem.eql(u8, expected, actual);
+    return std.mem.eql(u8, expected.value, actual);
 }
 
 fn urlMatches(
@@ -1413,6 +1455,7 @@ const sensitive_body_fields = [_][]const u8{
     "clientsecret",
     "clientassertion",
     "password",
+    "pwd",
     "secret",
     "credential",
     "credentials",
@@ -1500,7 +1543,11 @@ pub fn isSensitiveHeader(name: []const u8) bool {
         containsIgnoreCase(name, "account-key") or
         containsIgnoreCase(name, "access-key") or
         containsIgnoreCase(name, "secret-key") or
-        containsIgnoreCase(name, "shared-key"))
+        containsIgnoreCase(name, "shared-key") or
+        normalizedFieldEndsWith(name, "password") or
+        normalizedFieldEndsWith(name, "pwd") or
+        normalizedFieldEndsWith(name, "privatekey") or
+        normalizedFieldEndsWith(name, "connectionstring"))
     {
         return true;
     }
@@ -1528,6 +1575,7 @@ fn ensureExchangeBodySafe(
         .method = exchange.request_method,
         .url = exchange.request_url,
         .content_type = getHeaderPair(headers, "Content-Type"),
+        .content_encoding = getHeaderPair(headers, "Content-Encoding"),
         .body = bytes,
     };
     const decision = if (options.bodyPolicyFn) |policy|
@@ -1553,6 +1601,7 @@ fn ensureBodySafe(
         return error.SensitiveBodyRequiresSanitization;
 
     const content_type = context.content_type orelse "";
+    const content_encoding = context.content_encoding orelse "";
     const multipart = containsIgnoreCase(content_type, "multipart/") or
         (containsIgnoreCase(bytes, "content-disposition:") and
             containsIgnoreCase(bytes, "form-data"));
@@ -1563,7 +1612,17 @@ fn ensureBodySafe(
         return;
     }
 
-    if (!std.unicode.utf8ValidateSlice(bytes)) {
+    if (hasUnicodeBom(bytes) or
+        std.mem.indexOfScalar(u8, bytes, 0) != null or
+        declaresWideCharset(content_type) or
+        isBinaryContentType(content_type) or
+        (content_encoding.len != 0 and
+            !std.ascii.eqlIgnoreCase(
+                std.mem.trim(u8, content_encoding, " \t"),
+                "identity",
+            )) or
+        !std.unicode.utf8ValidateSlice(bytes))
+    {
         if (!allow_opaque) return error.OpaqueBodyNotAllowed;
         return;
     }
@@ -1576,7 +1635,7 @@ fn ensureBodySafe(
         return;
     }
 
-    if (looksLikeStructuredJson(bytes)) {
+    if (isJsonContentType(content_type) or looksLikeStructuredJson(bytes)) {
         const parsed = std.json.parseFromSlice(
             std.json.Value,
             allocator,
@@ -1588,8 +1647,7 @@ fn ensureBodySafe(
         };
         defer parsed.deinit();
         if (jsonContainsSensitiveField(parsed.value) or
-            (isKnownSecretEndpoint(context.url) and
-                jsonRootHasValueField(parsed.value)))
+            jsonContainsExchangeSensitiveSchema(parsed.value, context))
         {
             return error.SensitiveBodyRequiresSanitization;
         }
@@ -1651,19 +1709,168 @@ fn looksLikeXml(body: []const u8) bool {
     return trimmed.len != 0 and trimmed[0] == '<';
 }
 
-fn isKnownSecretEndpoint(url: []const u8) bool {
-    return containsIgnoreCase(url, "vault") and
-        containsIgnoreCase(url, "/secrets/");
+fn jsonContainsExchangeSensitiveSchema(
+    value: std.json.Value,
+    context: BodySafetyContext,
+) bool {
+    const target = parseUrlTarget(context.url) orelse return false;
+    if (isKeyVaultHost(target.host)) {
+        if ((pathHasResource(target.path, "secrets") or
+            pathHasResource(target.path, "certificates")) and
+            jsonRootHasField(value, "value"))
+        {
+            return true;
+        }
+        if (pathHasResource(target.path, "keys") and
+            jsonContainsJwkPrivateField(value))
+        {
+            return true;
+        }
+    }
+    if (isKustoHost(target.host) and
+        jsonContainsField(value, "sourceuri"))
+    {
+        return true;
+    }
+    return false;
 }
 
-fn jsonRootHasValueField(value: std.json.Value) bool {
+fn jsonRootHasField(value: std.json.Value, field: []const u8) bool {
     const object = switch (value) {
         .object => |result| result,
         else => return false,
     };
     var iterator = object.iterator();
     while (iterator.next()) |entry| {
-        if (normalizedFieldEquals(entry.key_ptr.*, "value")) return true;
+        if (normalizedFieldEquals(entry.key_ptr.*, field)) return true;
+    }
+    return false;
+}
+
+fn jsonContainsField(value: std.json.Value, field: []const u8) bool {
+    switch (value) {
+        .object => |object| {
+            var iterator = object.iterator();
+            while (iterator.next()) |entry| {
+                if (normalizedFieldEquals(entry.key_ptr.*, field) or
+                    jsonContainsField(entry.value_ptr.*, field))
+                {
+                    return true;
+                }
+            }
+        },
+        .array => |array| {
+            for (array.items) |item| {
+                if (jsonContainsField(item, field)) return true;
+            }
+        },
+        else => {},
+    }
+    return false;
+}
+
+fn jsonContainsJwkPrivateField(value: std.json.Value) bool {
+    switch (value) {
+        .object => |object| {
+            var iterator = object.iterator();
+            while (iterator.next()) |entry| {
+                const name = entry.key_ptr.*;
+                if (normalizedFieldEquals(name, "d") or
+                    normalizedFieldEquals(name, "p") or
+                    normalizedFieldEquals(name, "q") or
+                    normalizedFieldEquals(name, "dp") or
+                    normalizedFieldEquals(name, "dq") or
+                    normalizedFieldEquals(name, "qi") or
+                    jsonContainsJwkPrivateField(entry.value_ptr.*))
+                {
+                    return true;
+                }
+            }
+        },
+        .array => |array| {
+            for (array.items) |item| {
+                if (jsonContainsJwkPrivateField(item)) return true;
+            }
+        },
+        else => {},
+    }
+    return false;
+}
+
+const UrlTarget = struct {
+    host: []const u8,
+    path: []const u8,
+};
+
+fn parseUrlTarget(url: []const u8) ?UrlTarget {
+    const scheme = std.mem.indexOf(u8, url, "://") orelse return null;
+    if (!std.ascii.eqlIgnoreCase(url[0..scheme], "https")) return null;
+    const authority_start = scheme + 3;
+    const path_start = std.mem.indexOfAnyPos(
+        u8,
+        url,
+        authority_start,
+        "/?#",
+    ) orelse url.len;
+    var authority = url[authority_start..path_start];
+    if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| {
+        authority = authority[at + 1 ..];
+    }
+    var host = authority;
+    if (host.len != 0 and host[0] == '[') {
+        const close = std.mem.indexOfScalar(u8, host, ']') orelse return null;
+        host = host[0 .. close + 1];
+    } else if (std.mem.lastIndexOfScalar(u8, host, ':')) |colon| {
+        host = host[0..colon];
+    }
+    const path_end = std.mem.indexOfAnyPos(
+        u8,
+        url,
+        path_start,
+        "?#",
+    ) orelse url.len;
+    return .{
+        .host = host,
+        .path = if (path_start < url.len and url[path_start] == '/')
+            url[path_start..path_end]
+        else
+            "",
+    };
+}
+
+fn hostMatches(host: []const u8, suffix: []const u8) bool {
+    if (std.ascii.eqlIgnoreCase(host, suffix)) return true;
+    if (host.len <= suffix.len or host[host.len - suffix.len - 1] != '.')
+        return false;
+    return std.ascii.eqlIgnoreCase(
+        host[host.len - suffix.len ..],
+        suffix,
+    );
+}
+
+fn isKeyVaultHost(host: []const u8) bool {
+    return hostMatches(host, "vault.azure.net") or
+        hostMatches(host, "vault.azure.cn") or
+        hostMatches(host, "vault.usgovcloudapi.net") or
+        hostMatches(host, "vault.microsoftazure.de") or
+        hostMatches(host, "vaultcore.azure.net") or
+        hostMatches(host, "managedhsm.azure.net") or
+        hostMatches(host, "managedhsm.azure.cn") or
+        hostMatches(host, "managedhsm.usgovcloudapi.net");
+}
+
+fn isKustoHost(host: []const u8) bool {
+    return hostMatches(host, "kusto.windows.net") or
+        hostMatches(host, "kusto.chinacloudapi.cn") or
+        hostMatches(host, "kusto.usgovcloudapi.net") or
+        hostMatches(host, "kusto.cloudapi.de") or
+        hostMatches(host, "kusto.fabric.microsoft.com");
+}
+
+fn pathHasResource(path: []const u8, resource: []const u8) bool {
+    var segments = std.mem.splitScalar(u8, path, '/');
+    while (segments.next()) |segment| {
+        if (std.ascii.eqlIgnoreCase(segment, resource)) return true;
     }
     return false;
 }
@@ -1671,6 +1878,41 @@ fn jsonRootHasValueField(value: std.json.Value) bool {
 fn looksLikeStructuredJson(body: []const u8) bool {
     const trimmed = std.mem.trim(u8, body, " \t\r\n");
     return trimmed.len != 0 and (trimmed[0] == '{' or trimmed[0] == '[');
+}
+
+fn hasUnicodeBom(body: []const u8) bool {
+    return std.mem.startsWith(u8, body, "\xef\xbb\xbf") or
+        std.mem.startsWith(u8, body, "\xff\xfe") or
+        std.mem.startsWith(u8, body, "\xfe\xff") or
+        std.mem.startsWith(u8, body, "\xff\xfe\x00\x00") or
+        std.mem.startsWith(u8, body, "\x00\x00\xfe\xff");
+}
+
+fn declaresWideCharset(content_type: []const u8) bool {
+    return containsIgnoreCase(content_type, "charset=utf-16") or
+        containsIgnoreCase(content_type, "charset=\"utf-16") or
+        containsIgnoreCase(content_type, "charset=utf-32") or
+        containsIgnoreCase(content_type, "charset=\"utf-32");
+}
+
+fn isJsonContentType(content_type: []const u8) bool {
+    return containsIgnoreCase(content_type, "/json") or
+        containsIgnoreCase(content_type, "+json");
+}
+
+fn isBinaryContentType(content_type: []const u8) bool {
+    return containsIgnoreCase(content_type, "application/octet-stream") or
+        containsIgnoreCase(content_type, "application/pkcs12") or
+        containsIgnoreCase(content_type, "application/x-pkcs12") or
+        containsIgnoreCase(content_type, "application/pkcs8") or
+        containsIgnoreCase(content_type, "application/x-pem-file") or
+        containsIgnoreCase(content_type, "application/zip") or
+        containsIgnoreCase(content_type, "application/gzip") or
+        containsIgnoreCase(content_type, "application/x-gzip") or
+        containsIgnoreCase(content_type, "image/") or
+        containsIgnoreCase(content_type, "audio/") or
+        containsIgnoreCase(content_type, "video/") or
+        containsIgnoreCase(content_type, "font/");
 }
 
 fn jsonContainsSensitiveField(value: std.json.Value) bool {
@@ -1706,9 +1948,49 @@ fn jsonContainsSensitiveFieldInContext(
                 )) return true;
             }
         },
+        .string => |string| return containsSensitiveScalar(string),
         else => {},
     }
     return false;
+}
+
+fn containsSensitiveScalar(value: []const u8) bool {
+    return containsPrivateKeyMarker(value) or
+        containsSensitiveAssignment(value) or
+        containsSasCredential(value) or
+        looksLikeJwt(value);
+}
+
+fn containsSasCredential(value: []const u8) bool {
+    return containsIgnoreCase(value, "SharedAccessSignature") or
+        containsIgnoreCase(value, "?sig=") or
+        containsIgnoreCase(value, "&sig=") or
+        containsIgnoreCase(value, ";sig=") or
+        containsIgnoreCase(value, "&amp;sig=") or
+        containsIgnoreCase(value, "?aeg-sas-key=") or
+        containsIgnoreCase(value, "&aeg-sas-key=") or
+        containsIgnoreCase(value, "?aeg-sas-token=") or
+        containsIgnoreCase(value, "&aeg-sas-token=") or
+        containsIgnoreCase(value, "sig%3d") or
+        containsIgnoreCase(value, "sig%253d") or
+        (containsIgnoreCase(value, "&e=") and
+            containsIgnoreCase(value, "&s="));
+}
+
+fn looksLikeJwt(value: []const u8) bool {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    var dots: usize = 0;
+    for (trimmed) |byte| {
+        if (byte == '.') {
+            dots += 1;
+        } else if (!std.ascii.isAlphanumeric(byte) and
+            byte != '-' and
+            byte != '_')
+        {
+            return false;
+        }
+    }
+    return dots == 2 and trimmed.len >= 24;
 }
 
 fn isSensitiveBodyContainer(name: []const u8) bool {
@@ -1929,21 +2211,44 @@ fn containsSensitiveXml(body: []const u8) bool {
 fn writeHeaders(
     writer: *std.Io.Writer,
     allocator: std.mem.Allocator,
-    headers: []const HeaderPair,
+    options: RecordingOptions,
+    exchange: OwnedExchange,
+    direction: BodyDirection,
 ) !void {
+    const headers = switch (direction) {
+        .request => exchange.request_headers,
+        .response => exchange.response_headers,
+    };
     try writer.writeByte('[');
     for (headers, 0..) |header, index| {
         if (index != 0) try writer.writeByte(',');
         try writer.writeAll("{\"name\":");
         try writeJsonString(writer, header.name);
         try writer.writeAll(",\"value\":");
-        if (isSensitiveHeader(header.name)) {
+        const context = HeaderSafetyContext{
+            .direction = direction,
+            .method = exchange.request_method,
+            .url = exchange.request_url,
+            .name = header.name,
+            .value = header.value,
+        };
+        const decision = if (options.headerPolicyFn) |policy|
+            policy(options.header_policy_context, context)
+        else
+            .inspect;
+        const redact = header.redacted or switch (decision) {
+            .redact => true,
+            .preserve => false,
+            .inspect => isSensitiveHeader(header.name),
+        };
+        if (redact) {
             try writeJsonString(writer, redacted_value);
         } else if (isSanitizedUrlHeader(header.name)) {
             try writeSanitizedUrl(writer, allocator, header.value);
         } else {
             try writeJsonString(writer, header.value);
         }
+        try writer.print(",\"redacted\":{}", .{redact});
         try writer.writeByte('}');
     }
     try writer.writeByte(']');
@@ -2154,6 +2459,35 @@ fn allowKnownSafeOpaqueBody(
         .allow_opaque
     else
         .inspect;
+}
+
+fn preserveKnownSafeMetadata(
+    _: ?*anyopaque,
+    header: HeaderSafetyContext,
+) HeaderPolicyDecision {
+    if (std.ascii.eqlIgnoreCase(header.name, "x-ms-meta-pwd"))
+        return .preserve;
+    if (std.ascii.eqlIgnoreCase(header.name, "x-application-auth-material"))
+        return .redact;
+    return .inspect;
+}
+
+fn expectRejectedSerializationExcludes(
+    recorder: *const RecordingTransport,
+    expected_error: anyerror,
+    secrets: []const []const u8,
+) !void {
+    var output: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    try std.testing.expectError(
+        expected_error,
+        recorder.writeJson(&output.writer, std.testing.allocator),
+    );
+    for (secrets) |secret| {
+        try std.testing.expect(
+            std.mem.indexOf(u8, output.written(), secret) == null,
+        );
+    }
 }
 
 test "playback validates request and preserves duplicate response headers" {
@@ -2625,6 +2959,93 @@ test "sensitive Azure headers are classified case-insensitively" {
     try std.testing.expect(!isSensitiveHeader("x-ms-continuation-token"));
 }
 
+test "sensitive metadata headers redact with configurable exact overrides" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "response",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "X-MS-META-PASSWORD", .value = "response-password-value" },
+        .{ .name = "x-ms-meta-private-key", .value = "cmVzcG9uc2Uta2V5" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .headerPolicyFn = &preserveKnownSafeMetadata },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://storage.example/container/blob",
+    );
+    defer request.deinit();
+    try request.setHeader("x-Ms-MeTa-PaSsWoRd", "request-password-value");
+    try request.setHeader("X-MS-META-PRIVATE-KEY", "cmVxdWVzdC1rZXk=");
+    try request.setHeader(
+        "x-ms-meta-connection-string",
+        "RW5kcG9pbnQ9eDtBY2NvdW50S2V5PXk=",
+    );
+    try request.setHeader("X-MS-META-PWD", "known-safe-label");
+    try request.setHeader(
+        "X-Application-Auth-Material",
+        "custom-sensitive-value",
+    );
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    for ([_][]const u8{
+        "response-password-value",
+        "cmVzcG9uc2Uta2V5",
+        "request-password-value",
+        "cmVxdWVzdC1rZXk=",
+        "RW5kcG9pbnQ9eDtBY2NvdW50S2V5PXk=",
+        "custom-sensitive-value",
+    }) |secret| {
+        try std.testing.expect(std.mem.indexOf(u8, json, secret) == null);
+    }
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "known-safe-label") != null,
+    );
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://storage.example/container/blob",
+    );
+    defer live.deinit();
+    try live.setHeader("x-ms-meta-password", "rotated-password");
+    try live.setHeader("x-ms-meta-private-key", "rotated-private-key");
+    try live.setHeader(
+        "x-ms-meta-connection-string",
+        "rotated-connection-string",
+    );
+    try live.setHeader("x-ms-meta-pwd", "known-safe-label");
+    try live.setHeader("x-application-auth-material", "rotated-custom-value");
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
+
+    var mismatch = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    try live.setHeader("x-ms-meta-pwd", "different-safe-label");
+    try std.testing.expectError(
+        error.HeaderMismatch,
+        mismatch.asTransport().send(&live),
+    );
+}
+
 test "Event Grid key and SAS token redactions roundtrip" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -3039,9 +3460,10 @@ fn expectSensitiveResponseBodyRejected(body: []const u8) !void {
     defer request.deinit();
     var response = try recorder.asTransport().send(&request);
     response.deinit();
-    try std.testing.expectError(
+    try expectRejectedSerializationExcludes(
+        &recorder,
         error.SensitiveBodyRequiresSanitization,
-        recorder.toJson(std.testing.allocator),
+        &.{body},
     );
 }
 
@@ -3066,9 +3488,10 @@ fn expectSensitiveRequestBodyRejected(body: []const u8) !void {
     request.body = body;
     var response = try recorder.asTransport().send(&request);
     response.deinit();
-    try std.testing.expectError(
+    try expectRejectedSerializationExcludes(
+        &recorder,
         error.SensitiveBodyRequiresSanitization,
-        recorder.toJson(std.testing.allocator),
+        &.{body},
     );
 }
 
@@ -3116,9 +3539,10 @@ test "Key Vault root value bodies are endpoint-sensitive" {
         defer request.deinit();
         var response = try recorder.asTransport().send(&request);
         response.deinit();
-        try std.testing.expectError(
+        try expectRejectedSerializationExcludes(
+            &recorder,
             error.SensitiveBodyRequiresSanitization,
-            recorder.toJson(std.testing.allocator),
+            &.{"response-key-vault-value"},
         );
     }
     {
@@ -3142,9 +3566,204 @@ test "Key Vault root value bodies are endpoint-sensitive" {
         request.body = "{\"VaLuE\":\"request-key-vault-value\"}";
         var response = try recorder.asTransport().send(&request);
         response.deinit();
-        try std.testing.expectError(
+        try expectRejectedSerializationExcludes(
+            &recorder,
             error.SensitiveBodyRequiresSanitization,
-            recorder.toJson(std.testing.allocator),
+            &.{"request-key-vault-value"},
+        );
+    }
+}
+
+test "Key Vault path text on App Configuration hosts stays recordable and exact" {
+    const body = "{\"key\":\"team/vault/secrets/name\",\"value\":\"ordinary-setting\"}";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        body,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://store.azconfig.io/kv/team/vault/secrets/name?api-version=1.0",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "ordinary-setting") == null);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        body,
+        parsed.asSlice()[0].response_body,
+    );
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed = try playback.asTransport().send(&request);
+    defer replayed.deinit();
+    try std.testing.expectEqualSlices(u8, body, replayed.body);
+
+    var mismatch = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var different = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://store.azconfig.io/kv/team/vault/secrets/other?api-version=1.0",
+    );
+    defer different.deinit();
+    try std.testing.expectError(
+        error.UrlMismatch,
+        mismatch.asTransport().send(&different),
+    );
+}
+
+test "Key Vault exchange rules ignore untrusted origins" {
+    for ([_][]const u8{
+        "https://example.vault.azure.net.attacker.test/secrets/name",
+        "https://vault.azure.cn.attacker.test/certificates/name",
+        "http://example.vault.azure.net/secrets/name",
+    }) |url| {
+        const body = "{\"value\":\"ordinary-non-vault-value\"}";
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            body,
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        const json = try recorder.toJson(std.testing.allocator);
+        defer std.testing.allocator.free(json);
+        var parsed = try parseJson(std.testing.allocator, json);
+        defer parsed.deinit();
+        try std.testing.expectEqualSlices(
+            u8,
+            body,
+            parsed.asSlice()[0].response_body,
+        );
+    }
+}
+
+test "Key Vault private JWK and certificate import schemas are rejected" {
+    {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"key\":{\"kty\":\"RSA\",\"n\":\"public\",\"e\":\"AQAB\",\"D\":\"ZC1wcml2YXRl\",\"p\":\"cA==\",\"q\":\"cQ==\",\"dP\":\"ZHA=\",\"dq\":\"ZHE=\",\"QI\":\"cWk=\"}}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.vault.azure.net/keys/name/version?api-version=7.6",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{ "ZC1wcml2YXRl", "ZHA=", "cWk=" },
+        );
+    }
+    {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"id\":\"safe\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            "https://example.vault.azure.net/certificates/name/import?api-version=7.6",
+        );
+        defer request.deinit();
+        request.body =
+            "{\"value\":\"UEZYLUJBU0U2NC1WQUxVRQ==\",\"PwD\":\"certificate-password\"}";
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{ "UEZYLUJBU0U2NC1WQUxVRQ==", "certificate-password" },
+        );
+    }
+}
+
+test "Kusto source URIs and tabular credential scalars are rejected" {
+    for ([_][]const u8{
+        "{\"sourceUri\":\"https://storage.example/container?sig=kusto-source-sas\"}",
+        "{\"Tables\":[{\"Rows\":[[\"https://storage.example/blob?sig=row-sas\"]]}]}",
+        "{\"Tables\":[{\"Rows\":[[\"https%3A%2F%2Fstorage.example%2Fblob%3Fsv%3D1%26sig%3Dencoded-sas\"]]}]}",
+        "{\"Tables\":[{\"Rows\":[[\"aaaaaaaa.bbbbbbbb.cccccccc\"]]}]}",
+    }) |body| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            body,
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            "https://cluster.kusto.windows.net/v2/rest/query",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{
+                "kusto-source-sas",
+                "row-sas",
+                "encoded-sas",
+                "aaaaaaaa.bbbbbbbb.cccccccc",
+            },
         );
     }
 }
@@ -3222,6 +3841,9 @@ test "opaque bodies reject by default and require an explicit safe policy" {
     const opaque_bodies = [_][]const u8{
         "\x30\x82\xff\x00pkcs12-like",
         "\xff\xfeP\x00a\x00s\x00s\x00w\x00o\x00r\x00d\x00",
+        "A\x00c\x00c\x00o\x00u\x00n\x00t\x00K\x00e\x00y\x00=\x00v\x00a\x00l\x00u\x00e\x00",
+        "A\x00\x00\x00c\x00\x00\x00c\x00\x00\x00o\x00\x00\x00u\x00\x00\x00n\x00\x00\x00t\x00\x00\x00K\x00\x00\x00e\x00\x00\x00y\x00\x00\x00=\x00\x00\x00v\x00\x00\x00",
+        "\xef\xbb\xbf{\"message\":\"utf8-bom\"}",
         "{\"message\":\"malformed\xff\"}",
     };
     for (opaque_bodies) |body| {
@@ -3310,6 +3932,77 @@ test "recording JSON rejects malformed structured bodies explicitly" {
         error.UnsupportedBodySanitization,
         recorder.toJson(std.testing.allocator),
     );
+}
+
+test "declared encodings and opaque MIME bodies require explicit approval" {
+    const cases = [_]struct {
+        content_type: []const u8,
+        content_encoding: ?[]const u8 = null,
+        body: []const u8,
+        expected_error: anyerror,
+    }{
+        .{
+            .content_type = "application/json",
+            .body = "not-json",
+            .expected_error = error.UnsupportedBodySanitization,
+        },
+        .{
+            .content_type = "application/json; charset=utf-16le",
+            .body = "{\x00\"\x00v\x00a\x00l\x00u\x00e\x00\"\x00:\x00\"\x00x\x00\"\x00}\x00",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
+            .content_type = "application/json; charset=utf-32",
+            .body = "{\x00\x00\x00}\x00\x00\x00",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
+            .content_type = "application/octet-stream",
+            .body = "printable-but-opaque",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
+            .content_type = "application/json",
+            .content_encoding = "gzip",
+            .body = "compressed-looking-body",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+    };
+    for (cases) |case| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            case.body,
+        );
+        defer mock.deinit();
+        if (case.content_encoding) |encoding| {
+            mock.response_headers_list = &.{
+                .{ .name = "Content-Type", .value = case.content_type },
+                .{ .name = "Content-Encoding", .value = encoding },
+            };
+        } else {
+            mock.response_headers_list = &.{
+                .{ .name = "Content-Type", .value = case.content_type },
+            };
+        }
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/encoding",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            case.expected_error,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
 }
 
 test "recording JSON decodes safe structured bodies losslessly" {
@@ -3556,6 +4249,13 @@ test "recording parser reports version encoding and base64 errors" {
         parseJson(
             std.testing.allocator,
             "{\"version\":2,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"base64\",\"data\":\"***\"}}]}",
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidRecordingJson,
+        parseJson(
+            std.testing.allocator,
+            "{\"version\":2,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[{\"name\":\"x-test\",\"value\":\"value\",\"redacted\":\"yes\"}],\"request_body\":null,\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"base64\",\"data\":\"\"}}]}",
         ),
     );
 }

--- a/root.zig
+++ b/root.zig
@@ -3,7 +3,9 @@
 //! `PlaybackTransport` and `RecordingTransport` expose copyable Core 0.3
 //! transport descriptors whose opaque contexts borrow the transport values.
 //! The values and any wrapped backend contexts must outlive every descriptor
-//! copy and open operation. Both transports are caller-serialized.
+//! copy and open operation. Playback is caller-serialized. Recording attempt
+//! ordering/finalization is synchronized; borrowed slices and policy contexts
+//! still require caller synchronization.
 const std = @import("std");
 const core = @import("azure_sdk_core");
 
@@ -24,7 +26,7 @@ pub const RecordedOutcome = enum {
 
 /// Stable, serializable failure categories used instead of backend-specific
 /// error identities. Playback maps these to the corresponding
-/// `RecordedCancelled`, `RecordedTimeout`, `RecordedConnectionFailure`,
+/// `OperationCancelled`, `RecordedTimeout`, `RecordedConnectionFailure`,
 /// `RecordedTlsFailure`, `RecordedProtocolFailure`, `RecordedIoFailure`,
 /// `RecordedResourceExhausted`, `RecordedUnsupported`, or
 /// `RecordedUnknownFailure` error.
@@ -73,6 +75,7 @@ pub const OwnedExchange = struct {
     response_headers: []HeaderPair,
     outcome: RecordedOutcome = .response,
     error_category: ?RecordedErrorCategory = null,
+    resolved: bool = true,
 
     fn deinit(self: *OwnedExchange, allocator: std.mem.Allocator) void {
         allocator.free(self.request_url);
@@ -546,7 +549,7 @@ const PlaybackBodyReader = struct {
 
 fn recordedErrorValue(category: ?RecordedErrorCategory) anyerror {
     return switch (category orelse .unknown) {
-        .cancelled => error.RecordedCancelled,
+        .cancelled => error.OperationCancelled,
         .timeout => error.RecordedTimeout,
         .connection => error.RecordedConnectionFailure,
         .tls => error.RecordedTlsFailure,
@@ -612,7 +615,19 @@ fn classifyRecordedError(err: anyerror) RecordedErrorCategory {
     return .unknown;
 }
 
-/// Caller-serialized recording transport wrapping a full Core descriptor.
+const RecordingMutex = struct {
+    state: std.atomic.Mutex = .unlocked,
+
+    fn lock(self: *RecordingMutex) void {
+        while (!self.state.tryLock()) std.atomic.spinLoopHint();
+    }
+
+    fn unlock(self: *RecordingMutex) void {
+        self.state.unlock();
+    }
+};
+
+/// Recording transport wrapping a full Core descriptor.
 ///
 /// The inner descriptor is copied by value. Its context, this recording
 /// transport, and the recording allocator must outlive every open operation.
@@ -620,13 +635,15 @@ fn classifyRecordedError(err: anyerror) RecordedErrorCategory {
 /// `toJson`. Each exchange is one completed raw transport attempt, including
 /// redirect, retry, and stable staged failure outcomes. Post-dispatch
 /// bookkeeping failure poisons serialization rather than omitting an attempt.
-/// `deinit` does not deinitialize either borrowed context.
+/// Attempt ordering and finalization are internally synchronized. Borrowed
+/// slices from `getExchanges` still require caller synchronization. `deinit`
+/// does not deinitialize either borrowed context.
 pub const RecordingTransport = struct {
     inner: core.http.HttpTransport,
     exchanges: std.ArrayList(OwnedExchange) = .empty,
     allocator: std.mem.Allocator,
     options: RecordingOptions,
-    reserved_attempts: usize = 0,
+    mutex: RecordingMutex = .{},
     poisoned: bool = false,
 
     const vtable: core.http.HttpTransport.VTable = .{
@@ -665,6 +682,8 @@ pub const RecordingTransport = struct {
         self.* = undefined;
     }
 
+    /// Borrow all slots in dispatch order. Unresolved active slots have
+    /// `resolved == false`; do not retain this slice across concurrent calls.
     pub fn getExchanges(self: *const RecordingTransport) []const OwnedExchange {
         return self.exchanges.items;
     }
@@ -673,33 +692,93 @@ pub const RecordingTransport = struct {
     /// deinitialized without a terminal event. `toJson` then returns
     /// `error.IncompleteRecording`.
     pub fn isComplete(self: *const RecordingTransport) bool {
-        return !self.poisoned;
+        const mutex = @constCast(&self.mutex);
+        mutex.lock();
+        defer mutex.unlock();
+        return self.isCompleteLocked();
     }
 
-    fn reserveAttempt(self: *RecordingTransport) !void {
+    fn isCompleteLocked(self: *const RecordingTransport) bool {
+        if (self.poisoned) return false;
+        for (self.exchanges.items) |exchange| {
+            if (!exchange.resolved) return false;
+        }
+        return true;
+    }
+
+    fn ensureCanDispatch(self: *RecordingTransport) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
         if (self.poisoned) return error.IncompleteRecording;
-        try self.exchanges.ensureUnusedCapacity(
-            self.allocator,
-            self.reserved_attempts + 1,
-        );
-        self.reserved_attempts += 1;
     }
 
-    fn releaseAttempt(self: *RecordingTransport) void {
-        std.debug.assert(self.reserved_attempts != 0);
-        self.reserved_attempts -= 1;
-    }
-
-    fn appendAttempt(
+    fn reserveAttempt(
         self: *RecordingTransport,
-        exchange: OwnedExchange,
-    ) void {
-        self.releaseAttempt();
-        self.exchanges.appendAssumeCapacity(exchange);
+        pending: *PendingRequest,
+    ) !usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.poisoned) return error.IncompleteRecording;
+        try self.exchanges.ensureUnusedCapacity(self.allocator, 1);
+        const ticket = self.exchanges.items.len;
+        self.exchanges.appendAssumeCapacity(pending.intoSlot());
+        return ticket;
     }
 
-    fn poisonAttempt(self: *RecordingTransport) void {
-        self.releaseAttempt();
+    fn setRequestBody(
+        self: *RecordingTransport,
+        ticket: usize,
+        body: []u8,
+    ) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const slot = &self.exchanges.items[ticket];
+        std.debug.assert(!slot.resolved);
+        std.debug.assert(slot.request_body == null);
+        slot.request_body = body;
+    }
+
+    fn finalizePreResponse(
+        self: *RecordingTransport,
+        ticket: usize,
+        outcome: RecordedOutcome,
+        category: RecordedErrorCategory,
+    ) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const slot = &self.exchanges.items[ticket];
+        std.debug.assert(!slot.resolved);
+        slot.outcome = outcome;
+        slot.error_category = category;
+        slot.resolved = true;
+    }
+
+    fn finalizeResponse(
+        self: *RecordingTransport,
+        ticket: usize,
+        response: OwnedResponse,
+        outcome: RecordedOutcome,
+        category: ?RecordedErrorCategory,
+    ) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const slot = &self.exchanges.items[ticket];
+        std.debug.assert(!slot.resolved);
+        self.allocator.free(slot.response_body);
+        deinitHeaderPairs(self.allocator, slot.response_headers);
+        slot.response_status = response.status;
+        slot.response_body = response.body;
+        slot.response_body_allocation = response.body_allocation;
+        slot.response_headers = response.headers;
+        slot.outcome = outcome;
+        slot.error_category = category;
+        slot.resolved = true;
+    }
+
+    fn poisonAttempt(self: *RecordingTransport, ticket: usize) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        std.debug.assert(ticket < self.exchanges.items.len);
         self.poisoned = true;
     }
 
@@ -721,7 +800,6 @@ pub const RecordingTransport = struct {
         self: *const RecordingTransport,
         allocator: std.mem.Allocator,
     ) ![]u8 {
-        if (self.poisoned) return error.IncompleteRecording;
         var output: std.Io.Writer.Allocating = .init(allocator);
         errdefer output.deinit();
         const writer = &output.writer;
@@ -737,7 +815,10 @@ pub const RecordingTransport = struct {
         writer: *std.Io.Writer,
         allocator: std.mem.Allocator,
     ) !void {
-        if (self.poisoned) return error.IncompleteRecording;
+        const mutex = @constCast(&self.mutex);
+        mutex.lock();
+        defer mutex.unlock();
+        if (!self.isCompleteLocked()) return error.IncompleteRecording;
         try writer.print(
             "{{\"version\":{d},\"exchanges\":[",
             .{recording_format_version},
@@ -812,7 +893,7 @@ pub const RecordingTransport = struct {
         request: *core.http.Request,
     ) !core.http.Response {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
-        if (self.poisoned) return error.IncompleteRecording;
+        try self.ensureCanDispatch();
         var pending = try PendingRequest.init(
             self.allocator,
             request,
@@ -820,37 +901,30 @@ pub const RecordingTransport = struct {
         );
         var pending_owned = true;
         defer if (pending_owned) pending.deinit(self.allocator);
-        try self.reserveAttempt();
-        var reservation_owned = true;
-        errdefer if (reservation_owned) self.releaseAttempt();
+        const ticket = try self.reserveAttempt(&pending);
+        pending_owned = false;
 
         var response = self.inner.vtable.send(
             self.inner.context,
             request,
         ) catch |err| {
-            self.appendAttempt(pending.failureExchange(
+            self.finalizePreResponse(
+                ticket,
                 .transport_error,
                 classifyRecordedError(err),
-            ));
-            pending_owned = false;
-            reservation_owned = false;
+            );
             return err;
         };
         errdefer response.deinit();
-        var exchange = ownedExchangeFromResponse(
+        const owned_response = ownedResponseFromResponse(
             self.allocator,
-            &pending,
             &response,
             response.body,
         ) catch |err| {
-            self.poisonAttempt();
-            reservation_owned = false;
+            self.poisonAttempt(ticket);
             return err;
         };
-        pending_owned = false;
-        errdefer exchange.deinit(self.allocator);
-        self.appendAttempt(exchange);
-        reservation_owned = false;
+        self.finalizeResponse(ticket, owned_response, .response, null);
         return response;
     }
 
@@ -860,7 +934,7 @@ pub const RecordingTransport = struct {
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
-        if (self.poisoned) return error.IncompleteRecording;
+        try self.ensureCanDispatch();
         if (options.body != null and request.body != null)
             return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
@@ -875,9 +949,8 @@ pub const RecordingTransport = struct {
         );
         var pending_owned = true;
         defer if (pending_owned) pending.deinit(self.allocator);
-        try self.reserveAttempt();
-        var reservation_owned = true;
-        errdefer if (reservation_owned) self.releaseAttempt();
+        const ticket = try self.reserveAttempt(&pending);
+        pending_owned = false;
 
         var inner_options = options;
         var request_capture: CapturingReader = undefined;
@@ -901,31 +974,28 @@ pub const RecordingTransport = struct {
             ) catch |err| {
                 if (has_capture) {
                     if (request_capture.bookkeeping_failed) {
-                        self.poisonAttempt();
-                        reservation_owned = false;
+                        self.poisonAttempt(ticket);
                         return error.OutOfMemory;
                     }
-                    pending.body = request_capture.toOwnedSlice() catch |capture_err| {
-                        self.poisonAttempt();
-                        reservation_owned = false;
+                    const captured = request_capture.toOwnedSlice() catch |capture_err| {
+                        self.poisonAttempt(ticket);
                         return capture_err;
                     };
+                    self.setRequestBody(ticket, captured);
                     if (request_capture.failure) |failure| {
-                        self.appendAttempt(pending.failureExchange(
+                        self.finalizePreResponse(
+                            ticket,
                             .open_error,
                             classifyRecordedError(failure),
-                        ));
-                        pending_owned = false;
-                        reservation_owned = false;
+                        );
                         return failure;
                     }
                 }
-                self.appendAttempt(pending.failureExchange(
+                self.finalizePreResponse(
+                    ticket,
                     .open_error,
                     classifyRecordedError(err),
-                ));
-                pending_owned = false;
-                reservation_owned = false;
+                );
                 return err;
             };
             break :blk operation;
@@ -934,17 +1004,15 @@ pub const RecordingTransport = struct {
                 self.inner.context,
                 request,
             ) catch |err| {
-                self.appendAttempt(pending.failureExchange(
+                self.finalizePreResponse(
+                    ticket,
                     .open_error,
                     classifyRecordedError(err),
-                ));
-                pending_owned = false;
-                reservation_owned = false;
+                );
                 return err;
             };
             const operation = BufferedInnerOperation.create(response) catch |err| {
-                self.poisonAttempt();
-                reservation_owned = false;
+                self.poisonAttempt(ticket);
                 return err;
             };
             break :blk operation;
@@ -956,36 +1024,31 @@ pub const RecordingTransport = struct {
 
         if (has_capture) {
             if (request_capture.bookkeeping_failed) {
-                self.poisonAttempt();
-                reservation_owned = false;
+                self.poisonAttempt(ticket);
                 return error.OutOfMemory;
             }
-            pending.body = request_capture.toOwnedSlice() catch |err| {
-                self.poisonAttempt();
-                reservation_owned = false;
+            const captured = request_capture.toOwnedSlice() catch |err| {
+                self.poisonAttempt(ticket);
                 return err;
             };
+            self.setRequestBody(ticket, captured);
             if (request_capture.failure) |failure| {
-                self.appendAttempt(pending.failureExchange(
+                self.finalizePreResponse(
+                    ticket,
                     .open_error,
                     classifyRecordedError(failure),
-                ));
-                pending_owned = false;
-                reservation_owned = false;
+                );
                 return failure;
             }
         }
         const operation = RecordingOperation.create(
             self,
             inner_operation,
-            pending,
+            ticket,
         ) catch |err| {
-            self.poisonAttempt();
-            reservation_owned = false;
+            self.poisonAttempt(ticket);
             return err;
         };
-        pending_owned = false;
-        reservation_owned = false;
         return operation;
     }
 };
@@ -1034,14 +1097,9 @@ const PendingRequest = struct {
         self.* = undefined;
     }
 
-    fn failureExchange(
+    fn intoSlot(
         self: *PendingRequest,
-        outcome: RecordedOutcome,
-        category: RecordedErrorCategory,
     ) OwnedExchange {
-        std.debug.assert(
-            outcome == .transport_error or outcome == .open_error,
-        );
         const exchange = OwnedExchange{
             .request_method = self.method,
             .request_url = self.url,
@@ -1050,8 +1108,7 @@ const PendingRequest = struct {
             .response_status = 0,
             .response_body = self.empty_response_body,
             .response_headers = self.empty_response_headers,
-            .outcome = outcome,
-            .error_category = category,
+            .resolved = false,
         };
         self.* = undefined;
         return exchange;
@@ -1109,14 +1166,14 @@ const RecordingOperation = struct {
     allocator: std.mem.Allocator,
     owner: *RecordingTransport,
     inner: *core.http.HttpOperation,
-    pending: ?PendingRequest,
+    ticket: ?usize,
     attempt_headers: ?[]HeaderPair,
     response_reader: CapturingReader,
 
     fn create(
         owner: *RecordingTransport,
         inner: *core.http.HttpOperation,
-        pending_value: PendingRequest,
+        ticket: usize,
     ) !*core.http.HttpOperation {
         const self = try owner.allocator.create(RecordingOperation);
         errdefer owner.allocator.destroy(self);
@@ -1135,7 +1192,7 @@ const RecordingOperation = struct {
             .allocator = owner.allocator,
             .owner = owner,
             .inner = inner,
-            .pending = pending_value,
+            .ticket = ticket,
             .attempt_headers = attempt_headers,
             .response_reader = undefined,
         };
@@ -1159,40 +1216,36 @@ const RecordingOperation = struct {
         outcome: RecordedOutcome,
         category: ?RecordedErrorCategory,
     ) void {
-        const pending = self.pending orelse return;
-        self.pending = null;
+        const ticket = self.ticket orelse return;
+        self.ticket = null;
         const response_headers = self.attempt_headers.?;
         self.attempt_headers = null;
         const captured = self.response_reader.captured.toArrayList();
         const allocation = captured.allocatedSlice();
-        self.allocator.free(pending.empty_response_body);
-        self.allocator.free(pending.empty_response_headers);
-        self.owner.appendAttempt(.{
-            .request_method = pending.method,
-            .request_url = pending.url,
-            .request_headers = pending.headers,
-            .request_body = pending.body,
-            .response_status = self.operation.status_code,
-            .response_body = allocation[0..captured.items.len],
-            .response_body_allocation = if (allocation.len == 0)
-                null
-            else
-                allocation,
-            .response_headers = response_headers,
-            .outcome = outcome,
-            .error_category = category,
-        });
+        self.owner.finalizeResponse(
+            ticket,
+            .{
+                .status = self.operation.status_code,
+                .body = allocation[0..captured.items.len],
+                .body_allocation = if (allocation.len == 0)
+                    null
+                else
+                    allocation,
+                .headers = response_headers,
+            },
+            outcome,
+            category,
+        );
     }
 
     fn poisonIncompleteAttempt(self: *RecordingOperation) void {
-        if (self.pending) |*pending| {
-            pending.deinit(self.allocator);
-            self.pending = null;
+        if (self.ticket) |ticket| {
+            self.ticket = null;
             if (self.attempt_headers) |headers| {
                 deinitHeaderPairs(self.allocator, headers);
                 self.attempt_headers = null;
             }
-            self.owner.poisonAttempt();
+            self.owner.poisonAttempt(ticket);
         }
     }
 
@@ -1298,10 +1351,7 @@ const RecordingOperation = struct {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.deinit();
-        if (self.pending) |*pending| {
-            self.owner.poisonAttempt();
-            pending.deinit(self.allocator);
-        }
+        if (self.ticket != null) self.poisonIncompleteAttempt();
         if (self.attempt_headers) |headers| {
             deinitHeaderPairs(self.allocator, headers);
         }
@@ -1322,7 +1372,6 @@ const CapturingReader = struct {
     source_operation: ?*core.http.HttpOperation,
     failure: ?anyerror = null,
     bookkeeping_failed: bool = false,
-    reader_buffer: [64]u8 = undefined,
     scratch: [4096]u8 = undefined,
 
     fn init(
@@ -1339,7 +1388,7 @@ const CapturingReader = struct {
         };
         self.interface = .{
             .vtable = &.{ .stream = &stream },
-            .buffer = &self.reader_buffer,
+            .buffer = &.{},
             .seek = 0,
             .end = 0,
         };
@@ -1495,12 +1544,18 @@ fn cloneResponseHeaders(
     return result;
 }
 
-fn ownedExchangeFromResponse(
+const OwnedResponse = struct {
+    status: u16,
+    body: []u8,
+    body_allocation: ?[]u8 = null,
+    headers: []HeaderPair,
+};
+
+fn ownedResponseFromResponse(
     allocator: std.mem.Allocator,
-    pending: *PendingRequest,
     response: *const core.http.Response,
     response_body: []const u8,
-) !OwnedExchange {
+) !OwnedResponse {
     const body = try allocator.dupe(u8, response_body);
     errdefer allocator.free(body);
     const headers = try cloneResponseHeaders(
@@ -1508,19 +1563,11 @@ fn ownedExchangeFromResponse(
         &response.headers,
         &response.response_headers,
     );
-    allocator.free(pending.empty_response_body);
-    allocator.free(pending.empty_response_headers);
-    const exchange = OwnedExchange{
-        .request_method = pending.method,
-        .request_url = pending.url,
-        .request_headers = pending.headers,
-        .request_body = pending.body,
-        .response_status = response.status_code,
-        .response_body = body,
-        .response_headers = headers,
+    return .{
+        .status = response.status_code,
+        .body = body,
+        .headers = headers,
     };
-    pending.* = undefined;
-    return exchange;
 }
 
 fn parseExchange(
@@ -3825,6 +3872,8 @@ fn sanitizeQueryValueAlloc(
             else => return err,
         };
         defer allocator.free(sanitized_nested);
+        if (std.mem.eql(u8, current, sanitized_nested))
+            return allocator.dupe(u8, encoded);
         return percentEncodeQueryValueAlloc(allocator, sanitized_nested);
     }
 
@@ -4174,6 +4223,8 @@ const FailureStageTransport = struct {
         open,
         body,
         finish,
+        cancel_open,
+        cancel_body,
     },
     call_count: usize = 0,
 
@@ -4209,13 +4260,24 @@ const FailureStageTransport = struct {
         self.call_count += 1;
         if (self.mode == .open and self.call_count == 1)
             return error.ConnectionResetByPeer;
+        if (self.mode == .cancel_open and self.call_count == 1) {
+            var prefix: [3]u8 = undefined;
+            try options.body.?.reader.readSliceAll(&prefix);
+            return error.OperationCancelled;
+        }
         if (self.call_count == 1 and
-            (self.mode == .body or self.mode == .finish))
+            (self.mode == .body or
+                self.mode == .finish or
+                self.mode == .cancel_body))
         {
             return FailureStageOperation.create(
                 self.allocator,
-                self.mode == .body,
+                self.mode == .body or self.mode == .cancel_body,
                 self.mode == .finish,
+                if (self.mode == .cancel_body)
+                    error.OperationCancelled
+                else
+                    error.ConnectionResetByPeer,
             );
         }
         const transport = self.inner.asTransport();
@@ -4233,11 +4295,13 @@ const FailureStageOperation = struct {
     reader: FailureStageReader,
     fail_body: bool,
     fail_finish: bool,
+    failure: anyerror,
 
     fn create(
         allocator: std.mem.Allocator,
         fail_body: bool,
         fail_finish: bool,
+        failure: anyerror,
     ) !*core.http.HttpOperation {
         const self = try allocator.create(FailureStageOperation);
         errdefer allocator.destroy(self);
@@ -4251,6 +4315,7 @@ const FailureStageOperation = struct {
             .reader = undefined,
             .fail_body = fail_body,
             .fail_finish = fail_finish,
+            .failure = failure,
         };
         self.reader.init(if (fail_body) "partial" else "", fail_body);
         self.operation = .{
@@ -4270,7 +4335,7 @@ const FailureStageOperation = struct {
     fn finish(operation: *core.http.HttpOperation) !void {
         const self: *FailureStageOperation =
             @alignCast(@fieldParentPtr("operation", operation));
-        if (self.fail_finish) return error.ConnectionResetByPeer;
+        if (self.fail_finish) return self.failure;
     }
 
     fn abort(_: *core.http.HttpOperation) void {}
@@ -4278,7 +4343,7 @@ const FailureStageOperation = struct {
     fn bodyError(operation: *const core.http.HttpOperation) ?anyerror {
         const self: *const FailureStageOperation =
             @alignCast(@fieldParentPtr("operation", operation));
-        return if (self.fail_body) error.ConnectionResetByPeer else null;
+        return if (self.fail_body) self.failure else null;
     }
 
     fn deinit(operation: *core.http.HttpOperation) void {
@@ -4358,6 +4423,34 @@ const FailureStageReader = struct {
         }
         if (total != 0) return total;
         return error.EndOfStream;
+    }
+};
+
+const ReplayableRequestBody = struct {
+    bytes: []const u8,
+    reader: std.Io.Reader,
+    rewind_count: usize = 0,
+
+    fn init(bytes: []const u8) ReplayableRequestBody {
+        return .{
+            .bytes = bytes,
+            .reader = std.Io.Reader.fixed(bytes),
+        };
+    }
+
+    fn streaming(self: *ReplayableRequestBody) core.http.StreamingRequestBody {
+        return core.http.StreamingRequestBody.chunked(&self.reader).withRewind(
+            self,
+            &rewind,
+        );
+    }
+
+    fn rewind(context: *anyopaque) !*std.Io.Reader {
+        const self: *ReplayableRequestBody =
+            @ptrCast(@alignCast(context));
+        self.rewind_count += 1;
+        self.reader = std.Io.Reader.fixed(self.bytes);
+        return &self.reader;
     }
 };
 
@@ -4894,6 +4987,86 @@ test "recording wraps streaming operations and copies descriptor by value" {
     try std.testing.expectEqual(@as(usize, 1), mock.stream_deinit_count);
 }
 
+test "overlapping attempts retain dispatch order and block serialization" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+
+    var request_a = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/a",
+    );
+    defer request_a.deinit();
+    var request_b = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/b",
+    );
+    defer request_b.deinit();
+    var request_c = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/c",
+    );
+    defer request_c.deinit();
+
+    var operation_a = try recorder.asTransport().open(&request_a, .{});
+    var operation_b = try recorder.asTransport().open(&request_b, .{});
+    var response_c = try recorder.asTransport().send(&request_c);
+    response_c.deinit();
+
+    var slots = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 3), slots.len);
+    try std.testing.expectEqualStrings(request_a.url, slots[0].request_url);
+    try std.testing.expectEqualStrings(request_b.url, slots[1].request_url);
+    try std.testing.expectEqualStrings(request_c.url, slots[2].request_url);
+    try std.testing.expect(!slots[0].resolved);
+    try std.testing.expect(!slots[1].resolved);
+    try std.testing.expect(slots[2].resolved);
+    try std.testing.expect(!recorder.isComplete());
+    try std.testing.expectError(
+        error.IncompleteRecording,
+        recorder.toJson(std.testing.allocator),
+    );
+
+    try operation_b.finish();
+    operation_b.deinit();
+    slots = recorder.getExchanges();
+    try std.testing.expect(!slots[0].resolved);
+    try std.testing.expect(slots[1].resolved);
+    try std.testing.expect(slots[2].resolved);
+    try std.testing.expect(!recorder.isComplete());
+
+    try operation_a.finish();
+    operation_a.deinit();
+    try std.testing.expect(recorder.isComplete());
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings(
+        request_a.url,
+        parsed.asSlice()[0].request_url,
+    );
+    try std.testing.expectEqualStrings(
+        request_b.url,
+        parsed.asSlice()[1].request_url,
+    );
+    try std.testing.expectEqualStrings(
+        request_c.url,
+        parsed.asSlice()[2].request_url,
+    );
+}
+
 test "recording preserves buffered open fallback" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -5250,6 +5423,166 @@ test "finish errors record and replay before retry success" {
     try std.testing.expectEqualStrings("done", replayed_body);
     try replayed_retry.finish();
     replayed_retry.deinit();
+}
+
+test "mid-upload cancellation remains terminal through playback retry policy" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var cancelling = FailureStageTransport{
+        .allocator = std.testing.allocator,
+        .inner = &mock,
+        .mode = .cancel_open,
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        cancelling.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var retry = core.http.RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    retry.max_delay_ms = 0;
+    retry.max_retries = 2;
+    var policies = [_]*core.http.HttpPolicy{retry.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(recorder.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.test/upload-cancel",
+    );
+    defer request.deinit();
+    var upload = ReplayableRequestBody.init("payload");
+    try std.testing.expectError(
+        error.OperationCancelled,
+        pipeline.open(&request, .{ .body = upload.streaming() }),
+    );
+    try std.testing.expectEqual(@as(usize, 1), cancelling.call_count);
+    try std.testing.expectEqual(@as(usize, 0), upload.rewind_count);
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(
+        RecordedOutcome.open_error,
+        parsed.asSlice()[0].outcome,
+    );
+    try std.testing.expectEqual(
+        RecordedErrorCategory.cancelled,
+        parsed.asSlice()[0].error_category.?,
+    );
+    try std.testing.expectEqualStrings(
+        "pay",
+        parsed.asSlice()[0].request_body.?,
+    );
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var playback_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var playback_retry = core.http.RetryPolicy.init();
+    playback_retry.initial_delay_ms = 0;
+    playback_retry.max_delay_ms = 0;
+    playback_retry.max_retries = 2;
+    var playback_policies = [_]*core.http.HttpPolicy{
+        playback_retry.asPolicy(),
+    };
+    var playback_pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(
+            playback.asTransport(),
+            playback_crypto.asProvider(),
+        ),
+        &playback_policies,
+    );
+    var replay_upload = ReplayableRequestBody.init("payload");
+    try std.testing.expectError(
+        error.OperationCancelled,
+        playback_pipeline.open(
+            &request,
+            .{ .body = replay_upload.streaming() },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
+    try std.testing.expectEqual(@as(usize, 0), replay_upload.rewind_count);
+    try std.testing.expectEqual(@as(usize, 3), replay_upload.reader.seek);
+}
+
+test "response body cancellation replays exact terminal error once" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var cancelling = FailureStageTransport{
+        .allocator = std.testing.allocator,
+        .inner = &mock,
+        .mode = .cancel_body,
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        cancelling.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/body-cancel",
+    );
+    defer request.deinit();
+    var operation = try recorder.asTransport().open(&request, .{});
+    var partial: [7]u8 = undefined;
+    try (try operation.reader()).readSliceAll(&partial);
+    var extra: [1]u8 = undefined;
+    try std.testing.expectError(
+        error.ReadFailed,
+        (try operation.reader()).readSliceAll(&extra),
+    );
+    try std.testing.expectEqual(
+        error.OperationCancelled,
+        operation.bodyError().?,
+    );
+    operation.abort();
+    operation.deinit();
+    try std.testing.expectEqual(@as(usize, 1), cancelling.call_count);
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(
+        RecordedErrorCategory.cancelled,
+        parsed.asSlice()[0].error_category.?,
+    );
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed = try playback.asTransport().open(&request, .{});
+    var replayed_partial: [7]u8 = undefined;
+    try (try replayed.reader()).readSliceAll(&replayed_partial);
+    try std.testing.expectEqualStrings("partial", &replayed_partial);
+    try std.testing.expectError(
+        error.ReadFailed,
+        (try replayed.reader()).readSliceAll(&extra),
+    );
+    try std.testing.expectEqual(
+        error.OperationCancelled,
+        replayed.bodyError().?,
+    );
+    replayed.abort();
+    replayed.deinit();
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
 }
 
 test "recording stores abort and cancel as completed raw attempts" {
@@ -6645,6 +6978,100 @@ test "nested signed URI preserves exact host path and nonsensitive fields" {
     }
 }
 
+test "safe nested URI preserves caller encoding exactly" {
+    const urls = [_][]const u8{
+        "https://example.test/callback?return=" ++
+            "https%3a%2f%2fstorage.example%2fitem",
+        "https://example.test/callback?return=" ++
+            "https%3A%2F%2Fstorage.example%2F%7Euser",
+        "https://example.test/callback?return=" ++
+            "https%3A%2F%2Fstorage.example%2Fitem%3Flabel%3Da+b",
+        "https://example.test/callback?return=" ++
+            "https%3A%2F%2Fstorage.example%2Fitem%3Flabel%3Da%20b",
+    };
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{ .status = 200, .body = "" },
+            .{ .status = 200, .body = "" },
+            .{ .status = 200, .body = "" },
+            .{ .status = 200, .body = "" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    for (urls) |url| {
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+    }
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    for (urls, parsed.asSlice()) |expected, exchange| {
+        try std.testing.expectEqualStrings(expected, exchange.request_url);
+    }
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    for (urls) |url| {
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try playback.asTransport().send(&request);
+        response.deinit();
+    }
+
+    for ([_]struct {
+        index: usize,
+        different: []const u8,
+    }{
+        .{
+            .index = 0,
+            .different = "https://example.test/callback?return=" ++
+                "https%3A%2F%2Fstorage.example%2Fitem",
+        },
+        .{
+            .index = 1,
+            .different = "https://example.test/callback?return=" ++
+                "https%3A%2F%2Fstorage.example%2F~user",
+        },
+        .{
+            .index = 2,
+            .different = urls[3],
+        },
+    }) |case| {
+        var mismatch_playback = PlaybackTransport.init(
+            std.testing.allocator,
+            parsed.asSlice()[case.index..],
+        );
+        var mismatch = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            case.different,
+        );
+        defer mismatch.deinit();
+        try std.testing.expectError(
+            error.UrlMismatch,
+            mismatch_playback.asTransport().send(&mismatch),
+        );
+    }
+}
+
 test "pathless absolute and network-path URLs sanitize without range failures" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -7216,7 +7643,7 @@ test "location headers preserve replayable URLs and rotated SAS next exchanges" 
         ).?,
     );
     try std.testing.expectEqualStrings(
-        "/callback?return=https%3A%2F%2Fsafe.example%2Fnext&mode=one",
+        "/callback?return=https://safe.example/next&mode=one",
         getHeaderPair(
             recordings[1].response_headers,
             "Content-Location",

--- a/root.zig
+++ b/root.zig
@@ -268,7 +268,9 @@ pub fn initHttpRuntime(
 /// descriptor copies and open operations are deinitialized. Each recording is
 /// one raw transport invocation and is consumed when its recorded pre-response
 /// error is returned or its response head has been allocated, including
-/// redirect and retry attempts.
+/// redirect and retry attempts. A cooperative upload cancellation consumes a
+/// matching recorded cancelled-open prefix; preflight cancellation and
+/// cancellation against a non-cancelled attempt do not advance playback.
 pub const PlaybackTransport = struct {
     recordings: []const RecordedExchange,
     index: usize = 0,
@@ -356,9 +358,19 @@ pub const PlaybackTransport = struct {
                     captured = try readRequestBodyPrefix(
                         self.allocator,
                         streaming,
-                        options.cancellation,
                         expected_body.len,
                     );
+                    if (isCancelled(options.cancellation)) {
+                        if (exchange.error_category == .cancelled) {
+                            try matchRequest(
+                                exchange,
+                                request,
+                                captured.?,
+                            );
+                            self.index += 1;
+                        }
+                        return error.OperationCancelled;
+                    }
                     break :blk captured.?;
                 }
             }
@@ -894,6 +906,8 @@ pub const RecordingTransport = struct {
     /// content.
     /// Generated URL wildcard locations are serialized as explicit templates;
     /// literal `REDACTED` URL values remain exact-match data.
+    /// Non-UTF-8 URL and header bytes use explicit lossless base64 metadata
+    /// objects rather than being emitted as invalid JSON strings.
     ///
     /// Structurally recognized credential-bearing JSON, form, connection
     /// string, XML, and private-key bodies cause
@@ -965,7 +979,11 @@ pub const RecordingTransport = struct {
                 exchange.request_url,
             );
             defer allocator.free(sanitized_request_url);
-            try writeJsonString(writer, sanitized_request_url);
+            try writeMetadataBytes(
+                writer,
+                allocator,
+                sanitized_request_url,
+            );
             try writer.writeAll(",\"request_url_redaction_template\":");
             if (!std.mem.eql(
                 u8,
@@ -979,7 +997,7 @@ pub const RecordingTransport = struct {
                 );
                 defer allocator.free(template);
                 if (std.mem.indexOfScalar(u8, template, 0) != null)
-                    try writeJsonString(writer, template)
+                    try writeMetadataBytes(writer, allocator, template)
                 else
                     try writer.writeAll("null");
             } else {
@@ -1724,11 +1742,11 @@ fn parseExchange(
         if (format_version == 2 or
         object.get("request_url_redaction_template") == null)
             null
-        else switch (object.get("request_url_redaction_template").?) {
-            .null => null,
-            .string => |template| try allocator.dupe(u8, template),
-            else => return error.InvalidRecordingJson,
-        };
+        else
+            try parseOptionalMetadataBytes(
+                allocator,
+                object.get("request_url_redaction_template").?,
+            );
     errdefer if (request_url_redaction_template) |template|
         allocator.free(template);
     const request_headers_value = object.get("request_headers") orelse
@@ -1736,7 +1754,7 @@ fn parseExchange(
     const request_body_value = object.get("request_body") orelse
         return error.InvalidRecordingJson;
     const method = try parseMethod(try jsonString(method_value));
-    const request_url = try allocator.dupe(u8, try jsonString(request_url_value));
+    const request_url = try parseMetadataBytes(allocator, request_url_value);
     errdefer allocator.free(request_url);
     if (request_url_redaction_template) |template|
         try validateUrlRedactionTemplate(request_url, template);
@@ -1865,18 +1883,14 @@ fn parseHeaders(
         } else false;
         const url_redaction_template: ?[]u8 =
             if (object.get("url_redaction_template")) |template_value|
-                switch (template_value) {
-                    .null => null,
-                    .string => |template| try allocator.dupe(u8, template),
-                    else => return error.InvalidRecordingJson,
-                }
+                try parseOptionalMetadataBytes(allocator, template_value)
             else
                 null;
         errdefer if (url_redaction_template) |template|
             allocator.free(template);
-        header.name = try allocator.dupe(u8, try jsonString(name_value));
+        header.name = try parseMetadataBytes(allocator, name_value);
         errdefer allocator.free(header.name);
-        header.value = try allocator.dupe(u8, try jsonString(field_value));
+        header.value = try parseMetadataBytes(allocator, field_value);
         errdefer allocator.free(header.value);
         header.redacted = redacted;
         header.url_redaction_template = url_redaction_template;
@@ -1919,6 +1933,27 @@ fn parseBody(
     std.base64.standard.Decoder.decode(decoded, encoded) catch
         return error.InvalidRecordingBody;
     return decoded;
+}
+
+fn parseMetadataBytes(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) ![]u8 {
+    return switch (value) {
+        .string => |bytes| allocator.dupe(u8, bytes),
+        .object => parseBody(allocator, value),
+        else => error.InvalidRecordingJson,
+    };
+}
+
+fn parseOptionalMetadataBytes(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !?[]u8 {
+    return switch (value) {
+        .null => null,
+        else => try parseMetadataBytes(allocator, value),
+    };
 }
 
 fn jsonString(value: std.json.Value) ![]const u8 {
@@ -2122,24 +2157,23 @@ fn readRequestBody(
 fn readRequestBodyPrefix(
     allocator: std.mem.Allocator,
     body: core.http.StreamingRequestBody,
-    cancellation: ?*const core.http.CancellationToken,
     length: usize,
 ) ![]u8 {
     const result = try allocator.alloc(u8, length);
     errdefer allocator.free(result);
-    try checkCancelled(cancellation);
     body.reader.readSliceAll(result) catch |err| switch (err) {
         error.EndOfStream => return error.RequestBodyTooShort,
         else => return err,
     };
-    try checkCancelled(cancellation);
     return result;
 }
 
+fn isCancelled(token: ?*const core.http.CancellationToken) bool {
+    return if (token) |value| value.isCancelled() else false;
+}
+
 fn checkCancelled(token: ?*const core.http.CancellationToken) !void {
-    if (token) |value| {
-        if (value.isCancelled()) return error.OperationCancelled;
-    }
+    if (isCancelled(token)) return error.OperationCancelled;
 }
 
 fn cloneRequestHeaders(
@@ -2577,14 +2611,15 @@ fn ensureBodySafe(
 
     const xml = valid_text and identity_encoding and
         (containsIgnoreCase(content_type, "xml") or looksLikeXml(bytes));
-    if (xml and
-        (try containsSensitiveXml(allocator, bytes) or
+    if (xml) {
+        if (try inspectXmlDocument(allocator, bytes) or
             try containsSensitiveAssignment(allocator, bytes) or
             (try isStorageUserDelegationKeyExchange(allocator, context) and
                 containsIgnoreCase(bytes, "<UserDelegationKey") and
-                containsIgnoreCase(bytes, "<Value"))))
-    {
-        return error.SensitiveBodyRequiresSanitization;
+                containsIgnoreCase(bytes, "<Value")))
+        {
+            return error.SensitiveBodyRequiresSanitization;
+        }
     }
 
     if (!valid_text or
@@ -2719,17 +2754,19 @@ fn containsSensitiveMultipartPart(
         return error.UnsupportedBodySanitization;
     const outer_headers = part[0..outer_separator.start];
     var payload = part[outer_separator.end..];
-    var payload_content_type = headerValueFromBlock(
+    var payload_content_type = try headerValueFromBlockWithStartLine(
         outer_headers,
         "Content-Type",
+        false,
     );
     if (looksLikeHttpMessage(payload)) {
         const inner_separator = findHeaderSeparator(payload) orelse
             return error.UnsupportedBodySanitization;
         const inner_headers = payload[0..inner_separator.start];
-        payload_content_type = headerValueFromBlock(
+        payload_content_type = try headerValueFromBlockWithStartLine(
             inner_headers,
             "Content-Type",
+            true,
         );
         payload = payload[inner_separator.end..];
     }
@@ -2755,11 +2792,7 @@ fn containsSensitiveLoosePayload(
     const payload = std.mem.trim(u8, raw_payload, " \t\r\n");
     if (payload.len == 0) return false;
     if (try containsSensitiveScalar(allocator, payload)) return true;
-    if (try containsSensitiveXml(allocator, payload) or
-        try containsSensitiveAssignment(allocator, payload))
-    {
-        return true;
-    }
+    if (try containsSensitiveAssignment(allocator, payload)) return true;
     if (looksLikeStructuredJson(payload)) {
         const parsed = std.json.parseFromSlice(
             std.json.Value,
@@ -2775,7 +2808,9 @@ fn containsSensitiveLoosePayload(
             return true;
         return false;
     }
-    if (looksLikeXml(payload)) return false;
+    if (looksLikeXml(payload))
+        return inspectXmlDocument(allocator, payload);
+    if (try containsSensitiveXml(allocator, payload)) return true;
     if (std.mem.indexOfAny(u8, payload, "{}[]<>") != null)
         return error.UnsupportedBodySanitization;
     return false;
@@ -2857,19 +2892,47 @@ fn multipartBoundary(content_type: []const u8) ![]const u8 {
     return error.UnsupportedBodySanitization;
 }
 
-fn headerValueFromBlock(
+fn headerValueFromBlockWithStartLine(
     headers: []const u8,
     expected_name: []const u8,
-) ?[]const u8 {
+    allow_http_start_line: bool,
+) !?[]const u8 {
     var lines = std.mem.splitScalar(u8, headers, '\n');
+    var line_index: usize = 0;
+    var result: ?[]const u8 = null;
     while (lines.next()) |raw_line| {
-        const line = std.mem.trim(u8, raw_line, " \t\r");
-        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
-        const name = std.mem.trim(u8, line[0..colon], " \t");
+        if (raw_line.len != 0 and
+            (raw_line[0] == ' ' or raw_line[0] == '\t'))
+        {
+            return error.UnsupportedBodySanitization;
+        }
+        const line = std.mem.trimEnd(u8, raw_line, "\r");
+        if (std.mem.indexOfScalar(u8, line, '\r') != null)
+            return error.UnsupportedBodySanitization;
+        if (line.len == 0) return error.UnsupportedBodySanitization;
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse {
+            if (allow_http_start_line and line_index == 0 and
+                looksLikeHttpMessage(line))
+            {
+                line_index += 1;
+                continue;
+            }
+            return error.UnsupportedBodySanitization;
+        };
+        const name = line[0..colon];
+        if (name.len == 0) return error.UnsupportedBodySanitization;
+        for (name) |byte| {
+            if (byte <= 0x20 or byte >= 0x7f or
+                std.mem.indexOfScalar(u8, "()<>@,;:\\\"/[]?={}", byte) != null)
+            {
+                return error.UnsupportedBodySanitization;
+            }
+        }
         if (std.ascii.eqlIgnoreCase(name, expected_name))
-            return std.mem.trim(u8, line[colon + 1 ..], " \t");
+            result = std.mem.trim(u8, line[colon + 1 ..], " \t");
+        line_index += 1;
     }
-    return null;
+    return result;
 }
 
 fn containsSensitiveHttpHeaderLine(
@@ -3630,6 +3693,290 @@ fn percentDecodeFieldName(
     return buffer[0..output_index];
 }
 
+const XmlInspector = struct {
+    allocator: std.mem.Allocator,
+    bytes: []const u8,
+    index: usize = 0,
+    sensitive: bool = false,
+
+    fn inspect(self: *XmlInspector) !bool {
+        self.skipWhitespace();
+        if (std.mem.startsWith(u8, self.bytes[self.index..], "<?xml")) {
+            try self.parseProcessingInstruction();
+            self.skipWhitespace();
+        }
+        while (try self.parseMisc()) self.skipWhitespace();
+        if (self.index >= self.bytes.len or self.bytes[self.index] != '<')
+            return error.UnsupportedBodySanitization;
+        try self.parseElement(0);
+        self.skipWhitespace();
+        while (try self.parseMisc()) self.skipWhitespace();
+        if (self.index != self.bytes.len)
+            return error.UnsupportedBodySanitization;
+        return self.sensitive;
+    }
+
+    fn parseElement(self: *XmlInspector, depth: usize) !void {
+        if (depth >= 128 or
+            self.index >= self.bytes.len or
+            self.bytes[self.index] != '<' or
+            std.mem.startsWith(u8, self.bytes[self.index..], "</") or
+            std.mem.startsWith(u8, self.bytes[self.index..], "<!") or
+            std.mem.startsWith(u8, self.bytes[self.index..], "<?"))
+        {
+            return error.UnsupportedBodySanitization;
+        }
+        self.index += 1;
+        const element_name = try self.parseName();
+        if (isSensitiveBodyField(xmlLocalName(element_name)))
+            self.sensitive = true;
+
+        var attribute_names: [64][]const u8 = undefined;
+        var attribute_count: usize = 0;
+        while (true) {
+            self.skipWhitespace();
+            if (self.consume("/>")) return;
+            if (self.consume(">")) break;
+            if (attribute_count == attribute_names.len)
+                return error.UnsupportedBodySanitization;
+            const attribute_name = try self.parseName();
+            for (attribute_names[0..attribute_count]) |previous| {
+                if (std.mem.eql(u8, previous, attribute_name))
+                    return error.UnsupportedBodySanitization;
+            }
+            attribute_names[attribute_count] = attribute_name;
+            attribute_count += 1;
+            self.skipWhitespace();
+            if (!self.consume("="))
+                return error.UnsupportedBodySanitization;
+            self.skipWhitespace();
+            const attribute_value = try self.parseQuotedValue();
+            if (try self.attributeSensitive(
+                xmlLocalName(attribute_name),
+                attribute_value,
+            )) self.sensitive = true;
+        }
+
+        while (true) {
+            if (self.index >= self.bytes.len)
+                return error.UnsupportedBodySanitization;
+            if (std.mem.startsWith(u8, self.bytes[self.index..], "</")) {
+                self.index += 2;
+                const closing_name = try self.parseName();
+                self.skipWhitespace();
+                if (!self.consume(">") or
+                    !std.mem.eql(u8, element_name, closing_name))
+                {
+                    return error.UnsupportedBodySanitization;
+                }
+                return;
+            }
+            if (std.mem.startsWith(
+                u8,
+                self.bytes[self.index..],
+                "<!--",
+            )) {
+                try self.parseComment();
+                continue;
+            }
+            if (std.mem.startsWith(
+                u8,
+                self.bytes[self.index..],
+                "<![CDATA[",
+            )) {
+                try self.parseCdata();
+                continue;
+            }
+            if (std.mem.startsWith(u8, self.bytes[self.index..], "<?")) {
+                try self.parseProcessingInstruction();
+                continue;
+            }
+            if (std.mem.startsWith(u8, self.bytes[self.index..], "<!"))
+                return error.UnsupportedBodySanitization;
+            if (self.bytes[self.index] == '<') {
+                try self.parseElement(depth + 1);
+                continue;
+            }
+            const text_start = self.index;
+            while (self.index < self.bytes.len and
+                self.bytes[self.index] != '<')
+            {
+                self.index += 1;
+            }
+            try self.inspectText(self.bytes[text_start..self.index]);
+        }
+    }
+
+    fn parseMisc(self: *XmlInspector) !bool {
+        if (std.mem.startsWith(u8, self.bytes[self.index..], "<!--")) {
+            try self.parseComment();
+            return true;
+        }
+        if (std.mem.startsWith(u8, self.bytes[self.index..], "<?")) {
+            try self.parseProcessingInstruction();
+            return true;
+        }
+        return false;
+    }
+
+    fn parseComment(self: *XmlInspector) !void {
+        if (!self.consume("<!--"))
+            return error.UnsupportedBodySanitization;
+        const end = std.mem.indexOfPos(
+            u8,
+            self.bytes,
+            self.index,
+            "-->",
+        ) orelse return error.UnsupportedBodySanitization;
+        const value = self.bytes[self.index..end];
+        if (std.mem.indexOf(u8, value, "--") != null)
+            return error.UnsupportedBodySanitization;
+        try self.inspectText(value);
+        self.index = end + 3;
+    }
+
+    fn parseCdata(self: *XmlInspector) !void {
+        if (!self.consume("<![CDATA["))
+            return error.UnsupportedBodySanitization;
+        const end = std.mem.indexOfPos(
+            u8,
+            self.bytes,
+            self.index,
+            "]]>",
+        ) orelse return error.UnsupportedBodySanitization;
+        try self.inspectText(self.bytes[self.index..end]);
+        self.index = end + 3;
+    }
+
+    fn parseProcessingInstruction(self: *XmlInspector) !void {
+        if (!self.consume("<?"))
+            return error.UnsupportedBodySanitization;
+        const end = std.mem.indexOfPos(
+            u8,
+            self.bytes,
+            self.index,
+            "?>",
+        ) orelse return error.UnsupportedBodySanitization;
+        try self.inspectText(self.bytes[self.index..end]);
+        self.index = end + 2;
+    }
+
+    fn parseName(self: *XmlInspector) ![]const u8 {
+        if (self.index >= self.bytes.len or
+            !isXmlNameStart(self.bytes[self.index]))
+        {
+            return error.UnsupportedBodySanitization;
+        }
+        const start = self.index;
+        self.index += 1;
+        while (self.index < self.bytes.len and
+            isXmlNameByte(self.bytes[self.index]))
+        {
+            self.index += 1;
+        }
+        return self.bytes[start..self.index];
+    }
+
+    fn parseQuotedValue(self: *XmlInspector) ![]const u8 {
+        if (self.index >= self.bytes.len or
+            (self.bytes[self.index] != '"' and
+                self.bytes[self.index] != '\''))
+        {
+            return error.UnsupportedBodySanitization;
+        }
+        const quote = self.bytes[self.index];
+        self.index += 1;
+        const start = self.index;
+        while (self.index < self.bytes.len and
+            self.bytes[self.index] != quote)
+        {
+            if (self.bytes[self.index] == '<' or
+                self.bytes[self.index] == '&')
+            {
+                return error.UnsupportedBodySanitization;
+            }
+            self.index += 1;
+        }
+        if (self.index >= self.bytes.len)
+            return error.UnsupportedBodySanitization;
+        const value = self.bytes[start..self.index];
+        self.index += 1;
+        return value;
+    }
+
+    fn attributeSensitive(
+        self: *XmlInspector,
+        name: []const u8,
+        value: []const u8,
+    ) !bool {
+        return isSensitiveBodyField(name) or
+            ((normalizedFieldEquals(name, "key") or
+                normalizedFieldEquals(name, "name") or
+                normalizedFieldEquals(name, "field") or
+                normalizedFieldEquals(name, "property")) and
+                isSensitiveBodyField(value)) or
+            try containsSensitiveAssignment(self.allocator, value) or
+            try containsSensitiveScalar(self.allocator, value) or
+            containsPrivateKeyMarker(value);
+    }
+
+    fn inspectText(self: *XmlInspector, value: []const u8) !void {
+        if (std.mem.indexOfScalar(u8, value, '&') != null)
+            return error.UnsupportedBodySanitization;
+        if (try containsSensitiveAssignment(self.allocator, value) or
+            try containsSensitiveScalar(self.allocator, value) or
+            containsPrivateKeyMarker(value))
+        {
+            self.sensitive = true;
+        }
+    }
+
+    fn skipWhitespace(self: *XmlInspector) void {
+        while (self.index < self.bytes.len and
+            (self.bytes[self.index] == ' ' or
+                self.bytes[self.index] == '\t' or
+                self.bytes[self.index] == '\r' or
+                self.bytes[self.index] == '\n'))
+        {
+            self.index += 1;
+        }
+    }
+
+    fn consume(self: *XmlInspector, value: []const u8) bool {
+        if (!std.mem.startsWith(u8, self.bytes[self.index..], value))
+            return false;
+        self.index += value.len;
+        return true;
+    }
+};
+
+fn inspectXmlDocument(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !bool {
+    var inspector = XmlInspector{
+        .allocator = allocator,
+        .bytes = body,
+    };
+    return inspector.inspect();
+}
+
+fn xmlLocalName(name: []const u8) []const u8 {
+    if (std.mem.lastIndexOfScalar(u8, name, ':')) |colon|
+        return name[colon + 1 ..];
+    return name;
+}
+
+fn isXmlNameStart(byte: u8) bool {
+    return std.ascii.isAlphabetic(byte) or
+        byte == '_' or byte == ':' or byte >= 0x80;
+}
+
+fn isXmlNameByte(byte: u8) bool {
+    return isXmlNameStart(byte) or
+        std.ascii.isDigit(byte) or byte == '-' or byte == '.';
+}
+
 fn containsSensitiveXml(
     allocator: std.mem.Allocator,
     body: []const u8,
@@ -3754,7 +4101,7 @@ fn writeHeaders(
     for (headers, 0..) |header, index| {
         if (index != 0) try writer.writeByte(',');
         try writer.writeAll("{\"name\":");
-        try writeJsonString(writer, header.name);
+        try writeMetadataBytes(writer, allocator, header.name);
         try writer.writeAll(",\"value\":");
         const context = HeaderSafetyContext{
             .direction = direction,
@@ -3812,15 +4159,15 @@ fn writeHeaders(
         if (redact) {
             try writeJsonString(writer, redacted_value);
         } else if (sanitized_url) |url| {
-            try writeJsonString(writer, url);
+            try writeMetadataBytes(writer, allocator, url);
         } else {
-            try writeJsonString(writer, header.value);
+            try writeMetadataBytes(writer, allocator, header.value);
         }
         try writer.print(",\"redacted\":{}", .{redact});
         try writer.writeAll(",\"url_redaction_template\":");
         if (!redact) {
             if (sanitized_template) |template|
-                try writeJsonString(writer, template)
+                try writeMetadataBytes(writer, allocator, template)
             else
                 try writer.writeAll("null");
         } else {
@@ -4425,6 +4772,18 @@ fn writeBody(
     try writer.writeByte('}');
 }
 
+fn writeMetadataBytes(
+    writer: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !void {
+    if (std.unicode.utf8ValidateSlice(value)) {
+        try writeJsonString(writer, value);
+    } else {
+        try writeBody(writer, allocator, value);
+    }
+}
+
 fn writeJsonString(writer: *std.Io.Writer, value: []const u8) !void {
     try writer.writeByte('"');
     for (value) |byte| {
@@ -4842,6 +5201,77 @@ const ReplayableRequestBody = struct {
         self.rewind_count += 1;
         self.reader = std.Io.Reader.fixed(self.bytes);
         return &self.reader;
+    }
+};
+
+const CooperativeCancellingReader = struct {
+    interface: std.Io.Reader,
+    bytes: []const u8,
+    offset: usize = 0,
+    cancellation: *core.http.CancellationToken,
+
+    fn init(
+        self: *CooperativeCancellingReader,
+        bytes: []const u8,
+        cancellation: *core.http.CancellationToken,
+    ) void {
+        self.* = .{
+            .interface = undefined,
+            .bytes = bytes,
+            .cancellation = cancellation,
+        };
+        self.interface = .{
+            .vtable = &.{
+                .stream = &stream,
+                .readVec = &readVec,
+            },
+            .buffer = &.{},
+            .seek = 0,
+            .end = 0,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *CooperativeCancellingReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        const count = @min(
+            limit.minInt(self.bytes.len - self.offset),
+            self.bytes.len - self.offset,
+        );
+        if (count == 0) return error.EndOfStream;
+        try writer.writeAll(self.bytes[self.offset..][0..count]);
+        self.offset += count;
+        if (self.offset == self.bytes.len) self.cancellation.cancel();
+        return count;
+    }
+
+    fn readVec(
+        interface: *std.Io.Reader,
+        data: [][]u8,
+    ) std.Io.Reader.Error!usize {
+        const self: *CooperativeCancellingReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        var total: usize = 0;
+        for (data) |destination| {
+            const count = @min(
+                destination.len,
+                self.bytes.len - self.offset,
+            );
+            @memcpy(
+                destination[0..count],
+                self.bytes[self.offset..][0..count],
+            );
+            self.offset += count;
+            total += count;
+            if (self.offset == self.bytes.len) break;
+        }
+        if (self.offset == self.bytes.len) self.cancellation.cancel();
+        if (total != 0) return total;
+        return error.EndOfStream;
     }
 };
 
@@ -5950,6 +6380,111 @@ test "mid-upload cancellation remains terminal through playback retry policy" {
     try std.testing.expectEqual(@as(usize, 1), playback.index);
     try std.testing.expectEqual(@as(usize, 0), replay_upload.rewind_count);
     try std.testing.expectEqual(@as(usize, 3), replay_upload.reader.seek);
+}
+
+test "cooperative upload cancellation consumes only matching cancelled attempt" {
+    const cancelled_recording = RecordedExchange{
+        .request_method = .POST,
+        .request_url = "https://example.test/cancelled-upload",
+        .request_body = "pay",
+        .outcome = .open_error,
+        .error_category = .cancelled,
+    };
+    const next_recording = RecordedExchange{
+        .request_method = .GET,
+        .request_url = "https://example.test/next",
+        .response_status = 200,
+        .response_body = "next",
+    };
+    const recordings = [_]RecordedExchange{
+        cancelled_recording,
+        next_recording,
+    };
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        cancelled_recording.request_url,
+    );
+    defer request.deinit();
+    var cancellation = core.http.CancellationToken{};
+    var reader: CooperativeCancellingReader = undefined;
+    reader.init("pay", &cancellation);
+    try std.testing.expectError(
+        error.OperationCancelled,
+        playback.asTransport().open(
+            &request,
+            .{
+                .body = core.http.StreamingRequestBody.chunked(
+                    &reader.interface,
+                ),
+                .cancellation = &cancellation,
+            },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
+
+    var next_request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        next_recording.request_url,
+    );
+    defer next_request.deinit();
+    var next_response = try playback.asTransport().send(&next_request);
+    defer next_response.deinit();
+    try std.testing.expectEqualStrings("next", next_response.body);
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
+
+    var preflight_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var preflight_cancellation = core.http.CancellationToken{};
+    preflight_cancellation.cancel();
+    var preflight_reader = std.Io.Reader.fixed("pay");
+    try std.testing.expectError(
+        error.OperationCancelled,
+        preflight_playback.asTransport().open(
+            &request,
+            .{
+                .body = core.http.StreamingRequestBody.chunked(
+                    &preflight_reader,
+                ),
+                .cancellation = &preflight_cancellation,
+            },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 0), preflight_playback.index);
+
+    const successful_recording = [_]RecordedExchange{.{
+        .request_method = .POST,
+        .request_url = cancelled_recording.request_url,
+        .request_body = "pay",
+        .response_status = 200,
+    }};
+    var successful_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &successful_recording,
+    );
+    var live_cancellation = core.http.CancellationToken{};
+    var live_reader: CooperativeCancellingReader = undefined;
+    live_reader.init("pay", &live_cancellation);
+    try std.testing.expectError(
+        error.OperationCancelled,
+        successful_playback.asTransport().open(
+            &request,
+            .{
+                .body = core.http.StreamingRequestBody.chunked(
+                    &live_reader.interface,
+                ),
+                .cancellation = &live_cancellation,
+            },
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 0), successful_playback.index);
 }
 
 test "response body cancellation replays exact terminal error once" {
@@ -7608,6 +8143,119 @@ test "legacy recordings never infer URL wildcards from marker text" {
             mismatch_playback.asTransport().send(&mismatch),
         );
     }
+}
+
+test "non UTF-8 URL and header metadata roundtrip as encoded bytes" {
+    const recorded_url = "https://example.test/\xff";
+    const rotated_url = "https://example.test/\xfe";
+    const recorded_header = [_]u8{ 0xff, 'a', 0x80 };
+    const different_header = [_]u8{ 0xfe, 'a', 0x80 };
+    const response_header = [_]u8{ 'b', 0xff, 0x81 };
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "ETag", .value = &response_header },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        recorded_url,
+    );
+    defer request.deinit();
+    try request.setHeader("ETag", &recorded_header);
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(json));
+    try std.testing.expect(std.mem.indexOfScalar(u8, json, 0xff) == null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "\"encoding\":\"base64\"") != null,
+    );
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    const exchange = parsed.asSlice()[0];
+    try std.testing.expectEqualSlices(
+        u8,
+        recorded_url,
+        exchange.request_url,
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        &recorded_header,
+        getHeaderPair(exchange.request_headers, "ETag").?,
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        &response_header,
+        getHeaderPair(exchange.response_headers, "ETag").?,
+    );
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var exact = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        recorded_url,
+    );
+    defer exact.deinit();
+    try exact.setHeader("ETag", &recorded_header);
+    var replayed = try playback.asTransport().send(&exact);
+    defer replayed.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        &response_header,
+        replayed.getHeader("ETag").?,
+    );
+
+    var header_mismatch_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var header_mismatch = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        recorded_url,
+    );
+    defer header_mismatch.deinit();
+    try header_mismatch.setHeader("ETag", &different_header);
+    try std.testing.expectError(
+        error.HeaderMismatch,
+        header_mismatch_playback.asTransport().send(&header_mismatch),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        header_mismatch_playback.index,
+    );
+
+    var url_mismatch_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var url_mismatch = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        rotated_url,
+    );
+    defer url_mismatch.deinit();
+    try url_mismatch.setHeader("ETag", &recorded_header);
+    try std.testing.expectError(
+        error.UrlMismatch,
+        url_mismatch_playback.asTransport().send(&url_mismatch),
+    );
+    try std.testing.expectEqual(@as(usize, 0), url_mismatch_playback.index);
 }
 
 test "safe nested URI preserves caller encoding exactly" {
@@ -9820,6 +10468,142 @@ test "multipart preamble and epilogue structures fail closed" {
     }
 }
 
+test "folded multipart headers fail closed before credential persistence" {
+    const folded_parts = [_][]const u8{
+        "--batch\r\nContent-Disposition: form-data;\r\n" ++
+            " name=\"password\"\r\n\r\nfolded-space-secret\r\n" ++
+            "--batch--\r\n",
+        "--batch\r\nContent-Disposition: form-data;\r\n" ++
+            "\tname=\"accessToken\"\r\n\r\nfolded-tab-secret\r\n" ++
+            "--batch--\r\n",
+        "--batch\r\nContent-Type: application/http\r\n\r\n" ++
+            "POST /resource HTTP/1.1\r\nAuthorization:\r\n" ++
+            "\tBearer embedded-auth-secret\r\n" ++
+            "Content-Type: text/plain\r\n\r\nsafe\r\n" ++
+            "--batch--\r\n",
+    };
+    for (folded_parts[0..2]) |body| {
+        try std.testing.expectError(
+            error.UnsupportedBodySanitization,
+            containsSensitiveMultipartContent(
+                std.testing.allocator,
+                "multipart/mixed; boundary=batch",
+                body,
+                0,
+            ),
+        );
+    }
+    try std.testing.expect(try containsSensitiveMultipartContent(
+        std.testing.allocator,
+        "multipart/mixed; boundary=batch",
+        folded_parts[2],
+        0,
+    ));
+
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        folded_parts[2],
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{
+            .name = "Content-Type",
+            .value = "multipart/mixed; boundary=batch",
+        },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &allowOpaqueBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/folded-multipart",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    var output: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    if (recorder.writeJson(
+        &output.writer,
+        std.testing.allocator,
+    )) |_| {
+        return error.TestExpectedError;
+    } else |err| {
+        try std.testing.expect(
+            err == error.UnsupportedBodySanitization or
+                err == error.SensitiveBodyRequiresSanitization,
+        );
+    }
+    try std.testing.expect(
+        std.mem.indexOf(u8, output.written(), "embedded-auth-secret") ==
+            null,
+    );
+}
+
+test "malformed and trailing mixed XML structures fail closed" {
+    const malformed = [_][]const u8{
+        "<notice>{\"token\":\"malformed-prefix-secret\"}",
+        "<notice/>{\"token\":\"trailing-json-secret\"}",
+        "<notice><child>safe</notice>",
+        "<notice>safe</notice><trailing/>",
+    };
+    for (malformed) |body| {
+        try std.testing.expectError(
+            error.UnsupportedBodySanitization,
+            inspectXmlDocument(std.testing.allocator, body),
+        );
+    }
+
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        malformed[0],
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/xml" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/malformed-xml",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    var output: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    if (recorder.writeJson(
+        &output.writer,
+        std.testing.allocator,
+    )) |_| {
+        return error.TestExpectedError;
+    } else |err| {
+        try std.testing.expect(
+            err == error.UnsupportedBodySanitization or
+                err == error.SensitiveBodyRequiresSanitization,
+        );
+    }
+    try std.testing.expect(
+        std.mem.indexOf(
+            u8,
+            output.written(),
+            "malformed-prefix-secret",
+        ) == null,
+    );
+}
+
 test "safe multipart application http batch roundtrips explicitly" {
     const body =
         "legal MIME preamble\r\n" ++
@@ -10445,6 +11229,37 @@ fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
     allocator.free(json);
 }
 
+fn binaryMetadataSerializationAllocationFixture(
+    allocator: std.mem.Allocator,
+) !void {
+    const header_value = [_]u8{ 0xff, 'a' };
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "ETag", .value = &header_value },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/\xff",
+    );
+    defer request.deinit();
+    try request.setHeader("ETag", &header_value);
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(allocator);
+    allocator.free(json);
+}
+
 fn multipartSerializationAllocationFixture(
     allocator: std.mem.Allocator,
 ) !void {
@@ -10590,6 +11405,35 @@ fn redactionTemplateParsingAllocationFixture(
     parsed.deinit();
 }
 
+const binary_metadata_allocation_fixture_json =
+    \\{"version":3,"exchanges":[{
+    \\"request_method":"GET",
+    \\"request_url":{"encoding":"base64","data":"aHR0cHM6Ly9leGFtcGxlLnRlc3Qv/w=="},
+    \\"request_url_redaction_template":null,
+    \\"request_headers":[{
+    \\"name":"ETag",
+    \\"value":{"encoding":"base64","data":"/2E="},
+    \\"redacted":false,
+    \\"url_redaction_template":null
+    \\}],
+    \\"request_body":null,
+    \\"outcome":"response",
+    \\"response_status":200,
+    \\"response_headers":[],
+    \\"response_body":{"encoding":"base64","data":""}
+    \\}]}
+;
+
+fn binaryMetadataParsingAllocationFixture(
+    allocator: std.mem.Allocator,
+) !void {
+    var parsed = try parseJson(
+        allocator,
+        binary_metadata_allocation_fixture_json,
+    );
+    parsed.deinit();
+}
+
 test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
@@ -10614,6 +11458,11 @@ test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         serializationAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        binaryMetadataSerializationAllocationFixture,
         .{},
     );
     try std.testing.checkAllAllocationFailures(
@@ -10644,6 +11493,11 @@ test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         redactionTemplateParsingAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        binaryMetadataParsingAllocationFixture,
         .{},
     );
 }

--- a/root.zig
+++ b/root.zig
@@ -3056,21 +3056,16 @@ fn sanitizeUrlAllocDepth(
         if (!first) try output.writer.writeByte('&');
         first = false;
         const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse {
-            const decoded = try percentDecodeAlloc(
+            if (try encodedQueryNameIsSensitive(
+                allocator,
+                parameter,
+            ) or try encodedComponentIsSensitive(
                 allocator,
                 parameter,
                 true,
-            );
-            defer allocator.free(decoded);
-            if (isSensitiveQueryField(decoded) or
-                try encodedComponentIsSensitive(
-                    allocator,
-                    parameter,
-                    true,
-                    true,
-                    nesting,
-                ))
-            {
+                true,
+                nesting,
+            )) {
                 try output.writer.writeAll(parameter);
                 try output.writer.writeAll("=");
                 try output.writer.writeAll(redacted_value);
@@ -3081,13 +3076,10 @@ fn sanitizeUrlAllocDepth(
         };
         const encoded_name = parameter[0..equals];
         const encoded_value = parameter[equals + 1 ..];
-        const decoded_name = try percentDecodeAlloc(
+        const redact = try encodedQueryNameIsSensitive(
             allocator,
             encoded_name,
-            true,
-        );
-        defer allocator.free(decoded_name);
-        const redact = isSensitiveQueryField(decoded_name) or
+        ) or
             try encodedComponentIsSensitive(
                 allocator,
                 encoded_value,
@@ -3103,6 +3095,29 @@ fn sanitizeUrlAllocDepth(
         try output.writer.writeAll(url[fragment_start..]);
     }
     return output.toOwnedSlice();
+}
+
+fn encodedQueryNameIsSensitive(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+) !bool {
+    if (encoded.len > max_sanitized_url_length) return true;
+    var current = try allocator.dupe(u8, encoded);
+    defer allocator.free(current);
+    var decode_count: usize = 0;
+    while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+        const decoded = try percentDecodeAlloc(
+            allocator,
+            current,
+            decode_count == 0,
+        );
+        const changed = !std.mem.eql(u8, current, decoded);
+        allocator.free(current);
+        current = decoded;
+        if (isSensitiveQueryField(current)) return true;
+        if (!changed) return false;
+    }
+    return containsPercentEscape(current);
 }
 
 fn encodedComponentIsSensitive(
@@ -4767,7 +4782,8 @@ test "URL sanitization recursively decodes nested URI credentials" {
     const recorded_url =
         "https://example.test/callback?return=" ++
         "https%253A%252F%252Fstorage.example%252Fblob%253F" ++
-        "%252573%252569%252567%253Dnested-sas-secret&stable=one";
+        "%252573%252569%252567%253Dnested-sas-secret&" ++
+        "%252573%252569%252567=top-level-sas-secret&stable=one";
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
         200,
@@ -4793,6 +4809,9 @@ test "URL sanitization recursively decodes nested URI credentials" {
         std.mem.indexOf(u8, json, "nested-sas-secret") == null,
     );
     try std.testing.expect(
+        std.mem.indexOf(u8, json, "top-level-sas-secret") == null,
+    );
+    try std.testing.expect(
         std.mem.indexOf(u8, json, "return=REDACTED") != null,
     );
 
@@ -4807,7 +4826,8 @@ test "URL sanitization recursively decodes nested URI credentials" {
         .GET,
         "https://example.test/callback?return=" ++
             "https%253A%252F%252Fstorage.example%252Fblob%253F" ++
-            "%252573%252569%252567%253Drotated-sas-secret&stable=one",
+            "%252573%252569%252567%253Drotated-sas-secret&" ++
+            "%252573%252569%252567=rotated-top-level-sas&stable=one",
     );
     defer live.deinit();
     var replayed = try playback.asTransport().send(&live);

--- a/root.zig
+++ b/root.zig
@@ -451,12 +451,24 @@ const PlaybackOperation = struct {
 /// The inner descriptor is copied by value. Its context, this recording
 /// transport, and the recording allocator must outlive every open operation.
 /// A configured body-policy context is also borrowed and must outlive calls to
-/// `toJson`. `deinit` does not deinitialize either borrowed context.
+/// `toJson`. Redirect/retry chains remain tentative until their final buffered
+/// response is accepted or final streaming operation finishes; restart,
+/// failure, abort, or cancellation discards the entire tentative chain.
+/// `deinit` does not deinitialize either borrowed context.
 pub const RecordingTransport = struct {
     inner: core.http.HttpTransport,
     exchanges: std.ArrayList(OwnedExchange) = .empty,
+    staged_exchanges: std.ArrayList(OwnedExchange) = .empty,
+    staged_origin: ?*const core.http.Request = null,
+    staged_state: ?StagedRecordingState = null,
+    staged_expected_url: ?[]u8 = null,
     allocator: std.mem.Allocator,
     options: RecordingOptions,
+
+    const StagedRecordingState = enum {
+        redirect_pending,
+        retryable_final,
+    };
 
     const vtable: core.http.HttpTransport.VTable = .{
         .send = &sendImpl,
@@ -490,12 +502,115 @@ pub const RecordingTransport = struct {
         for (self.exchanges.items) |*exchange| {
             exchange.deinit(self.allocator);
         }
+        for (self.staged_exchanges.items) |*exchange| {
+            exchange.deinit(self.allocator);
+        }
+        if (self.staged_expected_url) |url| self.allocator.free(url);
         self.exchanges.deinit(self.allocator);
+        self.staged_exchanges.deinit(self.allocator);
         self.* = undefined;
     }
 
-    pub fn getExchanges(self: *const RecordingTransport) []const OwnedExchange {
+    pub fn getExchanges(self: *RecordingTransport) []const OwnedExchange {
+        self.finalizeStagedForRead();
         return self.exchanges.items;
+    }
+
+    fn reserveStagedSlot(self: *RecordingTransport) !void {
+        try self.staged_exchanges.ensureUnusedCapacity(self.allocator, 1);
+        try self.exchanges.ensureUnusedCapacity(
+            self.allocator,
+            self.staged_exchanges.items.len + 1,
+        );
+    }
+
+    fn stageExchangeAssumeCapacity(
+        self: *RecordingTransport,
+        exchange: OwnedExchange,
+        origin: *const core.http.Request,
+    ) void {
+        if (self.staged_exchanges.items.len == 0)
+            self.staged_origin = origin;
+        self.staged_exchanges.appendAssumeCapacity(exchange);
+    }
+
+    fn stageExchange(
+        self: *RecordingTransport,
+        exchange: OwnedExchange,
+        origin: *const core.http.Request,
+    ) !void {
+        try self.reserveStagedSlot();
+        self.stageExchangeAssumeCapacity(exchange, origin);
+    }
+
+    fn commitStaged(self: *RecordingTransport) void {
+        for (self.staged_exchanges.items) |exchange| {
+            self.exchanges.appendAssumeCapacity(exchange);
+        }
+        self.staged_exchanges.clearRetainingCapacity();
+        self.staged_origin = null;
+        self.staged_state = null;
+        if (self.staged_expected_url) |url| self.allocator.free(url);
+        self.staged_expected_url = null;
+    }
+
+    fn discardStaged(self: *RecordingTransport) void {
+        for (self.staged_exchanges.items) |*exchange| {
+            exchange.deinit(self.allocator);
+        }
+        self.staged_exchanges.clearRetainingCapacity();
+        self.staged_origin = null;
+        self.staged_state = null;
+        if (self.staged_expected_url) |url| self.allocator.free(url);
+        self.staged_expected_url = null;
+    }
+
+    fn prepareRawCall(
+        self: *RecordingTransport,
+        request: *const core.http.Request,
+    ) void {
+        const state = self.staged_state orelse return;
+        if (request == self.staged_origin) {
+            self.discardStaged();
+            return;
+        }
+        if (state == .retryable_final) {
+            const origin = self.staged_exchanges.items[0];
+            const same_body =
+                (origin.request_body == null) == (request.body == null) and
+                (origin.request_body == null or std.mem.eql(
+                    u8,
+                    origin.request_body.?,
+                    request.body.?,
+                ));
+            if (origin.request_method == request.method and
+                std.mem.eql(u8, origin.request_url, request.url) and
+                same_body)
+            {
+                self.discardStaged();
+            } else {
+                self.commitStaged();
+            }
+            return;
+        }
+        const expected = self.staged_expected_url orelse {
+            self.discardStaged();
+            return;
+        };
+        if (!std.mem.eql(u8, request.url, expected)) {
+            self.discardStaged();
+            return;
+        }
+        self.allocator.free(expected);
+        self.staged_expected_url = null;
+    }
+
+    fn finalizeStagedForRead(self: *RecordingTransport) void {
+        const state = self.staged_state orelse return;
+        if (state == .retryable_final)
+            self.commitStaged()
+        else
+            self.discardStaged();
     }
 
     /// Serialize version 2 recordings with lossless base64 bodies while
@@ -512,7 +627,7 @@ pub const RecordingTransport = struct {
     /// and unapproved opaque encodings cause an explicit error; neither is
     /// silently emitted under a false sanitization guarantee.
     pub fn toJson(
-        self: *const RecordingTransport,
+        self: *RecordingTransport,
         allocator: std.mem.Allocator,
     ) ![]u8 {
         var output: std.Io.Writer.Allocating = .init(allocator);
@@ -526,10 +641,11 @@ pub const RecordingTransport = struct {
     }
 
     fn writeJson(
-        self: *const RecordingTransport,
+        self: *RecordingTransport,
         writer: *std.Io.Writer,
         allocator: std.mem.Allocator,
     ) !void {
+        self.finalizeStagedForRead();
         try writer.print(
             "{{\"version\":{d},\"exchanges\":[",
             .{recording_format_version},
@@ -584,17 +700,47 @@ pub const RecordingTransport = struct {
         request: *core.http.Request,
     ) !core.http.Response {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
-        var response = try self.inner.vtable.send(self.inner.context, request);
+        self.prepareRawCall(request);
+        var response = self.inner.vtable.send(
+            self.inner.context,
+            request,
+        ) catch |err| {
+            self.discardStaged();
+            return err;
+        };
         errdefer response.deinit();
-        var exchange = try ownedExchangeFromResponse(
+        var exchange = ownedExchangeFromResponse(
             self.allocator,
             request,
             request.body,
             &response,
             response.body,
-        );
-        errdefer exchange.deinit(self.allocator);
-        try self.exchanges.append(self.allocator, exchange);
+        ) catch |err| {
+            self.discardStaged();
+            return err;
+        };
+        self.stageExchange(exchange, request) catch |err| {
+            exchange.deinit(self.allocator);
+            self.discardStaged();
+            return err;
+        };
+        if (responseRecordsRedirect(request, response)) {
+            self.staged_expected_url = resolveRecordingRedirectAlloc(
+                self.allocator,
+                request.url,
+                response.getHeader("Location").?,
+            ) catch |err| {
+                self.discardStaged();
+                return err;
+            };
+            self.staged_state = .redirect_pending;
+        } else if (request.retryable and
+            isRetryableRecordingStatus(response.status_code))
+        {
+            self.staged_state = .retryable_final;
+        } else {
+            self.commitStaged();
+        }
         return response;
     }
 
@@ -604,6 +750,8 @@ pub const RecordingTransport = struct {
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        self.prepareRawCall(request);
+        errdefer self.discardStaged();
         if (options.body != null and request.body != null)
             return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
@@ -660,6 +808,7 @@ pub const RecordingTransport = struct {
             inner_operation,
             pending,
             recordsRedirect(request, options, inner_operation),
+            request,
         );
     }
 };
@@ -750,8 +899,10 @@ const RecordingOperation = struct {
     allocator: std.mem.Allocator,
     owner: *RecordingTransport,
     inner: *core.http.HttpOperation,
+    request_identity: *const core.http.Request,
     pending: ?PendingRequest,
     redirect_exchange: ?OwnedExchange,
+    redirect_target: ?[]u8,
     response_reader: CapturingReader,
 
     fn create(
@@ -759,6 +910,7 @@ const RecordingOperation = struct {
         inner: *core.http.HttpOperation,
         pending_value: PendingRequest,
         record_redirect: bool,
+        request_identity: *const core.http.Request,
     ) !*core.http.HttpOperation {
         const self = try owner.allocator.create(RecordingOperation);
         errdefer owner.allocator.destroy(self);
@@ -770,14 +922,21 @@ const RecordingOperation = struct {
             deinitHeaderPairs(owner.allocator, headers);
         var redirect_body: ?[]u8 = null;
         errdefer if (redirect_body) |body| owner.allocator.free(body);
+        var redirect_target: ?[]u8 = null;
+        errdefer if (redirect_target) |url| owner.allocator.free(url);
         if (record_redirect) {
-            try owner.exchanges.ensureUnusedCapacity(owner.allocator, 1);
+            try owner.reserveStagedSlot();
             redirect_headers = try cloneResponseHeaders(
                 owner.allocator,
                 &inner.headers,
                 &inner.response_headers,
             );
             redirect_body = try owner.allocator.dupe(u8, "");
+            redirect_target = try resolveRecordingRedirectAlloc(
+                owner.allocator,
+                pending_value.url,
+                inner.getHeader("Location").?,
+            );
         }
 
         self.* = .{
@@ -785,6 +944,7 @@ const RecordingOperation = struct {
             .allocator = owner.allocator,
             .owner = owner,
             .inner = inner,
+            .request_identity = request_identity,
             .pending = if (record_redirect) null else pending_value,
             .redirect_exchange = if (record_redirect) .{
                 .request_method = pending_value.method,
@@ -795,6 +955,7 @@ const RecordingOperation = struct {
                 .response_body = redirect_body.?,
                 .response_headers = redirect_headers.?,
             } else null,
+            .redirect_target = redirect_target,
             .response_reader = undefined,
         };
         self.response_reader.init(owner.allocator, inner_reader, inner);
@@ -847,10 +1008,15 @@ const RecordingOperation = struct {
             .response_body = body,
             .response_headers = response_headers,
         };
-        self.owner.exchanges.append(self.allocator, exchange) catch |err| {
+        self.owner.stageExchange(
+            exchange,
+            self.request_identity,
+        ) catch |err| {
             exchange.deinit(self.allocator);
+            self.owner.discardStaged();
             return err;
         };
+        self.owner.commitStaged();
     }
 
     fn abortImpl(operation: *core.http.HttpOperation) void {
@@ -858,8 +1024,16 @@ const RecordingOperation = struct {
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.abort();
         if (self.redirect_exchange) |exchange| {
-            self.owner.exchanges.appendAssumeCapacity(exchange);
+            self.owner.stageExchangeAssumeCapacity(
+                exchange,
+                self.request_identity,
+            );
+            self.owner.staged_expected_url = self.redirect_target;
+            self.redirect_target = null;
+            self.owner.staged_state = .redirect_pending;
             self.redirect_exchange = null;
+        } else {
+            self.owner.discardStaged();
         }
     }
 
@@ -867,6 +1041,7 @@ const RecordingOperation = struct {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.cancel();
+        self.owner.discardStaged();
     }
 
     fn bodyErrorImpl(operation: *const core.http.HttpOperation) ?anyerror {
@@ -884,6 +1059,7 @@ const RecordingOperation = struct {
         if (self.redirect_exchange) |*exchange| {
             exchange.deinit(self.allocator);
         }
+        if (self.redirect_target) |url| self.allocator.free(url);
         self.response_reader.deinit();
         deinitResponseStorage(
             self.allocator,
@@ -925,6 +1101,37 @@ fn responseRecordsRedirect(
         301, 302, 303, 307, 308 => true,
         else => false,
     };
+}
+
+fn isRetryableRecordingStatus(status: u16) bool {
+    return status == 408 or status == 429 or status == 500 or
+        status == 502 or status == 503 or status == 504;
+}
+
+fn resolveRecordingRedirectAlloc(
+    allocator: std.mem.Allocator,
+    base_url: []const u8,
+    location: []const u8,
+) ![]u8 {
+    var resolved = core.url.resolveUrl(
+        allocator,
+        base_url,
+        location,
+    ) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
+        else => return err,
+    };
+    errdefer allocator.free(resolved);
+    if (std.mem.indexOfScalar(u8, resolved, '#')) |fragment_start| {
+        const without_fragment = try allocator.dupe(
+            u8,
+            resolved[0..fragment_start],
+        );
+        allocator.free(resolved);
+        resolved = without_fragment;
+    }
+    try core.url.validateHttpsUrl(resolved, &.{});
+    return resolved;
 }
 
 const CapturingReader = struct {
@@ -1850,7 +2057,11 @@ fn ensureBodySafe(
         };
         defer parsed.deinit();
         if (try jsonContainsSensitiveField(allocator, parsed.value) or
-            jsonContainsExchangeSensitiveSchema(parsed.value, context))
+            try jsonContainsExchangeSensitiveSchema(
+                allocator,
+                parsed.value,
+                context,
+            ))
         {
             return error.SensitiveBodyRequiresSanitization;
         }
@@ -1861,7 +2072,7 @@ fn ensureBodySafe(
     if (xml and
         (containsSensitiveXml(bytes) or
             containsSensitiveAssignment(bytes) or
-            (isStorageUserDelegationKeyExchange(context) and
+            (try isStorageUserDelegationKeyExchange(allocator, context) and
                 containsIgnoreCase(bytes, "<UserDelegationKey") and
                 containsIgnoreCase(bytes, "<Value"))))
     {
@@ -2199,18 +2410,19 @@ fn looksLikeXml(body: []const u8) bool {
 }
 
 fn jsonContainsExchangeSensitiveSchema(
+    allocator: std.mem.Allocator,
     value: std.json.Value,
     context: BodySafetyContext,
-) bool {
+) !bool {
     const target = parseUrlTarget(context.url) orelse return false;
     if (isKeyVaultHost(target.host)) {
-        if ((pathHasResource(target.path, "secrets") or
-            pathHasResource(target.path, "certificates")) and
+        if ((try pathHasResource(allocator, target.path, "secrets") or
+            try pathHasResource(allocator, target.path, "certificates")) and
             jsonRootHasField(value, "value"))
         {
             return true;
         }
-        if (pathHasResource(target.path, "keys") and
+        if (try pathHasResource(allocator, target.path, "keys") and
             (jsonRootHasField(value, "value") or
                 jsonContainsJwkPrivateField(value)))
         {
@@ -2223,16 +2435,20 @@ fn jsonContainsExchangeSensitiveSchema(
         return true;
     }
     if (isAzureManagementHost(target.host) and
-        isAzureKeyManagementPath(target.path) and
+        try isAzureKeyManagementPath(allocator, target.path) and
         (jsonRootHasField(value, "key1") or
             jsonRootHasField(value, "key2")))
     {
         return true;
     }
     if (isAzureManagementHost(target.host) and
-        pathHasResource(target.path, "Microsoft.DocumentDB") and
-        (pathHasResource(target.path, "listKeys") or
-            pathHasResource(target.path, "listReadOnlyKeys")) and
+        try pathHasResource(allocator, target.path, "Microsoft.DocumentDB") and
+        (try pathHasResource(allocator, target.path, "listKeys") or
+            try pathHasResource(
+                allocator,
+                target.path,
+                "listReadOnlyKeys",
+            )) and
         (jsonContainsField(value, "primarymasterkey") or
             jsonContainsField(value, "secondarymasterkey") or
             jsonContainsField(value, "primaryreadonlymasterkey") or
@@ -2241,23 +2457,27 @@ fn jsonContainsExchangeSensitiveSchema(
         return true;
     }
     if (isAzureManagementHost(target.host) and
-        pathHasResource(target.path, "Microsoft.ContainerRegistry") and
-        pathHasResource(target.path, "listCredentials") and
+        try pathHasResource(
+            allocator,
+            target.path,
+            "Microsoft.ContainerRegistry",
+        ) and
+        try pathHasResource(allocator, target.path, "listCredentials") and
         jsonContainsField(value, "passwords"))
     {
         return true;
     }
     if (isAzureManagementHost(target.host) and
-        pathHasResource(target.path, "Microsoft.Batch") and
-        pathHasResource(target.path, "listKeys") and
+        try pathHasResource(allocator, target.path, "Microsoft.Batch") and
+        try pathHasResource(allocator, target.path, "listKeys") and
         (jsonRootHasField(value, "primary") or
             jsonRootHasField(value, "secondary")))
     {
         return true;
     }
     if (isAzureManagementHost(target.host) and
-        pathHasResource(target.path, "Microsoft.Search") and
-        pathHasResource(target.path, "listQueryKeys") and
+        try pathHasResource(allocator, target.path, "Microsoft.Search") and
+        try pathHasResource(allocator, target.path, "listQueryKeys") and
         jsonContainsField(value, "key"))
     {
         return true;
@@ -2386,7 +2606,8 @@ fn isKeyVaultHost(host: []const u8) bool {
         hostMatches(host, "vaultcore.azure.net") or
         hostMatches(host, "managedhsm.azure.net") or
         hostMatches(host, "managedhsm.azure.cn") or
-        hostMatches(host, "managedhsm.usgovcloudapi.net");
+        hostMatches(host, "managedhsm.usgovcloudapi.net") or
+        hostMatches(host, "managedhsm.microsoftazure.de");
 }
 
 fn isKustoHost(host: []const u8) bool {
@@ -2411,7 +2632,10 @@ fn isStorageBlobHost(host: []const u8) bool {
         hostMatches(host, "blob.core.cloudapi.de");
 }
 
-fn isStorageUserDelegationKeyExchange(context: BodySafetyContext) bool {
+fn isStorageUserDelegationKeyExchange(
+    allocator: std.mem.Allocator,
+    context: BodySafetyContext,
+) !bool {
     if (context.direction != .response) return false;
     const target = parseUrlTarget(context.url) orelse return false;
     if (!isStorageBlobHost(target.host)) return false;
@@ -2430,8 +2654,20 @@ fn isStorageUserDelegationKeyExchange(context: BodySafetyContext) bool {
     );
     while (fields.next()) |field| {
         const equals = std.mem.indexOfScalar(u8, field, '=') orelse continue;
-        if (std.ascii.eqlIgnoreCase(field[0..equals], "comp") and
-            std.ascii.eqlIgnoreCase(field[equals + 1 ..], "userdelegationkey"))
+        const name = try canonicalUrlComponentAlloc(
+            allocator,
+            field[0..equals],
+            true,
+        );
+        defer allocator.free(name);
+        const value = try canonicalUrlComponentAlloc(
+            allocator,
+            field[equals + 1 ..],
+            true,
+        );
+        defer allocator.free(value);
+        if (std.ascii.eqlIgnoreCase(name, "comp") and
+            std.ascii.eqlIgnoreCase(value, "userdelegationkey"))
         {
             return true;
         }
@@ -2439,21 +2675,37 @@ fn isStorageUserDelegationKeyExchange(context: BodySafetyContext) bool {
     return false;
 }
 
-fn isAzureKeyManagementPath(path: []const u8) bool {
+fn isAzureKeyManagementPath(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+) !bool {
     const recognized_provider =
-        pathHasResource(path, "Microsoft.EventGrid") or
-        pathHasResource(path, "Microsoft.CognitiveServices");
+        try pathHasResource(allocator, path, "Microsoft.EventGrid") or
+        try pathHasResource(allocator, path, "Microsoft.CognitiveServices");
     const recognized_action =
-        pathHasResource(path, "listKeys") or
-        pathHasResource(path, "regenerateKey") or
-        pathHasResource(path, "regenerateKeys");
+        try pathHasResource(allocator, path, "listKeys") or
+        try pathHasResource(allocator, path, "regenerateKey") or
+        try pathHasResource(allocator, path, "regenerateKeys");
     return recognized_provider and recognized_action;
 }
 
-fn pathHasResource(path: []const u8, resource: []const u8) bool {
+fn pathHasResource(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    resource: []const u8,
+) !bool {
     var segments = std.mem.splitScalar(u8, path, '/');
-    while (segments.next()) |segment| {
-        if (std.ascii.eqlIgnoreCase(segment, resource)) return true;
+    while (segments.next()) |encoded_segment| {
+        const segment = try canonicalUrlComponentAlloc(
+            allocator,
+            encoded_segment,
+            false,
+        );
+        defer allocator.free(segment);
+        var decoded_segments = std.mem.splitScalar(u8, segment, '/');
+        while (decoded_segments.next()) |decoded| {
+            if (std.ascii.eqlIgnoreCase(decoded, resource)) return true;
+        }
     }
     return false;
 }
@@ -2975,6 +3227,43 @@ const max_url_decode_depth = 3;
 const max_nested_url_depth = 4;
 const max_sanitized_url_length = 256 * 1024;
 
+fn canonicalUrlComponentAlloc(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+    plus_as_space: bool,
+) ![]u8 {
+    if (encoded.len > max_sanitized_url_length)
+        return error.SensitiveBodyRequiresSanitization;
+    var current: ?[]u8 = try allocator.dupe(u8, encoded);
+    errdefer if (current) |bytes| allocator.free(bytes);
+    var decode_count: usize = 0;
+    while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+        const decoded = percentDecodeAlloc(
+            allocator,
+            current.?,
+            plus_as_space and decode_count == 0,
+        ) catch |err| switch (err) {
+            error.SensitiveUrlRequiresSanitization => return error.SensitiveBodyRequiresSanitization,
+            else => return err,
+        };
+        const changed = !std.mem.eql(u8, current.?, decoded);
+        allocator.free(current.?);
+        current = decoded;
+        if (std.mem.indexOfAny(u8, decoded, "\x00\r\n") != null)
+            return error.SensitiveBodyRequiresSanitization;
+        if (!changed) {
+            const result = current.?;
+            current = null;
+            return result;
+        }
+    }
+    if (containsPercentEscape(current.?))
+        return error.SensitiveBodyRequiresSanitization;
+    const result = current.?;
+    current = null;
+    return result;
+}
+
 fn sanitizeUrlAllocDepth(
     allocator: std.mem.Allocator,
     url: []const u8,
@@ -2992,6 +3281,7 @@ fn sanitizeUrlAllocDepth(
     const reference_end = fragment orelse url.len;
     const question = std.mem.indexOfScalar(u8, url[0..reference_end], '?');
     var path_start: usize = 0;
+    var authority_range: ?struct { start: usize, end: usize } = null;
     const scheme_end_value = schemeEndAtReferenceStart(url, reference_end);
     if (scheme_end_value) |scheme_end| {
         const scheme = url[0..scheme_end];
@@ -3003,28 +3293,42 @@ fn sanitizeUrlAllocDepth(
         if (!std.mem.startsWith(u8, url[scheme_end + 1 ..], "//"))
             return error.SensitiveUrlRequiresSanitization;
         const authority_start = scheme_end + 3;
-        const slash = std.mem.indexOfScalarPos(
+        const authority_end = std.mem.indexOfAnyPos(
             u8,
             url,
             authority_start,
-            '/',
-        );
-        const authority_end = if (slash) |index|
-            @min(index, reference_end)
-        else
-            reference_end;
-        const authority = url[authority_start..authority_end];
+            "/?#",
+        ) orelse url.len;
+        authority_range = .{ .start = authority_start, .end = authority_end };
+        path_start = authority_end;
+    } else if (std.mem.startsWith(u8, url, "//")) {
+        const authority_start = 2;
+        const authority_end = std.mem.indexOfAnyPos(
+            u8,
+            url,
+            authority_start,
+            "/?#",
+        ) orelse url.len;
+        authority_range = .{ .start = authority_start, .end = authority_end };
+        path_start = authority_end;
+    }
+    if (authority_range) |range| {
+        if (range.end < range.start or range.end > reference_end)
+            return error.SensitiveUrlRequiresSanitization;
+        const authority = url[range.start..range.end];
         if (authority.len == 0 or
-            std.mem.indexOfScalar(u8, authority, '@') != null)
+            try encodedAuthorityIsSensitive(
+                allocator,
+                authority,
+            ))
         {
             return error.SensitiveUrlRequiresSanitization;
         }
-        path_start = authority_end;
-    } else if (std.mem.startsWith(u8, url, "//")) {
-        return error.SensitiveUrlRequiresSanitization;
     }
 
     const query_start = question orelse reference_end;
+    if (path_start > query_start)
+        return error.SensitiveUrlRequiresSanitization;
     if (try encodedComponentIsSensitive(
         allocator,
         url[path_start..query_start],
@@ -3095,6 +3399,29 @@ fn sanitizeUrlAllocDepth(
         try output.writer.writeAll(url[fragment_start..]);
     }
     return output.toOwnedSlice();
+}
+
+fn encodedAuthorityIsSensitive(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+) !bool {
+    if (encoded.len > max_sanitized_url_length) return true;
+    var current = try allocator.dupe(u8, encoded);
+    defer allocator.free(current);
+    var decode_count: usize = 0;
+    while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+        const decoded = try percentDecodeAlloc(allocator, current, false);
+        const changed = !std.mem.eql(u8, current, decoded);
+        allocator.free(current);
+        current = decoded;
+        if (std.mem.indexOfAny(u8, current, "@\x00\r\n") != null or
+            try containsSensitiveScalar(allocator, current))
+        {
+            return true;
+        }
+        if (!changed) return false;
+    }
+    return containsPercentEscape(current);
 }
 
 fn encodedQueryNameIsSensitive(
@@ -3423,7 +3750,7 @@ fn preserveRequestDate(
 }
 
 fn expectRejectedSerializationExcludes(
-    recorder: *const RecordingTransport,
+    recorder: *RecordingTransport,
     expected_error: anyerror,
     secrets: []const []const u8,
 ) !void {
@@ -4107,6 +4434,38 @@ test "recording forwards abort and cancel without recording partial responses" {
     try std.testing.expectEqual(@as(usize, 2), mock.stream_deinit_count);
 }
 
+test "recording cancellation discards every tentative redirect exchange" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 200, .body = "body" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start",
+    );
+    defer request.deinit();
+    var operation = try recorder.asTransport().open(&request, .{});
+    operation.cancel();
+    operation.deinit();
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        recorder.getExchanges().len,
+    );
+}
+
 test "recording and playback preserve streaming redirect sequences" {
     var sequence = core.http.SequenceMockTransport.init(
         std.testing.allocator,
@@ -4164,6 +4523,286 @@ test "recording and playback preserve streaming redirect sequences" {
     try std.testing.expectEqualStrings("done", body);
     try replay.finish();
     replay.deinit();
+}
+
+test "recording stages buffered redirect and retry chains atomically" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 503, .body = "retry" },
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 200, .body = "done" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var retry = core.http.RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    retry.max_delay_ms = 0;
+    var policies = [_]*core.http.HttpPolicy{retry.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(recorder.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start",
+    );
+    defer request.deinit();
+    var response = try pipeline.send(&request);
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+    try std.testing.expectEqualStrings("done", response.body);
+
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
+    try std.testing.expectEqualStrings(
+        "https://example.test/start",
+        exchanges[0].request_url,
+    );
+    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
+    try std.testing.expectEqualStrings(
+        "https://example.test/final",
+        exchanges[1].request_url,
+    );
+
+    var recordings: [2]RecordedExchange = undefined;
+    for (exchanges, &recordings) |exchange, *recording| {
+        recording.* = .{
+            .request_method = exchange.request_method,
+            .request_url = exchange.request_url,
+            .request_headers = exchange.request_headers,
+            .request_body = exchange.request_body,
+            .response_status = exchange.response_status,
+            .response_body = exchange.response_body,
+            .response_headers = exchange.response_headers,
+        };
+    }
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var replayed = try playback.asTransport().send(&request);
+    defer replayed.deinit();
+    try std.testing.expectEqual(@as(u16, 200), replayed.status_code);
+    try std.testing.expectEqualStrings("done", replayed.body);
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
+}
+
+test "recording stages streaming redirect and retry chains atomically" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 503, .body = "retry" },
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 200, .body = "done" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var retry = core.http.RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    retry.max_delay_ms = 0;
+    var policies = [_]*core.http.HttpPolicy{retry.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(recorder.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start",
+    );
+    defer request.deinit();
+    var operation = try pipeline.open(&request, .{});
+    const body = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("done", body);
+    try operation.finish();
+    operation.deinit();
+
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
+    var recordings: [2]RecordedExchange = undefined;
+    for (exchanges, &recordings) |exchange, *recording| {
+        recording.* = .{
+            .request_method = exchange.request_method,
+            .request_url = exchange.request_url,
+            .request_headers = exchange.request_headers,
+            .request_body = exchange.request_body,
+            .response_status = exchange.response_status,
+            .response_body = exchange.response_body,
+            .response_headers = exchange.response_headers,
+        };
+    }
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var replayed = try playback.asTransport().open(&request, .{});
+    const replayed_body = try (try replayed.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(replayed_body);
+    try std.testing.expectEqualStrings("done", replayed_body);
+    try replayed.finish();
+    replayed.deinit();
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
+}
+
+test "recording redirect allocation failure discards the tentative chain" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 200, .body = "done" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    var request = core.http.Request.init(
+        failing.allocator(),
+        .GET,
+        "https://example.test/start",
+    );
+    defer request.deinit();
+    const transport = recorder.asTransport();
+    const first = transport.send(&request);
+    if (first) |response_value| {
+        var unexpected = response_value;
+        unexpected.deinit();
+        return error.TestExpectedError;
+    } else |err| {
+        try std.testing.expect(
+            err == error.OutOfMemory or err == error.WriteFailed,
+        );
+    }
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        recorder.getExchanges().len,
+    );
+
+    failing.fail_index = std.math.maxInt(usize);
+    var response = try transport.send(&request);
+    defer response.deinit();
+    try std.testing.expectEqualStrings("done", response.body);
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
+}
+
+test "recording streaming redirect OOM abort stays tentative" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{.{ .name = "Location", .value = "/final" }},
+            },
+            .{ .status = 200, .body = "done" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    var request = core.http.Request.init(
+        failing.allocator(),
+        .GET,
+        "https://example.test/start",
+    );
+    defer request.deinit();
+    const transport = recorder.asTransport();
+    const first = transport.open(&request, .{});
+    if (first) |unexpected| {
+        unexpected.deinit();
+        return error.TestExpectedError;
+    } else |err| {
+        try std.testing.expect(
+            err == error.OutOfMemory or err == error.WriteFailed,
+        );
+    }
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        recorder.getExchanges().len,
+    );
+
+    failing.fail_index = std.math.maxInt(usize);
+    var operation = try transport.open(&request, .{});
+    const body = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("done", body);
+    try operation.finish();
+    operation.deinit();
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
 }
 
 test "recording JSON redacts headers and URL query credentials" {
@@ -4877,6 +5516,97 @@ test "URL sanitization recursively decodes nested URI credentials" {
     }
 }
 
+test "pathless absolute and network-path URLs sanitize without range failures" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        302,
+        "",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{
+            .name = "Location",
+            .value = "https://next.example?sig=location-secret&mode=one",
+        },
+        .{
+            .name = "Operation-Location",
+            .value = "//next.example/final?sig=network-secret#section",
+        },
+        .{
+            .name = "Content-Location",
+            .value = "//user:password@next.example/final",
+        },
+        .{
+            .name = "Azure-AsyncOperation",
+            .value = "//user%40next.example/final",
+        },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test?sig=request-secret&return=" ++
+            "https%3A%2F%2Fnested.example%3Fsig%3Dnested-secret&mode=one",
+    );
+    request.redirect_policy = .not_allowed;
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    for ([_][]const u8{
+        "request-secret",
+        "nested-secret",
+        "location-secret",
+        "network-secret",
+        "password",
+        "user%40",
+    }) |secret| {
+        try std.testing.expect(std.mem.indexOf(u8, json, secret) == null);
+    }
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    const exchange = parsed.asSlice()[0];
+    try std.testing.expectEqualStrings(
+        "https://example.test?sig=REDACTED&return=REDACTED&mode=one",
+        exchange.request_url,
+    );
+    try std.testing.expectEqualStrings(
+        "https://next.example?sig=REDACTED&mode=one",
+        getHeaderPair(exchange.response_headers, "Location").?,
+    );
+    try std.testing.expectEqualStrings(
+        "//next.example/final?sig=REDACTED#section",
+        getHeaderPair(exchange.response_headers, "Operation-Location").?,
+    );
+    for (exchange.response_headers) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, "Content-Location") or
+            std.ascii.eqlIgnoreCase(header.name, "Azure-AsyncOperation"))
+        {
+            try std.testing.expect(header.redacted);
+        }
+    }
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test?sig=rotated-request&return=" ++
+            "https%3A%2F%2Fnested.example%3Fsig%3Drotated-nested&mode=one",
+    );
+    live.redirect_policy = .not_allowed;
+    defer live.deinit();
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
+}
+
 test "authenticated recording JSON roundtrips with structured redactions" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -5197,7 +5927,10 @@ test "safe Location fragments remain replayable through Core redirects" {
                 .status = 302,
                 .body = "",
                 .headers = &.{
-                    .{ .name = "Location", .value = "/final#section" },
+                    .{
+                        .name = "Location",
+                        .value = "//example.test/final#section",
+                    },
                 },
             },
             .{ .status = 200, .body = "" },
@@ -5223,7 +5956,7 @@ test "safe Location fragments remain replayable through Core redirects" {
     var parsed = try parseJson(std.testing.allocator, json);
     defer parsed.deinit();
     try std.testing.expectEqualStrings(
-        "/final#section",
+        "//example.test/final#section",
         getHeaderPair(
             parsed.asSlice()[0].response_headers,
             "Location",
@@ -5694,6 +6427,85 @@ test "Key Vault key operation root values are rejected" {
     );
 }
 
+test "encoded Managed HSM key paths are rejected on every sovereign host" {
+    const hosts = [_][]const u8{
+        "example.managedhsm.azure.net",
+        "example.managedhsm.usgovcloudapi.net",
+        "example.managedhsm.azure.cn",
+        "example.managedhsm.microsoftazure.de",
+    };
+    for (hosts) |host| {
+        const url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://{s}/key%73/name/backup?api-version=7.6",
+            .{host},
+        );
+        defer std.testing.allocator.free(url);
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"value\":\"managed-hsm-backup-secret\"}",
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "application/json" },
+        };
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{"managed-hsm-backup-secret"},
+        );
+    }
+}
+
+test "malformed or over-depth credential endpoint encodings fail closed" {
+    for ([_][]const u8{
+        "https://example.vault.azure.net/key%ZZ/name/backup",
+        "https://example.vault.azure.net/key%25252573/name/backup",
+    }) |url| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"ordinary\":\"safe\"}",
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "application/json" },
+        };
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &inspectKnownSafeBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.SensitiveBodyRequiresSanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
+}
+
 test "Azure key management key1 and key2 responses are rejected" {
     for ([_][]const u8{
         "https://management.azure.com/subscriptions/s/resourceGroups/r/providers/Microsoft.EventGrid/topics/t/listKeys?api-version=2025-02-15",
@@ -5789,27 +6601,27 @@ test "ARM credential schemas cover every trusted sovereign management host" {
         secrets: []const []const u8,
     }{
         .{
-            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.Batch/batchAccounts/a/listKeys?api-version=2024-07-01",
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.Batch/batchAccounts/a/list%4Beys?api-version=2024-07-01",
             .body = "{\"primary\":\"batch-primary\",\"secondary\":\"batch-secondary\"}",
             .secrets = &.{ "batch-primary", "batch-secondary" },
         },
         .{
-            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.Search/searchServices/a/listQueryKeys?api-version=2024-03-01-preview",
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.Search/searchServices/a/listQuery%4Beys?api-version=2024-03-01-preview",
             .body = "{\"value\":[{\"name\":\"query-key\",\"key\":\"search-query-secret\"}]}",
             .secrets = &.{"search-query-secret"},
         },
         .{
-            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.EventGrid/topics/t/listKeys?api-version=2025-02-15",
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.EventGrid/topics/t/list%4Beys?api-version=2025-02-15",
             .body = "{\"key1\":\"event-grid-one\",\"key2\":\"event-grid-two\"}",
             .secrets = &.{ "event-grid-one", "event-grid-two" },
         },
         .{
-            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.DocumentDB/databaseAccounts/a/listKeys?api-version=2025-04-15",
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.DocumentDB/databaseAccounts/a/list%4Beys?api-version=2025-04-15",
             .body = "{\"primaryMasterKey\":\"cosmos-one\",\"secondaryMasterKey\":\"cosmos-two\"}",
             .secrets = &.{ "cosmos-one", "cosmos-two" },
         },
         .{
-            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.ContainerRegistry/registries/a/listCredentials?api-version=2025-04-01",
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.ContainerRegistry/registries/a/list%43redentials?api-version=2025-04-01",
             .body = "{\"passwords\":[{\"name\":\"password\",\"value\":\"acr-secret\"}]}",
             .secrets = &.{"acr-secret"},
         },
@@ -5941,7 +6753,7 @@ test "Storage user delegation key XML is rejected on trusted blob hosts" {
     for (hosts) |host| {
         const url = try std.fmt.allocPrint(
             std.testing.allocator,
-            "https://{s}/?restype=service&comp=userdelegationkey",
+            "https://{s}/?restype=service&co%6dp=user%64elegationkey",
             .{host},
         );
         defer std.testing.allocator.free(url);
@@ -6011,6 +6823,37 @@ test "Storage delegation XML schema ignores untrusted hosts" {
         u8,
         body,
         parsed.asSlice()[0].response_body,
+    );
+}
+
+test "malformed Storage delegation action encoding fails closed" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "<Document><Value>ordinary</Value></Document>",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/xml" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://account.blob.core.windows.net/" ++
+            "?restype=service&comp=user%25252564elegationkey",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    try std.testing.expectError(
+        error.SensitiveBodyRequiresSanitization,
+        recorder.toJson(std.testing.allocator),
     );
 }
 
@@ -6945,6 +7788,35 @@ fn jwtHeaderAllocationFixture(allocator: std.mem.Allocator) !void {
     allocator.free(json);
 }
 
+fn endpointSchemaAllocationFixture(allocator: std.mem.Allocator) !void {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "{\"ordinary\":\"safe\"}",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://management.azure.com/subscriptions/s/" ++
+            "providers/Microsoft.Batch/resources/ordinary",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(allocator);
+    allocator.free(json);
+}
+
 const allocation_fixture_json =
     \\{"version":2,"exchanges":[{"request_method":"POST","request_url":"https://example.com","request_headers":[],"request_body":{"encoding":"base64","data":"cmVxdWVzdA=="},"response_status":200,"response_headers":[],"response_body":{"encoding":"base64","data":"cmVzcG9uc2U="}}]}
 ;
@@ -6988,6 +7860,11 @@ test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         jwtHeaderAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        endpointSchemaAllocationFixture,
         .{},
     );
     try std.testing.checkAllAllocationFailures(

--- a/root.zig
+++ b/root.zig
@@ -214,10 +214,14 @@ pub fn initHttpRuntime(
 /// Caller-serialized playback transport.
 ///
 /// The returned descriptor borrows this value. Keep it alive until all
-/// descriptor copies and open operations are deinitialized.
+/// descriptor copies and open operations are deinitialized. Redirect chains
+/// commit atomically at the final buffered response or successful streaming
+/// `finish`; failed allocation, abort, or cancellation leaves the original
+/// exchange retryable.
 pub const PlaybackTransport = struct {
     recordings: []const RecordedExchange,
     index: usize = 0,
+    pending_redirect: ?usize = null,
     allocator: std.mem.Allocator,
     open_count: usize = 0,
     finish_count: usize = 0,
@@ -241,19 +245,64 @@ pub const PlaybackTransport = struct {
         return .{ .context = self, .vtable = &vtable };
     }
 
-    fn next(self: *PlaybackTransport) !RecordedExchange {
-        if (self.index >= self.recordings.len) return error.NoMoreRecordings;
-        return self.recordings[self.index];
-    }
-
     fn matchNext(
         self: *PlaybackTransport,
         request: *const core.http.Request,
         body: ?[]const u8,
-    ) !RecordedExchange {
-        const exchange = try self.next();
+    ) !struct { exchange: RecordedExchange, index: usize } {
+        if (self.pending_redirect) |pending| {
+            const redirected = pending + 1;
+            if (redirected < self.recordings.len and
+                try requestMatches(
+                    self.recordings[redirected],
+                    request,
+                    body,
+                ))
+            {
+                return .{
+                    .exchange = self.recordings[redirected],
+                    .index = redirected,
+                };
+            }
+            if (try requestMatches(
+                self.recordings[self.index],
+                request,
+                body,
+            )) {
+                self.pending_redirect = null;
+                return .{
+                    .exchange = self.recordings[self.index],
+                    .index = self.index,
+                };
+            }
+            if (pending != self.index and
+                try requestMatches(
+                    self.recordings[pending],
+                    request,
+                    body,
+                ))
+            {
+                return .{
+                    .exchange = self.recordings[pending],
+                    .index = pending,
+                };
+            }
+            const expected = if (redirected < self.recordings.len)
+                redirected
+            else
+                pending;
+            try matchRequest(self.recordings[expected], request, body);
+            unreachable;
+        }
+        if (self.index >= self.recordings.len) return error.NoMoreRecordings;
+        const exchange = self.recordings[self.index];
         try matchRequest(exchange, request, body);
-        return exchange;
+        return .{ .exchange = exchange, .index = self.index };
+    }
+
+    fn commit(self: *PlaybackTransport, exchange_index: usize) void {
+        self.pending_redirect = null;
+        self.index = exchange_index + 1;
     }
 
     fn sendImpl(
@@ -261,9 +310,16 @@ pub const PlaybackTransport = struct {
         request: *core.http.Request,
     ) !core.http.Response {
         const self: *PlaybackTransport = @ptrCast(@alignCast(context));
-        const exchange = try self.matchNext(request, request.body);
-        const response = try responseFromExchange(self.allocator, exchange);
-        self.index += 1;
+        const matched = try self.matchNext(request, request.body);
+        const response = try responseFromExchange(
+            self.allocator,
+            matched.exchange,
+        );
+        if (responseRecordsRedirect(request, response)) {
+            self.pending_redirect = matched.index;
+        } else {
+            self.commit(matched.index);
+        }
         return response;
     }
 
@@ -289,9 +345,15 @@ pub const PlaybackTransport = struct {
             break :blk captured.?;
         } else request.body;
 
-        const exchange = try self.matchNext(request, body);
-        const operation = try PlaybackOperation.create(self, exchange);
-        self.index += 1;
+        const matched = try self.matchNext(request, body);
+        const operation = try PlaybackOperation.create(
+            self,
+            matched.exchange,
+            matched.index,
+        );
+        if (recordsRedirect(request, options, operation)) {
+            self.pending_redirect = matched.index;
+        }
         self.open_count += 1;
         return operation;
     }
@@ -301,12 +363,15 @@ const PlaybackOperation = struct {
     operation: core.http.HttpOperation,
     allocator: std.mem.Allocator,
     owner: *PlaybackTransport,
+    exchange_index: usize,
+    committed: bool = false,
     response_body: []u8,
     reader_impl: std.Io.Reader,
 
     fn create(
         owner: *PlaybackTransport,
         exchange: RecordedExchange,
+        exchange_index: usize,
     ) !*core.http.HttpOperation {
         const self = try owner.allocator.create(PlaybackOperation);
         errdefer owner.allocator.destroy(self);
@@ -322,6 +387,7 @@ const PlaybackOperation = struct {
             .operation = undefined,
             .allocator = owner.allocator,
             .owner = owner,
+            .exchange_index = exchange_index,
             .response_body = body,
             .reader_impl = std.Io.Reader.fixed(body),
         };
@@ -342,6 +408,10 @@ const PlaybackOperation = struct {
         const self: *PlaybackOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         _ = try self.reader_impl.discardRemaining();
+        if (!self.committed) {
+            self.owner.commit(self.exchange_index);
+            self.committed = true;
+        }
         self.owner.finish_count += 1;
     }
 
@@ -354,6 +424,11 @@ const PlaybackOperation = struct {
     fn cancelImpl(operation: *core.http.HttpOperation) void {
         const self: *PlaybackOperation =
             @alignCast(@fieldParentPtr("operation", operation));
+        if (!self.committed and
+            self.owner.pending_redirect != null)
+        {
+            self.owner.pending_redirect = null;
+        }
         self.owner.cancel_count += 1;
     }
 
@@ -837,6 +912,21 @@ fn recordsRedirect(
     };
 }
 
+fn responseRecordsRedirect(
+    request: *const core.http.Request,
+    response: core.http.Response,
+) bool {
+    if (request.redirect_policy == .not_allowed or
+        response.getHeader("Location") == null)
+    {
+        return false;
+    }
+    return switch (response.status_code) {
+        301, 302, 303, 307, 308 => true,
+        else => false,
+    };
+}
+
 const CapturingReader = struct {
     interface: std.Io.Reader,
     source: *std.Io.Reader,
@@ -1198,6 +1288,22 @@ fn matchRequest(
         ))
             return error.HeaderMismatch;
     }
+}
+
+fn requestMatches(
+    exchange: RecordedExchange,
+    request: *const core.http.Request,
+    body: ?[]const u8,
+) !bool {
+    matchRequest(exchange, request, body) catch |err| switch (err) {
+        error.MethodMismatch,
+        error.UrlMismatch,
+        error.BodyMismatch,
+        error.HeaderMismatch,
+        => return false,
+        else => return err,
+    };
+    return true;
 }
 
 fn headerValueMatches(
@@ -1753,7 +1859,11 @@ fn ensureBodySafe(
     const xml = valid_text and identity_encoding and
         (containsIgnoreCase(content_type, "xml") or looksLikeXml(bytes));
     if (xml and
-        (containsSensitiveXml(bytes) or containsSensitiveAssignment(bytes)))
+        (containsSensitiveXml(bytes) or
+            containsSensitiveAssignment(bytes) or
+            (isStorageUserDelegationKeyExchange(context) and
+                containsIgnoreCase(bytes, "<UserDelegationKey") and
+                containsIgnoreCase(bytes, "<Value"))))
     {
         return error.SensitiveBodyRequiresSanitization;
     }
@@ -1826,7 +1936,7 @@ fn containsSensitiveMultipartContent(
     content_type: []const u8,
     body: []const u8,
     depth: usize,
-) !bool {
+) anyerror!bool {
     if (depth >= 8) return error.UnsupportedBodySanitization;
     if (containsSensitiveMultipartField(body)) return true;
     if (try containsSensitiveHttpHeaderLine(allocator, body)) return true;
@@ -1834,90 +1944,155 @@ fn containsSensitiveMultipartContent(
     const boundary = try multipartBoundary(content_type);
     const delimiter = try std.fmt.allocPrint(allocator, "--{s}", .{boundary});
     defer allocator.free(delimiter);
-    var delimiter_start: ?usize = null;
-    var search_start: usize = 0;
-    while (std.mem.indexOfPos(u8, body, search_start, delimiter)) |index| {
-        if (index == 0 or body[index - 1] == '\n') {
-            delimiter_start = index;
-            break;
-        }
-        search_start = index + delimiter.len;
-    }
-    const first_delimiter = delimiter_start orelse
+    const first = try findMultipartBoundaryLine(body, delimiter, 0) orelse
         return error.UnsupportedBodySanitization;
+    if (first.closing) return error.UnsupportedBodySanitization;
+    if (try containsSensitiveLoosePayload(
+        allocator,
+        body[0..first.start],
+    )) return true;
 
-    var parts = std.mem.splitSequence(u8, body[first_delimiter..], delimiter);
-    _ = parts.next();
+    var part_start = first.after;
     var saw_part = false;
-    var saw_close = false;
-    while (parts.next()) |raw_part| {
-        const part = std.mem.trim(u8, raw_part, " \t\r\n");
-        if (std.mem.startsWith(u8, part, "--")) {
-            saw_close = true;
+    while (true) {
+        const next = try findMultipartBoundaryLine(
+            body,
+            delimiter,
+            part_start,
+        ) orelse return error.UnsupportedBodySanitization;
+        const part = std.mem.trim(
+            u8,
+            body[part_start..next.start],
+            " \t\r\n",
+        );
+        if (part.len == 0) return error.UnsupportedBodySanitization;
+        saw_part = true;
+        if (try containsSensitiveMultipartPart(
+            allocator,
+            part,
+            depth,
+        )) return true;
+        if (next.closing) {
+            const epilogue = body[next.after..];
+            if (try findMultipartBoundaryLine(
+                epilogue,
+                delimiter,
+                0,
+            ) != null) return error.UnsupportedBodySanitization;
+            if (try containsSensitiveLoosePayload(
+                allocator,
+                epilogue,
+            )) return true;
             break;
         }
-        if (part.len == 0) continue;
-        saw_part = true;
-        const outer_separator = findHeaderSeparator(part) orelse
+        part_start = next.after;
+    }
+    if (!saw_part) return error.UnsupportedBodySanitization;
+    return false;
+}
+
+fn containsSensitiveMultipartPart(
+    allocator: std.mem.Allocator,
+    part: []const u8,
+    depth: usize,
+) anyerror!bool {
+    const outer_separator = findHeaderSeparator(part) orelse
+        return error.UnsupportedBodySanitization;
+    const outer_headers = part[0..outer_separator.start];
+    var payload = part[outer_separator.end..];
+    var payload_content_type = headerValueFromBlock(
+        outer_headers,
+        "Content-Type",
+    );
+    if (looksLikeHttpMessage(payload)) {
+        const inner_separator = findHeaderSeparator(payload) orelse
             return error.UnsupportedBodySanitization;
-        const outer_headers = part[0..outer_separator.start];
-        var payload = part[outer_separator.end..];
-        var payload_content_type = headerValueFromBlock(
-            outer_headers,
+        const inner_headers = payload[0..inner_separator.start];
+        payload_content_type = headerValueFromBlock(
+            inner_headers,
             "Content-Type",
         );
-        if (looksLikeHttpMessage(payload)) {
-            const inner_separator = findHeaderSeparator(payload) orelse
-                return error.UnsupportedBodySanitization;
-            const inner_headers = payload[0..inner_separator.start];
-            payload_content_type = headerValueFromBlock(
-                inner_headers,
-                "Content-Type",
-            );
-            payload = payload[inner_separator.end..];
-        }
-        payload = std.mem.trim(u8, payload, " \t\r\n");
-        if (payload.len == 0) continue;
-        if (payload_content_type) |part_type| {
-            if (containsIgnoreCase(part_type, "multipart/")) {
-                if (try containsSensitiveMultipartContent(
-                    allocator,
-                    part_type,
-                    payload,
-                    depth + 1,
-                )) return true;
-                continue;
-            }
-        }
-        if (try containsSensitiveScalar(allocator, payload)) return true;
-        const declared_json = if (payload_content_type) |part_type|
-            isJsonContentType(part_type)
-        else
-            false;
-        if (declared_json or looksLikeStructuredJson(payload)) {
-            const parsed = std.json.parseFromSlice(
-                std.json.Value,
+        payload = payload[inner_separator.end..];
+    }
+    payload = std.mem.trim(u8, payload, " \t\r\n");
+    if (payload.len == 0) return false;
+    if (payload_content_type) |part_type| {
+        if (containsIgnoreCase(part_type, "multipart/")) {
+            return containsSensitiveMultipartContent(
                 allocator,
+                part_type,
                 payload,
-                .{},
-            ) catch |err| switch (err) {
-                error.OutOfMemory => return err,
-                else => return error.UnsupportedBodySanitization,
-            };
-            defer parsed.deinit();
-            if (try jsonContainsSensitiveField(allocator, parsed.value))
-                return true;
-        }
-        if (looksLikeXml(payload) and
-            (containsSensitiveXml(payload) or
-                containsSensitiveAssignment(payload)))
-        {
-            return true;
+                depth + 1,
+            );
         }
     }
-    if (!saw_part or !saw_close)
-        return error.UnsupportedBodySanitization;
+    return containsSensitiveLoosePayload(allocator, payload);
+}
+
+fn containsSensitiveLoosePayload(
+    allocator: std.mem.Allocator,
+    raw_payload: []const u8,
+) !bool {
+    const payload = std.mem.trim(u8, raw_payload, " \t\r\n");
+    if (payload.len == 0) return false;
+    if (try containsSensitiveScalar(allocator, payload)) return true;
+    if (looksLikeStructuredJson(payload)) {
+        const parsed = std.json.parseFromSlice(
+            std.json.Value,
+            allocator,
+            payload,
+            .{},
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.UnsupportedBodySanitization,
+        };
+        defer parsed.deinit();
+        if (try jsonContainsSensitiveField(allocator, parsed.value))
+            return true;
+    }
+    if (looksLikeXml(payload) and
+        (containsSensitiveXml(payload) or
+            containsSensitiveAssignment(payload)))
+    {
+        return true;
+    }
     return false;
+}
+
+const MultipartBoundaryLine = struct {
+    start: usize,
+    after: usize,
+    closing: bool,
+};
+
+fn findMultipartBoundaryLine(
+    body: []const u8,
+    delimiter: []const u8,
+    start: usize,
+) !?MultipartBoundaryLine {
+    var search_start = start;
+    while (std.mem.indexOfPos(u8, body, search_start, delimiter)) |index| {
+        if (index != 0 and body[index - 1] != '\n') {
+            search_start = index + delimiter.len;
+            continue;
+        }
+        var suffix = index + delimiter.len;
+        var closing = false;
+        if (std.mem.startsWith(u8, body[suffix..], "--")) {
+            closing = true;
+            suffix += 2;
+        }
+        const after = if (suffix == body.len)
+            suffix
+        else if (std.mem.startsWith(u8, body[suffix..], "\r\n"))
+            suffix + 2
+        else if (body[suffix] == '\n')
+            suffix + 1
+        else
+            return error.UnsupportedBodySanitization;
+        return .{ .start = index, .after = after, .closing = closing };
+    }
+    return null;
 }
 
 fn multipartBoundary(content_type: []const u8) ![]const u8 {
@@ -2072,6 +2247,21 @@ fn jsonContainsExchangeSensitiveSchema(
     {
         return true;
     }
+    if (isAzureManagementHost(target.host) and
+        pathHasResource(target.path, "Microsoft.Batch") and
+        pathHasResource(target.path, "listKeys") and
+        (jsonRootHasField(value, "primary") or
+            jsonRootHasField(value, "secondary")))
+    {
+        return true;
+    }
+    if (isAzureManagementHost(target.host) and
+        pathHasResource(target.path, "Microsoft.Search") and
+        pathHasResource(target.path, "listQueryKeys") and
+        jsonContainsField(value, "key"))
+    {
+        return true;
+    }
     return false;
 }
 
@@ -2209,9 +2399,44 @@ fn isKustoHost(host: []const u8) bool {
 
 fn isAzureManagementHost(host: []const u8) bool {
     return std.ascii.eqlIgnoreCase(host, "management.azure.com") or
-        std.ascii.eqlIgnoreCase(host, "management.azure.cn") or
         std.ascii.eqlIgnoreCase(host, "management.usgovcloudapi.net") or
+        std.ascii.eqlIgnoreCase(host, "management.chinacloudapi.cn") or
         std.ascii.eqlIgnoreCase(host, "management.microsoftazure.de");
+}
+
+fn isStorageBlobHost(host: []const u8) bool {
+    return hostMatches(host, "blob.core.windows.net") or
+        hostMatches(host, "blob.core.usgovcloudapi.net") or
+        hostMatches(host, "blob.core.chinacloudapi.cn") or
+        hostMatches(host, "blob.core.cloudapi.de");
+}
+
+fn isStorageUserDelegationKeyExchange(context: BodySafetyContext) bool {
+    if (context.direction != .response) return false;
+    const target = parseUrlTarget(context.url) orelse return false;
+    if (!isStorageBlobHost(target.host)) return false;
+    const query_start = std.mem.indexOfScalar(u8, context.url, '?') orelse
+        return false;
+    const fragment_start = std.mem.indexOfPos(
+        u8,
+        context.url,
+        query_start,
+        "#",
+    ) orelse context.url.len;
+    var fields = std.mem.splitScalar(
+        u8,
+        context.url[query_start + 1 .. fragment_start],
+        '&',
+    );
+    while (fields.next()) |field| {
+        const equals = std.mem.indexOfScalar(u8, field, '=') orelse continue;
+        if (std.ascii.eqlIgnoreCase(field[0..equals], "comp") and
+            std.ascii.eqlIgnoreCase(field[equals + 1 ..], "userdelegationkey"))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 fn isAzureKeyManagementPath(path: []const u8) bool {
@@ -2743,13 +2968,29 @@ fn sanitizeUrlAlloc(
     allocator: std.mem.Allocator,
     url: []const u8,
 ) ![]u8 {
-    if (url.len == 0 or std.mem.indexOfAny(u8, url, "\x00\r\n") != null)
-        return error.SensitiveUrlRequiresSanitization;
-    if (std.mem.indexOfScalar(u8, url, '#') != null)
-        return error.SensitiveUrlRequiresSanitization;
+    return sanitizeUrlAllocDepth(allocator, url, 0);
+}
 
-    const question = std.mem.indexOfScalar(u8, url, '?');
-    const reference_end = question orelse url.len;
+const max_url_decode_depth = 3;
+const max_nested_url_depth = 4;
+const max_sanitized_url_length = 256 * 1024;
+
+fn sanitizeUrlAllocDepth(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    nesting: usize,
+) anyerror![]u8 {
+    if (nesting > max_nested_url_depth or
+        url.len == 0 or
+        url.len > max_sanitized_url_length or
+        std.mem.indexOfAny(u8, url, "\x00\r\n") != null)
+    {
+        return error.SensitiveUrlRequiresSanitization;
+    }
+
+    const fragment = std.mem.indexOfScalar(u8, url, '#');
+    const reference_end = fragment orelse url.len;
+    const question = std.mem.indexOfScalar(u8, url[0..reference_end], '?');
     var path_start: usize = 0;
     const scheme_end_value = schemeEndAtReferenceStart(url, reference_end);
     if (scheme_end_value) |scheme_end| {
@@ -2779,28 +3020,38 @@ fn sanitizeUrlAlloc(
             return error.SensitiveUrlRequiresSanitization;
         }
         path_start = authority_end;
-    } else if (std.mem.startsWith(u8, url, "//") or
-        std.mem.indexOf(u8, url[0..reference_end], "://") != null)
-    {
+    } else if (std.mem.startsWith(u8, url, "//")) {
         return error.SensitiveUrlRequiresSanitization;
     }
 
-    const encoded_path = url[path_start..reference_end];
-    const decoded_path = try percentDecodeAlloc(
+    const query_start = question orelse reference_end;
+    if (try encodedComponentIsSensitive(
         allocator,
-        encoded_path,
+        url[path_start..query_start],
         false,
-    );
-    defer allocator.free(decoded_path);
-    if (try containsSensitiveScalar(allocator, decoded_path))
-        return error.SensitiveUrlRequiresSanitization;
+        false,
+        nesting,
+    )) return error.SensitiveUrlRequiresSanitization;
+    if (fragment) |fragment_start| {
+        if (try encodedComponentIsSensitive(
+            allocator,
+            url[fragment_start + 1 ..],
+            false,
+            true,
+            nesting,
+        )) return error.SensitiveUrlRequiresSanitization;
+    }
 
-    const query_start = question orelse return allocator.dupe(u8, url);
+    if (question == null) return allocator.dupe(u8, url);
     var output: std.Io.Writer.Allocating = .init(allocator);
     errdefer output.deinit();
     try output.writer.writeAll(url[0 .. query_start + 1]);
     var first = true;
-    var iterator = std.mem.splitScalar(u8, url[query_start + 1 ..], '&');
+    var iterator = std.mem.splitScalar(
+        u8,
+        url[query_start + 1 .. reference_end],
+        '&',
+    );
     while (iterator.next()) |parameter| {
         if (!first) try output.writer.writeByte('&');
         first = false;
@@ -2812,7 +3063,13 @@ fn sanitizeUrlAlloc(
             );
             defer allocator.free(decoded);
             if (isSensitiveQueryField(decoded) or
-                try containsSensitiveScalar(allocator, decoded))
+                try encodedComponentIsSensitive(
+                    allocator,
+                    parameter,
+                    true,
+                    true,
+                    nesting,
+                ))
             {
                 try output.writer.writeAll(parameter);
                 try output.writer.writeAll("=");
@@ -2830,19 +3087,87 @@ fn sanitizeUrlAlloc(
             true,
         );
         defer allocator.free(decoded_name);
-        const decoded_value = try percentDecodeAlloc(
-            allocator,
-            encoded_value,
-            true,
-        );
-        defer allocator.free(decoded_value);
         const redact = isSensitiveQueryField(decoded_name) or
-            try containsSensitiveScalar(allocator, decoded_value);
+            try encodedComponentIsSensitive(
+                allocator,
+                encoded_value,
+                true,
+                true,
+                nesting,
+            );
         try output.writer.writeAll(encoded_name);
         try output.writer.writeByte('=');
         try output.writer.writeAll(if (redact) redacted_value else encoded_value);
     }
+    if (fragment) |fragment_start| {
+        try output.writer.writeAll(url[fragment_start..]);
+    }
     return output.toOwnedSlice();
+}
+
+fn encodedComponentIsSensitive(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+    plus_as_space: bool,
+    inspect_uri: bool,
+    nesting: usize,
+) anyerror!bool {
+    if (encoded.len > max_sanitized_url_length) return true;
+    var current = try allocator.dupe(u8, encoded);
+    defer allocator.free(current);
+    var decode_count: usize = 0;
+    while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+        const decoded = try percentDecodeAlloc(
+            allocator,
+            current,
+            plus_as_space and decode_count == 0,
+        );
+        const changed = !std.mem.eql(u8, current, decoded);
+        allocator.free(current);
+        current = decoded;
+        if (try containsSensitiveScalar(allocator, current)) return true;
+        if (inspect_uri and looksLikeNestedUriReference(current)) {
+            if (nesting >= max_nested_url_depth) return true;
+            const sanitized = sanitizeUrlAllocDepth(
+                allocator,
+                current,
+                nesting + 1,
+            ) catch |err| switch (err) {
+                error.SensitiveUrlRequiresSanitization => return true,
+                else => return err,
+            };
+            defer allocator.free(sanitized);
+            if (!std.mem.eql(u8, current, sanitized)) return true;
+        }
+        if (!changed) return false;
+    }
+    return containsPercentEscape(current);
+}
+
+fn looksLikeNestedUriReference(value: []const u8) bool {
+    if (value.len == 0) return false;
+    return value[0] == '/' or
+        std.mem.indexOfAny(u8, value, "?#") != null or
+        schemeEndAtReferenceStart(value, value.len) != null;
+}
+
+fn containsPercentEscape(value: []const u8) bool {
+    var index: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, value, index, '%')) |percent| {
+        if (percent + 2 < value.len) {
+            _ = std.fmt.charToDigit(value[percent + 1], 16) catch {
+                index = percent + 1;
+                continue;
+            };
+            _ = std.fmt.charToDigit(value[percent + 2], 16) catch {
+                index = percent + 1;
+                continue;
+            };
+            return true;
+        }
+        index = percent + 1;
+    }
+    return false;
 }
 
 fn schemeEndAtReferenceStart(url: []const u8, reference_end: usize) ?usize {
@@ -3189,6 +3514,10 @@ test "playback preserves abort and cancellation semantics" {
     var aborted = try playback.asTransport().open(&abort_request, .{});
     aborted.abort();
     aborted.deinit();
+    try std.testing.expectEqual(@as(usize, 0), playback.index);
+    var abort_retry = try playback.asTransport().open(&abort_request, .{});
+    try abort_retry.finish();
+    abort_retry.deinit();
 
     var cancel_request = core.http.Request.init(
         std.testing.allocator,
@@ -3199,9 +3528,14 @@ test "playback preserves abort and cancellation semantics" {
     var cancelled = try playback.asTransport().open(&cancel_request, .{});
     cancelled.cancel();
     cancelled.deinit();
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
+    var cancel_retry = try playback.asTransport().open(&cancel_request, .{});
+    try cancel_retry.finish();
+    cancel_retry.deinit();
     try std.testing.expectEqual(@as(usize, 1), playback.abort_count);
     try std.testing.expectEqual(@as(usize, 1), playback.cancel_count);
-    try std.testing.expectEqual(@as(usize, 2), playback.deinit_count);
+    try std.testing.expectEqual(@as(usize, 2), playback.finish_count);
+    try std.testing.expectEqual(@as(usize, 4), playback.deinit_count);
 }
 
 test "playback follows redirects and cleans intermediate operations" {
@@ -3406,6 +3740,236 @@ test "playback allocation failures do not consume streaming exchanges" {
     try operation.finish();
     try std.testing.expectEqual(@as(usize, 1), playback.index);
     try std.testing.expectEqual(@as(usize, 1), playback.open_count);
+}
+
+test "Core buffered redirect allocation failure leaves playback retryable" {
+    const recordings = [_]RecordedExchange{
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/start",
+            .response_status = 302,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/final" },
+            },
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/final",
+            .response_status = 200,
+            .response_body = "done",
+        },
+    };
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    var request = core.http.Request.init(
+        failing.allocator(),
+        .GET,
+        "https://example.test/start",
+    );
+    defer request.deinit();
+    try std.testing.expectError(
+        error.OutOfMemory,
+        playback.asTransport().send(&request),
+    );
+    try std.testing.expectEqual(@as(usize, 0), playback.index);
+    try std.testing.expectEqual(@as(?usize, 0), playback.pending_redirect);
+
+    failing.fail_index = std.math.maxInt(usize);
+    var response = try playback.asTransport().send(&request);
+    defer response.deinit();
+    try std.testing.expectEqualStrings("done", response.body);
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
+    try std.testing.expectEqual(@as(?usize, null), playback.pending_redirect);
+}
+
+test "Core streaming redirect allocation failure leaves playback retryable" {
+    const recordings = [_]RecordedExchange{
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/start-stream",
+            .response_status = 302,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/final-stream" },
+            },
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/final-stream",
+            .response_status = 200,
+            .response_body = "stream-done",
+        },
+    };
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    var request = core.http.Request.init(
+        failing.allocator(),
+        .GET,
+        "https://example.test/start-stream",
+    );
+    defer request.deinit();
+    try std.testing.expectError(
+        error.OutOfMemory,
+        playback.asTransport().open(&request, .{}),
+    );
+    try std.testing.expectEqual(@as(usize, 0), playback.index);
+    try std.testing.expectEqual(@as(?usize, 0), playback.pending_redirect);
+    try std.testing.expectEqual(@as(usize, 1), playback.abort_count);
+
+    failing.fail_index = std.math.maxInt(usize);
+    var operation = try playback.asTransport().open(&request, .{});
+    defer operation.deinit();
+    const body = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("stream-done", body);
+    try operation.finish();
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
+    try std.testing.expectEqual(@as(?usize, null), playback.pending_redirect);
+}
+
+test "every Core redirect-chain request allocation failure rolls back playback" {
+    const recordings = [_]RecordedExchange{
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/start-chain",
+            .response_status = 302,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/middle-chain" },
+            },
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/middle-chain",
+            .response_status = 307,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/final-chain" },
+            },
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/final-chain",
+            .response_status = 200,
+            .response_body = "complete",
+        },
+    };
+    var saw_later_redirect_failure = false;
+    for (0..64) |fail_index| {
+        var playback = PlaybackTransport.init(
+            std.testing.allocator,
+            &recordings,
+        );
+        var failing = std.testing.FailingAllocator.init(
+            std.testing.allocator,
+            .{ .fail_index = fail_index },
+        );
+        var request = core.http.Request.init(
+            failing.allocator(),
+            .GET,
+            "https://example.test/start-chain",
+        );
+        defer request.deinit();
+        const transport = playback.asTransport();
+        if (transport.send(&request)) |response_value| {
+            var response = response_value;
+            response.deinit();
+            break;
+        } else |err| {
+            if (err != error.OutOfMemory and err != error.WriteFailed)
+                return err;
+            saw_later_redirect_failure = saw_later_redirect_failure or
+                playback.pending_redirect == 1;
+            try std.testing.expectEqual(@as(usize, 0), playback.index);
+            failing.fail_index = std.math.maxInt(usize);
+            var retry = try transport.send(&request);
+            defer retry.deinit();
+            try std.testing.expectEqualStrings("complete", retry.body);
+            try std.testing.expectEqual(@as(usize, 3), playback.index);
+        }
+    }
+    try std.testing.expect(saw_later_redirect_failure);
+}
+
+test "every Core streaming redirect-chain allocation failure rolls back playback" {
+    const recordings = [_]RecordedExchange{
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/start-open-chain",
+            .response_status = 302,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/middle-open-chain" },
+            },
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/middle-open-chain",
+            .response_status = 307,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/final-open-chain" },
+            },
+        },
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/final-open-chain",
+            .response_status = 200,
+            .response_body = "complete",
+        },
+    };
+    var saw_later_redirect_failure = false;
+    for (0..64) |fail_index| {
+        var playback = PlaybackTransport.init(
+            std.testing.allocator,
+            &recordings,
+        );
+        var failing = std.testing.FailingAllocator.init(
+            std.testing.allocator,
+            .{ .fail_index = fail_index },
+        );
+        var request = core.http.Request.init(
+            failing.allocator(),
+            .GET,
+            "https://example.test/start-open-chain",
+        );
+        defer request.deinit();
+        const transport = playback.asTransport();
+        if (transport.open(&request, .{})) |operation_value| {
+            var operation = operation_value;
+            try operation.finish();
+            operation.deinit();
+            break;
+        } else |err| {
+            if (err != error.OutOfMemory and err != error.WriteFailed)
+                return err;
+            saw_later_redirect_failure = saw_later_redirect_failure or
+                playback.pending_redirect == 1;
+            try std.testing.expectEqual(@as(usize, 0), playback.index);
+            failing.fail_index = std.math.maxInt(usize);
+            var retry = try transport.open(&request, .{});
+            try retry.finish();
+            retry.deinit();
+            try std.testing.expectEqual(@as(usize, 3), playback.index);
+        }
+    }
+    try std.testing.expect(saw_later_redirect_failure);
 }
 
 test "recording wraps streaming operations and copies descriptor by value" {
@@ -4199,6 +4763,100 @@ test "URL sanitization inspects decoded query path and fragment components" {
     }
 }
 
+test "URL sanitization recursively decodes nested URI credentials" {
+    const recorded_url =
+        "https://example.test/callback?return=" ++
+        "https%253A%252F%252Fstorage.example%252Fblob%253F" ++
+        "%252573%252569%252567%253Dnested-sas-secret&stable=one";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        recorded_url,
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "nested-sas-secret") == null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "return=REDACTED") != null,
+    );
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/callback?return=" ++
+            "https%253A%252F%252Fstorage.example%252Fblob%253F" ++
+            "%252573%252569%252567%253Drotated-sas-secret&stable=one",
+    );
+    defer live.deinit();
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
+
+    for ([_][]const u8{
+        "https://example.test/callback?return=%ZZ",
+        "https://example.test/callback?return=%2525252573%2525252569%2525252567%253Ddecode-depth-secret",
+    }) |unsafe_url| {
+        var unsafe_mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "",
+        );
+        defer unsafe_mock.deinit();
+        var unsafe_recorder = RecordingTransport.init(
+            std.testing.allocator,
+            unsafe_mock.asTransport(),
+        );
+        defer unsafe_recorder.deinit();
+        var unsafe_request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            unsafe_url,
+        );
+        defer unsafe_request.deinit();
+        var unsafe_response =
+            try unsafe_recorder.asTransport().send(&unsafe_request);
+        unsafe_response.deinit();
+        if (std.mem.indexOf(u8, unsafe_url, "%ZZ") != null) {
+            try std.testing.expectError(
+                error.SensitiveUrlRequiresSanitization,
+                unsafe_recorder.toJson(std.testing.allocator),
+            );
+        } else {
+            const unsafe_json =
+                try unsafe_recorder.toJson(std.testing.allocator);
+            defer std.testing.allocator.free(unsafe_json);
+            try std.testing.expect(
+                std.mem.indexOf(u8, unsafe_json, "decode-depth-secret") ==
+                    null,
+            );
+            try std.testing.expect(
+                std.mem.indexOf(u8, unsafe_json, "return=REDACTED") != null,
+            );
+        }
+    }
+}
+
 test "authenticated recording JSON roundtrips with structured redactions" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -4509,6 +5167,61 @@ test "location headers preserve replayable URLs and rotated SAS next exchanges" 
         var response = try playback.asTransport().send(&request);
         response.deinit();
     }
+}
+
+test "safe Location fragments remain replayable through Core redirects" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{
+                    .{ .name = "Location", .value = "/final#section" },
+                },
+            },
+            .{ .status = 200, .body = "" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status_code);
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings(
+        "/final#section",
+        getHeaderPair(
+            parsed.asSlice()[0].response_headers,
+            "Location",
+        ).?,
+    );
+    try std.testing.expectEqualStrings(
+        "https://example.test/final",
+        parsed.asSlice()[1].request_url,
+    );
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed = try playback.asTransport().send(&request);
+    defer replayed.deinit();
+    try std.testing.expectEqual(@as(u16, 200), replayed.status_code);
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
 }
 
 test "recording JSON base64 bodies roundtrip arbitrary bytes" {
@@ -5043,6 +5756,244 @@ test "Cosmos and Container Registry credential schemas are rejected" {
     }
 }
 
+test "ARM credential schemas cover every trusted sovereign management host" {
+    const hosts = [_][]const u8{
+        "management.azure.com",
+        "management.usgovcloudapi.net",
+        "management.chinacloudapi.cn",
+        "management.microsoftazure.de",
+    };
+    const schemas = [_]struct {
+        path: []const u8,
+        body: []const u8,
+        secrets: []const []const u8,
+    }{
+        .{
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.Batch/batchAccounts/a/listKeys?api-version=2024-07-01",
+            .body = "{\"primary\":\"batch-primary\",\"secondary\":\"batch-secondary\"}",
+            .secrets = &.{ "batch-primary", "batch-secondary" },
+        },
+        .{
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.Search/searchServices/a/listQueryKeys?api-version=2024-03-01-preview",
+            .body = "{\"value\":[{\"name\":\"query-key\",\"key\":\"search-query-secret\"}]}",
+            .secrets = &.{"search-query-secret"},
+        },
+        .{
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.EventGrid/topics/t/listKeys?api-version=2025-02-15",
+            .body = "{\"key1\":\"event-grid-one\",\"key2\":\"event-grid-two\"}",
+            .secrets = &.{ "event-grid-one", "event-grid-two" },
+        },
+        .{
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.DocumentDB/databaseAccounts/a/listKeys?api-version=2025-04-15",
+            .body = "{\"primaryMasterKey\":\"cosmos-one\",\"secondaryMasterKey\":\"cosmos-two\"}",
+            .secrets = &.{ "cosmos-one", "cosmos-two" },
+        },
+        .{
+            .path = "/subscriptions/s/resourceGroups/r/providers/Microsoft.ContainerRegistry/registries/a/listCredentials?api-version=2025-04-01",
+            .body = "{\"passwords\":[{\"name\":\"password\",\"value\":\"acr-secret\"}]}",
+            .secrets = &.{"acr-secret"},
+        },
+    };
+    for (hosts) |host| {
+        for (schemas) |schema| {
+            const url = try std.fmt.allocPrint(
+                std.testing.allocator,
+                "https://{s}{s}",
+                .{ host, schema.path },
+            );
+            defer std.testing.allocator.free(url);
+            var mock = core.http.MockTransport.init(
+                std.testing.allocator,
+                200,
+                schema.body,
+            );
+            defer mock.deinit();
+            mock.response_headers_list = &.{
+                .{ .name = "Content-Type", .value = "application/json" },
+            };
+            var recorder = RecordingTransport.init(
+                std.testing.allocator,
+                mock.asTransport(),
+            );
+            defer recorder.deinit();
+            var request = core.http.Request.init(
+                std.testing.allocator,
+                .POST,
+                url,
+            );
+            defer request.deinit();
+            var response = try recorder.asTransport().send(&request);
+            response.deinit();
+            try expectRejectedSerializationExcludes(
+                &recorder,
+                error.SensitiveBodyRequiresSanitization,
+                schema.secrets,
+            );
+        }
+    }
+}
+
+test "legacy China management hostname does not activate ARM schemas" {
+    const body = "{\"primary\":\"ordinary\",\"secondary\":\"setting\"}";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        body,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://management.azure.cn/subscriptions/s/providers/Microsoft.Batch/batchAccounts/a/listKeys",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        body,
+        parsed.asSlice()[0].response_body,
+    );
+}
+
+test "ARM key-shaped fields remain safe outside trusted credential actions" {
+    const body =
+        "{\"primary\":\"one\",\"secondary\":\"two\"," ++
+        "\"value\":[{\"name\":\"setting\",\"key\":\"ordinary\"}]}";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        body,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://store.azconfig.io/kv/schema-regression?api-version=1.0",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        body,
+        parsed.asSlice()[0].response_body,
+    );
+}
+
+test "Storage user delegation key XML is rejected on trusted blob hosts" {
+    const hosts = [_][]const u8{
+        "account.blob.core.windows.net",
+        "account.blob.core.usgovcloudapi.net",
+        "account.blob.core.chinacloudapi.cn",
+        "account.blob.core.cloudapi.de",
+    };
+    const body =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>" ++
+        "<UserDelegationKey><SignedOid>oid</SignedOid>" ++
+        "<Value>delegation-key-secret</Value></UserDelegationKey>";
+    for (hosts) |host| {
+        const url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://{s}/?restype=service&comp=userdelegationkey",
+            .{host},
+        );
+        defer std.testing.allocator.free(url);
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            body,
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "application/xml" },
+        };
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{"delegation-key-secret"},
+        );
+    }
+}
+
+test "Storage delegation XML schema ignores untrusted hosts" {
+    const body =
+        "<UserDelegationKey><Value>ordinary-value</Value>" ++
+        "</UserDelegationKey>";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        body,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/xml" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://account.blob.core.windows.net.attacker.test/" ++
+            "?restype=service&comp=userdelegationkey",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        body,
+        parsed.asSlice()[0].response_body,
+    );
+}
+
 test "Kusto source URIs and tabular credential scalars are rejected" {
     const jwt =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
@@ -5374,6 +6325,73 @@ test "declared malformed multipart fails closed despite allow opaque" {
             recorder.toJson(std.testing.allocator),
         );
     }
+}
+
+test "multipart boundaries require exact delimiter line syntax" {
+    const malformed =
+        "--batch\r\nContent-Type: text/plain\r\n\r\nsafe\r\n" ++
+        "--batch--invalid\r\n" ++
+        "--batch\r\nContent-Type: text/plain\r\n\r\nlater\r\n" ++
+        "--batch--\r\n";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        malformed,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{
+            .name = "Content-Type",
+            .value = "multipart/mixed; boundary=batch",
+        },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &allowOpaqueBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://account.table.core.windows.net/$batch",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    try expectRejectedSerializationExcludes(
+        &recorder,
+        error.UnsupportedBodySanitization,
+        &.{"later"},
+    );
+
+    const credential_after_fake_close =
+        "--batch\r\nContent-Type: text/plain\r\n\r\nsafe\r\n" ++
+        "--batch--invalid\r\n" ++
+        "--batch\r\nContent-Type: application/http\r\n\r\n" ++
+        "GET / HTTP/1.1\r\nAuthorization: SharedKey account:later-secret\r\n\r\n" ++
+        "--batch--\r\n";
+    var secret_mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        credential_after_fake_close,
+    );
+    defer secret_mock.deinit();
+    secret_mock.response_headers_list = mock.response_headers_list;
+    var secret_recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        secret_mock.asTransport(),
+        .{ .bodyPolicyFn = &allowOpaqueBody },
+    );
+    defer secret_recorder.deinit();
+    var secret_response =
+        try secret_recorder.asTransport().send(&request);
+    secret_response.deinit();
+    try expectRejectedSerializationExcludes(
+        &secret_recorder,
+        error.SensitiveBodyRequiresSanitization,
+        &.{"later-secret"},
+    );
 }
 
 test "opaque bodies reject by default and require an explicit safe policy" {

--- a/root.zig
+++ b/root.zig
@@ -13,6 +13,33 @@ pub const HeaderPair = struct {
     redacted: bool = false,
 };
 
+/// Stable failure stages represented by a raw transport attempt.
+pub const RecordedOutcome = enum {
+    response,
+    transport_error,
+    open_error,
+    body_error,
+    finish_error,
+};
+
+/// Stable, serializable failure categories used instead of backend-specific
+/// error identities. Playback maps these to the corresponding
+/// `RecordedCancelled`, `RecordedTimeout`, `RecordedConnectionFailure`,
+/// `RecordedTlsFailure`, `RecordedProtocolFailure`, `RecordedIoFailure`,
+/// `RecordedResourceExhausted`, `RecordedUnsupported`, or
+/// `RecordedUnknownFailure` error.
+pub const RecordedErrorCategory = enum {
+    cancelled,
+    timeout,
+    connection,
+    tls,
+    protocol,
+    io,
+    resource_exhausted,
+    unsupported,
+    unknown,
+};
+
 /// A borrowed HTTP exchange used by playback.
 ///
 /// Method, URL, and body are matched exactly, including whether a body is
@@ -20,15 +47,18 @@ pub const HeaderPair = struct {
 /// additional live headers are allowed. `REDACTED` values produced by
 /// `toJson` wildcard only recognized sensitive header values and sensitive
 /// URL query values; nonsensitive fields remain exact. Response headers retain
-/// wire order and duplicate values.
+/// wire order and duplicate values. `outcome` replays stable failure
+/// categories at transport, open, response-body, or finish stages.
 pub const RecordedExchange = struct {
     request_method: core.http.Method,
     request_url: []const u8,
     request_headers: []const HeaderPair = &.{},
     request_body: ?[]const u8 = null,
-    response_status: u16,
-    response_body: []const u8,
+    response_status: u16 = 0,
+    response_body: []const u8 = "",
     response_headers: []const HeaderPair = &.{},
+    outcome: RecordedOutcome = .response,
+    error_category: ?RecordedErrorCategory = null,
 };
 
 /// An allocator-owned exchange captured by `RecordingTransport`.
@@ -41,6 +71,8 @@ pub const OwnedExchange = struct {
     response_body: []u8,
     response_body_allocation: ?[]u8 = null,
     response_headers: []HeaderPair,
+    outcome: RecordedOutcome = .response,
+    error_category: ?RecordedErrorCategory = null,
 
     fn deinit(self: *OwnedExchange, allocator: std.mem.Allocator) void {
         allocator.free(self.request_url);
@@ -143,7 +175,9 @@ pub const RecordingOptions = struct {
 /// Parse the versioned, lossless JSON format emitted by `toJson`.
 ///
 /// All returned strings and decoded bodies are allocator-owned. Invalid JSON,
-/// unsupported versions or encodings, and invalid base64 are distinct errors.
+/// unsupported versions or encodings, invalid outcomes, and invalid base64
+/// are distinct errors. Version 2 successful-response recordings remain
+/// readable; new recordings use version 3 failure outcomes.
 pub fn parseJson(
     allocator: std.mem.Allocator,
     json: []const u8,
@@ -164,8 +198,11 @@ pub fn parseJson(
         else => return error.InvalidRecordingJson,
     };
     const version = root.get("version") orelse return error.InvalidRecordingJson;
-    if (version != .integer or version.integer != recording_format_version)
+    if (version != .integer or
+        (version.integer != 2 and
+            version.integer != recording_format_version))
         return error.UnsupportedRecordingVersion;
+    const format_version: u32 = @intCast(version.integer);
     const exchanges_value = root.get("exchanges") orelse
         return error.InvalidRecordingJson;
     const exchange_values = switch (exchanges_value) {
@@ -180,7 +217,7 @@ pub fn parseJson(
         allocator.free(owned);
     }
     for (exchange_values, owned) |value, *exchange| {
-        exchange.* = try parseExchange(allocator, value);
+        exchange.* = try parseExchange(allocator, value, format_version);
         initialized += 1;
     }
 
@@ -194,6 +231,8 @@ pub fn parseJson(
             .response_status = exchange.response_status,
             .response_body = exchange.response_body,
             .response_headers = exchange.response_headers,
+            .outcome = exchange.outcome,
+            .error_category = exchange.error_category,
         };
     }
     return .{
@@ -216,8 +255,9 @@ pub fn initHttpRuntime(
 ///
 /// The returned descriptor borrows this value. Keep it alive until all
 /// descriptor copies and open operations are deinitialized. Each recording is
-/// one raw transport invocation and is consumed when its response head has
-/// been allocated, including redirect and retry attempts.
+/// one raw transport invocation and is consumed when its recorded pre-response
+/// error is returned or its response head has been allocated, including
+/// redirect and retry attempts.
 pub const PlaybackTransport = struct {
     recordings: []const RecordedExchange,
     index: usize = 0,
@@ -251,6 +291,11 @@ pub const PlaybackTransport = struct {
     ) !RecordedExchange {
         if (self.index >= self.recordings.len) return error.NoMoreRecordings;
         const exchange = self.recordings[self.index];
+        if ((exchange.outcome == .response) !=
+            (exchange.error_category == null))
+        {
+            return error.InvalidRecordedOutcome;
+        }
         try matchRequest(exchange, request, body);
         return exchange;
     }
@@ -261,6 +306,12 @@ pub const PlaybackTransport = struct {
     ) !core.http.Response {
         const self: *PlaybackTransport = @ptrCast(@alignCast(context));
         const exchange = try self.matchNext(request, request.body);
+        if (exchange.outcome != .response) {
+            if (exchange.outcome != .transport_error)
+                return error.RecordedOutcomeStageMismatch;
+            self.index += 1;
+            return replayRecordedError(exchange.error_category);
+        }
         const response = try responseFromExchange(
             self.allocator,
             exchange,
@@ -282,7 +333,24 @@ pub const PlaybackTransport = struct {
 
         var captured: ?[]u8 = null;
         defer if (captured) |body| self.allocator.free(body);
+        const expected = if (self.index < self.recordings.len)
+            self.recordings[self.index]
+        else
+            null;
         const body: ?[]const u8 = if (options.body) |streaming| blk: {
+            if (expected) |exchange| {
+                if (exchange.outcome == .open_error) {
+                    const expected_body = exchange.request_body orelse
+                        return error.BodyMismatch;
+                    captured = try readRequestBodyPrefix(
+                        self.allocator,
+                        streaming,
+                        options.cancellation,
+                        expected_body.len,
+                    );
+                    break :blk captured.?;
+                }
+            }
             captured = try readRequestBody(
                 self.allocator,
                 streaming,
@@ -292,6 +360,14 @@ pub const PlaybackTransport = struct {
         } else request.body;
 
         const exchange = try self.matchNext(request, body);
+        if (exchange.outcome == .transport_error or
+            exchange.outcome == .open_error)
+        {
+            if (exchange.outcome != .open_error)
+                return error.RecordedOutcomeStageMismatch;
+            self.index += 1;
+            return replayRecordedError(exchange.error_category);
+        }
         const operation = try PlaybackOperation.create(self, exchange);
         self.index += 1;
         self.open_count += 1;
@@ -304,7 +380,9 @@ const PlaybackOperation = struct {
     allocator: std.mem.Allocator,
     owner: *PlaybackTransport,
     response_body: []u8,
-    reader_impl: std.Io.Reader,
+    reader_impl: PlaybackBodyReader,
+    outcome: RecordedOutcome,
+    error_category: ?RecordedErrorCategory,
 
     fn create(
         owner: *PlaybackTransport,
@@ -325,17 +403,25 @@ const PlaybackOperation = struct {
             .allocator = owner.allocator,
             .owner = owner,
             .response_body = body,
-            .reader_impl = std.Io.Reader.fixed(body),
+            .reader_impl = undefined,
+            .outcome = exchange.outcome,
+            .error_category = exchange.error_category,
         };
+        self.reader_impl.init(
+            body,
+            exchange.outcome == .body_error,
+            exchange.error_category,
+        );
         self.operation = .{
             .status_code = exchange.response_status,
             .headers = header_set.map,
             .response_headers = header_set.ordered,
-            .body_reader = &self.reader_impl,
+            .body_reader = &self.reader_impl.interface,
             .finishFn = &finishImpl,
             .abortFn = &abortImpl,
             .cancelFn = &cancelImpl,
             .deinitFn = &deinitImpl,
+            .bodyErrorFn = &bodyErrorImpl,
         };
         return &self.operation;
     }
@@ -343,7 +429,10 @@ const PlaybackOperation = struct {
     fn finishImpl(operation: *core.http.HttpOperation) !void {
         const self: *PlaybackOperation =
             @alignCast(@fieldParentPtr("operation", operation));
-        _ = try self.reader_impl.discardRemaining();
+        _ = self.reader_impl.interface.discardRemaining() catch
+            return replayRecordedError(self.error_category);
+        if (self.outcome == .finish_error)
+            return replayRecordedError(self.error_category);
         self.owner.finish_count += 1;
     }
 
@@ -357,6 +446,13 @@ const PlaybackOperation = struct {
         const self: *PlaybackOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.owner.cancel_count += 1;
+    }
+
+    fn bodyErrorImpl(operation: *const core.http.HttpOperation) ?anyerror {
+        const self: *const PlaybackOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        if (self.outcome != .body_error) return null;
+        return recordedErrorValue(self.error_category);
     }
 
     fn deinitImpl(operation: *core.http.HttpOperation) void {
@@ -373,19 +469,165 @@ const PlaybackOperation = struct {
     }
 };
 
+const PlaybackBodyReader = struct {
+    interface: std.Io.Reader,
+    bytes: []const u8,
+    offset: usize = 0,
+    fail_after_body: bool,
+
+    fn init(
+        self: *PlaybackBodyReader,
+        bytes: []u8,
+        fail_after_body: bool,
+        _: ?RecordedErrorCategory,
+    ) void {
+        self.* = .{
+            .interface = undefined,
+            .bytes = bytes,
+            .fail_after_body = fail_after_body,
+        };
+        self.interface = .{
+            .vtable = &.{
+                .stream = &stream,
+                .readVec = &readVec,
+            },
+            .buffer = &.{},
+            .seek = 0,
+            .end = 0,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *PlaybackBodyReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        if (self.offset != self.bytes.len) {
+            const count = @min(
+                limit.minInt(self.bytes.len - self.offset),
+                self.bytes.len - self.offset,
+            );
+            if (count == 0) return 0;
+            try writer.writeAll(self.bytes[self.offset..][0..count]);
+            self.offset += count;
+            return count;
+        }
+        if (self.fail_after_body) return error.ReadFailed;
+        return error.EndOfStream;
+    }
+
+    fn readVec(
+        interface: *std.Io.Reader,
+        data: [][]u8,
+    ) std.Io.Reader.Error!usize {
+        const self: *PlaybackBodyReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        var total: usize = 0;
+        for (data) |destination| {
+            const count = @min(
+                destination.len,
+                self.bytes.len - self.offset,
+            );
+            @memcpy(
+                destination[0..count],
+                self.bytes[self.offset..][0..count],
+            );
+            self.offset += count;
+            total += count;
+            if (self.offset == self.bytes.len) break;
+        }
+        if (total != 0) return total;
+        if (self.fail_after_body) return error.ReadFailed;
+        return error.EndOfStream;
+    }
+};
+
+fn recordedErrorValue(category: ?RecordedErrorCategory) anyerror {
+    return switch (category orelse .unknown) {
+        .cancelled => error.RecordedCancelled,
+        .timeout => error.RecordedTimeout,
+        .connection => error.RecordedConnectionFailure,
+        .tls => error.RecordedTlsFailure,
+        .protocol => error.RecordedProtocolFailure,
+        .io => error.RecordedIoFailure,
+        .resource_exhausted => error.RecordedResourceExhausted,
+        .unsupported => error.RecordedUnsupported,
+        .unknown => error.RecordedUnknownFailure,
+    };
+}
+
+fn replayRecordedError(category: ?RecordedErrorCategory) anyerror {
+    return recordedErrorValue(category);
+}
+
+fn classifyRecordedError(err: anyerror) RecordedErrorCategory {
+    const name = @errorName(err);
+    if (containsIgnoreCase(name, "cancel")) return .cancelled;
+    if (containsIgnoreCase(name, "timeout") or
+        containsIgnoreCase(name, "timedout"))
+    {
+        return .timeout;
+    }
+    if (std.mem.eql(u8, name, "OutOfMemory") or
+        containsIgnoreCase(name, "resourceexhaust"))
+    {
+        return .resource_exhausted;
+    }
+    if (containsIgnoreCase(name, "tls") or
+        containsIgnoreCase(name, "ssl") or
+        containsIgnoreCase(name, "certificate"))
+    {
+        return .tls;
+    }
+    if (containsIgnoreCase(name, "connection") or
+        containsIgnoreCase(name, "network") or
+        containsIgnoreCase(name, "socket") or
+        containsIgnoreCase(name, "dns") or
+        containsIgnoreCase(name, "hostnotfound") or
+        containsIgnoreCase(name, "brokenpipe"))
+    {
+        return .connection;
+    }
+    if (containsIgnoreCase(name, "unsupported") or
+        containsIgnoreCase(name, "notimplemented"))
+    {
+        return .unsupported;
+    }
+    if (containsIgnoreCase(name, "read") or
+        containsIgnoreCase(name, "write") or
+        containsIgnoreCase(name, "inputoutput") or
+        containsIgnoreCase(name, "ioerror"))
+    {
+        return .io;
+    }
+    if (containsIgnoreCase(name, "protocol") or
+        containsIgnoreCase(name, "http") or
+        containsIgnoreCase(name, "invalidresponse") or
+        containsIgnoreCase(name, "malformed"))
+    {
+        return .protocol;
+    }
+    return .unknown;
+}
+
 /// Caller-serialized recording transport wrapping a full Core descriptor.
 ///
 /// The inner descriptor is copied by value. Its context, this recording
 /// transport, and the recording allocator must outlive every open operation.
 /// A configured body-policy context is also borrowed and must outlive calls to
 /// `toJson`. Each exchange is one completed raw transport attempt, including
-/// redirect and retry responses. `deinit` does not deinitialize either
-/// borrowed context.
+/// redirect, retry, and stable staged failure outcomes. Post-dispatch
+/// bookkeeping failure poisons serialization rather than omitting an attempt.
+/// `deinit` does not deinitialize either borrowed context.
 pub const RecordingTransport = struct {
     inner: core.http.HttpTransport,
     exchanges: std.ArrayList(OwnedExchange) = .empty,
     allocator: std.mem.Allocator,
     options: RecordingOptions,
+    reserved_attempts: usize = 0,
+    poisoned: bool = false,
 
     const vtable: core.http.HttpTransport.VTable = .{
         .send = &sendImpl,
@@ -427,7 +669,42 @@ pub const RecordingTransport = struct {
         return self.exchanges.items;
     }
 
-    /// Serialize version 2 recordings with lossless base64 bodies while
+    /// False when post-dispatch bookkeeping failed or an open operation was
+    /// deinitialized without a terminal event. `toJson` then returns
+    /// `error.IncompleteRecording`.
+    pub fn isComplete(self: *const RecordingTransport) bool {
+        return !self.poisoned;
+    }
+
+    fn reserveAttempt(self: *RecordingTransport) !void {
+        if (self.poisoned) return error.IncompleteRecording;
+        try self.exchanges.ensureUnusedCapacity(
+            self.allocator,
+            self.reserved_attempts + 1,
+        );
+        self.reserved_attempts += 1;
+    }
+
+    fn releaseAttempt(self: *RecordingTransport) void {
+        std.debug.assert(self.reserved_attempts != 0);
+        self.reserved_attempts -= 1;
+    }
+
+    fn appendAttempt(
+        self: *RecordingTransport,
+        exchange: OwnedExchange,
+    ) void {
+        self.releaseAttempt();
+        self.exchanges.appendAssumeCapacity(exchange);
+    }
+
+    fn poisonAttempt(self: *RecordingTransport) void {
+        self.releaseAttempt();
+        self.poisoned = true;
+    }
+
+    /// Serialize version 3 recordings with lossless base64 bodies and stable
+    /// raw-attempt failure outcomes while
     /// redacting sensitive header values and sensitive URL query parameters.
     ///
     /// Every non-empty body requires a configured `bodyPolicyFn`. Returning
@@ -444,6 +721,7 @@ pub const RecordingTransport = struct {
         self: *const RecordingTransport,
         allocator: std.mem.Allocator,
     ) ![]u8 {
+        if (self.poisoned) return error.IncompleteRecording;
         var output: std.Io.Writer.Allocating = .init(allocator);
         errdefer output.deinit();
         const writer = &output.writer;
@@ -459,6 +737,7 @@ pub const RecordingTransport = struct {
         writer: *std.Io.Writer,
         allocator: std.mem.Allocator,
     ) !void {
+        if (self.poisoned) return error.IncompleteRecording;
         try writer.print(
             "{{\"version\":{d},\"exchanges\":[",
             .{recording_format_version},
@@ -470,12 +749,22 @@ pub const RecordingTransport = struct {
                 exchange,
                 .request,
             );
-            try ensureExchangeBodySafe(
-                allocator,
-                self.options,
-                exchange,
-                .response,
-            );
+            const has_response = exchange.outcome == .response or
+                exchange.outcome == .body_error or
+                exchange.outcome == .finish_error;
+            if (has_response) {
+                try ensureExchangeBodySafe(
+                    allocator,
+                    self.options,
+                    exchange,
+                    .response,
+                );
+            }
+            if ((exchange.outcome == .response) !=
+                (exchange.error_category == null))
+            {
+                return error.InvalidRecordedOutcome;
+            }
             if (index != 0) try writer.writeAll(",");
             try writer.writeAll("\n  {\"request_method\":");
             try writeJsonString(writer, methodToString(exchange.request_method));
@@ -491,6 +780,16 @@ pub const RecordingTransport = struct {
             );
             try writer.writeAll(",\"request_body\":");
             try writeOptionalBody(writer, allocator, exchange.request_body);
+            try writer.writeAll(",\"outcome\":");
+            try writeJsonString(writer, @tagName(exchange.outcome));
+            if (exchange.error_category) |category| {
+                try writer.writeAll(",\"error_category\":");
+                try writeJsonString(writer, @tagName(category));
+            }
+            if (!has_response) {
+                try writer.writeAll("}");
+                continue;
+            }
             try writer.writeAll(",\"response_status\":");
             try writer.print("{d}", .{exchange.response_status});
             try writer.writeAll(",\"response_headers\":");
@@ -513,17 +812,45 @@ pub const RecordingTransport = struct {
         request: *core.http.Request,
     ) !core.http.Response {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
-        var response = try self.inner.vtable.send(self.inner.context, request);
-        errdefer response.deinit();
-        var exchange = try ownedExchangeFromResponse(
+        if (self.poisoned) return error.IncompleteRecording;
+        var pending = try PendingRequest.init(
             self.allocator,
             request,
             request.body,
+        );
+        var pending_owned = true;
+        defer if (pending_owned) pending.deinit(self.allocator);
+        try self.reserveAttempt();
+        var reservation_owned = true;
+        errdefer if (reservation_owned) self.releaseAttempt();
+
+        var response = self.inner.vtable.send(
+            self.inner.context,
+            request,
+        ) catch |err| {
+            self.appendAttempt(pending.failureExchange(
+                .transport_error,
+                classifyRecordedError(err),
+            ));
+            pending_owned = false;
+            reservation_owned = false;
+            return err;
+        };
+        errdefer response.deinit();
+        var exchange = ownedExchangeFromResponse(
+            self.allocator,
+            &pending,
             &response,
             response.body,
-        );
+        ) catch |err| {
+            self.poisonAttempt();
+            reservation_owned = false;
+            return err;
+        };
+        pending_owned = false;
         errdefer exchange.deinit(self.allocator);
-        try self.exchanges.append(self.allocator, exchange);
+        self.appendAttempt(exchange);
+        reservation_owned = false;
         return response;
     }
 
@@ -533,6 +860,7 @@ pub const RecordingTransport = struct {
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
+        if (self.poisoned) return error.IncompleteRecording;
         if (options.body != null and request.body != null)
             return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
@@ -545,7 +873,11 @@ pub const RecordingTransport = struct {
             request,
             request.body,
         );
-        errdefer pending.deinit(self.allocator);
+        var pending_owned = true;
+        defer if (pending_owned) pending.deinit(self.allocator);
+        try self.reserveAttempt();
+        var reservation_owned = true;
+        errdefer if (reservation_owned) self.releaseAttempt();
 
         var inner_options = options;
         var request_capture: CapturingReader = undefined;
@@ -561,34 +893,100 @@ pub const RecordingTransport = struct {
         }
         defer if (has_capture) request_capture.deinit();
 
-        const inner_operation = if (open_fn) |call_open|
-            call_open(
+        const inner_operation = if (open_fn) |call_open| blk: {
+            const operation = call_open(
                 self.inner.context,
                 request,
                 inner_options,
             ) catch |err| {
                 if (has_capture) {
-                    if (request_capture.failure) |failure| return failure;
+                    if (request_capture.bookkeeping_failed) {
+                        self.poisonAttempt();
+                        reservation_owned = false;
+                        return error.OutOfMemory;
+                    }
+                    pending.body = request_capture.toOwnedSlice() catch |capture_err| {
+                        self.poisonAttempt();
+                        reservation_owned = false;
+                        return capture_err;
+                    };
+                    if (request_capture.failure) |failure| {
+                        self.appendAttempt(pending.failureExchange(
+                            .open_error,
+                            classifyRecordedError(failure),
+                        ));
+                        pending_owned = false;
+                        reservation_owned = false;
+                        return failure;
+                    }
                 }
+                self.appendAttempt(pending.failureExchange(
+                    .open_error,
+                    classifyRecordedError(err),
+                ));
+                pending_owned = false;
+                reservation_owned = false;
                 return err;
-            }
-        else
-            try BufferedInnerOperation.create(
-                try self.inner.vtable.send(self.inner.context, request),
-            );
+            };
+            break :blk operation;
+        } else blk: {
+            const response = self.inner.vtable.send(
+                self.inner.context,
+                request,
+            ) catch |err| {
+                self.appendAttempt(pending.failureExchange(
+                    .open_error,
+                    classifyRecordedError(err),
+                ));
+                pending_owned = false;
+                reservation_owned = false;
+                return err;
+            };
+            const operation = BufferedInnerOperation.create(response) catch |err| {
+                self.poisonAttempt();
+                reservation_owned = false;
+                return err;
+            };
+            break :blk operation;
+        };
         errdefer {
             inner_operation.abort();
             inner_operation.deinit();
         }
 
         if (has_capture) {
-            pending.body = try request_capture.toOwnedSlice();
+            if (request_capture.bookkeeping_failed) {
+                self.poisonAttempt();
+                reservation_owned = false;
+                return error.OutOfMemory;
+            }
+            pending.body = request_capture.toOwnedSlice() catch |err| {
+                self.poisonAttempt();
+                reservation_owned = false;
+                return err;
+            };
+            if (request_capture.failure) |failure| {
+                self.appendAttempt(pending.failureExchange(
+                    .open_error,
+                    classifyRecordedError(failure),
+                ));
+                pending_owned = false;
+                reservation_owned = false;
+                return failure;
+            }
         }
-        return RecordingOperation.create(
+        const operation = RecordingOperation.create(
             self,
             inner_operation,
             pending,
-        );
+        ) catch |err| {
+            self.poisonAttempt();
+            reservation_owned = false;
+            return err;
+        };
+        pending_owned = false;
+        reservation_owned = false;
+        return operation;
     }
 };
 
@@ -597,6 +995,8 @@ const PendingRequest = struct {
     url: []u8,
     headers: []HeaderPair,
     body: ?[]u8,
+    empty_response_body: []u8,
+    empty_response_headers: []HeaderPair,
 
     fn init(
         allocator: std.mem.Allocator,
@@ -611,11 +1011,17 @@ const PendingRequest = struct {
             try allocator.dupe(u8, bytes)
         else
             null;
+        errdefer if (owned_body) |bytes| allocator.free(bytes);
+        const empty_response_body = try allocator.dupe(u8, "");
+        errdefer allocator.free(empty_response_body);
+        const empty_response_headers = try allocator.alloc(HeaderPair, 0);
         return .{
             .method = request.method,
             .url = url,
             .headers = headers,
             .body = owned_body,
+            .empty_response_body = empty_response_body,
+            .empty_response_headers = empty_response_headers,
         };
     }
 
@@ -623,7 +1029,32 @@ const PendingRequest = struct {
         allocator.free(self.url);
         deinitHeaderPairs(allocator, self.headers);
         if (self.body) |body| allocator.free(body);
+        allocator.free(self.empty_response_body);
+        allocator.free(self.empty_response_headers);
         self.* = undefined;
+    }
+
+    fn failureExchange(
+        self: *PendingRequest,
+        outcome: RecordedOutcome,
+        category: RecordedErrorCategory,
+    ) OwnedExchange {
+        std.debug.assert(
+            outcome == .transport_error or outcome == .open_error,
+        );
+        const exchange = OwnedExchange{
+            .request_method = self.method,
+            .request_url = self.url,
+            .request_headers = self.headers,
+            .request_body = self.body,
+            .response_status = 0,
+            .response_body = self.empty_response_body,
+            .response_headers = self.empty_response_headers,
+            .outcome = outcome,
+            .error_category = category,
+        };
+        self.* = undefined;
+        return exchange;
     }
 };
 
@@ -687,7 +1118,6 @@ const RecordingOperation = struct {
         inner: *core.http.HttpOperation,
         pending_value: PendingRequest,
     ) !*core.http.HttpOperation {
-        try owner.exchanges.ensureUnusedCapacity(owner.allocator, 1);
         const self = try owner.allocator.create(RecordingOperation);
         errdefer owner.allocator.destroy(self);
         var header_set = try cloneOperationHeaders(owner.allocator, inner);
@@ -724,14 +1154,20 @@ const RecordingOperation = struct {
         return &self.operation;
     }
 
-    fn completeAttempt(self: *RecordingOperation) void {
+    fn completeAttempt(
+        self: *RecordingOperation,
+        outcome: RecordedOutcome,
+        category: ?RecordedErrorCategory,
+    ) void {
         const pending = self.pending orelse return;
         self.pending = null;
         const response_headers = self.attempt_headers.?;
         self.attempt_headers = null;
         const captured = self.response_reader.captured.toArrayList();
         const allocation = captured.allocatedSlice();
-        self.owner.exchanges.appendAssumeCapacity(.{
+        self.allocator.free(pending.empty_response_body);
+        self.allocator.free(pending.empty_response_headers);
+        self.owner.appendAttempt(.{
             .request_method = pending.method,
             .request_url = pending.url,
             .request_headers = pending.headers,
@@ -743,34 +1179,112 @@ const RecordingOperation = struct {
             else
                 allocation,
             .response_headers = response_headers,
+            .outcome = outcome,
+            .error_category = category,
         });
+    }
+
+    fn poisonIncompleteAttempt(self: *RecordingOperation) void {
+        if (self.pending) |*pending| {
+            pending.deinit(self.allocator);
+            self.pending = null;
+            if (self.attempt_headers) |headers| {
+                deinitHeaderPairs(self.allocator, headers);
+                self.attempt_headers = null;
+            }
+            self.owner.poisonAttempt();
+        }
     }
 
     fn finishImpl(operation: *core.http.HttpOperation) !void {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         _ = self.response_reader.interface.discardRemaining() catch |err| {
-            if (self.response_reader.failure) |failure| return failure;
-            if (self.inner.bodyError()) |failure| return failure;
+            if (self.response_reader.bookkeeping_failed) {
+                self.poisonIncompleteAttempt();
+                return error.OutOfMemory;
+            }
+            if (self.response_reader.failure) |failure| {
+                self.completeAttempt(
+                    .body_error,
+                    classifyRecordedError(failure),
+                );
+                return failure;
+            }
+            if (self.inner.bodyError()) |failure| {
+                self.completeAttempt(
+                    .body_error,
+                    classifyRecordedError(failure),
+                );
+                return failure;
+            }
+            self.completeAttempt(
+                .body_error,
+                classifyRecordedError(err),
+            );
             return err;
         };
-        try self.inner.finish();
-        if (self.response_reader.failure) |failure| return failure;
-        self.completeAttempt();
+        self.inner.finish() catch |err| {
+            self.completeAttempt(
+                .finish_error,
+                classifyRecordedError(err),
+            );
+            return err;
+        };
+        if (self.response_reader.failure) |failure| {
+            self.completeAttempt(
+                .body_error,
+                classifyRecordedError(failure),
+            );
+            return failure;
+        }
+        self.completeAttempt(.response, null);
     }
 
     fn abortImpl(operation: *core.http.HttpOperation) void {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.abort();
-        self.completeAttempt();
+        if (self.response_reader.bookkeeping_failed) {
+            self.poisonIncompleteAttempt();
+            return;
+        }
+        if (self.response_reader.failure) |failure| {
+            self.completeAttempt(
+                .body_error,
+                classifyRecordedError(failure),
+            );
+        } else if (self.inner.bodyError()) |failure| {
+            self.completeAttempt(
+                .body_error,
+                classifyRecordedError(failure),
+            );
+        } else {
+            self.completeAttempt(.response, null);
+        }
     }
 
     fn cancelImpl(operation: *core.http.HttpOperation) void {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.cancel();
-        self.completeAttempt();
+        if (self.response_reader.bookkeeping_failed) {
+            self.poisonIncompleteAttempt();
+            return;
+        }
+        if (self.response_reader.failure) |failure| {
+            self.completeAttempt(
+                .body_error,
+                classifyRecordedError(failure),
+            );
+        } else if (self.inner.bodyError()) |failure| {
+            self.completeAttempt(
+                .body_error,
+                classifyRecordedError(failure),
+            );
+        } else {
+            self.completeAttempt(.response, null);
+        }
     }
 
     fn bodyErrorImpl(operation: *const core.http.HttpOperation) ?anyerror {
@@ -784,7 +1298,10 @@ const RecordingOperation = struct {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.deinit();
-        if (self.pending) |*pending| pending.deinit(self.allocator);
+        if (self.pending) |*pending| {
+            self.owner.poisonAttempt();
+            pending.deinit(self.allocator);
+        }
         if (self.attempt_headers) |headers| {
             deinitHeaderPairs(self.allocator, headers);
         }
@@ -804,6 +1321,7 @@ const CapturingReader = struct {
     captured: std.Io.Writer.Allocating,
     source_operation: ?*core.http.HttpOperation,
     failure: ?anyerror = null,
+    bookkeeping_failed: bool = false,
     reader_buffer: [64]u8 = undefined,
     scratch: [4096]u8 = undefined,
 
@@ -843,9 +1361,18 @@ const CapturingReader = struct {
                 err;
             return error.ReadFailed;
         };
-        if (count == 0) return error.EndOfStream;
+        if (count == 0) {
+            if (self.source_operation) |operation| {
+                if (operation.bodyError()) |failure| {
+                    self.failure = failure;
+                    return error.ReadFailed;
+                }
+            }
+            return error.EndOfStream;
+        }
         self.captured.writer.writeAll(self.scratch[0..count]) catch {
             self.failure = error.OutOfMemory;
+            self.bookkeeping_failed = true;
             return error.ReadFailed;
         };
         try writer.writeAll(self.scratch[0..count]);
@@ -970,13 +1497,10 @@ fn cloneResponseHeaders(
 
 fn ownedExchangeFromResponse(
     allocator: std.mem.Allocator,
-    request: *const core.http.Request,
-    request_body: ?[]const u8,
+    pending: *PendingRequest,
     response: *const core.http.Response,
     response_body: []const u8,
 ) !OwnedExchange {
-    var pending = try PendingRequest.init(allocator, request, request_body);
-    errdefer pending.deinit(allocator);
     const body = try allocator.dupe(u8, response_body);
     errdefer allocator.free(body);
     const headers = try cloneResponseHeaders(
@@ -984,7 +1508,9 @@ fn ownedExchangeFromResponse(
         &response.headers,
         &response.response_headers,
     );
-    return .{
+    allocator.free(pending.empty_response_body);
+    allocator.free(pending.empty_response_headers);
+    const exchange = OwnedExchange{
         .request_method = pending.method,
         .request_url = pending.url,
         .request_headers = pending.headers,
@@ -993,11 +1519,14 @@ fn ownedExchangeFromResponse(
         .response_body = body,
         .response_headers = headers,
     };
+    pending.* = undefined;
+    return exchange;
 }
 
 fn parseExchange(
     allocator: std.mem.Allocator,
     value: std.json.Value,
+    format_version: u32,
 ) !OwnedExchange {
     const object = switch (value) {
         .object => |result| result,
@@ -1011,13 +1540,6 @@ fn parseExchange(
         return error.InvalidRecordingJson;
     const request_body_value = object.get("request_body") orelse
         return error.InvalidRecordingJson;
-    const response_status_value = object.get("response_status") orelse
-        return error.InvalidRecordingJson;
-    const response_headers_value = object.get("response_headers") orelse
-        return error.InvalidRecordingJson;
-    const response_body_value = object.get("response_body") orelse
-        return error.InvalidRecordingJson;
-
     const method = try parseMethod(try jsonString(method_value));
     const request_url = try allocator.dupe(u8, try jsonString(request_url_value));
     errdefer allocator.free(request_url);
@@ -1026,6 +1548,45 @@ fn parseExchange(
     const request_body = try parseOptionalBody(allocator, request_body_value);
     errdefer if (request_body) |body| allocator.free(body);
 
+    const outcome = if (format_version == 2)
+        RecordedOutcome.response
+    else
+        try parseRecordedOutcome(object.get("outcome") orelse
+            return error.InvalidRecordingJson);
+    const error_category = if (outcome == .response) blk: {
+        if (object.get("error_category") != null)
+            return error.InvalidRecordingJson;
+        break :blk null;
+    } else try parseRecordedErrorCategory(
+        object.get("error_category") orelse
+            return error.InvalidRecordingJson,
+    );
+    const has_response = outcome == .response or
+        outcome == .body_error or
+        outcome == .finish_error;
+    if (!has_response) {
+        const response_body = try allocator.dupe(u8, "");
+        errdefer allocator.free(response_body);
+        const response_headers = try allocator.alloc(HeaderPair, 0);
+        return .{
+            .request_method = method,
+            .request_url = request_url,
+            .request_headers = request_headers,
+            .request_body = request_body,
+            .response_status = 0,
+            .response_body = response_body,
+            .response_headers = response_headers,
+            .outcome = outcome,
+            .error_category = error_category,
+        };
+    }
+
+    const response_status_value = object.get("response_status") orelse
+        return error.InvalidRecordingJson;
+    const response_headers_value = object.get("response_headers") orelse
+        return error.InvalidRecordingJson;
+    const response_body_value = object.get("response_body") orelse
+        return error.InvalidRecordingJson;
     const response_status_integer = switch (response_status_value) {
         .integer => |result| result,
         else => return error.InvalidRecordingJson,
@@ -1045,7 +1606,29 @@ fn parseExchange(
         .response_status = @intCast(response_status_integer),
         .response_body = response_body,
         .response_headers = response_headers,
+        .outcome = outcome,
+        .error_category = error_category,
     };
+}
+
+fn parseRecordedOutcome(value: std.json.Value) !RecordedOutcome {
+    const name = try jsonString(value);
+    inline for (std.meta.fields(RecordedOutcome)) |field| {
+        if (std.mem.eql(u8, name, field.name))
+            return @enumFromInt(field.value);
+    }
+    return error.InvalidRecordingOutcome;
+}
+
+fn parseRecordedErrorCategory(
+    value: std.json.Value,
+) !RecordedErrorCategory {
+    const name = try jsonString(value);
+    inline for (std.meta.fields(RecordedErrorCategory)) |field| {
+        if (std.mem.eql(u8, name, field.name))
+            return @enumFromInt(field.value);
+    }
+    return error.InvalidRecordingErrorCategory;
 }
 
 fn parseHeaders(
@@ -1168,7 +1751,9 @@ fn headerValueMatches(
 ) !bool {
     if (expected.redacted) return true;
     if (isSanitizedUrlHeader(expected.name)) {
-        return urlMatches(allocator, expected.value, actual);
+        const sanitized = try sanitizeLocationUrlAlloc(allocator, actual);
+        defer allocator.free(sanitized);
+        return std.mem.eql(u8, expected.value, sanitized);
     }
     return std.mem.eql(u8, expected.value, actual);
 }
@@ -1178,14 +1763,19 @@ fn urlMatches(
     expected: []const u8,
     actual: []const u8,
 ) !bool {
-    if (!hasRedactedSensitiveQuery(expected))
+    if (!try hasRedactedSensitiveQuery(allocator, expected, 0))
         return std.mem.eql(u8, expected, actual);
     const sanitized = try sanitizeUrlAlloc(allocator, actual);
     defer allocator.free(sanitized);
     return std.mem.eql(u8, expected, sanitized);
 }
 
-fn hasRedactedSensitiveQuery(url: []const u8) bool {
+fn hasRedactedSensitiveQuery(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    nesting: usize,
+) !bool {
+    if (nesting > max_nested_url_depth) return false;
     const question = std.mem.indexOfScalar(u8, url, '?') orelse return false;
     const fragment = std.mem.indexOfScalarPos(u8, url, question + 1, '#') orelse
         url.len;
@@ -1193,6 +1783,29 @@ fn hasRedactedSensitiveQuery(url: []const u8) bool {
     while (iterator.next()) |parameter| {
         const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse continue;
         if (std.mem.eql(u8, parameter[equals + 1 ..], redacted_value)) {
+            return true;
+        }
+        var decoded = try allocator.dupe(u8, parameter[equals + 1 ..]);
+        defer allocator.free(decoded);
+        var decode_count: usize = 0;
+        while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+            const next = try percentDecodeAlloc(
+                allocator,
+                decoded,
+                decode_count == 0,
+            );
+            const changed = !std.mem.eql(u8, decoded, next);
+            allocator.free(decoded);
+            decoded = next;
+            if (!changed) break;
+        }
+        if (looksLikeNestedUriReference(decoded) and
+            try hasRedactedSensitiveQuery(
+                allocator,
+                decoded,
+                nesting + 1,
+            ))
+        {
             return true;
         }
     }
@@ -1276,6 +1889,23 @@ fn readRequestBody(
         }
     }
     return output.toOwnedSlice();
+}
+
+fn readRequestBodyPrefix(
+    allocator: std.mem.Allocator,
+    body: core.http.StreamingRequestBody,
+    cancellation: ?*const core.http.CancellationToken,
+    length: usize,
+) ![]u8 {
+    const result = try allocator.alloc(u8, length);
+    errdefer allocator.free(result);
+    try checkCancelled(cancellation);
+    body.reader.readSliceAll(result) catch |err| switch (err) {
+        error.EndOfStream => return error.RequestBodyTooShort,
+        else => return err,
+    };
+    try checkCancelled(cancellation);
+    return result;
 }
 
 fn checkCancelled(token: ?*const core.http.CancellationToken) !void {
@@ -1376,7 +2006,7 @@ fn deinitResponseStorage(
 }
 
 pub const redacted_value = "REDACTED";
-const recording_format_version = 2;
+const recording_format_version = 3;
 
 const explicitly_sensitive_headers = [_][]const u8{
     "authorization",
@@ -2911,7 +3541,7 @@ fn writeHeaders(
             .redact => redact = true,
             .preserve => {},
             .inspect => if (isSanitizedUrlHeader(header.name)) {
-                sanitized_url = sanitizeUrlAlloc(
+                sanitized_url = sanitizeLocationUrlAlloc(
                     allocator,
                     header.value,
                 ) catch |err| switch (err) {
@@ -2956,6 +3586,24 @@ fn sanitizeUrlAlloc(
     url: []const u8,
 ) ![]u8 {
     return sanitizeUrlAllocDepth(allocator, url, 0);
+}
+
+fn sanitizeLocationUrlAlloc(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+) ![]u8 {
+    if (std.mem.indexOfScalar(u8, url, '#')) |fragment| {
+        if (try encodedComponentIsSensitive(
+            allocator,
+            url[fragment + 1 ..],
+            false,
+            true,
+            0,
+        )) {
+            return sanitizeUrlAlloc(allocator, url[0..fragment]);
+        }
+    }
+    return sanitizeUrlAlloc(allocator, url);
 }
 
 const max_url_decode_depth = 3;
@@ -3115,23 +3763,93 @@ fn sanitizeUrlAllocDepth(
         };
         const encoded_name = parameter[0..equals];
         const encoded_value = parameter[equals + 1 ..];
-        const redact = try encodedQueryNameIsSensitive(
+        const redact_name = try encodedQueryNameIsSensitive(
             allocator,
             encoded_name,
-        ) or
-            try encodedComponentIsSensitive(
-                allocator,
-                encoded_value,
-                true,
-                true,
-                nesting,
-            );
+        );
         try output.writer.writeAll(encoded_name);
         try output.writer.writeByte('=');
-        try output.writer.writeAll(if (redact) redacted_value else encoded_value);
+        if (redact_name) {
+            try output.writer.writeAll(redacted_value);
+        } else {
+            const sanitized_value = try sanitizeQueryValueAlloc(
+                allocator,
+                encoded_value,
+                nesting,
+            );
+            defer allocator.free(sanitized_value);
+            try output.writer.writeAll(sanitized_value);
+        }
     }
     if (fragment) |fragment_start| {
         try output.writer.writeAll(url[fragment_start..]);
+    }
+    return output.toOwnedSlice();
+}
+
+fn sanitizeQueryValueAlloc(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+    nesting: usize,
+) ![]u8 {
+    if (encoded.len > max_sanitized_url_length)
+        return allocator.dupe(u8, redacted_value);
+    var current = try allocator.dupe(u8, encoded);
+    defer allocator.free(current);
+    var decode_count: usize = 0;
+    while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+        const decoded = try percentDecodeAlloc(
+            allocator,
+            current,
+            decode_count == 0,
+        );
+        const changed = !std.mem.eql(u8, current, decoded);
+        allocator.free(current);
+        current = decoded;
+        if (!changed) break;
+    }
+    if (containsPercentEscape(current))
+        return allocator.dupe(u8, redacted_value);
+
+    if (looksLikeNestedUriReference(current)) {
+        if (nesting >= max_nested_url_depth)
+            return allocator.dupe(u8, redacted_value);
+        const sanitized_nested = sanitizeUrlAllocDepth(
+            allocator,
+            current,
+            nesting + 1,
+        ) catch |err| switch (err) {
+            error.SensitiveUrlRequiresSanitization => {
+                return allocator.dupe(u8, redacted_value);
+            },
+            else => return err,
+        };
+        defer allocator.free(sanitized_nested);
+        return percentEncodeQueryValueAlloc(allocator, sanitized_nested);
+    }
+
+    if (try containsSensitiveScalar(allocator, current))
+        return allocator.dupe(u8, redacted_value);
+    return allocator.dupe(u8, encoded);
+}
+
+fn percentEncodeQueryValueAlloc(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) ![]u8 {
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    errdefer output.deinit();
+    const hex = "0123456789ABCDEF";
+    for (value) |byte| {
+        if (std.ascii.isAlphanumeric(byte) or
+            byte == '-' or byte == '.' or byte == '_' or byte == '~')
+        {
+            try output.writer.writeByte(byte);
+        } else {
+            try output.writer.writeByte('%');
+            try output.writer.writeByte(hex[byte >> 4]);
+            try output.writer.writeByte(hex[byte & 0x0f]);
+        }
     }
     return output.toOwnedSlice();
 }
@@ -3445,6 +4163,201 @@ const BufferedOnlyTransport = struct {
         const self: *BufferedOnlyTransport = @ptrCast(@alignCast(context));
         const transport = self.inner.asTransport();
         return transport.vtable.send(transport.context, request);
+    }
+};
+
+const FailureStageTransport = struct {
+    allocator: std.mem.Allocator,
+    inner: *core.http.MockTransport,
+    mode: enum {
+        transport,
+        open,
+        body,
+        finish,
+    },
+    call_count: usize = 0,
+
+    const vtable: core.http.HttpTransport.VTable = .{
+        .send = &send,
+        .open = &open,
+    };
+
+    fn asTransport(self: *FailureStageTransport) core.http.HttpTransport {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    fn send(
+        context: *anyopaque,
+        request: *core.http.Request,
+    ) !core.http.Response {
+        const self: *FailureStageTransport =
+            @ptrCast(@alignCast(context));
+        self.call_count += 1;
+        if (self.mode == .transport and self.call_count == 1)
+            return error.ConnectionResetByPeer;
+        const transport = self.inner.asTransport();
+        return transport.vtable.send(transport.context, request);
+    }
+
+    fn open(
+        context: *anyopaque,
+        request: *core.http.Request,
+        options: core.http.OpenOptions,
+    ) !*core.http.HttpOperation {
+        const self: *FailureStageTransport =
+            @ptrCast(@alignCast(context));
+        self.call_count += 1;
+        if (self.mode == .open and self.call_count == 1)
+            return error.ConnectionResetByPeer;
+        if (self.call_count == 1 and
+            (self.mode == .body or self.mode == .finish))
+        {
+            return FailureStageOperation.create(
+                self.allocator,
+                self.mode == .body,
+                self.mode == .finish,
+            );
+        }
+        const transport = self.inner.asTransport();
+        return transport.vtable.open.?(
+            transport.context,
+            request,
+            options,
+        );
+    }
+};
+
+const FailureStageOperation = struct {
+    operation: core.http.HttpOperation,
+    allocator: std.mem.Allocator,
+    reader: FailureStageReader,
+    fail_body: bool,
+    fail_finish: bool,
+
+    fn create(
+        allocator: std.mem.Allocator,
+        fail_body: bool,
+        fail_finish: bool,
+    ) !*core.http.HttpOperation {
+        const self = try allocator.create(FailureStageOperation);
+        errdefer allocator.destroy(self);
+        var headers = std.StringHashMap([]const u8).init(allocator);
+        errdefer headers.deinit();
+        var response_headers = core.http.ResponseHeaders.init(allocator);
+        errdefer response_headers.deinit();
+        self.* = .{
+            .operation = undefined,
+            .allocator = allocator,
+            .reader = undefined,
+            .fail_body = fail_body,
+            .fail_finish = fail_finish,
+        };
+        self.reader.init(if (fail_body) "partial" else "", fail_body);
+        self.operation = .{
+            .status_code = 200,
+            .headers = headers,
+            .response_headers = response_headers,
+            .body_reader = &self.reader.interface,
+            .finishFn = &finish,
+            .abortFn = &abort,
+            .cancelFn = &abort,
+            .deinitFn = &deinit,
+            .bodyErrorFn = &bodyError,
+        };
+        return &self.operation;
+    }
+
+    fn finish(operation: *core.http.HttpOperation) !void {
+        const self: *FailureStageOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        if (self.fail_finish) return error.ConnectionResetByPeer;
+    }
+
+    fn abort(_: *core.http.HttpOperation) void {}
+
+    fn bodyError(operation: *const core.http.HttpOperation) ?anyerror {
+        const self: *const FailureStageOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        return if (self.fail_body) error.ConnectionResetByPeer else null;
+    }
+
+    fn deinit(operation: *core.http.HttpOperation) void {
+        const self: *FailureStageOperation =
+            @alignCast(@fieldParentPtr("operation", operation));
+        self.operation.headers.deinit();
+        self.operation.response_headers.deinit();
+        self.allocator.destroy(self);
+    }
+};
+
+const FailureStageReader = struct {
+    interface: std.Io.Reader,
+    bytes: []const u8,
+    offset: usize = 0,
+    buffer: [32]u8 = undefined,
+
+    fn init(
+        self: *FailureStageReader,
+        bytes: []const u8,
+        _: bool,
+    ) void {
+        self.* = .{
+            .interface = undefined,
+            .bytes = bytes,
+        };
+        self.interface = .{
+            .vtable = &.{
+                .stream = &stream,
+                .readVec = &readVec,
+            },
+            .buffer = &self.buffer,
+            .seek = 0,
+            .end = 0,
+        };
+    }
+
+    fn stream(
+        interface: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *FailureStageReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        if (self.offset != self.bytes.len) {
+            const count = @min(
+                limit.minInt(self.bytes.len - self.offset),
+                self.bytes.len - self.offset,
+            );
+            if (count == 0) return 0;
+            try writer.writeAll(self.bytes[self.offset..][0..count]);
+            self.offset += count;
+            return count;
+        }
+        return error.EndOfStream;
+    }
+
+    fn readVec(
+        interface: *std.Io.Reader,
+        data: [][]u8,
+    ) std.Io.Reader.Error!usize {
+        const self: *FailureStageReader =
+            @alignCast(@fieldParentPtr("interface", interface));
+        var total: usize = 0;
+        for (data) |destination| {
+            const count = @min(
+                destination.len,
+                self.bytes.len - self.offset,
+            );
+            @memcpy(
+                destination[0..count],
+                self.bytes[self.offset..][0..count],
+            );
+            self.offset += count;
+            total += count;
+            if (self.offset == self.bytes.len) break;
+        }
+        if (total != 0) return total;
+        return error.EndOfStream;
     }
 };
 
@@ -4031,6 +4944,312 @@ test "recording preserves buffered open fallback" {
         }),
     );
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
+}
+
+test "transport errors record and replay before retry success" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "done",
+    );
+    defer mock.deinit();
+    var failing = FailureStageTransport{
+        .allocator = std.testing.allocator,
+        .inner = &mock,
+        .mode = .transport,
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        failing.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/transport-error",
+    );
+    defer request.deinit();
+    try std.testing.expectError(
+        error.ConnectionResetByPeer,
+        recorder.asTransport().send(&request),
+    );
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "\"version\":3") != null,
+    );
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        json,
+        "\"outcome\":\"transport_error\"",
+    ) != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "ConnectionResetByPeer") == null,
+    );
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(
+        RecordedOutcome.transport_error,
+        parsed.asSlice()[0].outcome,
+    );
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    try std.testing.expectError(
+        error.RecordedConnectionFailure,
+        playback.asTransport().send(&request),
+    );
+    var replayed = try playback.asTransport().send(&request);
+    defer replayed.deinit();
+    try std.testing.expectEqualStrings("done", replayed.body);
+}
+
+test "open errors record and replay before retry success" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "done",
+    );
+    defer mock.deinit();
+    var failing = FailureStageTransport{
+        .allocator = std.testing.allocator,
+        .inner = &mock,
+        .mode = .open,
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        failing.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/open-error",
+    );
+    defer request.deinit();
+    var failed_source = std.Io.Reader.fixed("request-body");
+    try std.testing.expectError(
+        error.ConnectionResetByPeer,
+        recorder.asTransport().open(&request, .{
+            .body = core.http.StreamingRequestBody.chunked(&failed_source),
+        }),
+    );
+    try std.testing.expectEqual(@as(usize, 0), failed_source.seek);
+    var retry_source = std.Io.Reader.fixed("request-body");
+    var operation = try recorder.asTransport().open(&request, .{
+        .body = core.http.StreamingRequestBody.chunked(&retry_source),
+    });
+    const body = try (try operation.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(body);
+    try operation.finish();
+    operation.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(
+        RecordedOutcome.open_error,
+        parsed.asSlice()[0].outcome,
+    );
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed_failed_source = std.Io.Reader.fixed("request-body");
+    try std.testing.expectError(
+        error.RecordedConnectionFailure,
+        playback.asTransport().open(&request, .{
+            .body = core.http.StreamingRequestBody.chunked(
+                &replayed_failed_source,
+            ),
+        }),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        replayed_failed_source.seek,
+    );
+    var replayed_retry_source = std.Io.Reader.fixed("request-body");
+    var replayed = try playback.asTransport().open(&request, .{
+        .body = core.http.StreamingRequestBody.chunked(
+            &replayed_retry_source,
+        ),
+    });
+    const replayed_body = try (try replayed.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(replayed_body);
+    try std.testing.expectEqualStrings("done", replayed_body);
+    try replayed.finish();
+    replayed.deinit();
+}
+
+test "partial body errors record and replay before retry success" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "done",
+    );
+    defer mock.deinit();
+    var failing = FailureStageTransport{
+        .allocator = std.testing.allocator,
+        .inner = &mock,
+        .mode = .body,
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        failing.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/body-error",
+    );
+    defer request.deinit();
+    var failed = try recorder.asTransport().open(&request, .{});
+    var partial: [7]u8 = undefined;
+    try (try failed.reader()).readSliceAll(&partial);
+    try std.testing.expectEqualStrings("partial", &partial);
+    var extra: [1]u8 = undefined;
+    try std.testing.expectError(
+        error.ReadFailed,
+        (try failed.reader()).readSliceAll(&extra),
+    );
+    try std.testing.expectEqual(
+        error.ConnectionResetByPeer,
+        failed.bodyError().?,
+    );
+    failed.abort();
+    failed.deinit();
+
+    var retry = try recorder.asTransport().open(&request, .{});
+    const retry_body = try (try retry.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(retry_body);
+    try retry.finish();
+    retry.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(
+        RecordedOutcome.body_error,
+        parsed.asSlice()[0].outcome,
+    );
+    try std.testing.expectEqualStrings(
+        "partial",
+        parsed.asSlice()[0].response_body,
+    );
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed_failure = try playback.asTransport().open(&request, .{});
+    var replayed_partial: [7]u8 = undefined;
+    try (try replayed_failure.reader()).readSliceAll(&replayed_partial);
+    try std.testing.expectEqualStrings("partial", &replayed_partial);
+    try std.testing.expectError(
+        error.ReadFailed,
+        (try replayed_failure.reader()).readSliceAll(&extra),
+    );
+    try std.testing.expectEqual(
+        error.RecordedConnectionFailure,
+        replayed_failure.bodyError().?,
+    );
+    replayed_failure.abort();
+    replayed_failure.deinit();
+    var replayed_retry = try playback.asTransport().open(&request, .{});
+    const replayed_body = try (try replayed_retry.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(replayed_body);
+    try std.testing.expectEqualStrings("done", replayed_body);
+    try replayed_retry.finish();
+    replayed_retry.deinit();
+}
+
+test "finish errors record and replay before retry success" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "done",
+    );
+    defer mock.deinit();
+    var failing = FailureStageTransport{
+        .allocator = std.testing.allocator,
+        .inner = &mock,
+        .mode = .finish,
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        failing.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/finish-error",
+    );
+    defer request.deinit();
+    var failed = try recorder.asTransport().open(&request, .{});
+    try std.testing.expectError(
+        error.ConnectionResetByPeer,
+        failed.finish(),
+    );
+    failed.deinit();
+    var retry = try recorder.asTransport().open(&request, .{});
+    const retry_body = try (try retry.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(retry_body);
+    try retry.finish();
+    retry.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(
+        RecordedOutcome.finish_error,
+        parsed.asSlice()[0].outcome,
+    );
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed_failure = try playback.asTransport().open(&request, .{});
+    try std.testing.expectError(
+        error.RecordedConnectionFailure,
+        replayed_failure.finish(),
+    );
+    replayed_failure.deinit();
+    var replayed_retry = try playback.asTransport().open(&request, .{});
+    const replayed_body = try (try replayed_retry.reader()).allocRemaining(
+        std.testing.allocator,
+        .unlimited,
+    );
+    defer std.testing.allocator.free(replayed_body);
+    try std.testing.expectEqualStrings("done", replayed_body);
+    try replayed_retry.finish();
+    replayed_retry.deinit();
 }
 
 test "recording stores abort and cancel as completed raw attempts" {
@@ -5182,6 +6401,35 @@ test "URL sanitization inspects decoded query path and fragment components" {
     replayed.deinit();
 
     for ([_][]const u8{
+        "https%253A%252F%252Fother.example%252Fblob%253F" ++
+            "%252573%252569%252567%253Drotated-sas-secret",
+        "https%253A%252F%252Fstorage.example%252Fother-blob%253F" ++
+            "%252573%252569%252567%253Drotated-sas-secret",
+    }) |different_nested| {
+        var mismatch_playback = PlaybackTransport.init(
+            std.testing.allocator,
+            parsed.asSlice(),
+        );
+        const mismatch_url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://example.test/callback?return={s}&" ++
+                "%252573%252569%252567=rotated-top-level-sas&stable=one",
+            .{different_nested},
+        );
+        defer std.testing.allocator.free(mismatch_url);
+        var mismatch = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            mismatch_url,
+        );
+        defer mismatch.deinit();
+        try std.testing.expectError(
+            error.UrlMismatch,
+            mismatch_playback.asTransport().send(&mismatch),
+        );
+    }
+
+    for ([_][]const u8{
         "https://example.test/callback/Bearer%20path-secret",
         "https://example.test/callback#access_token=fragment-secret",
     }) |unsafe_url| {
@@ -5247,8 +6495,10 @@ test "URL sanitization recursively decodes nested URI credentials" {
         std.mem.indexOf(u8, json, "top-level-sas-secret") == null,
     );
     try std.testing.expect(
-        std.mem.indexOf(u8, json, "return=REDACTED") != null,
+        std.mem.indexOf(u8, json, "storage.example") != null,
     );
+    try std.testing.expect(std.mem.indexOf(u8, json, "blob") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "REDACTED") != null);
 
     var parsed = try parseJson(std.testing.allocator, json);
     defer parsed.deinit();
@@ -5312,6 +6562,89 @@ test "URL sanitization recursively decodes nested URI credentials" {
     }
 }
 
+test "nested signed URI preserves exact host path and nonsensitive fields" {
+    const recorded_url =
+        "https://example.test/callback?return=" ++
+        "https%3A%2F%2Fstorage.example%2Fblob%3F" ++
+        "X-Amz-Signature%3Drecorded-secret%26mode%3Done";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        recorded_url,
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "recorded-secret") == null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "storage.example") != null,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, json, "blob") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "mode") != null);
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var rotated = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/callback?return=" ++
+            "https%3A%2F%2Fstorage.example%2Fblob%3F" ++
+            "X-Amz-Signature%3Drotated-secret%26mode%3Done",
+    );
+    defer rotated.deinit();
+    var replayed = try playback.asTransport().send(&rotated);
+    replayed.deinit();
+
+    for ([_][]const u8{
+        "https%3A%2F%2Fother.example%2Fblob%3F" ++
+            "X-Amz-Signature%3Drotated-secret%26mode%3Done",
+        "https%3A%2F%2Fstorage.example%2Fother%3F" ++
+            "X-Amz-Signature%3Drotated-secret%26mode%3Done",
+        "https%3A%2F%2Fstorage.example%2Fblob%3F" ++
+            "X-Amz-Signature%3Drotated-secret%26mode%3Dtwo",
+    }) |different_nested| {
+        var mismatch_playback = PlaybackTransport.init(
+            std.testing.allocator,
+            parsed.asSlice(),
+        );
+        const mismatch_url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://example.test/callback?return={s}",
+            .{different_nested},
+        );
+        defer std.testing.allocator.free(mismatch_url);
+        var mismatch = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            mismatch_url,
+        );
+        defer mismatch.deinit();
+        try std.testing.expectError(
+            error.UrlMismatch,
+            mismatch_playback.asTransport().send(&mismatch),
+        );
+    }
+}
+
 test "pathless absolute and network-path URLs sanitize without range failures" {
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
@@ -5368,7 +6701,8 @@ test "pathless absolute and network-path URLs sanitize without range failures" {
     defer parsed.deinit();
     const exchange = parsed.asSlice()[0];
     try std.testing.expectEqualStrings(
-        "https://example.test?sig=REDACTED&return=REDACTED&mode=one",
+        "https://example.test?sig=REDACTED&" ++
+            "return=https%3A%2F%2Fnested.example%3Fsig%3DREDACTED&mode=one",
         exchange.request_url,
     );
     try std.testing.expectEqualStrings(
@@ -5882,7 +7216,7 @@ test "location headers preserve replayable URLs and rotated SAS next exchanges" 
         ).?,
     );
     try std.testing.expectEqualStrings(
-        "/callback?return=https://safe.example/next&mode=one",
+        "/callback?return=https%3A%2F%2Fsafe.example%2Fnext&mode=one",
         getHeaderPair(
             recordings[1].response_headers,
             "Content-Location",
@@ -5964,6 +7298,66 @@ test "safe Location fragments remain replayable through Core redirects" {
     );
     try std.testing.expectEqualStrings(
         "https://example.test/final",
+        parsed.asSlice()[1].request_url,
+    );
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed = try playback.asTransport().send(&request);
+    defer replayed.deinit();
+    try std.testing.expectEqual(@as(u16, 200), replayed.status_code);
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
+}
+
+test "sensitive Location fragments strip to replayable redirect targets" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{
+                    .{
+                        .name = "Location",
+                        .value = "/final?mode=one#sig=fragment-secret",
+                    },
+                },
+            },
+            .{ .status = 200, .body = "" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start-sensitive-fragment",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(
+        std.mem.indexOf(u8, json, "fragment-secret") == null,
+    );
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings(
+        "/final?mode=one",
+        getHeaderPair(
+            parsed.asSlice()[0].response_headers,
+            "Location",
+        ).?,
+    );
+    try std.testing.expectEqualStrings(
+        "https://example.test/final?mode=one",
         parsed.asSlice()[1].request_url,
     );
 
@@ -8040,6 +9434,18 @@ fn parsingAllocationFixture(allocator: std.mem.Allocator) !void {
     parsed.deinit();
 }
 
+const failure_allocation_fixture_json =
+    \\{"version":3,"exchanges":[
+    \\{"request_method":"GET","request_url":"https://example.com/open","request_headers":[],"request_body":null,"outcome":"open_error","error_category":"connection"},
+    \\{"request_method":"GET","request_url":"https://example.com/body","request_headers":[],"request_body":null,"outcome":"body_error","error_category":"io","response_status":200,"response_headers":[],"response_body":{"encoding":"base64","data":"cGFydGlhbA=="}}
+    \\]}
+;
+
+fn failureParsingAllocationFixture(allocator: std.mem.Allocator) !void {
+    var parsed = try parseJson(allocator, failure_allocation_fixture_json);
+    parsed.deinit();
+}
+
 test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
@@ -8086,6 +9492,135 @@ test "transport allocation failures clean up" {
         parsingAllocationFixture,
         .{},
     );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        failureParsingAllocationFixture,
+        .{},
+    );
+}
+
+test "post-dispatch recorder allocation failure poisons serialization" {
+    var found_post_dispatch_failure = false;
+    for (0..64) |fail_index| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "response",
+        );
+        defer mock.deinit();
+        var failing = std.testing.FailingAllocator.init(
+            std.testing.allocator,
+            .{ .fail_index = fail_index },
+        );
+        var recorder = RecordingTransport.init(
+            failing.allocator(),
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/bookkeeping",
+        );
+        defer request.deinit();
+        if (recorder.asTransport().send(&request)) |response_value| {
+            var response = response_value;
+            response.deinit();
+        } else |err| {
+            if (err == error.OutOfMemory and mock.call_count != 0) {
+                found_post_dispatch_failure = true;
+                try std.testing.expect(!recorder.isComplete());
+                try std.testing.expectError(
+                    error.IncompleteRecording,
+                    recorder.toJson(std.testing.allocator),
+                );
+                try std.testing.expectError(
+                    error.IncompleteRecording,
+                    recorder.asTransport().send(&request),
+                );
+                break;
+            }
+        }
+    }
+    try std.testing.expect(found_post_dispatch_failure);
+}
+
+test "stream capture allocation failure poisons serialization" {
+    var found_capture_failure = false;
+    for (0..96) |fail_index| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "response body large enough to allocate capture storage",
+        );
+        defer mock.deinit();
+        var failing = std.testing.FailingAllocator.init(
+            std.testing.allocator,
+            .{ .fail_index = fail_index },
+        );
+        var recorder = RecordingTransport.init(
+            failing.allocator(),
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/stream-bookkeeping",
+        );
+        defer request.deinit();
+        const opened = recorder.asTransport().open(&request, .{}) catch
+            continue;
+        var operation = opened;
+        const read_result = (try operation.reader()).allocRemaining(
+            std.testing.allocator,
+            .unlimited,
+        );
+        if (read_result) |body| {
+            std.testing.allocator.free(body);
+            operation.finish() catch {};
+            operation.deinit();
+        } else |err| {
+            const body_error = operation.bodyError();
+            if (err == error.ReadFailed and body_error != null and
+                body_error.? == error.OutOfMemory)
+            {
+                operation.abort();
+                operation.deinit();
+                found_capture_failure = true;
+                try std.testing.expect(!recorder.isComplete());
+                try std.testing.expectError(
+                    error.IncompleteRecording,
+                    recorder.toJson(std.testing.allocator),
+                );
+                break;
+            }
+            operation.abort();
+            operation.deinit();
+        }
+    }
+    try std.testing.expect(found_capture_failure);
+}
+
+test "version 2 success recordings remain readable" {
+    const json =
+        \\{"version":2,"exchanges":[{
+        \\  "request_method":"GET",
+        \\  "request_url":"https://example.test/v2",
+        \\  "request_headers":[],
+        \\  "request_body":null,
+        \\  "response_status":200,
+        \\  "response_headers":[],
+        \\  "response_body":{"encoding":"base64","data":""}
+        \\}]}
+    ;
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(
+        RecordedOutcome.response,
+        parsed.asSlice()[0].outcome,
+    );
+    try std.testing.expect(parsed.asSlice()[0].error_category == null);
 }
 
 test "recording parser reports version encoding and base64 errors" {
@@ -8115,6 +9650,27 @@ test "recording parser reports version encoding and base64 errors" {
         parseJson(
             std.testing.allocator,
             "{\"version\":2,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[{\"name\":\"x-test\",\"value\":\"value\",\"redacted\":\"yes\"}],\"request_body\":null,\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"base64\",\"data\":\"\"}}]}",
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidRecordingOutcome,
+        parseJson(
+            std.testing.allocator,
+            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"outcome\":\"backend_specific\"}]}",
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidRecordingJson,
+        parseJson(
+            std.testing.allocator,
+            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"outcome\":\"transport_error\"}]}",
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidRecordingJson,
+        parseJson(
+            std.testing.allocator,
+            "{\"version\":3,\"exchanges\":[{\"request_method\":\"GET\",\"request_url\":\"https://example.com\",\"request_headers\":[],\"request_body\":null,\"outcome\":\"response\",\"error_category\":\"unknown\",\"response_status\":200,\"response_headers\":[],\"response_body\":{\"encoding\":\"base64\",\"data\":\"\"}}]}",
         ),
     );
 }

--- a/root.zig
+++ b/root.zig
@@ -39,13 +39,14 @@ pub const OwnedExchange = struct {
     request_body: ?[]u8,
     response_status: u16,
     response_body: []u8,
+    response_body_allocation: ?[]u8 = null,
     response_headers: []HeaderPair,
 
     fn deinit(self: *OwnedExchange, allocator: std.mem.Allocator) void {
         allocator.free(self.request_url);
         deinitHeaderPairs(allocator, self.request_headers);
         if (self.request_body) |body| allocator.free(body);
-        allocator.free(self.response_body);
+        allocator.free(self.response_body_allocation orelse self.response_body);
         deinitHeaderPairs(allocator, self.response_headers);
         self.* = undefined;
     }
@@ -214,14 +215,12 @@ pub fn initHttpRuntime(
 /// Caller-serialized playback transport.
 ///
 /// The returned descriptor borrows this value. Keep it alive until all
-/// descriptor copies and open operations are deinitialized. Redirect chains
-/// commit atomically at the final buffered response or successful streaming
-/// `finish`; failed allocation, abort, or cancellation leaves the original
-/// exchange retryable.
+/// descriptor copies and open operations are deinitialized. Each recording is
+/// one raw transport invocation and is consumed when its response head has
+/// been allocated, including redirect and retry attempts.
 pub const PlaybackTransport = struct {
     recordings: []const RecordedExchange,
     index: usize = 0,
-    pending_redirect: ?usize = null,
     allocator: std.mem.Allocator,
     open_count: usize = 0,
     finish_count: usize = 0,
@@ -249,60 +248,11 @@ pub const PlaybackTransport = struct {
         self: *PlaybackTransport,
         request: *const core.http.Request,
         body: ?[]const u8,
-    ) !struct { exchange: RecordedExchange, index: usize } {
-        if (self.pending_redirect) |pending| {
-            const redirected = pending + 1;
-            if (redirected < self.recordings.len and
-                try requestMatches(
-                    self.recordings[redirected],
-                    request,
-                    body,
-                ))
-            {
-                return .{
-                    .exchange = self.recordings[redirected],
-                    .index = redirected,
-                };
-            }
-            if (try requestMatches(
-                self.recordings[self.index],
-                request,
-                body,
-            )) {
-                self.pending_redirect = null;
-                return .{
-                    .exchange = self.recordings[self.index],
-                    .index = self.index,
-                };
-            }
-            if (pending != self.index and
-                try requestMatches(
-                    self.recordings[pending],
-                    request,
-                    body,
-                ))
-            {
-                return .{
-                    .exchange = self.recordings[pending],
-                    .index = pending,
-                };
-            }
-            const expected = if (redirected < self.recordings.len)
-                redirected
-            else
-                pending;
-            try matchRequest(self.recordings[expected], request, body);
-            unreachable;
-        }
+    ) !RecordedExchange {
         if (self.index >= self.recordings.len) return error.NoMoreRecordings;
         const exchange = self.recordings[self.index];
         try matchRequest(exchange, request, body);
-        return .{ .exchange = exchange, .index = self.index };
-    }
-
-    fn commit(self: *PlaybackTransport, exchange_index: usize) void {
-        self.pending_redirect = null;
-        self.index = exchange_index + 1;
+        return exchange;
     }
 
     fn sendImpl(
@@ -310,16 +260,12 @@ pub const PlaybackTransport = struct {
         request: *core.http.Request,
     ) !core.http.Response {
         const self: *PlaybackTransport = @ptrCast(@alignCast(context));
-        const matched = try self.matchNext(request, request.body);
+        const exchange = try self.matchNext(request, request.body);
         const response = try responseFromExchange(
             self.allocator,
-            matched.exchange,
+            exchange,
         );
-        if (responseRecordsRedirect(request, response)) {
-            self.pending_redirect = matched.index;
-        } else {
-            self.commit(matched.index);
-        }
+        self.index += 1;
         return response;
     }
 
@@ -345,15 +291,9 @@ pub const PlaybackTransport = struct {
             break :blk captured.?;
         } else request.body;
 
-        const matched = try self.matchNext(request, body);
-        const operation = try PlaybackOperation.create(
-            self,
-            matched.exchange,
-            matched.index,
-        );
-        if (recordsRedirect(request, options, operation)) {
-            self.pending_redirect = matched.index;
-        }
+        const exchange = try self.matchNext(request, body);
+        const operation = try PlaybackOperation.create(self, exchange);
+        self.index += 1;
         self.open_count += 1;
         return operation;
     }
@@ -363,15 +303,12 @@ const PlaybackOperation = struct {
     operation: core.http.HttpOperation,
     allocator: std.mem.Allocator,
     owner: *PlaybackTransport,
-    exchange_index: usize,
-    committed: bool = false,
     response_body: []u8,
     reader_impl: std.Io.Reader,
 
     fn create(
         owner: *PlaybackTransport,
         exchange: RecordedExchange,
-        exchange_index: usize,
     ) !*core.http.HttpOperation {
         const self = try owner.allocator.create(PlaybackOperation);
         errdefer owner.allocator.destroy(self);
@@ -387,7 +324,6 @@ const PlaybackOperation = struct {
             .operation = undefined,
             .allocator = owner.allocator,
             .owner = owner,
-            .exchange_index = exchange_index,
             .response_body = body,
             .reader_impl = std.Io.Reader.fixed(body),
         };
@@ -408,10 +344,6 @@ const PlaybackOperation = struct {
         const self: *PlaybackOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         _ = try self.reader_impl.discardRemaining();
-        if (!self.committed) {
-            self.owner.commit(self.exchange_index);
-            self.committed = true;
-        }
         self.owner.finish_count += 1;
     }
 
@@ -424,11 +356,6 @@ const PlaybackOperation = struct {
     fn cancelImpl(operation: *core.http.HttpOperation) void {
         const self: *PlaybackOperation =
             @alignCast(@fieldParentPtr("operation", operation));
-        if (!self.committed and
-            self.owner.pending_redirect != null)
-        {
-            self.owner.pending_redirect = null;
-        }
         self.owner.cancel_count += 1;
     }
 
@@ -451,24 +378,14 @@ const PlaybackOperation = struct {
 /// The inner descriptor is copied by value. Its context, this recording
 /// transport, and the recording allocator must outlive every open operation.
 /// A configured body-policy context is also borrowed and must outlive calls to
-/// `toJson`. Redirect/retry chains remain tentative until their final buffered
-/// response is accepted or final streaming operation finishes; restart,
-/// failure, abort, or cancellation discards the entire tentative chain.
-/// `deinit` does not deinitialize either borrowed context.
+/// `toJson`. Each exchange is one completed raw transport attempt, including
+/// redirect and retry responses. `deinit` does not deinitialize either
+/// borrowed context.
 pub const RecordingTransport = struct {
     inner: core.http.HttpTransport,
     exchanges: std.ArrayList(OwnedExchange) = .empty,
-    staged_exchanges: std.ArrayList(OwnedExchange) = .empty,
-    staged_origin: ?*const core.http.Request = null,
-    staged_state: ?StagedRecordingState = null,
-    staged_expected_url: ?[]u8 = null,
     allocator: std.mem.Allocator,
     options: RecordingOptions,
-
-    const StagedRecordingState = enum {
-        redirect_pending,
-        retryable_final,
-    };
 
     const vtable: core.http.HttpTransport.VTable = .{
         .send = &sendImpl,
@@ -502,115 +419,12 @@ pub const RecordingTransport = struct {
         for (self.exchanges.items) |*exchange| {
             exchange.deinit(self.allocator);
         }
-        for (self.staged_exchanges.items) |*exchange| {
-            exchange.deinit(self.allocator);
-        }
-        if (self.staged_expected_url) |url| self.allocator.free(url);
         self.exchanges.deinit(self.allocator);
-        self.staged_exchanges.deinit(self.allocator);
         self.* = undefined;
     }
 
-    pub fn getExchanges(self: *RecordingTransport) []const OwnedExchange {
-        self.finalizeStagedForRead();
+    pub fn getExchanges(self: *const RecordingTransport) []const OwnedExchange {
         return self.exchanges.items;
-    }
-
-    fn reserveStagedSlot(self: *RecordingTransport) !void {
-        try self.staged_exchanges.ensureUnusedCapacity(self.allocator, 1);
-        try self.exchanges.ensureUnusedCapacity(
-            self.allocator,
-            self.staged_exchanges.items.len + 1,
-        );
-    }
-
-    fn stageExchangeAssumeCapacity(
-        self: *RecordingTransport,
-        exchange: OwnedExchange,
-        origin: *const core.http.Request,
-    ) void {
-        if (self.staged_exchanges.items.len == 0)
-            self.staged_origin = origin;
-        self.staged_exchanges.appendAssumeCapacity(exchange);
-    }
-
-    fn stageExchange(
-        self: *RecordingTransport,
-        exchange: OwnedExchange,
-        origin: *const core.http.Request,
-    ) !void {
-        try self.reserveStagedSlot();
-        self.stageExchangeAssumeCapacity(exchange, origin);
-    }
-
-    fn commitStaged(self: *RecordingTransport) void {
-        for (self.staged_exchanges.items) |exchange| {
-            self.exchanges.appendAssumeCapacity(exchange);
-        }
-        self.staged_exchanges.clearRetainingCapacity();
-        self.staged_origin = null;
-        self.staged_state = null;
-        if (self.staged_expected_url) |url| self.allocator.free(url);
-        self.staged_expected_url = null;
-    }
-
-    fn discardStaged(self: *RecordingTransport) void {
-        for (self.staged_exchanges.items) |*exchange| {
-            exchange.deinit(self.allocator);
-        }
-        self.staged_exchanges.clearRetainingCapacity();
-        self.staged_origin = null;
-        self.staged_state = null;
-        if (self.staged_expected_url) |url| self.allocator.free(url);
-        self.staged_expected_url = null;
-    }
-
-    fn prepareRawCall(
-        self: *RecordingTransport,
-        request: *const core.http.Request,
-    ) void {
-        const state = self.staged_state orelse return;
-        if (request == self.staged_origin) {
-            self.discardStaged();
-            return;
-        }
-        if (state == .retryable_final) {
-            const origin = self.staged_exchanges.items[0];
-            const same_body =
-                (origin.request_body == null) == (request.body == null) and
-                (origin.request_body == null or std.mem.eql(
-                    u8,
-                    origin.request_body.?,
-                    request.body.?,
-                ));
-            if (origin.request_method == request.method and
-                std.mem.eql(u8, origin.request_url, request.url) and
-                same_body)
-            {
-                self.discardStaged();
-            } else {
-                self.commitStaged();
-            }
-            return;
-        }
-        const expected = self.staged_expected_url orelse {
-            self.discardStaged();
-            return;
-        };
-        if (!std.mem.eql(u8, request.url, expected)) {
-            self.discardStaged();
-            return;
-        }
-        self.allocator.free(expected);
-        self.staged_expected_url = null;
-    }
-
-    fn finalizeStagedForRead(self: *RecordingTransport) void {
-        const state = self.staged_state orelse return;
-        if (state == .retryable_final)
-            self.commitStaged()
-        else
-            self.discardStaged();
     }
 
     /// Serialize version 2 recordings with lossless base64 bodies while
@@ -627,7 +441,7 @@ pub const RecordingTransport = struct {
     /// and unapproved opaque encodings cause an explicit error; neither is
     /// silently emitted under a false sanitization guarantee.
     pub fn toJson(
-        self: *RecordingTransport,
+        self: *const RecordingTransport,
         allocator: std.mem.Allocator,
     ) ![]u8 {
         var output: std.Io.Writer.Allocating = .init(allocator);
@@ -641,11 +455,10 @@ pub const RecordingTransport = struct {
     }
 
     fn writeJson(
-        self: *RecordingTransport,
+        self: *const RecordingTransport,
         writer: *std.Io.Writer,
         allocator: std.mem.Allocator,
     ) !void {
-        self.finalizeStagedForRead();
         try writer.print(
             "{{\"version\":{d},\"exchanges\":[",
             .{recording_format_version},
@@ -700,47 +513,17 @@ pub const RecordingTransport = struct {
         request: *core.http.Request,
     ) !core.http.Response {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
-        self.prepareRawCall(request);
-        var response = self.inner.vtable.send(
-            self.inner.context,
-            request,
-        ) catch |err| {
-            self.discardStaged();
-            return err;
-        };
+        var response = try self.inner.vtable.send(self.inner.context, request);
         errdefer response.deinit();
-        var exchange = ownedExchangeFromResponse(
+        var exchange = try ownedExchangeFromResponse(
             self.allocator,
             request,
             request.body,
             &response,
             response.body,
-        ) catch |err| {
-            self.discardStaged();
-            return err;
-        };
-        self.stageExchange(exchange, request) catch |err| {
-            exchange.deinit(self.allocator);
-            self.discardStaged();
-            return err;
-        };
-        if (responseRecordsRedirect(request, response)) {
-            self.staged_expected_url = resolveRecordingRedirectAlloc(
-                self.allocator,
-                request.url,
-                response.getHeader("Location").?,
-            ) catch |err| {
-                self.discardStaged();
-                return err;
-            };
-            self.staged_state = .redirect_pending;
-        } else if (request.retryable and
-            isRetryableRecordingStatus(response.status_code))
-        {
-            self.staged_state = .retryable_final;
-        } else {
-            self.commitStaged();
-        }
+        );
+        errdefer exchange.deinit(self.allocator);
+        try self.exchanges.append(self.allocator, exchange);
         return response;
     }
 
@@ -750,8 +533,6 @@ pub const RecordingTransport = struct {
         options: core.http.OpenOptions,
     ) !*core.http.HttpOperation {
         const self: *RecordingTransport = @ptrCast(@alignCast(context));
-        self.prepareRawCall(request);
-        errdefer self.discardStaged();
         if (options.body != null and request.body != null)
             return error.MultipleRequestBodies;
         try checkCancelled(options.cancellation);
@@ -807,8 +588,6 @@ pub const RecordingTransport = struct {
             self,
             inner_operation,
             pending,
-            recordsRedirect(request, options, inner_operation),
-            request,
         );
     }
 };
@@ -899,63 +678,35 @@ const RecordingOperation = struct {
     allocator: std.mem.Allocator,
     owner: *RecordingTransport,
     inner: *core.http.HttpOperation,
-    request_identity: *const core.http.Request,
     pending: ?PendingRequest,
-    redirect_exchange: ?OwnedExchange,
-    redirect_target: ?[]u8,
+    attempt_headers: ?[]HeaderPair,
     response_reader: CapturingReader,
 
     fn create(
         owner: *RecordingTransport,
         inner: *core.http.HttpOperation,
         pending_value: PendingRequest,
-        record_redirect: bool,
-        request_identity: *const core.http.Request,
     ) !*core.http.HttpOperation {
+        try owner.exchanges.ensureUnusedCapacity(owner.allocator, 1);
         const self = try owner.allocator.create(RecordingOperation);
         errdefer owner.allocator.destroy(self);
         var header_set = try cloneOperationHeaders(owner.allocator, inner);
         errdefer header_set.deinit(owner.allocator);
         const inner_reader = try inner.reader();
-        var redirect_headers: ?[]HeaderPair = null;
-        errdefer if (redirect_headers) |headers|
-            deinitHeaderPairs(owner.allocator, headers);
-        var redirect_body: ?[]u8 = null;
-        errdefer if (redirect_body) |body| owner.allocator.free(body);
-        var redirect_target: ?[]u8 = null;
-        errdefer if (redirect_target) |url| owner.allocator.free(url);
-        if (record_redirect) {
-            try owner.reserveStagedSlot();
-            redirect_headers = try cloneResponseHeaders(
-                owner.allocator,
-                &inner.headers,
-                &inner.response_headers,
-            );
-            redirect_body = try owner.allocator.dupe(u8, "");
-            redirect_target = try resolveRecordingRedirectAlloc(
-                owner.allocator,
-                pending_value.url,
-                inner.getHeader("Location").?,
-            );
-        }
+        const attempt_headers = try cloneResponseHeaders(
+            owner.allocator,
+            &inner.headers,
+            &inner.response_headers,
+        );
+        errdefer deinitHeaderPairs(owner.allocator, attempt_headers);
 
         self.* = .{
             .operation = undefined,
             .allocator = owner.allocator,
             .owner = owner,
             .inner = inner,
-            .request_identity = request_identity,
-            .pending = if (record_redirect) null else pending_value,
-            .redirect_exchange = if (record_redirect) .{
-                .request_method = pending_value.method,
-                .request_url = pending_value.url,
-                .request_headers = pending_value.headers,
-                .request_body = pending_value.body,
-                .response_status = inner.status_code,
-                .response_body = redirect_body.?,
-                .response_headers = redirect_headers.?,
-            } else null,
-            .redirect_target = redirect_target,
+            .pending = pending_value,
+            .attempt_headers = attempt_headers,
             .response_reader = undefined,
         };
         self.response_reader.init(owner.allocator, inner_reader, inner);
@@ -973,6 +724,28 @@ const RecordingOperation = struct {
         return &self.operation;
     }
 
+    fn completeAttempt(self: *RecordingOperation) void {
+        const pending = self.pending orelse return;
+        self.pending = null;
+        const response_headers = self.attempt_headers.?;
+        self.attempt_headers = null;
+        const captured = self.response_reader.captured.toArrayList();
+        const allocation = captured.allocatedSlice();
+        self.owner.exchanges.appendAssumeCapacity(.{
+            .request_method = pending.method,
+            .request_url = pending.url,
+            .request_headers = pending.headers,
+            .request_body = pending.body,
+            .response_status = self.operation.status_code,
+            .response_body = allocation[0..captured.items.len],
+            .response_body_allocation = if (allocation.len == 0)
+                null
+            else
+                allocation,
+            .response_headers = response_headers,
+        });
+    }
+
     fn finishImpl(operation: *core.http.HttpOperation) !void {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
@@ -983,65 +756,21 @@ const RecordingOperation = struct {
         };
         try self.inner.finish();
         if (self.response_reader.failure) |failure| return failure;
-
-        const body = try self.response_reader.toOwnedSlice();
-        const response_headers = cloneResponseHeaders(
-            self.allocator,
-            &self.operation.headers,
-            &self.operation.response_headers,
-        ) catch |err| {
-            self.allocator.free(body);
-            return err;
-        };
-        const pending = self.pending orelse {
-            self.allocator.free(body);
-            deinitHeaderPairs(self.allocator, response_headers);
-            return error.RecordingAlreadyFinalized;
-        };
-        self.pending = null;
-        var exchange = OwnedExchange{
-            .request_method = pending.method,
-            .request_url = pending.url,
-            .request_headers = pending.headers,
-            .request_body = pending.body,
-            .response_status = self.operation.status_code,
-            .response_body = body,
-            .response_headers = response_headers,
-        };
-        self.owner.stageExchange(
-            exchange,
-            self.request_identity,
-        ) catch |err| {
-            exchange.deinit(self.allocator);
-            self.owner.discardStaged();
-            return err;
-        };
-        self.owner.commitStaged();
+        self.completeAttempt();
     }
 
     fn abortImpl(operation: *core.http.HttpOperation) void {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.abort();
-        if (self.redirect_exchange) |exchange| {
-            self.owner.stageExchangeAssumeCapacity(
-                exchange,
-                self.request_identity,
-            );
-            self.owner.staged_expected_url = self.redirect_target;
-            self.redirect_target = null;
-            self.owner.staged_state = .redirect_pending;
-            self.redirect_exchange = null;
-        } else {
-            self.owner.discardStaged();
-        }
+        self.completeAttempt();
     }
 
     fn cancelImpl(operation: *core.http.HttpOperation) void {
         const self: *RecordingOperation =
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.cancel();
-        self.owner.discardStaged();
+        self.completeAttempt();
     }
 
     fn bodyErrorImpl(operation: *const core.http.HttpOperation) ?anyerror {
@@ -1056,10 +785,9 @@ const RecordingOperation = struct {
             @alignCast(@fieldParentPtr("operation", operation));
         self.inner.deinit();
         if (self.pending) |*pending| pending.deinit(self.allocator);
-        if (self.redirect_exchange) |*exchange| {
-            exchange.deinit(self.allocator);
+        if (self.attempt_headers) |headers| {
+            deinitHeaderPairs(self.allocator, headers);
         }
-        if (self.redirect_target) |url| self.allocator.free(url);
         self.response_reader.deinit();
         deinitResponseStorage(
             self.allocator,
@@ -1069,70 +797,6 @@ const RecordingOperation = struct {
         self.allocator.destroy(self);
     }
 };
-
-fn recordsRedirect(
-    request: *const core.http.Request,
-    options: core.http.OpenOptions,
-    operation: *const core.http.HttpOperation,
-) bool {
-    if (request.redirect_policy == .not_allowed or
-        operation.getHeader("Location") == null)
-    {
-        return false;
-    }
-    return switch (operation.status_code) {
-        301, 302 => request.method == .POST or options.isReplayable(),
-        303 => true,
-        307, 308 => options.isReplayable(),
-        else => false,
-    };
-}
-
-fn responseRecordsRedirect(
-    request: *const core.http.Request,
-    response: core.http.Response,
-) bool {
-    if (request.redirect_policy == .not_allowed or
-        response.getHeader("Location") == null)
-    {
-        return false;
-    }
-    return switch (response.status_code) {
-        301, 302, 303, 307, 308 => true,
-        else => false,
-    };
-}
-
-fn isRetryableRecordingStatus(status: u16) bool {
-    return status == 408 or status == 429 or status == 500 or
-        status == 502 or status == 503 or status == 504;
-}
-
-fn resolveRecordingRedirectAlloc(
-    allocator: std.mem.Allocator,
-    base_url: []const u8,
-    location: []const u8,
-) ![]u8 {
-    var resolved = core.url.resolveUrl(
-        allocator,
-        base_url,
-        location,
-    ) catch |err| switch (err) {
-        error.WriteFailed => return error.OutOfMemory,
-        else => return err,
-    };
-    errdefer allocator.free(resolved);
-    if (std.mem.indexOfScalar(u8, resolved, '#')) |fragment_start| {
-        const without_fragment = try allocator.dupe(
-            u8,
-            resolved[0..fragment_start],
-        );
-        allocator.free(resolved);
-        resolved = without_fragment;
-    }
-    try core.url.validateHttpsUrl(resolved, &.{});
-    return resolved;
-}
 
 const CapturingReader = struct {
     interface: std.Io.Reader,
@@ -1495,22 +1159,6 @@ fn matchRequest(
         ))
             return error.HeaderMismatch;
     }
-}
-
-fn requestMatches(
-    exchange: RecordedExchange,
-    request: *const core.http.Request,
-    body: ?[]const u8,
-) !bool {
-    matchRequest(exchange, request, body) catch |err| switch (err) {
-        error.MethodMismatch,
-        error.UrlMismatch,
-        error.BodyMismatch,
-        error.HeaderMismatch,
-        => return false,
-        else => return err,
-    };
-    return true;
 }
 
 fn headerValueMatches(
@@ -2070,8 +1718,8 @@ fn ensureBodySafe(
     const xml = valid_text and identity_encoding and
         (containsIgnoreCase(content_type, "xml") or looksLikeXml(bytes));
     if (xml and
-        (containsSensitiveXml(bytes) or
-            containsSensitiveAssignment(bytes) or
+        (try containsSensitiveXml(allocator, bytes) or
+            try containsSensitiveAssignment(allocator, bytes) or
             (try isStorageUserDelegationKeyExchange(allocator, context) and
                 containsIgnoreCase(bytes, "<UserDelegationKey") and
                 containsIgnoreCase(bytes, "<Value"))))
@@ -2090,8 +1738,8 @@ fn ensureBodySafe(
     }
 
     if (xml or json) return;
-    if (containsSensitiveAssignment(bytes) or
-        containsSensitiveXml(bytes))
+    if (try containsSensitiveAssignment(allocator, bytes) or
+        try containsSensitiveXml(allocator, bytes))
     {
         return error.SensitiveBodyRequiresSanitization;
     }
@@ -2262,8 +1910,8 @@ fn containsSensitiveLoosePayload(
             return true;
     }
     if (looksLikeXml(payload) and
-        (containsSensitiveXml(payload) or
-            containsSensitiveAssignment(payload)))
+        (try containsSensitiveXml(allocator, payload) or
+            try containsSensitiveAssignment(allocator, payload)))
     {
         return true;
     }
@@ -2414,7 +2062,11 @@ fn jsonContainsExchangeSensitiveSchema(
     value: std.json.Value,
     context: BodySafetyContext,
 ) !bool {
-    const target = parseUrlTarget(context.url) orelse return false;
+    var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const target = try parseUrlTarget(
+        context.url,
+        &host_buffer,
+    ) orelse return false;
     if (isKeyVaultHost(target.host)) {
         if ((try pathHasResource(allocator, target.path, "secrets") or
             try pathHasResource(allocator, target.path, "certificates")) and
@@ -2552,40 +2204,46 @@ const UrlTarget = struct {
     path: []const u8,
 };
 
-fn parseUrlTarget(url: []const u8) ?UrlTarget {
-    const scheme = std.mem.indexOf(u8, url, "://") orelse return null;
-    if (!std.ascii.eqlIgnoreCase(url[0..scheme], "https")) return null;
-    const authority_start = scheme + 3;
-    const path_start = std.mem.indexOfAnyPos(
-        u8,
-        url,
-        authority_start,
-        "/?#",
-    ) orelse url.len;
-    var authority = url[authority_start..path_start];
-    if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| {
-        authority = authority[at + 1 ..];
-    }
-    var host = authority;
-    if (host.len != 0 and host[0] == '[') {
-        const close = std.mem.indexOfScalar(u8, host, ']') orelse return null;
-        host = host[0 .. close + 1];
-    } else if (std.mem.lastIndexOfScalar(u8, host, ':')) |colon| {
-        host = host[0..colon];
-    }
-    const path_end = std.mem.indexOfAnyPos(
-        u8,
-        url,
-        path_start,
-        "?#",
-    ) orelse url.len;
+fn parseUrlTarget(
+    url: []const u8,
+    host_buffer: *[std.Io.net.HostName.max_len]u8,
+) !?UrlTarget {
+    const uri = std.Uri.parse(url) catch
+        return error.SensitiveBodyRequiresSanitization;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) return null;
+    if (uri.user != null or uri.password != null)
+        return error.SensitiveBodyRequiresSanitization;
+    const host_name = uri.getHost(host_buffer) catch
+        return error.SensitiveBodyRequiresSanitization;
+    var host = host_name.bytes;
+    if (host.len != 0 and host[host.len - 1] == '.')
+        host = host[0 .. host.len - 1];
+    if (!isCanonicalDnsHost(host))
+        return error.SensitiveBodyRequiresSanitization;
+    const path = switch (uri.path) {
+        .raw, .percent_encoded => |value| value,
+    };
     return .{
         .host = host,
-        .path = if (path_start < url.len and url[path_start] == '/')
-            url[path_start..path_end]
-        else
-            "",
+        .path = path,
     };
+}
+
+fn isCanonicalDnsHost(host: []const u8) bool {
+    if (host.len == 0 or host.len > 253) return false;
+    var labels = std.mem.splitScalar(u8, host, '.');
+    while (labels.next()) |label| {
+        if (label.len == 0 or label.len > 63 or
+            label[0] == '-' or label[label.len - 1] == '-')
+        {
+            return false;
+        }
+        for (label) |byte| {
+            if (!std.ascii.isAlphanumeric(byte) and byte != '-')
+                return false;
+        }
+    }
+    return true;
 }
 
 fn hostMatches(host: []const u8, suffix: []const u8) bool {
@@ -2637,7 +2295,11 @@ fn isStorageUserDelegationKeyExchange(
     context: BodySafetyContext,
 ) !bool {
     if (context.direction != .response) return false;
-    const target = parseUrlTarget(context.url) orelse return false;
+    var host_buffer: [std.Io.net.HostName.max_len]u8 = undefined;
+    const target = try parseUrlTarget(
+        context.url,
+        &host_buffer,
+    ) orelse return false;
     if (!isStorageBlobHost(target.host)) return false;
     const query_start = std.mem.indexOfScalar(u8, context.url, '?') orelse
         return false;
@@ -2800,8 +2462,67 @@ fn containsSensitiveScalar(
     allocator: std.mem.Allocator,
     value: []const u8,
 ) !bool {
+    if (try containsDirectSensitiveScalar(allocator, value)) return true;
+    var current = try allocator.dupe(u8, value);
+    defer allocator.free(current);
+    var decode_count: usize = 0;
+    while (decode_count < max_url_decode_depth) : (decode_count += 1) {
+        if (!containsPercentEscape(current)) return false;
+        const decoded = try percentDecodeLooseAlloc(allocator, current);
+        const changed = !std.mem.eql(u8, current, decoded);
+        allocator.free(current);
+        current = decoded;
+        if (try containsDirectSensitiveScalar(allocator, current)) return true;
+        if (!changed) return false;
+    }
+    return containsPercentEscape(current);
+}
+
+fn percentDecodeLooseAlloc(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+) ![]u8 {
+    const decoded = try allocator.alloc(u8, encoded.len);
+    errdefer allocator.free(decoded);
+    var input_index: usize = 0;
+    var output_index: usize = 0;
+    while (input_index < encoded.len) {
+        if (encoded[input_index] == '%' and input_index + 2 < encoded.len) {
+            const high = std.fmt.charToDigit(
+                encoded[input_index + 1],
+                16,
+            ) catch {
+                decoded[output_index] = encoded[input_index];
+                input_index += 1;
+                output_index += 1;
+                continue;
+            };
+            const low = std.fmt.charToDigit(
+                encoded[input_index + 2],
+                16,
+            ) catch {
+                decoded[output_index] = encoded[input_index];
+                input_index += 1;
+                output_index += 1;
+                continue;
+            };
+            decoded[output_index] = high * 16 + low;
+            input_index += 3;
+        } else {
+            decoded[output_index] = encoded[input_index];
+            input_index += 1;
+        }
+        output_index += 1;
+    }
+    return allocator.realloc(decoded, output_index);
+}
+
+fn containsDirectSensitiveScalar(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !bool {
     return containsPrivateKeyMarker(value) or
-        containsSensitiveAssignment(value) or
+        try containsSensitiveAssignment(allocator, value) or
         containsSasCredential(value) or
         containsIgnoreCase(value, "Bearer ") or
         containsIgnoreCase(value, "SharedKey ") or
@@ -2983,7 +2704,10 @@ fn normalizedFieldEndsWith(name: []const u8, suffix: []const u8) bool {
     return true;
 }
 
-fn containsSensitiveAssignment(body: []const u8) bool {
+fn containsSensitiveAssignment(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !bool {
     var start: usize = 0;
     var index: usize = 0;
     while (index <= body.len) : (index += 1) {
@@ -2998,15 +2722,23 @@ fn containsSensitiveAssignment(body: []const u8) bool {
         }
         const field = body[start..index];
         start = index + 1;
-        const equals = std.mem.indexOfScalar(u8, field, '=') orelse continue;
-        var name = std.mem.trim(u8, field[0..equals], " \t\"'{}[]");
-        if (std.mem.lastIndexOfScalar(u8, name, ':')) |colon| {
-            name = name[colon + 1 ..];
+        var equals_start: usize = 0;
+        while (std.mem.indexOfScalarPos(
+            u8,
+            field,
+            equals_start,
+            '=',
+        )) |equals| {
+            var name = std.mem.trim(u8, field[0..equals], " \t\"'{}[]");
+            if (std.mem.lastIndexOfAny(u8, name, "?#")) |delimiter| {
+                name = name[delimiter + 1 ..];
+            }
+            if (std.mem.lastIndexOfScalar(u8, name, ':')) |colon| {
+                name = name[colon + 1 ..];
+            }
+            if (try encodedQueryNameIsSensitive(allocator, name)) return true;
+            equals_start = equals + 1;
         }
-        var decoded_buffer: [256]u8 = undefined;
-        const decoded = percentDecodeFieldName(name, &decoded_buffer) orelse
-            continue;
-        if (isSensitiveBodyField(decoded)) return true;
     }
     return false;
 }
@@ -3035,7 +2767,10 @@ fn percentDecodeFieldName(
     return buffer[0..output_index];
 }
 
-fn containsSensitiveXml(body: []const u8) bool {
+fn containsSensitiveXml(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !bool {
     var index: usize = 0;
     while (std.mem.indexOfScalarPos(u8, body, index, '<')) |open| {
         index = open + 1;
@@ -3130,7 +2865,7 @@ fn containsSensitiveXml(body: []const u8) bool {
                     normalizedFieldEquals(attribute_name, "field") or
                     normalizedFieldEquals(attribute_name, "property")) and
                     isSensitiveBodyField(attribute_value)) or
-                containsSensitiveAssignment(attribute_value) or
+                try containsSensitiveAssignment(allocator, attribute_value) or
                 containsPrivateKeyMarker(attribute_value))
             {
                 return true;
@@ -3575,6 +3310,18 @@ fn isSensitiveQueryField(name: []const u8) bool {
     for (sensitive_query_fields) |sensitive| {
         if (std.ascii.eqlIgnoreCase(candidate, sensitive)) return true;
     }
+    for ([_][]const u8{
+        "xamzsignature",
+        "xamzcredential",
+        "xamzsecuritytoken",
+        "awsaccesskeyid",
+        "securitytoken",
+        "xgoogsignature",
+        "xgoogcredential",
+        "googleaccessid",
+    }) |vendor_credential| {
+        if (normalizedFieldEquals(candidate, vendor_credential)) return true;
+    }
     return isSensitiveBodyField(candidate);
 }
 
@@ -3856,10 +3603,7 @@ test "playback preserves abort and cancellation semantics" {
     var aborted = try playback.asTransport().open(&abort_request, .{});
     aborted.abort();
     aborted.deinit();
-    try std.testing.expectEqual(@as(usize, 0), playback.index);
-    var abort_retry = try playback.asTransport().open(&abort_request, .{});
-    try abort_retry.finish();
-    abort_retry.deinit();
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
 
     var cancel_request = core.http.Request.init(
         std.testing.allocator,
@@ -3870,14 +3614,11 @@ test "playback preserves abort and cancellation semantics" {
     var cancelled = try playback.asTransport().open(&cancel_request, .{});
     cancelled.cancel();
     cancelled.deinit();
-    try std.testing.expectEqual(@as(usize, 1), playback.index);
-    var cancel_retry = try playback.asTransport().open(&cancel_request, .{});
-    try cancel_retry.finish();
-    cancel_retry.deinit();
+    try std.testing.expectEqual(@as(usize, 2), playback.index);
     try std.testing.expectEqual(@as(usize, 1), playback.abort_count);
     try std.testing.expectEqual(@as(usize, 1), playback.cancel_count);
-    try std.testing.expectEqual(@as(usize, 2), playback.finish_count);
-    try std.testing.expectEqual(@as(usize, 4), playback.deinit_count);
+    try std.testing.expectEqual(@as(usize, 0), playback.finish_count);
+    try std.testing.expectEqual(@as(usize, 2), playback.deinit_count);
 }
 
 test "playback follows redirects and cleans intermediate operations" {
@@ -4084,8 +3825,17 @@ test "playback allocation failures do not consume streaming exchanges" {
     try std.testing.expectEqual(@as(usize, 1), playback.open_count);
 }
 
-test "Core buffered redirect allocation failure leaves playback retryable" {
+test "buffered redirect OOM consumes its raw playback attempt" {
     const recordings = [_]RecordedExchange{
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/start",
+            .response_status = 302,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/final" },
+            },
+        },
         .{
             .request_method = .GET,
             .request_url = "https://example.test/start",
@@ -4120,19 +3870,26 @@ test "Core buffered redirect allocation failure leaves playback retryable" {
         error.OutOfMemory,
         playback.asTransport().send(&request),
     );
-    try std.testing.expectEqual(@as(usize, 0), playback.index);
-    try std.testing.expectEqual(@as(?usize, 0), playback.pending_redirect);
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
 
     failing.fail_index = std.math.maxInt(usize);
     var response = try playback.asTransport().send(&request);
     defer response.deinit();
     try std.testing.expectEqualStrings("done", response.body);
-    try std.testing.expectEqual(@as(usize, 2), playback.index);
-    try std.testing.expectEqual(@as(?usize, null), playback.pending_redirect);
+    try std.testing.expectEqual(@as(usize, 3), playback.index);
 }
 
-test "Core streaming redirect allocation failure leaves playback retryable" {
+test "streaming redirect OOM consumes its raw playback attempt" {
     const recordings = [_]RecordedExchange{
+        .{
+            .request_method = .GET,
+            .request_url = "https://example.test/start-stream",
+            .response_status = 302,
+            .response_body = "",
+            .response_headers = &.{
+                .{ .name = "Location", .value = "/final-stream" },
+            },
+        },
         .{
             .request_method = .GET,
             .request_url = "https://example.test/start-stream",
@@ -4167,8 +3924,7 @@ test "Core streaming redirect allocation failure leaves playback retryable" {
         error.OutOfMemory,
         playback.asTransport().open(&request, .{}),
     );
-    try std.testing.expectEqual(@as(usize, 0), playback.index);
-    try std.testing.expectEqual(@as(?usize, 0), playback.pending_redirect);
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
     try std.testing.expectEqual(@as(usize, 1), playback.abort_count);
 
     failing.fail_index = std.math.maxInt(usize);
@@ -4181,137 +3937,7 @@ test "Core streaming redirect allocation failure leaves playback retryable" {
     defer std.testing.allocator.free(body);
     try std.testing.expectEqualStrings("stream-done", body);
     try operation.finish();
-    try std.testing.expectEqual(@as(usize, 2), playback.index);
-    try std.testing.expectEqual(@as(?usize, null), playback.pending_redirect);
-}
-
-test "every Core redirect-chain request allocation failure rolls back playback" {
-    const recordings = [_]RecordedExchange{
-        .{
-            .request_method = .GET,
-            .request_url = "https://example.test/start-chain",
-            .response_status = 302,
-            .response_body = "",
-            .response_headers = &.{
-                .{ .name = "Location", .value = "/middle-chain" },
-            },
-        },
-        .{
-            .request_method = .GET,
-            .request_url = "https://example.test/middle-chain",
-            .response_status = 307,
-            .response_body = "",
-            .response_headers = &.{
-                .{ .name = "Location", .value = "/final-chain" },
-            },
-        },
-        .{
-            .request_method = .GET,
-            .request_url = "https://example.test/final-chain",
-            .response_status = 200,
-            .response_body = "complete",
-        },
-    };
-    var saw_later_redirect_failure = false;
-    for (0..64) |fail_index| {
-        var playback = PlaybackTransport.init(
-            std.testing.allocator,
-            &recordings,
-        );
-        var failing = std.testing.FailingAllocator.init(
-            std.testing.allocator,
-            .{ .fail_index = fail_index },
-        );
-        var request = core.http.Request.init(
-            failing.allocator(),
-            .GET,
-            "https://example.test/start-chain",
-        );
-        defer request.deinit();
-        const transport = playback.asTransport();
-        if (transport.send(&request)) |response_value| {
-            var response = response_value;
-            response.deinit();
-            break;
-        } else |err| {
-            if (err != error.OutOfMemory and err != error.WriteFailed)
-                return err;
-            saw_later_redirect_failure = saw_later_redirect_failure or
-                playback.pending_redirect == 1;
-            try std.testing.expectEqual(@as(usize, 0), playback.index);
-            failing.fail_index = std.math.maxInt(usize);
-            var retry = try transport.send(&request);
-            defer retry.deinit();
-            try std.testing.expectEqualStrings("complete", retry.body);
-            try std.testing.expectEqual(@as(usize, 3), playback.index);
-        }
-    }
-    try std.testing.expect(saw_later_redirect_failure);
-}
-
-test "every Core streaming redirect-chain allocation failure rolls back playback" {
-    const recordings = [_]RecordedExchange{
-        .{
-            .request_method = .GET,
-            .request_url = "https://example.test/start-open-chain",
-            .response_status = 302,
-            .response_body = "",
-            .response_headers = &.{
-                .{ .name = "Location", .value = "/middle-open-chain" },
-            },
-        },
-        .{
-            .request_method = .GET,
-            .request_url = "https://example.test/middle-open-chain",
-            .response_status = 307,
-            .response_body = "",
-            .response_headers = &.{
-                .{ .name = "Location", .value = "/final-open-chain" },
-            },
-        },
-        .{
-            .request_method = .GET,
-            .request_url = "https://example.test/final-open-chain",
-            .response_status = 200,
-            .response_body = "complete",
-        },
-    };
-    var saw_later_redirect_failure = false;
-    for (0..64) |fail_index| {
-        var playback = PlaybackTransport.init(
-            std.testing.allocator,
-            &recordings,
-        );
-        var failing = std.testing.FailingAllocator.init(
-            std.testing.allocator,
-            .{ .fail_index = fail_index },
-        );
-        var request = core.http.Request.init(
-            failing.allocator(),
-            .GET,
-            "https://example.test/start-open-chain",
-        );
-        defer request.deinit();
-        const transport = playback.asTransport();
-        if (transport.open(&request, .{})) |operation_value| {
-            var operation = operation_value;
-            try operation.finish();
-            operation.deinit();
-            break;
-        } else |err| {
-            if (err != error.OutOfMemory and err != error.WriteFailed)
-                return err;
-            saw_later_redirect_failure = saw_later_redirect_failure or
-                playback.pending_redirect == 1;
-            try std.testing.expectEqual(@as(usize, 0), playback.index);
-            failing.fail_index = std.math.maxInt(usize);
-            var retry = try transport.open(&request, .{});
-            try retry.finish();
-            retry.deinit();
-            try std.testing.expectEqual(@as(usize, 3), playback.index);
-        }
-    }
-    try std.testing.expect(saw_later_redirect_failure);
+    try std.testing.expectEqual(@as(usize, 3), playback.index);
 }
 
 test "recording wraps streaming operations and copies descriptor by value" {
@@ -4407,7 +4033,7 @@ test "recording preserves buffered open fallback" {
     try std.testing.expectEqual(@as(usize, 1), mock.call_count);
 }
 
-test "recording forwards abort and cancel without recording partial responses" {
+test "recording stores abort and cancel as completed raw attempts" {
     var mock = core.http.MockTransport.init(std.testing.allocator, 200, "body");
     defer mock.deinit();
     var recorder = RecordingTransport.init(
@@ -4428,13 +4054,16 @@ test "recording forwards abort and cancel without recording partial responses" {
     var cancelled = try recorder.asTransport().open(&request, .{});
     cancelled.cancel();
     cancelled.deinit();
-    try std.testing.expectEqual(@as(usize, 0), recorder.getExchanges().len);
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(usize, 0), exchanges[0].response_body.len);
+    try std.testing.expectEqual(@as(usize, 0), exchanges[1].response_body.len);
     try std.testing.expectEqual(@as(usize, 1), mock.stream_abort_count);
     try std.testing.expectEqual(@as(usize, 1), mock.stream_cancel_count);
     try std.testing.expectEqual(@as(usize, 2), mock.stream_deinit_count);
 }
 
-test "recording cancellation discards every tentative redirect exchange" {
+test "recording cancellation preserves redirect and terminal raw attempts" {
     var sequence = core.http.SequenceMockTransport.init(
         std.testing.allocator,
         &.{
@@ -4460,10 +4089,11 @@ test "recording cancellation discards every tentative redirect exchange" {
     var operation = try recorder.asTransport().open(&request, .{});
     operation.cancel();
     operation.deinit();
-    try std.testing.expectEqual(
-        @as(usize, 0),
-        recorder.getExchanges().len,
-    );
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
+    try std.testing.expectEqual(@as(usize, 0), exchanges[1].response_body.len);
 }
 
 test "recording and playback preserve streaming redirect sequences" {
@@ -4525,7 +4155,7 @@ test "recording and playback preserve streaming redirect sequences" {
     replay.deinit();
 }
 
-test "recording stages buffered redirect and retry chains atomically" {
+test "buffered recorder and playback preserve raw redirect retry attempts" {
     var sequence = core.http.SequenceMockTransport.init(
         std.testing.allocator,
         &.{
@@ -4565,23 +4195,15 @@ test "recording stages buffered redirect and retry chains atomically" {
     defer request.deinit();
     var response = try pipeline.send(&request);
     defer response.deinit();
-    try std.testing.expectEqual(@as(u16, 200), response.status_code);
     try std.testing.expectEqualStrings("done", response.body);
 
     const exchanges = recorder.getExchanges();
-    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(usize, 4), exchanges.len);
     try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
-    try std.testing.expectEqualStrings(
-        "https://example.test/start",
-        exchanges[0].request_url,
-    );
-    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
-    try std.testing.expectEqualStrings(
-        "https://example.test/final",
-        exchanges[1].request_url,
-    );
-
-    var recordings: [2]RecordedExchange = undefined;
+    try std.testing.expectEqual(@as(u16, 503), exchanges[1].response_status);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[2].response_status);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[3].response_status);
+    var recordings: [4]RecordedExchange = undefined;
     for (exchanges, &recordings) |exchange, *recording| {
         recording.* = .{
             .request_method = exchange.request_method,
@@ -4597,26 +4219,45 @@ test "recording stages buffered redirect and retry chains atomically" {
         std.testing.allocator,
         &recordings,
     );
-    var replayed = try playback.asTransport().send(&request);
+    var playback_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var playback_retry = core.http.RetryPolicy.init();
+    playback_retry.initial_delay_ms = 0;
+    playback_retry.max_delay_ms = 0;
+    var playback_policies = [_]*core.http.HttpPolicy{
+        playback_retry.asPolicy(),
+    };
+    var playback_pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(
+            playback.asTransport(),
+            playback_crypto.asProvider(),
+        ),
+        &playback_policies,
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start",
+    );
+    defer live.deinit();
+    var replayed = try playback_pipeline.send(&live);
     defer replayed.deinit();
-    try std.testing.expectEqual(@as(u16, 200), replayed.status_code);
     try std.testing.expectEqualStrings("done", replayed.body);
-    try std.testing.expectEqual(@as(usize, 2), playback.index);
+    try std.testing.expectEqual(@as(usize, 4), playback.index);
 }
 
-test "recording stages streaming redirect and retry chains atomically" {
+test "streaming recorder and playback preserve raw redirect retry attempts" {
     var sequence = core.http.SequenceMockTransport.init(
         std.testing.allocator,
         &.{
             .{
                 .status = 302,
-                .body = "",
+                .body = "ignored-redirect",
                 .headers = &.{.{ .name = "Location", .value = "/final" }},
             },
-            .{ .status = 503, .body = "retry" },
+            .{ .status = 503, .body = "ignored-retry" },
             .{
                 .status = 302,
-                .body = "",
+                .body = "ignored-redirect",
                 .headers = &.{.{ .name = "Location", .value = "/final" }},
             },
             .{ .status = 200, .body = "done" },
@@ -4653,10 +4294,16 @@ test "recording stages streaming redirect and retry chains atomically" {
     operation.deinit();
 
     const exchanges = recorder.getExchanges();
-    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(usize, 4), exchanges.len);
     try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
-    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
-    var recordings: [2]RecordedExchange = undefined;
+    try std.testing.expectEqual(@as(usize, 0), exchanges[0].response_body.len);
+    try std.testing.expectEqual(@as(u16, 503), exchanges[1].response_status);
+    try std.testing.expectEqual(@as(usize, 0), exchanges[1].response_body.len);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[2].response_status);
+    try std.testing.expectEqual(@as(usize, 0), exchanges[2].response_body.len);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[3].response_status);
+    try std.testing.expectEqualStrings("done", exchanges[3].response_body);
+    var recordings: [4]RecordedExchange = undefined;
     for (exchanges, &recordings) |exchange, *recording| {
         recording.* = .{
             .request_method = exchange.request_method,
@@ -4672,7 +4319,27 @@ test "recording stages streaming redirect and retry chains atomically" {
         std.testing.allocator,
         &recordings,
     );
-    var replayed = try playback.asTransport().open(&request, .{});
+    var playback_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var playback_retry = core.http.RetryPolicy.init();
+    playback_retry.initial_delay_ms = 0;
+    playback_retry.max_delay_ms = 0;
+    var playback_policies = [_]*core.http.HttpPolicy{
+        playback_retry.asPolicy(),
+    };
+    var playback_pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(
+            playback.asTransport(),
+            playback_crypto.asProvider(),
+        ),
+        &playback_policies,
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start",
+    );
+    defer live.deinit();
+    var replayed = try playback_pipeline.open(&live, .{});
     const replayed_body = try (try replayed.reader()).allocRemaining(
         std.testing.allocator,
         .unlimited,
@@ -4681,10 +4348,10 @@ test "recording stages streaming redirect and retry chains atomically" {
     try std.testing.expectEqualStrings("done", replayed_body);
     try replayed.finish();
     replayed.deinit();
-    try std.testing.expectEqual(@as(usize, 2), playback.index);
+    try std.testing.expectEqual(@as(usize, 4), playback.index);
 }
 
-test "recording redirect allocation failure discards the tentative chain" {
+test "buffered recorder preserves redirect attempt consumed before OOM" {
     var sequence = core.http.SequenceMockTransport.init(
         std.testing.allocator,
         &.{
@@ -4717,43 +4384,32 @@ test "recording redirect allocation failure discards the tentative chain" {
     );
     defer request.deinit();
     const transport = recorder.asTransport();
-    const first = transport.send(&request);
-    if (first) |response_value| {
-        var unexpected = response_value;
-        unexpected.deinit();
-        return error.TestExpectedError;
-    } else |err| {
-        try std.testing.expect(
-            err == error.OutOfMemory or err == error.WriteFailed,
-        );
-    }
-    try std.testing.expectEqual(
-        @as(usize, 0),
-        recorder.getExchanges().len,
-    );
+    try std.testing.expectError(error.OutOfMemory, transport.send(&request));
+    try std.testing.expectEqual(@as(usize, 1), recorder.getExchanges().len);
 
     failing.fail_index = std.math.maxInt(usize);
     var response = try transport.send(&request);
     defer response.deinit();
     try std.testing.expectEqualStrings("done", response.body);
     const exchanges = recorder.getExchanges();
-    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(usize, 3), exchanges.len);
     try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
-    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[1].response_status);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[2].response_status);
 }
 
-test "recording streaming redirect OOM abort stays tentative" {
+test "streaming recorder preserves redirect attempt aborted after OOM" {
     var sequence = core.http.SequenceMockTransport.init(
         std.testing.allocator,
         &.{
             .{
                 .status = 302,
-                .body = "",
+                .body = "ignored",
                 .headers = &.{.{ .name = "Location", .value = "/final" }},
             },
             .{
                 .status = 302,
-                .body = "",
+                .body = "ignored",
                 .headers = &.{.{ .name = "Location", .value = "/final" }},
             },
             .{ .status = 200, .body = "done" },
@@ -4775,19 +4431,10 @@ test "recording streaming redirect OOM abort stays tentative" {
     );
     defer request.deinit();
     const transport = recorder.asTransport();
-    const first = transport.open(&request, .{});
-    if (first) |unexpected| {
-        unexpected.deinit();
-        return error.TestExpectedError;
-    } else |err| {
-        try std.testing.expect(
-            err == error.OutOfMemory or err == error.WriteFailed,
-        );
-    }
-    try std.testing.expectEqual(
-        @as(usize, 0),
-        recorder.getExchanges().len,
-    );
+    try std.testing.expectError(error.OutOfMemory, transport.open(&request, .{}));
+    const first = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 1), first.len);
+    try std.testing.expectEqual(@as(usize, 0), first[0].response_body.len);
 
     failing.fail_index = std.math.maxInt(usize);
     var operation = try transport.open(&request, .{});
@@ -4800,9 +4447,158 @@ test "recording streaming redirect OOM abort stays tentative" {
     try operation.finish();
     operation.deinit();
     const exchanges = recorder.getExchanges();
-    try std.testing.expectEqual(@as(usize, 2), exchanges.len);
+    try std.testing.expectEqual(@as(usize, 3), exchanges.len);
     try std.testing.expectEqual(@as(u16, 302), exchanges[0].response_status);
-    try std.testing.expectEqual(@as(u16, 200), exchanges[1].response_status);
+    try std.testing.expectEqual(@as(u16, 302), exchanges[1].response_status);
+    try std.testing.expectEqual(@as(u16, 200), exchanges[2].response_status);
+}
+
+test "recorder and playback preserve retry backoff timeout attempts" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{.{ .status = 503, .body = "unavailable" }},
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var retry = core.http.RetryPolicy.init();
+    retry.initial_delay_ms = 100;
+    var policies = [_]*core.http.HttpPolicy{retry.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(recorder.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/timeout",
+    );
+    request.operation_timeout_ms = 1;
+    defer request.deinit();
+    try std.testing.expectError(error.OperationTimedOut, pipeline.send(&request));
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 1), exchanges.len);
+    try std.testing.expectEqual(@as(u16, 503), exchanges[0].response_status);
+
+    const recordings = [_]RecordedExchange{.{
+        .request_method = exchanges[0].request_method,
+        .request_url = exchanges[0].request_url,
+        .request_headers = exchanges[0].request_headers,
+        .request_body = exchanges[0].request_body,
+        .response_status = exchanges[0].response_status,
+        .response_body = exchanges[0].response_body,
+        .response_headers = exchanges[0].response_headers,
+    }};
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var playback_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var playback_retry = core.http.RetryPolicy.init();
+    playback_retry.initial_delay_ms = 100;
+    var playback_policies = [_]*core.http.HttpPolicy{
+        playback_retry.asPolicy(),
+    };
+    var playback_pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(
+            playback.asTransport(),
+            playback_crypto.asProvider(),
+        ),
+        &playback_policies,
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/timeout",
+    );
+    live.operation_timeout_ms = 1;
+    defer live.deinit();
+    try std.testing.expectError(
+        error.OperationTimedOut,
+        playback_pipeline.send(&live),
+    );
+    try std.testing.expectEqual(@as(usize, 1), playback.index);
+}
+
+test "terminal retryable response records every configured attempt" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{.{ .status = 503, .body = "unavailable" }},
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    var crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var retry = core.http.RetryPolicy.init();
+    retry.initial_delay_ms = 0;
+    retry.max_delay_ms = 0;
+    retry.max_retries = 2;
+    var policies = [_]*core.http.HttpPolicy{retry.asPolicy()};
+    var pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(recorder.asTransport(), crypto.asProvider()),
+        &policies,
+    );
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/unavailable",
+    );
+    defer request.deinit();
+    var response = try pipeline.send(&request);
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 503), response.status_code);
+    const exchanges = recorder.getExchanges();
+    try std.testing.expectEqual(@as(usize, 3), exchanges.len);
+    for (exchanges) |exchange| {
+        try std.testing.expectEqual(@as(u16, 503), exchange.response_status);
+    }
+
+    var recordings: [3]RecordedExchange = undefined;
+    for (exchanges, &recordings) |exchange, *recording| {
+        recording.* = .{
+            .request_method = exchange.request_method,
+            .request_url = exchange.request_url,
+            .request_headers = exchange.request_headers,
+            .request_body = exchange.request_body,
+            .response_status = exchange.response_status,
+            .response_body = exchange.response_body,
+            .response_headers = exchange.response_headers,
+        };
+    }
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        &recordings,
+    );
+    var playback_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var playback_retry = core.http.RetryPolicy.init();
+    playback_retry.initial_delay_ms = 0;
+    playback_retry.max_delay_ms = 0;
+    playback_retry.max_retries = 2;
+    var playback_policies = [_]*core.http.HttpPolicy{
+        playback_retry.asPolicy(),
+    };
+    var playback_pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(
+            playback.asTransport(),
+            playback_crypto.asProvider(),
+        ),
+        &playback_policies,
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/unavailable",
+    );
+    defer live.deinit();
+    var replayed = try playback_pipeline.send(&live);
+    defer replayed.deinit();
+    try std.testing.expectEqual(@as(u16, 503), replayed.status_code);
+    try std.testing.expectEqual(@as(usize, 3), playback.index);
 }
 
 test "recording JSON redacts headers and URL query credentials" {
@@ -5605,6 +5401,210 @@ test "pathless absolute and network-path URLs sanitize without range failures" {
     defer live.deinit();
     var replayed = try playback.asTransport().send(&live);
     replayed.deinit();
+}
+
+test "vendor signed URL credentials redact across nested and header URLs" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{
+            .name = "Location",
+            .value = "https://download.example/object?" ++
+                "X-Amz-Credential=header-credential&" ++
+                "X-Goog-Signature=header-signature&mode=one",
+        },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start?" ++
+            "X-AmZ-SiGnAtUrE=request-signature&" ++
+            "X-Amz-Credential=request-credential&" ++
+            "X-Amz-Security-Token=request-token&" ++
+            "AWSAccessKeyId=request-access-id&" ++
+            "SecurityToken=request-security-token&" ++
+            "X-Goog-Signature=request-goog-signature&" ++
+            "GoogleAccessId=request-google-access-id&" ++
+            "return=https%253A%252F%252Fdownload.example%252Fobject" ++
+            "%253FX-Amz-Signature%253Dnested-signature&mode=one",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    for ([_][]const u8{
+        "request-signature",
+        "request-credential",
+        "request-token",
+        "request-access-id",
+        "request-security-token",
+        "request-goog-signature",
+        "request-google-access-id",
+        "nested-signature",
+        "header-credential",
+        "header-signature",
+    }) |secret| {
+        try std.testing.expect(std.mem.indexOf(u8, json, secret) == null);
+    }
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/start?" ++
+            "X-AmZ-SiGnAtUrE=rotated-signature&" ++
+            "X-Amz-Credential=rotated-credential&" ++
+            "X-Amz-Security-Token=rotated-token&" ++
+            "AWSAccessKeyId=rotated-access-id&" ++
+            "SecurityToken=rotated-security-token&" ++
+            "X-Goog-Signature=rotated-goog-signature&" ++
+            "GoogleAccessId=rotated-google-access-id&" ++
+            "return=https%253A%252F%252Fdownload.example%252Fobject" ++
+            "%253FX-Amz-Signature%253Drotated-nested&mode=one",
+    );
+    defer live.deinit();
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
+}
+
+test "vendor names near credentials remain exact" {
+    const url =
+        "https://example.test/filter?signatureVersion=4&" ++
+        "credentialMode=default&x-goog-algorithm=GOOG4-RSA-SHA256&" ++
+        "codecs=h264";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        url,
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "signatureVersion=4") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "credentialMode=default") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "codecs=h264") != null);
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var different = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/filter?signatureVersion=2&" ++
+            "credentialMode=default&x-goog-algorithm=GOOG4-RSA-SHA256&" ++
+            "codecs=h264",
+    );
+    defer different.deinit();
+    try std.testing.expectError(
+        error.UrlMismatch,
+        playback.asTransport().send(&different),
+    );
+}
+
+test "bare encoded and nested query assignments are sensitive in bodies" {
+    for ([_][]const u8{
+        "sig=bare-signature",
+        "signature=bare-signature",
+        "code=bare-code",
+        "https://example.test/path#sig=fragment-signature",
+        "https://example.test/path#%73%69%67=encoded-fragment",
+        "return=https://download.example/object?X-Amz-Signature=nested-signature",
+        "https%253A%252F%252Fdownload.example%252Fobject" ++
+            "%253FX-Goog-Signature%253Dencoded-vendor-signature",
+    }) |body| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            body,
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "text/plain" },
+        };
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &inspectKnownSafeBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/body",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{body},
+        );
+    }
+}
+
+test "credential query fields in request fragments are rejected" {
+    for ([_][]const u8{
+        "https://example.test/final#sig=fragment-secret",
+        "https://example.test/final#%73%69%67%6E%61%74%75%72%65=encoded-secret",
+        "https://example.test/final#return=https%253A%252F%252Fdownload.example" ++
+            "%252Fobject%253Fcode%253Dnested-secret",
+    }) |url| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.SensitiveUrlRequiresSanitization,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
 }
 
 test "authenticated recording JSON roundtrips with structured redactions" {
@@ -6468,6 +6468,220 @@ test "encoded Managed HSM key paths are rejected on every sovereign host" {
             error.SensitiveBodyRequiresSanitization,
             &.{"managed-hsm-backup-secret"},
         );
+    }
+}
+
+test "trusted service hosts decode labels and normalize terminal root dots" {
+    const key_hosts = [_][]const u8{
+        "example%2Ev%61ult%2Eazure%2Enet.",
+        "example%2Evault%2Eazure%2Ecn.",
+        "example%2Evault%2Eusgovcloudapi%2Enet.",
+        "example%2Evault%2Emicrosoftazure%2Ede.",
+        "example%2Em%61nagedhsm%2Eazure%2Enet.",
+        "example%2Emanagedhsm%2Eazure%2Ecn.",
+        "example%2Emanagedhsm%2Eusgovcloudapi%2Enet.",
+        "example%2Emanagedhsm%2Emicrosoftazure%2Ede.",
+    };
+    for (key_hosts) |host| {
+        const path = if (containsIgnoreCase(host, "managedhsm"))
+            "/keys/name/backup"
+        else
+            "/secrets/name";
+        const url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://{s}{s}",
+            .{ host, path },
+        );
+        defer std.testing.allocator.free(url);
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"value\":\"host-normalization-secret\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{"host-normalization-secret"},
+        );
+    }
+
+    const management_hosts = [_][]const u8{
+        "m%61nagement%2Eazure%2Ecom.",
+        "management%2Eusgovcloudapi%2Enet.",
+        "management%2Echinacloudapi%2Ecn.",
+        "management%2Emicrosoftazure%2Ede.",
+    };
+    for (management_hosts) |host| {
+        const url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://{s}/subscriptions/s/providers/" ++
+                "Microsoft.Batch/batchAccounts/a/listKeys",
+            .{host},
+        );
+        defer std.testing.allocator.free(url);
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"primary\":\"arm-host-secret\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{"arm-host-secret"},
+        );
+    }
+
+    const storage_hosts = [_][]const u8{
+        "account%2Ebl%6Fb%2Ecore%2Ewindows%2Enet.",
+        "account%2Eblob%2Ecore%2Eusgovcloudapi%2Enet.",
+        "account%2Eblob%2Ecore%2Echinacloudapi%2Ecn.",
+        "account%2Eblob%2Ecore%2Ecloudapi%2Ede.",
+    };
+    for (storage_hosts) |host| {
+        const url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://{s}/?restype=service&comp=userdelegationkey",
+            .{host},
+        );
+        defer std.testing.allocator.free(url);
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "<UserDelegationKey><Value>storage-host-secret</Value>" ++
+                "</UserDelegationKey>",
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "application/xml" },
+        };
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{"storage-host-secret"},
+        );
+    }
+
+    const kusto_hosts = [_][]const u8{
+        "cluster%2Ek%75sto%2Ewindows%2Enet.",
+        "cluster%2Ekusto%2Echinacloudapi%2Ecn.",
+        "cluster%2Ekusto%2Eusgovcloudapi%2Enet.",
+        "cluster%2Ekusto%2Ecloudapi%2Ede.",
+        "cluster%2Ekusto%2Efabric%2Emicrosoft%2Ecom.",
+    };
+    for (kusto_hosts) |host| {
+        const url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://{s}/v2/rest/query",
+            .{host},
+        );
+        defer std.testing.allocator.free(url);
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"sourceUri\":\"ordinary-kusto-value\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{"ordinary-kusto-value"},
+        );
+    }
+}
+
+test "endpoint host parsing rejects malformed and userinfo authorities" {
+    for ([_][]const u8{
+        "https://user@example.vault.azure.net/secrets/name",
+        "https://example%ZZ.vault.azure.net/secrets/name",
+        "https://example.vault.azure.net../secrets/name",
+        "https://example%2F.vault.azure.net/secrets/name",
+    }) |url| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"ordinary\":\"safe\"}",
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "application/json" },
+        };
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &inspectKnownSafeBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        if (recorder.toJson(std.testing.allocator)) |json| {
+            std.testing.allocator.free(json);
+            return error.TestExpectedError;
+        } else |err| {
+            try std.testing.expect(
+                err == error.SensitiveBodyRequiresSanitization or
+                    err == error.SensitiveUrlRequiresSanitization,
+            );
+        }
     }
 }
 

--- a/root.zig
+++ b/root.zig
@@ -1267,6 +1267,8 @@ const explicitly_sensitive_headers = [_][]const u8{
     "x-ms-encryption-key",
     "x-ms-encryption-key-sha256",
     "x-ms-sas-token",
+    "aeg-sas-key",
+    "aeg-sas-token",
     "ocp-apim-subscription-key",
     "api-key",
     "x-api-key",
@@ -1313,6 +1315,8 @@ const sensitive_query_fields = [_][]const u8{
     "password",
     "api_key",
     "subscription-key",
+    "aeg-sas-key",
+    "aeg-sas-token",
     "key",
     "secret",
     "code",
@@ -1944,6 +1948,8 @@ test "sensitive Azure headers are classified case-insensitively" {
         "OCP-APIM-SUBSCRIPTION-KEY",
         "x-functions-key",
         "X-Auth-Token",
+        "AeG-SaS-KeY",
+        "aEg-SaS-ToKeN",
         "Set-Cookie",
     }) |name| {
         try std.testing.expect(isSensitiveHeader(name));
@@ -1951,6 +1957,66 @@ test "sensitive Azure headers are classified case-insensitively" {
     try std.testing.expect(!isSensitiveHeader("Content-Type"));
     try std.testing.expect(!isSensitiveHeader("x-opt-partition-key"));
     try std.testing.expect(!isSensitiveHeader("x-ms-documentdb-partitionkey"));
+}
+
+test "Event Grid key and SAS token redactions roundtrip" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "response",
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "aEg-SaS-KeY", .value = "response-event-grid-key" },
+        .{ .name = "AEG-SAS-TOKEN", .value = "response-event-grid-token" },
+    };
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://topic.eventgrid.azure.net/api/events?AeG-SaS-KeY=query-event-grid-key&AeG-SaS-ToKeN=query-event-grid-token&mode=one",
+    );
+    defer request.deinit();
+    request.body = "event";
+    try request.setHeader("AeG-SaS-KeY", "header-event-grid-key");
+    try request.setHeader("aEg-SaS-ToKeN", "header-event-grid-token");
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    for ([_][]const u8{
+        "query-event-grid-key",
+        "query-event-grid-token",
+        "header-event-grid-key",
+        "header-event-grid-token",
+        "response-event-grid-key",
+        "response-event-grid-token",
+    }) |credential| {
+        try std.testing.expect(std.mem.indexOf(u8, json, credential) == null);
+    }
+
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://topic.eventgrid.azure.net/api/events?AeG-SaS-KeY=live-query-key&AeG-SaS-ToKeN=live-query-token&mode=one",
+    );
+    defer live.deinit();
+    live.body = "event";
+    try live.setHeader("aeg-sas-key", "live-header-key");
+    try live.setHeader("AEG-SAS-TOKEN", "live-header-token");
+    var replayed = try playback.asTransport().send(&live);
+    replayed.deinit();
 }
 
 test "authenticated recording JSON roundtrips with structured redactions" {

--- a/root.zig
+++ b/root.zig
@@ -88,10 +88,12 @@ pub const BodySafetyContext = struct {
 };
 
 /// A caller body policy may add a schema-specific rejection or explicitly
-/// allow an otherwise opaque/unsupported body that the caller knows is safe.
+/// request built-in inspection of a supported textual body, or allow an
+/// otherwise opaque/unsupported body that the caller knows is safe.
 ///
-/// Built-in recognized credentials and private-key markers are never bypassed
-/// by `allow_opaque`.
+/// Every non-empty body requires a configured policy. Built-in recognizable
+/// credentials and private-key markers are checked before default rejection;
+/// the callback is the explicit trust boundary for persistence.
 pub const BodyPolicyDecision = enum {
     inspect,
     reject_sensitive,
@@ -109,6 +111,8 @@ pub const HeaderSafetyContext = struct {
 
 /// Header policy decisions are serialized into structured matching metadata.
 ///
+/// `inspect` applies the built-in known-safe header-name allowlist and scans
+/// every value; unknown names and recognizable credentials are redacted.
 /// `preserve` is an explicit escape hatch for application headers that the
 /// built-in conservative name rules classify as sensitive. The caller is
 /// responsible for proving that the value is safe to persist.
@@ -418,6 +422,11 @@ pub const RecordingTransport = struct {
 
     /// Serialize version 2 recordings with lossless base64 bodies while
     /// redacting sensitive header values and sensitive URL query parameters.
+    ///
+    /// Every non-empty body requires a configured `bodyPolicyFn`. Returning
+    /// `.inspect` explicitly opts supported text into built-in checks;
+    /// `.allow_opaque` is the caller's trust boundary for known-safe opaque
+    /// content.
     ///
     /// Structurally recognized credential-bearing JSON, form, connection
     /// string, XML, and private-key bodies cause
@@ -1522,6 +1531,49 @@ const sensitive_query_fields = [_][]const u8{
     "code",
 };
 
+const known_safe_headers = [_][]const u8{
+    "accept",
+    "accept-charset",
+    "accept-encoding",
+    "accept-language",
+    "cache-control",
+    "connection",
+    "content-encoding",
+    "content-language",
+    "content-length",
+    "content-range",
+    "content-type",
+    "date",
+    "etag",
+    "expires",
+    "host",
+    "if-match",
+    "if-modified-since",
+    "if-none-match",
+    "if-unmodified-since",
+    "last-modified",
+    "location",
+    "content-location",
+    "operation-location",
+    "azure-asyncoperation",
+    "pragma",
+    "range",
+    "retry-after",
+    "server",
+    "traceparent",
+    "tracestate",
+    "transfer-encoding",
+    "user-agent",
+    "vary",
+    "x-ms-client-request-id",
+    "x-ms-continuation-token",
+    "x-ms-date",
+    "x-ms-error-code",
+    "x-ms-request-id",
+    "x-ms-return-client-request-id",
+    "x-ms-version",
+};
+
 pub fn isSensitiveHeader(name: []const u8) bool {
     for (explicitly_sensitive_headers) |sensitive| {
         if (std.ascii.eqlIgnoreCase(name, sensitive)) return true;
@@ -1554,6 +1606,23 @@ pub fn isSensitiveHeader(name: []const u8) bool {
     return isFullyRedactedUrlHeader(name);
 }
 
+fn isKnownSafeHeader(name: []const u8) bool {
+    for (known_safe_headers) |safe| {
+        if (std.ascii.eqlIgnoreCase(name, safe)) return true;
+    }
+    return false;
+}
+
+fn shouldRedactHeader(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    value: []const u8,
+) !bool {
+    return isSensitiveHeader(name) or
+        try containsSensitiveScalar(allocator, value) or
+        !isKnownSafeHeader(name);
+}
+
 fn ensureExchangeBodySafe(
     allocator: std.mem.Allocator,
     options: RecordingOptions,
@@ -1578,10 +1647,11 @@ fn ensureExchangeBodySafe(
         .content_encoding = getHeaderPair(headers, "Content-Encoding"),
         .body = bytes,
     };
-    const decision = if (options.bodyPolicyFn) |policy|
-        policy(options.body_policy_context, context)
-    else
-        .inspect;
+    const policy = options.bodyPolicyFn orelse {
+        try ensureBodySafe(allocator, context, false);
+        return error.BodyPolicyRequired;
+    };
+    const decision = policy(options.body_policy_context, context);
     if (decision == .reject_sensitive)
         return error.SensitiveBodyRequiresSanitization;
     return ensureBodySafe(
@@ -1612,30 +1682,20 @@ fn ensureBodySafe(
         return;
     }
 
-    if (hasUnicodeBom(bytes) or
-        std.mem.indexOfScalar(u8, bytes, 0) != null or
-        declaresWideCharset(content_type) or
-        isBinaryContentType(content_type) or
-        (content_encoding.len != 0 and
-            !std.ascii.eqlIgnoreCase(
-                std.mem.trim(u8, content_encoding, " \t"),
-                "identity",
-            )) or
-        !std.unicode.utf8ValidateSlice(bytes))
-    {
-        if (!allow_opaque) return error.OpaqueBodyNotAllowed;
-        return;
-    }
+    const valid_text = !hasUnicodeBom(bytes) and
+        std.mem.indexOfScalar(u8, bytes, 0) == null and
+        std.unicode.utf8ValidateSlice(bytes);
+    const identity_encoding = content_encoding.len == 0 or
+        std.ascii.eqlIgnoreCase(
+            std.mem.trim(u8, content_encoding, " \t"),
+            "identity",
+        );
+    if (valid_text and try containsSensitiveScalar(allocator, bytes))
+        return error.SensitiveBodyRequiresSanitization;
 
-    const xml = containsIgnoreCase(content_type, "xml") or looksLikeXml(bytes);
-    if (xml) {
-        if (containsSensitiveXml(bytes) or containsSensitiveAssignment(bytes))
-            return error.SensitiveBodyRequiresSanitization;
-        if (!allow_opaque) return error.UnsupportedBodySanitization;
-        return;
-    }
-
-    if (isJsonContentType(content_type) or looksLikeStructuredJson(bytes)) {
+    const json = valid_text and identity_encoding and
+        (isJsonContentType(content_type) or looksLikeStructuredJson(bytes));
+    if (json) {
         const parsed = std.json.parseFromSlice(
             std.json.Value,
             allocator,
@@ -1646,12 +1706,32 @@ fn ensureBodySafe(
             else => return error.UnsupportedBodySanitization,
         };
         defer parsed.deinit();
-        if (jsonContainsSensitiveField(parsed.value) or
+        if (try jsonContainsSensitiveField(allocator, parsed.value) or
             jsonContainsExchangeSensitiveSchema(parsed.value, context))
         {
             return error.SensitiveBodyRequiresSanitization;
         }
     }
+
+    const xml = valid_text and identity_encoding and
+        (containsIgnoreCase(content_type, "xml") or looksLikeXml(bytes));
+    if (xml and
+        (containsSensitiveXml(bytes) or containsSensitiveAssignment(bytes)))
+    {
+        return error.SensitiveBodyRequiresSanitization;
+    }
+
+    if (!valid_text or
+        std.mem.indexOfScalar(u8, bytes, 0) != null or
+        declaresWideCharset(content_type) or
+        !isSupportedTextContentType(content_type) or
+        !identity_encoding)
+    {
+        if (!allow_opaque) return error.OpaqueBodyNotAllowed;
+        return;
+    }
+
+    if (xml or json) return;
     if (containsSensitiveAssignment(bytes) or
         containsSensitiveXml(bytes))
     {
@@ -1722,13 +1802,21 @@ fn jsonContainsExchangeSensitiveSchema(
             return true;
         }
         if (pathHasResource(target.path, "keys") and
-            jsonContainsJwkPrivateField(value))
+            (jsonRootHasField(value, "value") or
+                jsonContainsJwkPrivateField(value)))
         {
             return true;
         }
     }
     if (isKustoHost(target.host) and
         jsonContainsField(value, "sourceuri"))
+    {
+        return true;
+    }
+    if (isAzureManagementHost(target.host) and
+        isAzureKeyManagementPath(target.path) and
+        (jsonRootHasField(value, "key1") or
+            jsonRootHasField(value, "key2")))
     {
         return true;
     }
@@ -1867,6 +1955,24 @@ fn isKustoHost(host: []const u8) bool {
         hostMatches(host, "kusto.fabric.microsoft.com");
 }
 
+fn isAzureManagementHost(host: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(host, "management.azure.com") or
+        std.ascii.eqlIgnoreCase(host, "management.azure.cn") or
+        std.ascii.eqlIgnoreCase(host, "management.usgovcloudapi.net") or
+        std.ascii.eqlIgnoreCase(host, "management.microsoftazure.de");
+}
+
+fn isAzureKeyManagementPath(path: []const u8) bool {
+    const recognized_provider =
+        pathHasResource(path, "Microsoft.EventGrid") or
+        pathHasResource(path, "Microsoft.CognitiveServices");
+    const recognized_action =
+        pathHasResource(path, "listKeys") or
+        pathHasResource(path, "regenerateKey") or
+        pathHasResource(path, "regenerateKeys");
+    return recognized_provider and recognized_action;
+}
+
 fn pathHasResource(path: []const u8, resource: []const u8) bool {
     var segments = std.mem.splitScalar(u8, path, '/');
     while (segments.next()) |segment| {
@@ -1900,29 +2006,34 @@ fn isJsonContentType(content_type: []const u8) bool {
         containsIgnoreCase(content_type, "+json");
 }
 
-fn isBinaryContentType(content_type: []const u8) bool {
-    return containsIgnoreCase(content_type, "application/octet-stream") or
-        containsIgnoreCase(content_type, "application/pkcs12") or
-        containsIgnoreCase(content_type, "application/x-pkcs12") or
-        containsIgnoreCase(content_type, "application/pkcs8") or
-        containsIgnoreCase(content_type, "application/x-pem-file") or
-        containsIgnoreCase(content_type, "application/zip") or
-        containsIgnoreCase(content_type, "application/gzip") or
-        containsIgnoreCase(content_type, "application/x-gzip") or
-        containsIgnoreCase(content_type, "image/") or
-        containsIgnoreCase(content_type, "audio/") or
-        containsIgnoreCase(content_type, "video/") or
-        containsIgnoreCase(content_type, "font/");
+fn isSupportedTextContentType(content_type: []const u8) bool {
+    const trimmed = std.mem.trim(u8, content_type, " \t");
+    if (trimmed.len == 0) return true;
+    return std.ascii.startsWithIgnoreCase(trimmed, "text/") or
+        isJsonContentType(trimmed) or
+        containsIgnoreCase(trimmed, "/xml") or
+        containsIgnoreCase(trimmed, "+xml") or
+        std.ascii.startsWithIgnoreCase(
+            trimmed,
+            "application/x-www-form-urlencoded",
+        ) or
+        std.ascii.startsWithIgnoreCase(trimmed, "application/javascript") or
+        std.ascii.startsWithIgnoreCase(trimmed, "application/ecmascript") or
+        std.ascii.startsWithIgnoreCase(trimmed, "application/graphql");
 }
 
-fn jsonContainsSensitiveField(value: std.json.Value) bool {
-    return jsonContainsSensitiveFieldInContext(value, false);
+fn jsonContainsSensitiveField(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !bool {
+    return jsonContainsSensitiveFieldInContext(allocator, value, false);
 }
 
 fn jsonContainsSensitiveFieldInContext(
+    allocator: std.mem.Allocator,
     value: std.json.Value,
     sensitive_container: bool,
-) bool {
+) !bool {
     switch (value) {
         .object => |object| {
             var iterator = object.iterator();
@@ -1930,7 +2041,8 @@ fn jsonContainsSensitiveFieldInContext(
                 if (isSensitiveBodyField(entry.key_ptr.*) or
                     (sensitive_container and
                         normalizedFieldEquals(entry.key_ptr.*, "value")) or
-                    jsonContainsSensitiveFieldInContext(
+                    try jsonContainsSensitiveFieldInContext(
+                        allocator,
                         entry.value_ptr.*,
                         sensitive_container or
                             isSensitiveBodyContainer(entry.key_ptr.*),
@@ -1942,23 +2054,30 @@ fn jsonContainsSensitiveFieldInContext(
         },
         .array => |array| {
             for (array.items) |item| {
-                if (jsonContainsSensitiveFieldInContext(
+                if (try jsonContainsSensitiveFieldInContext(
+                    allocator,
                     item,
                     sensitive_container,
                 )) return true;
             }
         },
-        .string => |string| return containsSensitiveScalar(string),
+        .string => |string| return containsSensitiveScalar(allocator, string),
         else => {},
     }
     return false;
 }
 
-fn containsSensitiveScalar(value: []const u8) bool {
+fn containsSensitiveScalar(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !bool {
     return containsPrivateKeyMarker(value) or
         containsSensitiveAssignment(value) or
         containsSasCredential(value) or
-        looksLikeJwt(value);
+        containsIgnoreCase(value, "Bearer ") or
+        containsIgnoreCase(value, "SharedKey ") or
+        containsIgnoreCase(value, "SharedKeyLite ") or
+        try containsJwtToken(allocator, value);
 }
 
 fn containsSasCredential(value: []const u8) bool {
@@ -1977,20 +2096,104 @@ fn containsSasCredential(value: []const u8) bool {
             containsIgnoreCase(value, "&s="));
 }
 
-fn looksLikeJwt(value: []const u8) bool {
+fn looksLikeJwt(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !bool {
     const trimmed = std.mem.trim(u8, value, " \t\r\n");
-    var dots: usize = 0;
-    for (trimmed) |byte| {
-        if (byte == '.') {
-            dots += 1;
-        } else if (!std.ascii.isAlphanumeric(byte) and
-            byte != '-' and
-            byte != '_')
-        {
-            return false;
-        }
+    var segments = std.mem.splitScalar(u8, trimmed, '.');
+    const encoded_header = segments.next() orelse return false;
+    const encoded_payload = segments.next() orelse return false;
+    const encoded_signature = segments.next() orelse return false;
+    if (segments.next() != null or
+        encoded_header.len == 0 or
+        encoded_payload.len == 0 or
+        encoded_signature.len < 16)
+    {
+        return false;
     }
-    return dots == 2 and trimmed.len >= 24;
+
+    const signature = decodeJwtSegment(
+        allocator,
+        encoded_signature,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return false,
+    };
+    defer allocator.free(signature);
+    if (signature.len < 12) return false;
+
+    const header = decodeJwtSegment(allocator, encoded_header) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return false,
+    };
+    defer allocator.free(header);
+    const payload = decodeJwtSegment(allocator, encoded_payload) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return false,
+    };
+    defer allocator.free(payload);
+    return try isPlausibleJwtObject(allocator, header, true) and
+        try isPlausibleJwtObject(allocator, payload, false);
+}
+
+fn containsJwtToken(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+) !bool {
+    var tokens = std.mem.tokenizeAny(
+        u8,
+        value,
+        " \t\r\n\"'[](){},;:=<>",
+    );
+    while (tokens.next()) |token| {
+        if (try looksLikeJwt(allocator, token)) return true;
+    }
+    return false;
+}
+
+fn decodeJwtSegment(
+    allocator: std.mem.Allocator,
+    encoded: []const u8,
+) ![]u8 {
+    const size = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(
+        encoded,
+    ) catch return error.InvalidBase64;
+    const decoded = try allocator.alloc(u8, size);
+    errdefer allocator.free(decoded);
+    std.base64.url_safe_no_pad.Decoder.decode(
+        decoded,
+        encoded,
+    ) catch return error.InvalidBase64;
+    return decoded;
+}
+
+fn isPlausibleJwtObject(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+    require_alg: bool,
+) !bool {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    const parsed = std.json.parseFromSlice(
+        std.json.Value,
+        allocator,
+        trimmed,
+        .{},
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return false,
+    };
+    defer parsed.deinit();
+    const object = switch (parsed.value) {
+        .object => |result| result,
+        else => return false,
+    };
+    if (!require_alg) return true;
+    const alg = object.get("alg") orelse return false;
+    return switch (alg) {
+        .string => |name| name.len != 0,
+        else => false,
+    };
 }
 
 fn isSensitiveBodyContainer(name: []const u8) bool {
@@ -2239,7 +2442,11 @@ fn writeHeaders(
         const redact = header.redacted or switch (decision) {
             .redact => true,
             .preserve => false,
-            .inspect => isSensitiveHeader(header.name),
+            .inspect => try shouldRedactHeader(
+                allocator,
+                header.name,
+                header.value,
+            ),
         };
         if (redact) {
             try writeJsonString(writer, redacted_value);
@@ -2461,11 +2668,27 @@ fn allowKnownSafeOpaqueBody(
         .inspect;
 }
 
+fn inspectKnownSafeBody(
+    _: ?*anyopaque,
+    _: BodySafetyContext,
+) BodyPolicyDecision {
+    return .inspect;
+}
+
+fn allowOpaqueBody(
+    _: ?*anyopaque,
+    _: BodySafetyContext,
+) BodyPolicyDecision {
+    return .allow_opaque;
+}
+
 fn preserveKnownSafeMetadata(
     _: ?*anyopaque,
     header: HeaderSafetyContext,
 ) HeaderPolicyDecision {
     if (std.ascii.eqlIgnoreCase(header.name, "x-ms-meta-pwd"))
+        return .preserve;
+    if (std.ascii.eqlIgnoreCase(header.name, "x-stable"))
         return .preserve;
     if (std.ascii.eqlIgnoreCase(header.name, "x-application-auth-material"))
         return .redact;
@@ -2911,9 +3134,10 @@ test "recording and playback preserve streaming redirect sequences" {
 test "recording JSON redacts headers and URL query credentials" {
     var mock = core.http.MockTransport.init(std.testing.allocator, 200, "ok");
     defer mock.deinit();
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -2960,6 +3184,12 @@ test "sensitive Azure headers are classified case-insensitively" {
 }
 
 test "sensitive metadata headers redact with configurable exact overrides" {
+    const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
+        "." ++
+        "eyJzdWIiOiJoZWFkZXIiLCJleHAiOjQxMDI0NDQ4MDB9" ++
+        "." ++
+        "c2lnbmF0dXJlLWJ5dGVzLXZhbHVl";
     var mock = core.http.MockTransport.init(
         std.testing.allocator,
         200,
@@ -2969,11 +3199,19 @@ test "sensitive metadata headers redact with configurable exact overrides" {
     mock.response_headers_list = &.{
         .{ .name = "X-MS-META-PASSWORD", .value = "response-password-value" },
         .{ .name = "x-ms-meta-private-key", .value = "cmVzcG9uc2Uta2V5" },
+        .{
+            .name = "x-ms-meta-source-uri",
+            .value = "https://storage.example/blob?sig=response-source-sas",
+        },
+        .{ .name = "ETag", .value = jwt },
     };
     var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
-        .{ .headerPolicyFn = &preserveKnownSafeMetadata },
+        .{
+            .bodyPolicyFn = &inspectKnownSafeBody,
+            .headerPolicyFn = &preserveKnownSafeMetadata,
+        },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -2990,6 +3228,17 @@ test "sensitive metadata headers redact with configurable exact overrides" {
     );
     try request.setHeader("X-MS-META-PWD", "known-safe-label");
     try request.setHeader(
+        "x-ms-meta-source-uri",
+        "https://storage.example/blob?sig=request-source-sas",
+    );
+    try request.setHeader("x-ms-meta-label", "unknown-metadata-value");
+    try request.setHeader("ETag", jwt);
+    try request.setHeader(
+        "Content-Language",
+        "Endpoint=https://example;AccountKey=header-account-key",
+    );
+    try request.setHeader("x-ms-request-id", "service.production.contoso");
+    try request.setHeader(
         "X-Application-Auth-Material",
         "custom-sensitive-value",
     );
@@ -3005,6 +3254,11 @@ test "sensitive metadata headers redact with configurable exact overrides" {
         "cmVxdWVzdC1rZXk=",
         "RW5kcG9pbnQ9eDtBY2NvdW50S2V5PXk=",
         "custom-sensitive-value",
+        "response-source-sas",
+        "request-source-sas",
+        "unknown-metadata-value",
+        "header-account-key",
+        jwt,
     }) |secret| {
         try std.testing.expect(std.mem.indexOf(u8, json, secret) == null);
     }
@@ -3014,6 +3268,24 @@ test "sensitive metadata headers redact with configurable exact overrides" {
 
     var parsed = try parseJson(std.testing.allocator, json);
     defer parsed.deinit();
+    for (parsed.asSlice()[0].request_headers) |header| {
+        if (header.redacted) {
+            try std.testing.expectEqualStrings(redacted_value, header.value);
+        } else {
+            try std.testing.expect(
+                std.mem.eql(u8, header.value, "known-safe-label") or
+                    std.mem.eql(
+                        u8,
+                        header.value,
+                        "service.production.contoso",
+                    ),
+            );
+        }
+    }
+    for (parsed.asSlice()[0].response_headers) |header| {
+        try std.testing.expect(header.redacted);
+        try std.testing.expectEqualStrings(redacted_value, header.value);
+    }
     var playback = PlaybackTransport.init(
         std.testing.allocator,
         parsed.asSlice(),
@@ -3031,6 +3303,17 @@ test "sensitive metadata headers redact with configurable exact overrides" {
         "rotated-connection-string",
     );
     try live.setHeader("x-ms-meta-pwd", "known-safe-label");
+    try live.setHeader(
+        "x-ms-meta-source-uri",
+        "https://storage.example/blob?sig=rotated-source-sas",
+    );
+    try live.setHeader("x-ms-meta-label", "rotated-metadata");
+    try live.setHeader("ETag", "rotated-jwt");
+    try live.setHeader(
+        "Content-Language",
+        "Endpoint=https://example;AccountKey=rotated-account-key",
+    );
+    try live.setHeader("x-ms-request-id", "service.production.contoso");
     try live.setHeader("x-application-auth-material", "rotated-custom-value");
     var replayed = try playback.asTransport().send(&live);
     replayed.deinit();
@@ -3057,9 +3340,10 @@ test "Event Grid key and SAS token redactions roundtrip" {
         .{ .name = "aEg-SaS-KeY", .value = "response-event-grid-key" },
         .{ .name = "AEG-SAS-TOKEN", .value = "response-event-grid-token" },
     };
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -3113,9 +3397,10 @@ test "Azure Files rename source URL redactions roundtrip" {
         "accepted",
     );
     defer mock.deinit();
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -3178,9 +3463,10 @@ test "App Configuration key query remains exact" {
         "setting",
     );
     defer mock.deinit();
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -3236,9 +3522,13 @@ test "authenticated recording JSON roundtrips with structured redactions" {
             .value = "https://storage.example/source?sig=response-copy-secret",
         },
     };
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{
+            .bodyPolicyFn = &inspectKnownSafeBody,
+            .headerPolicyFn = &preserveKnownSafeMetadata,
+        },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -3585,9 +3875,10 @@ test "Key Vault path text on App Configuration hosts stays recordable and exact"
     mock.response_headers_list = &.{
         .{ .name = "Content-Type", .value = "application/json" },
     };
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -3647,9 +3938,10 @@ test "Key Vault exchange rules ignore untrusted origins" {
             body,
         );
         defer mock.deinit();
-        var recorder = RecordingTransport.init(
+        var recorder = RecordingTransport.initWithOptions(
             std.testing.allocator,
             mock.asTransport(),
+            .{ .bodyPolicyFn = &inspectKnownSafeBody },
         );
         defer recorder.deinit();
         var request = core.http.Request.init(
@@ -3729,12 +4021,154 @@ test "Key Vault private JWK and certificate import schemas are rejected" {
     }
 }
 
+test "Key Vault key operation root values are rejected" {
+    for ([_][]const u8{
+        "/keys/name/version/encrypt",
+        "/keys/name/version/decrypt",
+        "/keys/name/version/wrapkey",
+        "/keys/name/version/unwrapkey",
+        "/keys/name/backup",
+        "/keys/restore",
+        "/keys/name/version/release",
+    }) |path| {
+        const url = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "https://example.vault.azure.net{s}?api-version=7.6",
+            .{path},
+        );
+        defer std.testing.allocator.free(url);
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"value\":\"operation-secret-value\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{"operation-secret-value"},
+        );
+    }
+
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var restore = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.vault.azure.net/keys/restore?api-version=7.6",
+    );
+    defer restore.deinit();
+    restore.body = "{\"value\":\"backup-blob-secret\"}";
+    var response = try recorder.asTransport().send(&restore);
+    response.deinit();
+    try expectRejectedSerializationExcludes(
+        &recorder,
+        error.SensitiveBodyRequiresSanitization,
+        &.{"backup-blob-secret"},
+    );
+
+    var opaque_mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "{\"value\":\"mislabelled-backup-secret\"}",
+    );
+    defer opaque_mock.deinit();
+    opaque_mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/pdf" },
+    };
+    var opaque_recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        opaque_mock.asTransport(),
+        .{ .bodyPolicyFn = &allowOpaqueBody },
+    );
+    defer opaque_recorder.deinit();
+    var backup = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://example.vault.azure.net/keys/name/backup?api-version=7.6",
+    );
+    defer backup.deinit();
+    var opaque_response = try opaque_recorder.asTransport().send(&backup);
+    opaque_response.deinit();
+    try expectRejectedSerializationExcludes(
+        &opaque_recorder,
+        error.SensitiveBodyRequiresSanitization,
+        &.{"mislabelled-backup-secret"},
+    );
+}
+
+test "Azure key management key1 and key2 responses are rejected" {
+    for ([_][]const u8{
+        "https://management.azure.com/subscriptions/s/resourceGroups/r/providers/Microsoft.EventGrid/topics/t/listKeys?api-version=2025-02-15",
+        "https://management.azure.com/subscriptions/s/resourceGroups/r/providers/Microsoft.CognitiveServices/accounts/a/regenerateKey?api-version=2024-10-01",
+    }) |url| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            "{\"KeY1\":\"first-service-key\",\"key2\":\"second-service-key\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{ "first-service-key", "second-service-key" },
+        );
+    }
+}
+
 test "Kusto source URIs and tabular credential scalars are rejected" {
+    const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
+        "." ++
+        "eyJzdWIiOiJpZGVudGl0eSIsImV4cCI6NDEwMjQ0NDgwMH0" ++
+        "." ++
+        "c2lnbmF0dXJlLWJ5dGVzLXZhbHVl";
+    const jwt_body = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"Tables\":[{{\"Rows\":[[\"{s}\"]]}}]}}",
+        .{jwt},
+    );
+    defer std.testing.allocator.free(jwt_body);
     for ([_][]const u8{
         "{\"sourceUri\":\"https://storage.example/container?sig=kusto-source-sas\"}",
         "{\"Tables\":[{\"Rows\":[[\"https://storage.example/blob?sig=row-sas\"]]}]}",
         "{\"Tables\":[{\"Rows\":[[\"https%3A%2F%2Fstorage.example%2Fblob%3Fsv%3D1%26sig%3Dencoded-sas\"]]}]}",
-        "{\"Tables\":[{\"Rows\":[[\"aaaaaaaa.bbbbbbbb.cccccccc\"]]}]}",
+        jwt_body,
     }) |body| {
         var mock = core.http.MockTransport.init(
             std.testing.allocator,
@@ -3762,8 +4196,56 @@ test "Kusto source URIs and tabular credential scalars are rejected" {
                 "kusto-source-sas",
                 "row-sas",
                 "encoded-sas",
-                "aaaaaaaa.bbbbbbbb.cccccccc",
+                jwt,
             },
+        );
+    }
+}
+
+test "plain text signed URLs and structurally valid JWTs are rejected" {
+    const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
+        "." ++
+        "eyJzdWIiOiJpZGVudGl0eSIsImV4cCI6NDEwMjQ0NDgwMH0" ++
+        "." ++
+        "c2lnbmF0dXJlLWJ5dGVzLXZhbHVl";
+    const jwt_text = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "identity token: {s}",
+        .{jwt},
+    );
+    defer std.testing.allocator.free(jwt_text);
+    for ([_][]const u8{
+        "https://storage.example/container/blob?sv=2026-01-01&sig=plain-sas",
+        jwt_text,
+    }) |body| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            body,
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{ .name = "Content-Type", .value = "text/plain" },
+        };
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &inspectKnownSafeBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            "https://example.test/plain",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{body},
         );
     }
 }
@@ -3962,6 +4444,31 @@ test "declared encodings and opaque MIME bodies require explicit approval" {
             .expected_error = error.OpaqueBodyNotAllowed,
         },
         .{
+            .content_type = "application/pdf",
+            .body = "%PDF-printable-fixture",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
+            .content_type = "application/cbor",
+            .body = "cbor-container-fixture",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
+            .content_type = "application/pkcs7-mime",
+            .body = "pkcs7-container-fixture",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
+            .content_type = "application/x-protobuf",
+            .body = "protobuf-container-fixture",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
+            .content_type = "application/vnd.contoso.binary",
+            .body = "vendor-container-fixture",
+            .expected_error = error.OpaqueBodyNotAllowed,
+        },
+        .{
             .content_type = "application/json",
             .content_encoding = "gzip",
             .body = "compressed-looking-body",
@@ -4005,6 +4512,79 @@ test "declared encodings and opaque MIME bodies require explicit approval" {
     }
 }
 
+test "non-empty bodies require an explicit caller policy" {
+    for ([_]bool{ false, true }) |request_has_body| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            if (request_has_body) "" else "{\"message\":\"ordinary\"}",
+        );
+        defer mock.deinit();
+        var recorder = RecordingTransport.init(
+            std.testing.allocator,
+            mock.asTransport(),
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            if (request_has_body) .POST else .GET,
+            "https://example.test/default-policy",
+        );
+        defer request.deinit();
+        if (request_has_body) request.body = "{\"message\":\"ordinary\"}";
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try std.testing.expectError(
+            error.BodyPolicyRequired,
+            recorder.toJson(std.testing.allocator),
+        );
+    }
+}
+
+test "App Configuration dotted values are not mistaken for JWTs" {
+    const body =
+        "{\"key\":\"endpoint\",\"key1\":\"configuration-label\",\"value\":\"service.production.contoso\"}";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        body,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "application/json" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://store.azconfig.io/kv/endpoint?api-version=1.0",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        body,
+        parsed.asSlice()[0].response_body,
+    );
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var replayed = try playback.asTransport().send(&request);
+    replayed.deinit();
+}
+
 test "recording JSON decodes safe structured bodies losslessly" {
     const request_body =
         "{\"key\":\"prod*\",\"value\":\"nonsensitive\",\"nested\":{\"kind\":\"filter\"}}";
@@ -4016,9 +4596,10 @@ test "recording JSON decodes safe structured bodies losslessly" {
         response_body,
     );
     defer mock.deinit();
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -4168,9 +4749,10 @@ fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
         "{\"message\":\"response\"}",
     );
     defer mock.deinit();
-    var recorder = RecordingTransport.init(
+    var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
+        .{ .bodyPolicyFn = &inspectKnownSafeBody },
     );
     defer recorder.deinit();
     var request = core.http.Request.init(
@@ -4181,6 +4763,37 @@ fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
     defer request.deinit();
     request.body = "{\"message\":\"request\"}";
     try request.setHeader("Authorization", "Bearer secret");
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(allocator);
+    allocator.free(json);
+}
+
+fn jwtHeaderAllocationFixture(allocator: std.mem.Allocator) !void {
+    const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
+        "." ++
+        "eyJzdWIiOiJoZWFkZXIiLCJleHAiOjQxMDI0NDQ4MDB9" ++
+        "." ++
+        "c2lnbmF0dXJlLWJ5dGVzLXZhbHVl";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.com",
+    );
+    defer request.deinit();
+    try request.setHeader("ETag", jwt);
     var response = try recorder.asTransport().send(&request);
     response.deinit();
     const json = try recorder.toJson(allocator);
@@ -4220,6 +4833,11 @@ test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         serializationAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        jwtHeaderAllocationFixture,
         .{},
     );
     try std.testing.checkAllAllocationFailures(

--- a/root.zig
+++ b/root.zig
@@ -111,8 +111,9 @@ pub const HeaderSafetyContext = struct {
 
 /// Header policy decisions are serialized into structured matching metadata.
 ///
-/// `inspect` applies the built-in known-safe header-name allowlist and scans
-/// every value; unknown names and recognizable credentials are redacted.
+/// `inspect` applies the built-in known-safe header-name allowlist, volatile
+/// request-header rules, and value scanning; unknown names and recognizable
+/// credentials are redacted.
 /// `preserve` is an explicit escape hatch for application headers that the
 /// built-in conservative name rules classify as sensitive. The caller is
 /// responsible for proving that the value is safe to persist.
@@ -1574,6 +1575,22 @@ const known_safe_headers = [_][]const u8{
     "x-ms-version",
 };
 
+const volatile_request_headers = [_][]const u8{
+    "date",
+    "x-ms-date",
+    "x-ms-client-request-id",
+    "client-request-id",
+    "request-id",
+    "x-request-id",
+    "x-ms-request-id",
+    "correlation-id",
+    "x-correlation-id",
+    "x-ms-correlation-request-id",
+    "x-ms-routing-request-id",
+    "traceparent",
+    "tracestate",
+};
+
 pub fn isSensitiveHeader(name: []const u8) bool {
     for (explicitly_sensitive_headers) |sensitive| {
         if (std.ascii.eqlIgnoreCase(name, sensitive)) return true;
@@ -1613,12 +1630,21 @@ fn isKnownSafeHeader(name: []const u8) bool {
     return false;
 }
 
+fn isVolatileRequestHeader(name: []const u8) bool {
+    for (volatile_request_headers) |header_name| {
+        if (std.ascii.eqlIgnoreCase(name, header_name)) return true;
+    }
+    return false;
+}
+
 fn shouldRedactHeader(
     allocator: std.mem.Allocator,
+    direction: BodyDirection,
     name: []const u8,
     value: []const u8,
 ) !bool {
-    return isSensitiveHeader(name) or
+    return (direction == .request and isVolatileRequestHeader(name)) or
+        isSensitiveHeader(name) or
         try containsSensitiveScalar(allocator, value) or
         !isKnownSafeHeader(name);
 }
@@ -1669,6 +1695,8 @@ fn ensureBodySafe(
     const bytes = context.body;
     if (containsPrivateKeyMarker(bytes))
         return error.SensitiveBodyRequiresSanitization;
+    if (try containsSensitiveScalar(allocator, bytes))
+        return error.SensitiveBodyRequiresSanitization;
 
     const content_type = context.content_type orelse "";
     const content_encoding = context.content_encoding orelse "";
@@ -1676,7 +1704,7 @@ fn ensureBodySafe(
         (containsIgnoreCase(bytes, "content-disposition:") and
             containsIgnoreCase(bytes, "form-data"));
     if (multipart) {
-        if (containsSensitiveMultipartField(bytes))
+        if (try containsSensitiveMultipartContent(allocator, bytes))
             return error.SensitiveBodyRequiresSanitization;
         if (!allow_opaque) return error.UnsupportedBodySanitization;
         return;
@@ -1690,9 +1718,6 @@ fn ensureBodySafe(
             std.mem.trim(u8, content_encoding, " \t"),
             "identity",
         );
-    if (valid_text and try containsSensitiveScalar(allocator, bytes))
-        return error.SensitiveBodyRequiresSanitization;
-
     const json = valid_text and identity_encoding and
         (isJsonContentType(content_type) or looksLikeStructuredJson(bytes));
     if (json) {
@@ -1782,6 +1807,99 @@ fn containsSensitiveMultipartField(body: []const u8) bool {
         search_start = line_end;
     }
     return false;
+}
+
+fn containsSensitiveMultipartContent(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !bool {
+    if (containsSensitiveMultipartField(body)) return true;
+    if (try containsSensitiveHttpHeaderLine(allocator, body)) return true;
+
+    const first_line_end = std.mem.indexOfAny(u8, body, "\r\n") orelse
+        return false;
+    const delimiter = std.mem.trim(u8, body[0..first_line_end], " \t");
+    if (!std.mem.startsWith(u8, delimiter, "--") or delimiter.len <= 2)
+        return false;
+
+    var parts = std.mem.splitSequence(u8, body, delimiter);
+    while (parts.next()) |raw_part| {
+        const part = std.mem.trim(u8, raw_part, " \t\r\n");
+        if (part.len == 0 or std.mem.eql(u8, part, "--")) continue;
+        const outer_separator = findHeaderSeparator(part) orelse continue;
+        var payload = part[outer_separator.end..];
+        if (looksLikeHttpMessage(payload)) {
+            const inner_separator = findHeaderSeparator(payload) orelse
+                continue;
+            payload = payload[inner_separator.end..];
+        }
+        payload = std.mem.trim(u8, payload, " \t\r\n");
+        if (payload.len == 0) continue;
+        if (try containsSensitiveScalar(allocator, payload)) return true;
+        if (looksLikeStructuredJson(payload)) {
+            const parsed = std.json.parseFromSlice(
+                std.json.Value,
+                allocator,
+                payload,
+                .{},
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => continue,
+            };
+            defer parsed.deinit();
+            if (try jsonContainsSensitiveField(allocator, parsed.value))
+                return true;
+        }
+        if (looksLikeXml(payload) and
+            (containsSensitiveXml(payload) or
+                containsSensitiveAssignment(payload)))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn containsSensitiveHttpHeaderLine(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !bool {
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const name = std.mem.trim(u8, line[0..colon], " \t");
+        if (name.len == 0 or std.mem.indexOfScalar(u8, name, ' ') != null)
+            continue;
+        const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
+        if (isSensitiveHeader(name) or
+            try containsSensitiveScalar(allocator, value))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+const HeaderSeparator = struct {
+    end: usize,
+};
+
+fn findHeaderSeparator(bytes: []const u8) ?HeaderSeparator {
+    if (std.mem.indexOf(u8, bytes, "\r\n\r\n")) |index|
+        return .{ .end = index + 4 };
+    if (std.mem.indexOf(u8, bytes, "\n\n")) |index|
+        return .{ .end = index + 2 };
+    return null;
+}
+
+fn looksLikeHttpMessage(bytes: []const u8) bool {
+    const trimmed = std.mem.trimStart(u8, bytes, " \t\r\n");
+    const line_end = std.mem.indexOfAny(u8, trimmed, "\r\n") orelse
+        trimmed.len;
+    const first_line = trimmed[0..line_end];
+    return std.ascii.startsWithIgnoreCase(first_line, "HTTP/") or
+        std.mem.indexOf(u8, first_line, " HTTP/") != null;
 }
 
 fn looksLikeXml(body: []const u8) bool {
@@ -2439,19 +2557,38 @@ fn writeHeaders(
             policy(options.header_policy_context, context)
         else
             .inspect;
-        const redact = header.redacted or switch (decision) {
-            .redact => true,
-            .preserve => false,
-            .inspect => try shouldRedactHeader(
-                allocator,
-                header.name,
-                header.value,
-            ),
+        var sanitized_url: ?[]u8 = null;
+        defer if (sanitized_url) |url| allocator.free(url);
+        var redact = header.redacted;
+        if (!redact) switch (decision) {
+            .redact => redact = true,
+            .preserve => {},
+            .inspect => if (isSanitizedUrlHeader(header.name)) {
+                if (try canSanitizeLocationHeader(allocator, header.value)) {
+                    sanitized_url = sanitizeUrlAlloc(
+                        allocator,
+                        header.value,
+                    ) catch |err| switch (err) {
+                        error.SensitiveUrlRequiresSanitization => null,
+                        else => return err,
+                    };
+                    redact = sanitized_url == null;
+                } else {
+                    redact = true;
+                }
+            } else {
+                redact = try shouldRedactHeader(
+                    allocator,
+                    direction,
+                    header.name,
+                    header.value,
+                );
+            },
         };
         if (redact) {
             try writeJsonString(writer, redacted_value);
-        } else if (isSanitizedUrlHeader(header.name)) {
-            try writeSanitizedUrl(writer, allocator, header.value);
+        } else if (sanitized_url) |url| {
+            try writeJsonString(writer, url);
         } else {
             try writeJsonString(writer, header.value);
         }
@@ -2459,6 +2596,80 @@ fn writeHeaders(
         try writer.writeByte('}');
     }
     try writer.writeByte(']');
+}
+
+fn canSanitizeLocationHeader(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+) !bool {
+    if (url.len == 0 or
+        std.mem.indexOfAny(u8, url, "\x00\r\n") != null)
+    {
+        return false;
+    }
+    if (std.mem.indexOf(u8, url, "://")) |scheme_end| {
+        const scheme = url[0..scheme_end];
+        if (!std.ascii.eqlIgnoreCase(scheme, "https") and
+            !std.ascii.eqlIgnoreCase(scheme, "http"))
+        {
+            return false;
+        }
+        const authority_start = scheme_end + 3;
+        const authority_end = std.mem.indexOfAnyPos(
+            u8,
+            url,
+            authority_start,
+            "/?#",
+        ) orelse url.len;
+        const authority = url[authority_start..authority_end];
+        if (authority.len == 0 or
+            std.mem.indexOfScalar(u8, authority, '@') != null)
+        {
+            return false;
+        }
+    } else if (std.mem.startsWith(u8, url, "//")) {
+        return false;
+    }
+
+    const question = std.mem.indexOfScalar(u8, url, '?') orelse {
+        return !try containsSensitiveScalar(allocator, url);
+    };
+    if (try containsSensitiveScalar(allocator, url[0..question]))
+        return false;
+    const fragment = std.mem.indexOfScalarPos(
+        u8,
+        url,
+        question + 1,
+        '#',
+    ) orelse url.len;
+    var parameters = std.mem.splitScalar(
+        u8,
+        url[question + 1 .. fragment],
+        '&',
+    );
+    while (parameters.next()) |parameter| {
+        const equals = std.mem.indexOfScalar(u8, parameter, '=') orelse {
+            if (try containsSensitiveScalar(allocator, parameter))
+                return false;
+            continue;
+        };
+        var decoded_name_buffer: [256]u8 = undefined;
+        const decoded_name = percentDecodeFieldName(
+            parameter[0..equals],
+            &decoded_name_buffer,
+        ) orelse return false;
+        if (isSensitiveQueryField(decoded_name)) continue;
+        if (try containsSensitiveScalar(
+            allocator,
+            parameter[equals + 1 ..],
+        )) return false;
+    }
+    if (fragment != url.len and
+        try containsSensitiveScalar(allocator, url[fragment + 1 ..]))
+    {
+        return false;
+    }
+    return true;
 }
 
 fn writeSanitizedUrl(
@@ -2528,8 +2739,11 @@ fn sanitizeUrlAlloc(
 }
 
 fn isSensitiveQueryField(name: []const u8) bool {
+    var decoded_buffer: [256]u8 = undefined;
+    const candidate = percentDecodeFieldName(name, &decoded_buffer) orelse
+        name;
     for (sensitive_query_fields) |sensitive| {
-        if (std.ascii.eqlIgnoreCase(name, sensitive)) return true;
+        if (std.ascii.eqlIgnoreCase(candidate, sensitive)) return true;
     }
     return false;
 }
@@ -2693,6 +2907,16 @@ fn preserveKnownSafeMetadata(
     if (std.ascii.eqlIgnoreCase(header.name, "x-application-auth-material"))
         return .redact;
     return .inspect;
+}
+
+fn preserveRequestDate(
+    _: ?*anyopaque,
+    header: HeaderSafetyContext,
+) HeaderPolicyDecision {
+    return if (std.ascii.eqlIgnoreCase(header.name, "x-ms-date"))
+        .preserve
+    else
+        .inspect;
 }
 
 fn expectRejectedSerializationExcludes(
@@ -3237,7 +3461,7 @@ test "sensitive metadata headers redact with configurable exact overrides" {
         "Content-Language",
         "Endpoint=https://example;AccountKey=header-account-key",
     );
-    try request.setHeader("x-ms-request-id", "service.production.contoso");
+    try request.setHeader("User-Agent", "service.production.contoso");
     try request.setHeader(
         "X-Application-Auth-Material",
         "custom-sensitive-value",
@@ -3313,7 +3537,7 @@ test "sensitive metadata headers redact with configurable exact overrides" {
         "Content-Language",
         "Endpoint=https://example;AccountKey=rotated-account-key",
     );
-    try live.setHeader("x-ms-request-id", "service.production.contoso");
+    try live.setHeader("User-Agent", "service.production.contoso");
     try live.setHeader("x-application-auth-material", "rotated-custom-value");
     var replayed = try playback.asTransport().send(&live);
     replayed.deinit();
@@ -3326,6 +3550,141 @@ test "sensitive metadata headers redact with configurable exact overrides" {
     try std.testing.expectError(
         error.HeaderMismatch,
         mismatch.asTransport().send(&live),
+    );
+}
+
+test "Core request ID pipeline replays with changed volatile headers" {
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer mock.deinit();
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        mock.asTransport(),
+    );
+    defer recorder.deinit();
+    var recording_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var recording_request_id = core.http.RequestIdPolicy.init();
+    var recording_policies = [_]*core.http.HttpPolicy{
+        recording_request_id.asPolicy(),
+    };
+    var recording_pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(
+            recorder.asTransport(),
+            recording_crypto.asProvider(),
+        ),
+        &recording_policies,
+    );
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/volatile",
+    );
+    defer request.deinit();
+    try request.setHeader("x-ms-date", "Sat, 29 Aug 2026 05:00:00 GMT");
+    try request.setHeader("Date", "Sat, 29 Aug 2026 05:00:00 GMT");
+    try request.setHeader(
+        "traceparent",
+        "00-11111111111111111111111111111111-2222222222222222-01",
+    );
+    try request.setHeader("tracestate", "vendor=first");
+    try request.setHeader("x-correlation-id", "first-correlation");
+    var response = try recording_pipeline.send(&request);
+    response.deinit();
+    const recorded_id = try std.testing.allocator.dupe(
+        u8,
+        request.getHeader("x-ms-client-request-id").?,
+    );
+    defer std.testing.allocator.free(recorded_id);
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    for (parsed.asSlice()[0].request_headers) |header| {
+        try std.testing.expect(header.redacted);
+        try std.testing.expectEqualStrings(redacted_value, header.value);
+    }
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        parsed.asSlice(),
+    );
+    var playback_crypto = core.crypto.StdCryptoProvider.init(std.testing.io);
+    var playback_request_id = core.http.RequestIdPolicy.init();
+    var playback_policies = [_]*core.http.HttpPolicy{
+        playback_request_id.asPolicy(),
+    };
+    var playback_pipeline = core.http.HttpPipeline.init(
+        initHttpRuntime(
+            playback.asTransport(),
+            playback_crypto.asProvider(),
+        ),
+        &playback_policies,
+    );
+    var live = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/volatile",
+    );
+    defer live.deinit();
+    try live.setHeader("x-ms-date", "Sat, 29 Aug 2026 06:00:00 GMT");
+    try live.setHeader("Date", "Sat, 29 Aug 2026 06:00:00 GMT");
+    try live.setHeader(
+        "traceparent",
+        "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    );
+    try live.setHeader("tracestate", "vendor=second");
+    try live.setHeader("x-correlation-id", "second-correlation");
+    var replayed = try playback_pipeline.send(&live);
+    replayed.deinit();
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        recorded_id,
+        live.getHeader("x-ms-client-request-id").?,
+    ));
+
+    var exact_mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        "",
+    );
+    defer exact_mock.deinit();
+    var exact_recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        exact_mock.asTransport(),
+        .{ .headerPolicyFn = &preserveRequestDate },
+    );
+    defer exact_recorder.deinit();
+    var exact_request = core.http.Request.init(
+        std.testing.allocator,
+        .GET,
+        "https://example.test/exact-date",
+    );
+    defer exact_request.deinit();
+    try exact_request.setHeader(
+        "x-ms-date",
+        "Sat, 29 Aug 2026 05:00:00 GMT",
+    );
+    var exact_response = try exact_recorder.asTransport().send(&exact_request);
+    exact_response.deinit();
+    const exact_json = try exact_recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(exact_json);
+    var exact_parsed = try parseJson(std.testing.allocator, exact_json);
+    defer exact_parsed.deinit();
+    var exact_playback = PlaybackTransport.init(
+        std.testing.allocator,
+        exact_parsed.asSlice(),
+    );
+    try exact_request.setHeader(
+        "x-ms-date",
+        "Sat, 29 Aug 2026 06:00:00 GMT",
+    );
+    try std.testing.expectError(
+        error.HeaderMismatch,
+        exact_playback.asTransport().send(&exact_request),
     );
 }
 
@@ -3590,6 +3949,7 @@ test "authenticated recording JSON roundtrips with structured redactions" {
     }) |secret| {
         try std.testing.expect(std.mem.indexOf(u8, json, secret) == null);
     }
+
     try std.testing.expect(
         std.mem.indexOf(u8, json, "https://storage.example/source") == null,
     );
@@ -3667,6 +4027,136 @@ test "authenticated recording JSON roundtrips with structured redactions" {
         error.BodyMismatch,
         body_mismatch.asTransport().send(&live),
     );
+}
+
+test "location headers preserve replayable URLs and rotated SAS next exchanges" {
+    var sequence = core.http.SequenceMockTransport.init(
+        std.testing.allocator,
+        &.{
+            .{
+                .status = 302,
+                .body = "",
+                .headers = &.{
+                    .{
+                        .name = "Location",
+                        .value = "https://example.test/final?sig=first-location-sas&mode=one",
+                    },
+                    .{
+                        .name = "Content-Location",
+                        .value = "/content/item?%73ig=content-sas&view=full",
+                    },
+                    .{
+                        .name = "Operation-Location",
+                        .value = "https://user:userinfo-secret@example.test/unsafe",
+                    },
+                },
+            },
+            .{
+                .status = 202,
+                .body = "",
+                .headers = &.{
+                    .{
+                        .name = "Operation-Location",
+                        .value = "https://example.test/operations/1?sig=operation-sas&api-version=1",
+                    },
+                    .{
+                        .name = "Azure-AsyncOperation",
+                        .value = "/operations/1/status?sig=async-sas&api-version=1",
+                    },
+                },
+            },
+            .{ .status = 200, .body = "" },
+        },
+    );
+    var recorder = RecordingTransport.init(
+        std.testing.allocator,
+        sequence.asTransport(),
+    );
+    defer recorder.deinit();
+    for ([_][]const u8{
+        "https://example.test/start",
+        "https://example.test/final?sig=first-location-sas&mode=one",
+        "https://example.test/operations/1?sig=operation-sas&api-version=1",
+    }) |url| {
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+    }
+
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    for ([_][]const u8{
+        "first-location-sas",
+        "content-sas",
+        "operation-sas",
+        "async-sas",
+        "userinfo-secret",
+    }) |secret| {
+        try std.testing.expect(std.mem.indexOf(u8, json, secret) == null);
+    }
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    const recordings = parsed.asSlice();
+    try std.testing.expectEqualStrings(
+        "https://example.test/final?sig=REDACTED&mode=one",
+        getHeaderPair(recordings[0].response_headers, "Location").?,
+    );
+    try std.testing.expectEqualStrings(
+        "/content/item?%73ig=REDACTED&view=full",
+        getHeaderPair(recordings[0].response_headers, "Content-Location").?,
+    );
+    try std.testing.expectEqualStrings(
+        redacted_value,
+        getHeaderPair(recordings[0].response_headers, "Operation-Location").?,
+    );
+    try std.testing.expectEqualStrings(
+        "https://example.test/operations/1?sig=REDACTED&api-version=1",
+        getHeaderPair(
+            recordings[1].response_headers,
+            "Operation-Location",
+        ).?,
+    );
+    try std.testing.expectEqualStrings(
+        "/operations/1/status?sig=REDACTED&api-version=1",
+        getHeaderPair(
+            recordings[1].response_headers,
+            "Azure-AsyncOperation",
+        ).?,
+    );
+    for (recordings[0].response_headers) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, "Operation-Location")) {
+            try std.testing.expect(header.redacted);
+        } else {
+            try std.testing.expect(!header.redacted);
+        }
+    }
+    for (recordings[1].response_headers) |header| {
+        try std.testing.expect(!header.redacted);
+    }
+
+    var playback = PlaybackTransport.init(
+        std.testing.allocator,
+        recordings,
+    );
+    for ([_][]const u8{
+        "https://example.test/start",
+        "https://example.test/final?sig=rotated-location-sas&mode=one",
+        "https://example.test/operations/1?sig=rotated-operation-sas&api-version=1",
+    }) |url| {
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .GET,
+            url,
+        );
+        defer request.deinit();
+        var response = try playback.asTransport().send(&request);
+        response.deinit();
+    }
 }
 
 test "recording JSON base64 bodies roundtrip arbitrary bytes" {
@@ -4319,20 +4809,133 @@ test "multipart token fields and XML credential attributes are rejected" {
     }
 }
 
-test "opaque bodies reject by default and require an explicit safe policy" {
-    const opaque_bodies = [_][]const u8{
-        "\x30\x82\xff\x00pkcs12-like",
-        "\xff\xfeP\x00a\x00s\x00s\x00w\x00o\x00r\x00d\x00",
-        "A\x00c\x00c\x00o\x00u\x00n\x00t\x00K\x00e\x00y\x00=\x00v\x00a\x00l\x00u\x00e\x00",
-        "A\x00\x00\x00c\x00\x00\x00c\x00\x00\x00o\x00\x00\x00u\x00\x00\x00n\x00\x00\x00t\x00\x00\x00K\x00\x00\x00e\x00\x00\x00y\x00\x00\x00=\x00\x00\x00v\x00\x00\x00",
-        "\xef\xbb\xbf{\"message\":\"utf8-bom\"}",
-        "{\"message\":\"malformed\xff\"}",
-    };
-    for (opaque_bodies) |body| {
+test "multipart application http credentials cannot bypass allow opaque" {
+    const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ++
+        "." ++
+        "eyJzdWIiOiJiYXRjaCIsImV4cCI6NDEwMjQ0NDgwMH0" ++
+        "." ++
+        "c2lnbmF0dXJlLWJ5dGVzLXZhbHVl";
+    const jwt_batch = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "--batch\r\nContent-Type: application/http\r\n\r\n" ++
+            "GET /table HTTP/1.1\r\nx-token: {s}\r\n\r\n--batch--\r\n",
+        .{jwt},
+    );
+    defer std.testing.allocator.free(jwt_batch);
+    for ([_][]const u8{
+        "--batch\r\nContent-Type: application/http\r\n" ++
+            "Content-Transfer-Encoding: binary\r\n\r\n" ++
+            "GET /table HTTP/1.1\r\n" ++
+            "Authorization: SharedKey account:shared-key-value\r\n\r\n" ++
+            "--batch--\r\n",
+        "--batch\r\nContent-Type: application/http\r\n\r\n" ++
+            "GET /table HTTP/1.1\r\n" ++
+            "Authorization: Bearer bearer-token-value\r\n\r\n" ++
+            "--batch--\r\n",
+        "--batch\r\nContent-Type: application/http\r\n\r\n" ++
+            "GET https://storage.example/table?sv=1&sig=batch-sas HTTP/1.1\r\n\r\n" ++
+            "--batch--\r\n",
+        jwt_batch,
+    }) |body| {
         var mock = core.http.MockTransport.init(
             std.testing.allocator,
             200,
             body,
+        );
+        defer mock.deinit();
+        mock.response_headers_list = &.{
+            .{
+                .name = "Content-Type",
+                .value = "multipart/mixed; boundary=batch",
+            },
+        };
+        var recorder = RecordingTransport.initWithOptions(
+            std.testing.allocator,
+            mock.asTransport(),
+            .{ .bodyPolicyFn = &allowOpaqueBody },
+        );
+        defer recorder.deinit();
+        var request = core.http.Request.init(
+            std.testing.allocator,
+            .POST,
+            "https://account.table.core.windows.net/$batch",
+        );
+        defer request.deinit();
+        var response = try recorder.asTransport().send(&request);
+        response.deinit();
+        try expectRejectedSerializationExcludes(
+            &recorder,
+            error.SensitiveBodyRequiresSanitization,
+            &.{body},
+        );
+    }
+}
+
+test "safe multipart application http batch roundtrips explicitly" {
+    const body =
+        "--batch\r\nContent-Type: application/http\r\n" ++
+        "Content-Transfer-Encoding: binary\r\n\r\n" ++
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n" ++
+        "{\"PartitionKey\":\"p\",\"RowKey\":\"r\",\"value\":\"safe\"}\r\n" ++
+        "--batch--\r\n";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        body,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "multipart/mixed; boundary=batch" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &allowOpaqueBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://account.table.core.windows.net/$batch",
+    );
+    defer request.deinit();
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try parseJson(std.testing.allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualSlices(
+        u8,
+        body,
+        parsed.asSlice()[0].response_body,
+    );
+}
+
+test "opaque bodies reject by default and require an explicit safe policy" {
+    const opaque_bodies = [_]struct {
+        body: []const u8,
+        expected_error: anyerror = error.OpaqueBodyNotAllowed,
+    }{
+        .{ .body = "\x30\x82\xff\x00pkcs12-like" },
+        .{ .body = "\xff\xfeP\x00a\x00s\x00s\x00w\x00o\x00r\x00d\x00" },
+        .{
+            .body = "A\x00c\x00c\x00o\x00u\x00n\x00t\x00K\x00e\x00y\x00=\x00v\x00a\x00l\x00u\x00e\x00",
+            .expected_error = error.SensitiveBodyRequiresSanitization,
+        },
+        .{
+            .body = "A\x00\x00\x00c\x00\x00\x00c\x00\x00\x00o\x00\x00\x00u\x00\x00\x00n\x00\x00\x00t\x00\x00\x00K\x00\x00\x00e\x00\x00\x00y\x00\x00\x00=\x00\x00\x00v\x00\x00\x00",
+            .expected_error = error.SensitiveBodyRequiresSanitization,
+        },
+        .{ .body = "\xef\xbb\xbf{\"message\":\"utf8-bom\"}" },
+        .{ .body = "{\"message\":\"malformed\xff\"}" },
+    };
+    for (opaque_bodies) |case| {
+        var mock = core.http.MockTransport.init(
+            std.testing.allocator,
+            200,
+            case.body,
         );
         defer mock.deinit();
         var recorder = RecordingTransport.init(
@@ -4349,7 +4952,7 @@ test "opaque bodies reject by default and require an explicit safe policy" {
         var response = try recorder.asTransport().send(&request);
         response.deinit();
         try std.testing.expectError(
-            error.OpaqueBodyNotAllowed,
+            case.expected_error,
             recorder.toJson(std.testing.allocator),
         );
     }
@@ -4749,6 +5352,12 @@ fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
         "{\"message\":\"response\"}",
     );
     defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{
+            .name = "Location",
+            .value = "https://example.com/next?sig=allocation-secret&mode=one",
+        },
+    };
     var recorder = RecordingTransport.initWithOptions(
         std.testing.allocator,
         mock.asTransport(),
@@ -4763,6 +5372,41 @@ fn serializationAllocationFixture(allocator: std.mem.Allocator) !void {
     defer request.deinit();
     request.body = "{\"message\":\"request\"}";
     try request.setHeader("Authorization", "Bearer secret");
+    var response = try recorder.asTransport().send(&request);
+    response.deinit();
+    const json = try recorder.toJson(allocator);
+    allocator.free(json);
+}
+
+fn multipartSerializationAllocationFixture(
+    allocator: std.mem.Allocator,
+) !void {
+    const body =
+        "--batch\r\nContent-Type: application/http\r\n\r\n" ++
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n" ++
+        "{\"PartitionKey\":\"p\",\"RowKey\":\"r\",\"value\":\"safe\"}\r\n" ++
+        "--batch--\r\n";
+    var mock = core.http.MockTransport.init(
+        std.testing.allocator,
+        200,
+        body,
+    );
+    defer mock.deinit();
+    mock.response_headers_list = &.{
+        .{ .name = "Content-Type", .value = "multipart/mixed; boundary=batch" },
+    };
+    var recorder = RecordingTransport.initWithOptions(
+        std.testing.allocator,
+        mock.asTransport(),
+        .{ .bodyPolicyFn = &allowOpaqueBody },
+    );
+    defer recorder.deinit();
+    var request = core.http.Request.init(
+        std.testing.allocator,
+        .POST,
+        "https://account.table.core.windows.net/$batch",
+    );
+    defer request.deinit();
     var response = try recorder.asTransport().send(&request);
     response.deinit();
     const json = try recorder.toJson(allocator);
@@ -4833,6 +5477,11 @@ test "transport allocation failures clean up" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         serializationAllocationFixture,
+        .{},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        multipartSerializationAllocationFixture,
         .{},
     );
     try std.testing.checkAllAllocationFailures(


### PR DESCRIPTION
Part of #412
Part of #414

## Summary
- bump `azure_sdk_testing` to 0.2.0 and pin `azure_sdk_core` 0.3.0 exactly:
  - commit `bc77bcacbb64af935ca53d60bf8a351c9592bc41`
  - hash `azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV`
- replace the self-referential transport pointer with copyable opaque-context/vtable descriptors and the full buffered/streaming operation contract
- define each recording as one deterministic raw HTTP transport attempt, including redirect/retry heads and staged transport/open/body/finish failures
- reserve ordered attempt slots before dispatch and serialize all recorder-owned allocator calls across overlapping callbacks
- preserve response ownership, duplicate headers, streaming/framing/cancellation/lifecycle behavior, buffered-open fallback, and allocation-failure cleanup
- make body recording deny-by-default with explicit caller policy and non-bypassable credential inspection for text, JSON, XML, form, multipart, private-key, signed-URL, and opaque content
- parse multipart boundaries exactly, inspect nested application/http parts, and fail closed on folded MIME/application-HTTP headers before continuation lines can hide disposition fields or authorization
- require XML-looking payloads to be one completely consumed, well-formed document; reject malformed prefixes, mismatched tags, extra roots, and trailing mixed structures
- consume a matching cancelled open attempt when a cooperative upload reader produces its recorded prefix and cancels; keep preflight and non-cancelled attempts unconsumed
- serialize non-UTF-8 URL/header metadata losslessly with explicit base64 encoding objects while retaining readable string compatibility and exact playback matching
- sanitize nested URI credentials without collapsing outer encoding depth or nonsensitive host/path/resource semantics
- store explicit v3 URL redaction templates; literal `REDACTED` data remains exact while generated credential positions wildcard rotated secrets
- parse legacy v2 and earlier v3 recordings conservatively without inferred wildcard positions
- add `initHttpRuntime` for independent transport and `CryptoProvider` selection without replacing provider failures with `std.crypto`

## Validation
- `zig fmt --check root.zig build.zig conformance_test.zig`
- `zig build`
- `zig build test --summary all` — 100/100 passed (97 package + 3 Core conformance targets)
- `zig build test -Doptimize=ReleaseSafe --summary all` — 100/100 passed
- Core `runRawTransportContracts`, `runPipelineContracts`, and allocation-failure contracts
- folded space/tab MIME continuation and embedded authorization rejection
- malformed/trailing mixed XML full-consumption regressions
- cooperative mid-upload cancellation consumption plus preflight/non-cancelled non-consumption
- non-UTF-8 request URL and request/response header roundtrip, mismatch, valid-JSON, and allocation cleanup
- `git diff --check`

The package branch exposes only `install` and `test`; main-only `package-check` / `package-history-check` steps are unavailable in this worktree. Main registry publish-path synchronization remains post-merge.

Head: `5492ac26b10e522a147ebe988830938234328900`

- [x] migrate-sdk-testing
