### PR TITLE
Add optional Core SymCrypt provider

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -7,35 +7,363 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: core-symcrypt-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SYMCRYPT_COMMIT: 286762b7730e2b780678f5ab11fef2b1bad639e0
+  ZIG_SYMCRYPT_COMMIT: 9b3c94a2a4e0d98e055f0d908e11e1d7031b9a4b
+
 jobs:
   package-test:
+    name: package-test (${{ matrix.os }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-    name: package-test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: ubuntu-latest
+            runner: ubuntu-24.04
+            platform: linux
+            target: x86_64-linux-gnu
+            arch: x86_64
+          - os: windows-latest
+            runner: windows-2025
+            platform: windows
+            target: x86_64-windows-msvc
+            arch: x86_64
+          - os: macos-latest
+            runner: macos-latest
+            platform: macos
+            target: x86_64-macos
+            arch: x86_64
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Zig via ghr
-        uses: cataggar/ghr/actions/install@v0.7.0
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
         with:
-          tools: |
-            cataggar/zig@v0.16.0 RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
-      - name: Check formatting
+          persist-credentials: false
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
+        with:
+          version: 0.16.0
+      - name: Check source and package tree
         shell: bash
-        run: git ls-files -z -- '*.zig' 'build.zig.zon' | xargs -0 zig fmt --check
-      - name: Run package tests
+        run: |
+          set -euo pipefail
+          zig build source-check -Dsource_only=true --summary all
+          zig build package-check -Dsource_only=true --summary all
+      - name: Confirm unsupported macOS native diagnostic
+        if: matrix.platform == 'macos'
         shell: bash
-        run: zig build test --summary all
-      - name: Build examples
+        run: |
+          set -euo pipefail
+          if zig build test > unsupported-native.log 2>&1; then
+            cat unsupported-native.log
+            echo "macOS native linkage unexpectedly succeeded" >&2
+            exit 1
+          fi
+          cat unsupported-native.log
+          grep -F "unsupported azure_sdk_core_symcrypt target" unsupported-native.log
+          grep -F "x86_64-linux-gnu, aarch64-linux-gnu, x86_64-windows-msvc, aarch64-windows-msvc" unsupported-native.log
+          rm unsupported-native.log
+      - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        if: matrix.platform != 'macos'
+        with:
+          repository: cataggar/zig-symcrypt
+          ref: ${{ env.ZIG_SYMCRYPT_COMMIT }}
+          path: .zig-symcrypt-ci
+          persist-credentials: false
+      - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        if: matrix.platform != 'macos'
+        with:
+          repository: microsoft/SymCrypt
+          ref: ${{ env.SYMCRYPT_COMMIT }}
+          path: .symcrypt-ci-source
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Prepare pinned Linux build tools
+        if: matrix.platform == 'linux'
         shell: bash
-        run: echo "No examples configured"
-      - name: Compile live tests
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends cmake ninja-build python3-pyelftools
+          git -C .symcrypt-ci-source submodule update --init --depth 1 \
+            3rdparty/jitterentropy-library
+      - name: Build verified Linux fixtures
+        if: matrix.platform == 'linux'
         shell: bash
-        run: echo "No live tests configured"
+        run: |
+          set -euo pipefail
+          .zig-symcrypt-ci/tools/build-linux-fixtures.sh \
+            "$GITHUB_WORKSPACE/.symcrypt-ci-source" \
+            "$GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}" \
+            "${{ matrix.arch }}"
+      - name: Validate Linux dynamic adapter
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture="$GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}"
+          include="$GITHUB_WORKSPACE/.zig-symcrypt-ci/vendor/symcrypt/include"
+          common=(
+            "-Dtarget=${{ matrix.target }}"
+            "-Dlinkage=dynamic"
+            "-Dsymcrypt_include_dir=$include"
+            "-Dsymcrypt_provenance=$fixture/provenance.json"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_plus.a"
+            "-Dsymcrypt_libraries=$fixture/module/generic/libsymcrypt.so"
+          )
+          zig build headers-check -Dheaders_only=true \
+            "-Dtarget=${{ matrix.target }}" "-Dsymcrypt_include_dir=$include" \
+            --summary all
+          zig build headers-check -Dheaders_only=true -Dsymcrypt_checked=true \
+            "-Dtarget=${{ matrix.target }}" "-Dsymcrypt_include_dir=$include" \
+            --summary all
+          zig build provenance-check "${common[@]}" --summary all
+          for optimize in Debug ReleaseSafe; do
+            zig build test "-Doptimize=$optimize" "${common[@]}" --summary all
+          done
+          zig build example-run -Doptimize=ReleaseSafe "${common[@]}" --summary all
+          zig build package-consumer-check -Doptimize=ReleaseSafe \
+            "${common[@]}" --summary all
+      - name: Validate Linux static adapter
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture="$GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}"
+          include="$GITHUB_WORKSPACE/.zig-symcrypt-ci/vendor/symcrypt/include"
+          common=(
+            "-Dtarget=${{ matrix.target }}"
+            "-Dlinkage=static"
+            "-Dsymcrypt_include_dir=$include"
+            "-Dsymcrypt_provenance=$fixture/provenance.json"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_plus.a"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_posixusermode.a"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_common.a"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_mlkem.a"
+          )
+          zig build provenance-check "${common[@]}" --summary all
+          for optimize in Debug ReleaseSafe; do
+            zig build test "-Doptimize=$optimize" "${common[@]}" --summary all
+          done
+          zig build example-run -Doptimize=ReleaseSafe "${common[@]}" --summary all
+          zig build package-consumer-check -Doptimize=ReleaseSafe \
+            "${common[@]}" --summary all
+      - name: Build verified Windows fixtures
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          ./.zig-symcrypt-ci/tools/build-windows-fixtures.ps1 `
+            -Source "$env:GITHUB_WORKSPACE/.symcrypt-ci-source" `
+            -Output "$env:GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}" `
+            -Architecture "${{ matrix.arch }}"
+      - name: Validate Windows dynamic adapter
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $fixture = "$env:GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}"
+          $include = "$env:GITHUB_WORKSPACE/.zig-symcrypt-ci/vendor/symcrypt/include"
+          $common = @(
+            "-Dtarget=${{ matrix.target }}",
+            "-Dlinkage=dynamic",
+            "-Dsymcrypt_include_dir=$include",
+            "-Dsymcrypt_provenance=$fixture/provenance.json",
+            "-Dsymcrypt_libraries=$fixture/lib/symcrypt_plus_NoCIL.lib",
+            "-Dsymcrypt_libraries=$fixture/dll/symcrypt_zig_103_13.lib"
+          )
+          zig build headers-check -Dheaders_only=true `
+            "-Dtarget=${{ matrix.target }}" "-Dsymcrypt_include_dir=$include" `
+            --summary all
+          if ($LASTEXITCODE -ne 0) { throw "FRE header check failed" }
+          zig build headers-check -Dheaders_only=true -Dsymcrypt_checked=true `
+            "-Dtarget=${{ matrix.target }}" "-Dsymcrypt_include_dir=$include" `
+            --summary all
+          if ($LASTEXITCODE -ne 0) { throw "checked header check failed" }
+          zig build provenance-check @common --summary all
+          if ($LASTEXITCODE -ne 0) { throw "dynamic provenance failed" }
+          foreach ($optimize in @("Debug", "ReleaseSafe")) {
+            zig build test "-Doptimize=$optimize" @common --summary all
+            if ($LASTEXITCODE -ne 0) { throw "dynamic $optimize tests failed" }
+          }
+          zig build example-run -Doptimize=ReleaseSafe @common --summary all
+          if ($LASTEXITCODE -ne 0) { throw "dynamic example failed" }
+          zig build package-consumer-check -Doptimize=ReleaseSafe @common --summary all
+          if ($LASTEXITCODE -ne 0) { throw "dynamic package consumer failed" }
+      - name: Validate Windows static adapter
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $fixture = "$env:GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}"
+          $include = "$env:GITHUB_WORKSPACE/.zig-symcrypt-ci/vendor/symcrypt/include"
+          $common = @(
+            "-Dtarget=${{ matrix.target }}",
+            "-Dlinkage=static",
+            "-Dsymcrypt_include_dir=$include",
+            "-Dsymcrypt_provenance=$fixture/provenance.json",
+            "-Dsymcrypt_libraries=$fixture/lib/symcrypt_plus_NoCIL.lib",
+            "-Dsymcrypt_libraries=$fixture/lib/symcrypt_static_NoCIL.lib"
+          )
+          zig build provenance-check @common --summary all
+          if ($LASTEXITCODE -ne 0) { throw "static provenance failed" }
+          foreach ($optimize in @("Debug", "ReleaseSafe")) {
+            zig build test "-Doptimize=$optimize" @common --summary all
+            if ($LASTEXITCODE -ne 0) { throw "static $optimize tests failed" }
+          }
+          zig build example-run -Doptimize=ReleaseSafe @common --summary all
+          if ($LASTEXITCODE -ne 0) { throw "static example failed" }
+          zig build package-consumer-check -Doptimize=ReleaseSafe @common --summary all
+          if ($LASTEXITCODE -ne 0) { throw "static package consumer failed" }
+
+  architecture-test:
+    name: architecture-test (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            target: aarch64-linux-gnu
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+          - platform: windows
+            target: aarch64-windows-msvc
+            arch: aarch64
+            runner: windows-11-vs2026-arm
+    steps:
+      - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        with:
+          repository: cataggar/zig-symcrypt
+          ref: ${{ env.ZIG_SYMCRYPT_COMMIT }}
+          path: .zig-symcrypt-ci
+          persist-credentials: false
+      - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        with:
+          repository: microsoft/SymCrypt
+          ref: ${{ env.SYMCRYPT_COMMIT }}
+          path: .symcrypt-ci-source
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
+        with:
+          version: 0.16.0
+      - name: Use verified x86-64 Zig under Windows Arm64 emulation
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $tools = "$env:GITHUB_WORKSPACE/.tools"
+          $archive = "$tools/zig-x86_64-windows-0.16.0.zip"
+          $directory = "$tools/zig-x86_64"
+          New-Item -ItemType Directory -Force -Path $tools | Out-Null
+          Invoke-WebRequest `
+            -Uri "https://ziglang.org/download/0.16.0/zig-x86_64-windows-0.16.0.zip" `
+            -OutFile $archive
+          $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+          $expected = "68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e"
+          if ($actual -ne $expected) {
+            throw "x86-64 Zig archive SHA-256 mismatch: found $actual, expected $expected"
+          }
+          Expand-Archive -LiteralPath $archive -DestinationPath $directory
+          (Join-Path $directory "zig-x86_64-windows-0.16.0") |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Prepare pinned Linux build tools
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends cmake ninja-build python3-pyelftools
+          git -C .symcrypt-ci-source submodule update --init --depth 1 \
+            3rdparty/jitterentropy-library
+      - name: Build and validate Linux Arm64
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          .zig-symcrypt-ci/tools/build-linux-fixtures.sh \
+            "$GITHUB_WORKSPACE/.symcrypt-ci-source" \
+            "$GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}" \
+            "${{ matrix.arch }}"
+          fixture="$GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}"
+          include="$GITHUB_WORKSPACE/.zig-symcrypt-ci/vendor/symcrypt/include"
+          dynamic=(
+            "-Dtarget=${{ matrix.target }}"
+            "-Dtarget_can_run=true"
+            "-Dlinkage=dynamic"
+            "-Dsymcrypt_include_dir=$include"
+            "-Dsymcrypt_provenance=$fixture/provenance.json"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_plus.a"
+            "-Dsymcrypt_libraries=$fixture/module/generic/libsymcrypt.so"
+          )
+          static=(
+            "-Dtarget=${{ matrix.target }}"
+            "-Dtarget_can_run=true"
+            "-Dlinkage=static"
+            "-Dsymcrypt_include_dir=$include"
+            "-Dsymcrypt_provenance=$fixture/provenance.json"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_plus.a"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_posixusermode.a"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_common.a"
+            "-Dsymcrypt_libraries=$fixture/lib/libsymcrypt_mlkem.a"
+          )
+          for optimize in Debug ReleaseSafe; do
+            zig build test "-Doptimize=$optimize" "${dynamic[@]}" --summary all
+            zig build test "-Doptimize=$optimize" "${static[@]}" --summary all
+          done
+          zig build example-run -Doptimize=ReleaseSafe "${dynamic[@]}" --summary all
+          zig build example-run -Doptimize=ReleaseSafe "${static[@]}" --summary all
+          zig build package-consumer-check -Doptimize=ReleaseSafe \
+            "${dynamic[@]}" --summary all
+          zig build package-consumer-check -Doptimize=ReleaseSafe \
+            "${static[@]}" --summary all
+      - name: Build verified Windows Arm64 fixtures
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          ./.zig-symcrypt-ci/tools/build-windows-fixtures.ps1 `
+            -Source "$env:GITHUB_WORKSPACE/.symcrypt-ci-source" `
+            -Output "$env:GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}" `
+            -Architecture "${{ matrix.arch }}"
+      - name: Validate Windows Arm64
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $fixture = "$env:GITHUB_WORKSPACE/.symcrypt-ci/${{ matrix.arch }}"
+          $include = "$env:GITHUB_WORKSPACE/.zig-symcrypt-ci/vendor/symcrypt/include"
+          $dynamic = @(
+            "-Dtarget=${{ matrix.target }}",
+            "-Dtarget_can_run=true",
+            "-Dlinkage=dynamic",
+            "-Dsymcrypt_include_dir=$include",
+            "-Dsymcrypt_provenance=$fixture/provenance.json",
+            "-Dsymcrypt_libraries=$fixture/lib/symcrypt_plus_NoCIL.lib",
+            "-Dsymcrypt_libraries=$fixture/dll/symcrypt_zig_103_13.lib"
+          )
+          $static = @(
+            "-Dtarget=${{ matrix.target }}",
+            "-Dtarget_can_run=true",
+            "-Dlinkage=static",
+            "-Dsymcrypt_include_dir=$include",
+            "-Dsymcrypt_provenance=$fixture/provenance.json",
+            "-Dsymcrypt_libraries=$fixture/lib/symcrypt_plus_NoCIL.lib",
+            "-Dsymcrypt_libraries=$fixture/lib/symcrypt_static_NoCIL.lib"
+          )
+          foreach ($optimize in @("Debug", "ReleaseSafe")) {
+            zig build test "-Doptimize=$optimize" @dynamic --summary all
+            if ($LASTEXITCODE -ne 0) { throw "dynamic Arm64 $optimize tests failed" }
+            zig build test "-Doptimize=$optimize" @static --summary all
+            if ($LASTEXITCODE -ne 0) { throw "static Arm64 $optimize tests failed" }
+          }
+          zig build example-run -Doptimize=ReleaseSafe @dynamic --summary all
+          if ($LASTEXITCODE -ne 0) { throw "dynamic Arm64 example failed" }
+          zig build example-run -Doptimize=ReleaseSafe @static --summary all
+          if ($LASTEXITCODE -ne 0) { throw "static Arm64 example failed" }
+          zig build package-consumer-check -Doptimize=ReleaseSafe @dynamic --summary all
+          if ($LASTEXITCODE -ne 0) { throw "dynamic Arm64 package consumer failed" }
+          zig build package-consumer-check -Doptimize=ReleaseSafe @static --summary all
+          if ($LASTEXITCODE -ne 0) { throw "static Arm64 package consumer failed" }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ zig-cache/
 zig-out/
 zig-pkg/
 .zig-cache/
+.agent-scratch/
+.symcrypt-ci/
+.symcrypt-ci-source/
+.zig-symcrypt-ci/
+.zig-verified-runs/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,169 @@
-# azure_sdk_testing
+# azure_sdk_core_symcrypt
 
-Testing helpers for Azure SDK packages, including playback-oriented HTTP
-transport support.
+Optional Microsoft SymCrypt 103.13.0 provider for
+`azure_sdk_core.crypto.CryptoProvider`.
 
-- Source: `sdk/core/testing`
-- Release branch: `sdk/core_testing`
-- Initial version: `0.1.0`
-- Internal dependency: `azure_sdk_core`
+- Package version: `0.1.0`
+- Release branch: `sdk/core_symcrypt`
+- Core dependency: `azure_sdk_core` `0.3.0`
+- Native wrapper dependency: `zig_symcrypt` `0.1.0`
+- Supported targets: `x86_64-linux-gnu`, `aarch64-linux-gnu`,
+  `x86_64-windows-msvc`, and `aarch64-windows-msvc`
 
-Run its independent tests from this directory:
+This package is optional. Applications that use only `azure_sdk_core` do not
+compile or link any C or SymCrypt symbols.
+
+## Scope
+
+The provider supplies secure random bytes, compatibility-only MD5, SHA-256,
+HMAC-SHA256, and allocator-backed incremental SHA-256. It changes Azure SDK
+hashing, integrity headers, and signing selected through `CryptoProvider`.
+
+It **does not** replace the TLS cryptography or X.509 trust implementation
+beneath `std.http.Client`. Selecting this package therefore does not make
+`std.http.Client` TLS use SymCrypt.
+
+MD5 is enabled in `zig_symcrypt` only because Azure Storage compatibility and
+integrity paths require it. The adapter does not expose SHA-1 or legacy RSA.
+MD5 must not be used as a security primitive.
+
+## Provider API
+
+```zig
+const core_symcrypt = @import("azure_sdk_core_symcrypt");
+
+var provider = try core_symcrypt.Provider.init();
+defer provider.deinit();
+
+const crypto_provider = provider.asProvider();
+const digest = try crypto_provider.sha256("payload");
+_ = digest;
+```
+
+`Provider` is single-owner and must not move after `asProvider`. Copyable Core
+descriptors borrow it and are valid until `deinit`; calls after deinitialization
+return `error.ProviderDeinitialized` while the owner storage remains alive.
+`deinit` must not race an operation. Hash/HMAC/default random calls are
+concurrent-safe. `initWithScratchAllocator` is also concurrent-safe only when
+its borrowed random staging allocator supports concurrent allocation.
+
+Incremental SHA-256 owns separate state allocated with the allocator supplied
+to `CryptoProvider.sha256Init`. It remains valid if the provider is later
+deinitialized, rejects update/final after finalization, and wipes both adapter
+and SymCrypt state before freeing it. Call its `deinit` exactly once.
+
+Initialization and primitive errors are returned unchanged. There is no
+`std.crypto` fallback. Digest, MAC, and random results are staged so a failed
+operation cannot expose partial caller output. Random staging allocation
+failure is returned as `error.OutOfMemory`.
+
+Dynamic initialization performs the recoverable SymCrypt API/minor handshake.
+Static initialization follows upstream's process-global contract; a mismatched
+static archive/header combination can terminate the process. Neither arbitrary
+static builds nor this adapter are claims of FIPS validation.
+
+## Build integration
+
+A final application selects linkage and forwards exact native inputs when it
+creates the package dependency:
+
+```zig
+const adapter = b.dependency("azure_sdk_core_symcrypt", .{
+    .target = target,
+    .optimize = optimize,
+    .linkage = .dynamic, // or .static
+    .symcrypt_libraries = libraries,
+    .symcrypt_include_dir = include_dir,
+    .symcrypt_system_include_dirs = system_include_dirs,
+    .symcrypt_checked = false,
+    .symcrypt_provenance = provenance,
+});
+root_module.addImport(
+    "azure_sdk_core_symcrypt",
+    adapter.module("azure_sdk_core_symcrypt"),
+);
+```
+
+Options are forwarded to the pinned `zig_symcrypt` build:
+
+- `linkage`: `dynamic` or `static`.
+- `symcrypt_libraries`: ordered, repeated exact library files.
+- `symcrypt_include_dir`: complete SymCrypt 103.13.0 public headers; omitted
+  uses the exact headers bundled by pinned `zig_symcrypt`.
+- `symcrypt_system_include_dirs`: ordered SDK/CRT paths for explicit
+  cross-toolchains.
+- `symcrypt_checked`: `true` only when headers and every library use the
+  checked/`DBG` ABI; default `false` is FRE.
+- `symcrypt_provenance`: exact fixture manifest used to verify source identity,
+  target, roles/order, architecture, and SHA-256 hashes. Windows dynamic
+  execution also verifies and stages the manifest-bound runtime DLL.
+- `headers_only`: supported-target adapter/header compilation without native
+  linkage.
+- `target_can_run`: permits execution when the runner is native for the target
+  but the Zig compiler process is another architecture under emulation.
+- `source_only`: package and formatting checks without configuring SymCrypt;
+  intended for macOS and other non-native validation hosts.
+
+The adapter always forwards `legacy=true`,
+`enable_legacy_rsa_pkcs1_encryption=false`, `enable_mlkem=false`, and
+`enable_tls_x25519_mlkem768=false`. Consumers cannot broaden this adapter's
+legacy surface.
+
+### Exact library order
+
+Linux dynamic:
+
+1. `libsymcrypt_plus.a`
+2. `libsymcrypt.so` or its exact versioned file
+
+Linux static:
+
+1. `libsymcrypt_plus.a`
+2. `libsymcrypt_posixusermode.a`
+3. `libsymcrypt_common.a`
+4. `libsymcrypt_mlkem.a`
+
+Windows dynamic:
+
+1. `symcrypt_plus_NoCIL.lib`
+2. import library for `symcrypt_zig_103_13.dll` (never pass the DLL as a link
+   input)
+
+Windows static:
+
+1. `symcrypt_plus_NoCIL.lib`
+2. `symcrypt_static_NoCIL.lib`
+
+Linux dynamic applications must provide the exact SONAME through an
+application rpath or controlled loader configuration. Windows dynamic
+applications must verify and place the exact manifest-bound
+`symcrypt_zig_103_13.dll` beside the executable.
+
+## Validation
+
+Native commands require exact libraries and provenance:
 
 ```bash
-zig build test --summary all
+zig build provenance-check [linkage and fixture options]
+zig build test [linkage and fixture options] --summary all
+zig build example-run [linkage and fixture options]
+zig build package-consumer-check [linkage and fixture options]
 ```
+
+Build-only and source checks:
+
+```bash
+zig build test-compile [linkage and fixture options] --summary all
+zig build headers-check -Dheaders_only=true [header options]
+zig build source-check -Dsource_only=true
+zig build package-check -Dsource_only=true --summary all
+```
+
+macOS and all unlisted native targets fail with a diagnostic naming the four
+supported triples. They can still run `source-check` and `package-check` with
+`-Dsource_only=true`.
+
+Package CI builds SymCrypt from Microsoft tag `v103.13.0`, commit
+`286762b7730e2b780678f5ab11fef2b1bad639e0`, with the pinned Jitterentropy
+gitlink. It uses the released `zig_symcrypt` fixture builders and provenance
+verification rather than downloading opaque native binaries.

--- a/build.zig
+++ b/build.zig
@@ -1,34 +1,491 @@
 const std = @import("std");
 
+const package_version = @import("build.zig.zon").version;
+
+pub const Linkage = enum { dynamic, static };
+
+const supported_targets =
+    "x86_64-linux-gnu, aarch64-linux-gnu, x86_64-windows-msvc, aarch64-windows-msvc";
+
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{});
+    const default_target: std.Target.Query = if (b.graph.host.result.os.tag == .windows)
+        .{
+            .cpu_arch = b.graph.host.result.cpu.arch,
+            .os_tag = .windows,
+            .abi = .msvc,
+        }
+    else
+        .{};
+    const target = b.standardTargetOptions(.{ .default_target = default_target });
     const optimize = b.standardOptimizeOption(.{});
+    const target_can_run = b.option(
+        bool,
+        "target_can_run",
+        "Allow target execution when the runner is native but Zig itself is emulated",
+    ) orelse canRunOnHost(b, target);
+    const source_only = b.option(
+        bool,
+        "source_only",
+        "Run source/package checks without configuring native SymCrypt",
+    ) orelse false;
+
+    const source_check = addSourceCheck(b);
+    const package = addPackageArchive(b);
+    const package_check = b.step(
+        "package-check",
+        "Validate the exact manifest-filtered source package",
+    );
+    package_check.dependOn(&package.fetch.step);
+
+    if (source_only) return;
+    if (!isSupportedTarget(target)) {
+        const triple = target.result.zigTriple(b.allocator) catch @panic("OOM");
+        std.log.err(
+            "unsupported azure_sdk_core_symcrypt target '{s}'; supported: {s}; macOS, musl, Windows GNU, WASI, and 32-bit native linkage are unavailable; use -Dsource_only=true for source/package validation",
+            .{ triple, supported_targets },
+        );
+        b.invalid_user_input = true;
+        return;
+    }
+
+    const linkage = b.option(
+        Linkage,
+        "linkage",
+        "SymCrypt linkage mode (dynamic or static)",
+    ) orelse .dynamic;
+    const libraries = b.option(
+        []const std.Build.LazyPath,
+        "symcrypt_libraries",
+        "Ordered exact SymCrypt library files; repeat for each file",
+    ) orelse &.{};
+    const include_dir = b.option(
+        std.Build.LazyPath,
+        "symcrypt_include_dir",
+        "Complete pinned SymCrypt public header directory",
+    );
+    const system_include_dirs = b.option(
+        []const std.Build.LazyPath,
+        "symcrypt_system_include_dirs",
+        "Ordered target SDK/CRT include directories for cross-toolchains",
+    ) orelse &.{};
+    const checked = b.option(
+        bool,
+        "symcrypt_checked",
+        "Match checked/DBG SymCrypt headers and libraries",
+    ) orelse false;
+    const provenance = b.option(
+        std.Build.LazyPath,
+        "symcrypt_provenance",
+        "Verified SymCrypt 103.13.0 fixture provenance manifest",
+    );
+    const headers_only = b.option(
+        bool,
+        "headers_only",
+        "Compile adapter/header ABI only without native libraries",
+    ) orelse false;
+
+    if (!headers_only and libraries.len == 0) {
+        std.log.err(
+            "no SymCrypt libraries supplied: pass ordered repeated -Dsymcrypt_libraries exact files; use -Dheaders_only=true for supported-target header compilation or -Dsource_only=true for package checks",
+            .{},
+        );
+        b.invalid_user_input = true;
+        return;
+    }
 
     const core_dep = b.dependency("azure_sdk_core", .{
         .target = target,
         .optimize = optimize,
     });
-    const core_mod = core_dep.module("azure_sdk_core");
+    const symcrypt_dep = b.dependency("zig_symcrypt", .{
+        .target = target,
+        .optimize = optimize,
+        .linkage = linkage,
+        .symcrypt_libraries = libraries,
+        .symcrypt_include_dir = include_dir,
+        .symcrypt_system_include_dirs = system_include_dirs,
+        .symcrypt_checked = checked,
+        .symcrypt_provenance = provenance,
+        .legacy = true,
+        .enable_legacy_rsa_pkcs1_encryption = false,
+        .enable_mlkem = false,
+        .enable_tls_x25519_mlkem768 = false,
+        .headers_only = headers_only,
+    });
 
-    _ = b.addModule("azure_sdk_testing", .{
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", package_version);
+    build_options.addOption(bool, "symcrypt_checked", checked);
+    const build_options_mod = build_options.createModule();
+
+    const adapter_mod = b.addModule("azure_sdk_core_symcrypt", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
-            .{ .name = "azure_sdk_core", .module = core_mod },
+            .{
+                .name = "azure_sdk_core",
+                .module = core_dep.module("azure_sdk_core"),
+            },
+            .{ .name = "symcrypt", .module = symcrypt_dep.module("symcrypt") },
+            .{ .name = "build_options", .module = build_options_mod },
         },
     });
 
-    const tests = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("root.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "azure_sdk_core", .module = core_mod },
-            },
-        }),
+    const header_object = b.addObject(.{
+        .name = "azure-sdk-core-symcrypt-header-check",
+        .root_module = adapter_mod,
     });
-    const test_step = b.step("test", "Run Core Testing tests");
-    test_step.dependOn(&b.addRunArtifact(tests).step);
+    const headers_step = b.step(
+        "headers-check",
+        "Compile the adapter and pinned SymCrypt headers without execution",
+    );
+    headers_step.dependOn(&header_object.step);
+    b.getInstallStep().dependOn(&header_object.step);
+
+    if (headers_only) return;
+
+    const test_mod = b.createModule(.{
+        .root_source_file = b.path("root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{
+                .name = "azure_sdk_core",
+                .module = core_dep.module("azure_sdk_core"),
+            },
+            .{ .name = "symcrypt", .module = symcrypt_dep.module("symcrypt") },
+            .{ .name = "build_options", .module = build_options_mod },
+            .{
+                .name = "azure_sdk_core_crypto_conformance",
+                .module = core_dep.module("azure_sdk_core_crypto_conformance"),
+            },
+        },
+    });
+    addLinuxDynamicRPath(test_mod, target, linkage, libraries);
+    const tests = b.addTest(.{ .root_module = test_mod });
+
+    const test_compile_step = b.step(
+        "test-compile",
+        "Compile and link adapter tests without running them",
+    );
+    test_compile_step.dependOn(&tests.step);
+
+    const provenance_command = addProvenanceVerification(
+        b,
+        symcrypt_dep,
+        target,
+        linkage,
+        provenance,
+        libraries,
+    );
+    const provenance_step = b.step(
+        "provenance-check",
+        "Verify exact SymCrypt 103.13.0 fixture provenance and libraries",
+    );
+    provenance_step.dependOn(provenance_command);
+
+    const test_step = b.step("test", "Run Core conformance and adapter tests");
+    if (target_can_run) {
+        const run = runArtifactStep(
+            b,
+            symcrypt_dep,
+            tests,
+            target,
+            linkage,
+            provenance,
+            libraries,
+        );
+        run.dependOn(provenance_command);
+        test_step.dependOn(run);
+    } else {
+        const fail = b.addFail(b.fmt(
+            "target {s} cannot execute on host {s}-{s}; use 'zig build test-compile' for build-only coverage",
+            .{
+                canonicalTargetTriple(b, target),
+                @tagName(b.graph.host.result.cpu.arch),
+                @tagName(b.graph.host.result.os.tag),
+            },
+        ));
+        test_step.dependOn(&fail.step);
+    }
+
+    const example_mod = b.createModule(.{
+        .root_source_file = b.path("examples/basic.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "azure_sdk_core_symcrypt", .module = adapter_mod },
+        },
+    });
+    addLinuxDynamicRPath(example_mod, target, linkage, libraries);
+    const example = b.addExecutable(.{
+        .name = "azure-sdk-core-symcrypt-example",
+        .root_module = example_mod,
+    });
+    const example_step = b.step("example", "Build the selected-linkage example");
+    example_step.dependOn(&example.step);
+    const example_run_step = b.step(
+        "example-run",
+        "Run the selected-linkage example",
+    );
+    if (target_can_run) {
+        const run = runArtifactStep(
+            b,
+            symcrypt_dep,
+            example,
+            target,
+            linkage,
+            provenance,
+            libraries,
+        );
+        run.dependOn(provenance_command);
+        example_run_step.dependOn(run);
+    } else {
+        const fail = b.addFail(
+            "the selected target is build-only on this host; use 'zig build example'",
+        );
+        example_run_step.dependOn(&fail.step);
+    }
+
+    const package_consumer = addPackageConsumerBuild(
+        b,
+        package,
+        target,
+        optimize,
+        linkage,
+        libraries,
+        include_dir,
+        system_include_dirs,
+        checked,
+        provenance,
+    );
+    const package_consumer_step = b.step(
+        "package-consumer-check",
+        "Compile a consumer of the manifest-filtered package archive",
+    );
+    package_consumer_step.dependOn(&package_consumer.step);
+    package_consumer_step.dependOn(source_check);
+}
+
+fn addSourceCheck(b: *std.Build) *std.Build.Step {
+    const format = b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "fmt",
+        "--check",
+        "build.zig",
+        "build.zig.zon",
+        "root.zig",
+        "examples",
+        "conformance",
+    });
+    const step = b.step("source-check", "Check all package Zig source formatting");
+    step.dependOn(&format.step);
+    return step;
+}
+
+const PackageArchive = struct {
+    archive: std.Build.LazyPath,
+    consumer_dir: std.Build.LazyPath,
+    fetch: *std.Build.Step.Run,
+};
+
+fn addPackageArchive(b: *std.Build) PackageArchive {
+    const archive_command = b.addSystemCommand(&.{
+        "python3",
+        "-c",
+        \\import pathlib, sys, tarfile
+        \\output = pathlib.Path(sys.argv[1])
+        \\root = pathlib.Path(sys.argv[2])
+        \\with tarfile.open(output, "w:gz") as archive:
+        \\    for name in sys.argv[3:]:
+        \\        archive.add(root / name, arcname=name, recursive=True)
+    });
+    archive_command.has_side_effects = true;
+    const archive = archive_command.addOutputFileArg(
+        "azure_sdk_core_symcrypt-manifest-filtered.tar.gz",
+    );
+    archive_command.addArg(b.pathFromRoot("."));
+    inline for (@import("build.zig.zon").paths) |included_path| {
+        archive_command.addArg(included_path);
+    }
+
+    const files = b.addWriteFiles();
+    _ = files.addCopyFile(
+        b.path("conformance/package_consumer/build.zig"),
+        "build.zig",
+    );
+    _ = files.addCopyFile(
+        b.path("conformance/package_consumer/build.zig.zon"),
+        "build.zig.zon",
+    );
+    _ = files.addCopyFile(
+        b.path("conformance/package_consumer/consumer.zig"),
+        "consumer.zig",
+    );
+    const consumer_dir = files.getDirectory();
+
+    const fetch = b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "fetch",
+        "--save=adapter",
+    });
+    fetch.setCwd(consumer_dir);
+    fetch.addFileArg(archive);
+    return .{
+        .archive = archive,
+        .consumer_dir = consumer_dir,
+        .fetch = fetch,
+    };
+}
+
+fn addPackageConsumerBuild(
+    b: *std.Build,
+    package: PackageArchive,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    linkage: Linkage,
+    libraries: []const std.Build.LazyPath,
+    include_dir: ?std.Build.LazyPath,
+    system_include_dirs: []const std.Build.LazyPath,
+    checked: bool,
+    provenance: ?std.Build.LazyPath,
+) *std.Build.Step.Run {
+    const command = b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "build",
+        "test-compile",
+        "--summary",
+        "all",
+        b.fmt("-Dtarget={s}", .{canonicalTargetTriple(b, target)}),
+        b.fmt("-Doptimize={s}", .{@tagName(optimize)}),
+        b.fmt("-Dlinkage={s}", .{@tagName(linkage)}),
+        b.fmt("-Dsymcrypt_checked={s}", .{if (checked) "true" else "false"}),
+    });
+    command.setCwd(package.consumer_dir);
+    command.step.dependOn(&package.fetch.step);
+    for (libraries) |library| {
+        command.addPrefixedFileArg("-Dsymcrypt_libraries=", library);
+    }
+    if (include_dir) |directory| {
+        command.addPrefixedDirectoryArg("-Dsymcrypt_include_dir=", directory);
+    }
+    for (system_include_dirs) |directory| {
+        command.addPrefixedDirectoryArg(
+            "-Dsymcrypt_system_include_dirs=",
+            directory,
+        );
+    }
+    if (provenance) |manifest| {
+        command.addPrefixedFileArg("-Dsymcrypt_provenance=", manifest);
+    }
+    return command;
+}
+
+fn addProvenanceVerification(
+    b: *std.Build,
+    symcrypt_dep: *std.Build.Dependency,
+    target: std.Build.ResolvedTarget,
+    linkage: Linkage,
+    provenance: ?std.Build.LazyPath,
+    libraries: []const std.Build.LazyPath,
+) *std.Build.Step {
+    const manifest = provenance orelse {
+        const fail = b.addFail(
+            "provenance-check and native execution require -Dsymcrypt_provenance=/exact/path/provenance.json",
+        );
+        return &fail.step;
+    };
+    const command = b.addSystemCommand(&.{"python3"});
+    command.addFileArg(symcrypt_dep.path("tools/fixture_manifest.py"));
+    command.addArgs(&.{
+        "verify",
+        "--manifest",
+    });
+    command.addFileArg(manifest);
+    command.addArgs(&.{
+        "--target",
+        canonicalTargetTriple(b, target),
+        "--linkage",
+        @tagName(linkage),
+    });
+    for (libraries) |library| {
+        command.addArg("--library");
+        command.addFileArg(library);
+    }
+    return &command.step;
+}
+
+fn runArtifactStep(
+    b: *std.Build,
+    symcrypt_dep: *std.Build.Dependency,
+    artifact: *std.Build.Step.Compile,
+    target: std.Build.ResolvedTarget,
+    linkage: Linkage,
+    provenance: ?std.Build.LazyPath,
+    libraries: []const std.Build.LazyPath,
+) *std.Build.Step {
+    if (target.result.os.tag != .windows or linkage != .dynamic) {
+        return &b.addRunArtifact(artifact).step;
+    }
+    const manifest = provenance orelse {
+        const fail = b.addFail(
+            "dynamic Windows execution requires -Dsymcrypt_provenance so the exact runtime DLL is verified and staged beside the executable",
+        );
+        return &fail.step;
+    };
+    const command = b.addSystemCommand(&.{"python3"});
+    command.addFileArg(symcrypt_dep.path("tools/run_verified.py"));
+    command.addArgs(&.{
+        "--manifest",
+    });
+    command.addFileArg(manifest);
+    command.addArgs(&.{
+        "--target",
+        canonicalTargetTriple(b, target),
+    });
+    for (libraries) |library| {
+        command.addArg("--library");
+        command.addFileArg(library);
+    }
+    command.addArtifactArg(artifact);
+    return &command.step;
+}
+
+fn addLinuxDynamicRPath(
+    module: *std.Build.Module,
+    target: std.Build.ResolvedTarget,
+    linkage: Linkage,
+    libraries: []const std.Build.LazyPath,
+) void {
+    if (target.result.os.tag == .linux and linkage == .dynamic) {
+        module.addRPath(libraries[libraries.len - 1].dirname());
+    }
+}
+
+fn isSupportedTarget(target: std.Build.ResolvedTarget) bool {
+    const value = target.result;
+    const arch_ok = value.cpu.arch == .x86_64 or value.cpu.arch == .aarch64;
+    const linux_ok = value.os.tag == .linux and value.abi == .gnu;
+    const windows_ok = value.os.tag == .windows and value.abi == .msvc;
+    return arch_ok and (linux_ok or windows_ok);
+}
+
+fn canRunOnHost(b: *std.Build, target: std.Build.ResolvedTarget) bool {
+    return target.result.cpu.arch == b.graph.host.result.cpu.arch and
+        target.result.os.tag == b.graph.host.result.os.tag;
+}
+
+fn canonicalTargetTriple(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+) []const u8 {
+    return b.fmt(
+        "{s}-{s}-{s}",
+        .{
+            @tagName(target.result.cpu.arch),
+            @tagName(target.result.os.tag),
+            @tagName(target.result.abi),
+        },
+    );
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,16 @@
 .{
-    .name = .azure_sdk_testing,
+    .name = .azure_sdk_core_symcrypt,
     .version = "0.1.0",
-    .fingerprint = 0xedf330a9407b1b45,
+    .fingerprint = 0x3475427fd5847371,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .azure_sdk_core = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#3acfe9d5779b98d2ffcbddbf4112348e11de7122",
-            .hash = "azure_sdk_core-0.2.0-eFY0Eq5jBgD71A09kDRyNUP1rUohQrm6KUpENFnYWQzY",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bc77bcacbb64af935ca53d60bf8a351c9592bc41",
+            .hash = "azure_sdk_core-0.3.0-eFY0Ev0-CACjsFaYPL6jS7CpeVNvsqYqTrXRfgQKiRFV",
+        },
+        .zig_symcrypt = .{
+            .url = "git+https://github.com/cataggar/zig-symcrypt.git#9b3c94a2a4e0d98e055f0d908e11e1d7031b9a4b",
+            .hash = "zig_symcrypt-0.1.0-QIw66SjCEAAi9B86kkwa2aD-unj5hbQsGhuhTZdL4XFf",
         },
     },
     .paths = .{
@@ -14,6 +18,8 @@
         "build.zig",
         "build.zig.zon",
         "root.zig",
+        "conformance",
+        "examples",
         "README.md",
         "LICENSE.txt",
     },

--- a/conformance/package_consumer/build.zig
+++ b/conformance/package_consumer/build.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+const Linkage = enum { dynamic, static };
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const linkage = b.option(Linkage, "linkage", "SymCrypt linkage") orelse .dynamic;
+    const libraries = b.option(
+        []const std.Build.LazyPath,
+        "symcrypt_libraries",
+        "Ordered exact SymCrypt libraries",
+    ) orelse &.{};
+    const include_dir = b.option(
+        std.Build.LazyPath,
+        "symcrypt_include_dir",
+        "Complete pinned SymCrypt public headers",
+    );
+    const system_include_dirs = b.option(
+        []const std.Build.LazyPath,
+        "symcrypt_system_include_dirs",
+        "Target SDK/CRT include directories",
+    ) orelse &.{};
+    const checked = b.option(
+        bool,
+        "symcrypt_checked",
+        "Match checked/DBG SymCrypt inputs",
+    ) orelse false;
+    const provenance = b.option(
+        std.Build.LazyPath,
+        "symcrypt_provenance",
+        "Exact fixture provenance",
+    );
+
+    const adapter = b.dependency("adapter", .{
+        .target = target,
+        .optimize = optimize,
+        .linkage = linkage,
+        .symcrypt_libraries = libraries,
+        .symcrypt_include_dir = include_dir,
+        .symcrypt_system_include_dirs = system_include_dirs,
+        .symcrypt_checked = checked,
+        .symcrypt_provenance = provenance,
+    });
+    const module = b.createModule(.{
+        .root_source_file = b.path("consumer.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{
+                .name = "azure_sdk_core_symcrypt",
+                .module = adapter.module("azure_sdk_core_symcrypt"),
+            },
+        },
+    });
+    if (target.result.os.tag == .linux and linkage == .dynamic) {
+        module.addRPath(libraries[libraries.len - 1].dirname());
+    }
+    const tests = b.addTest(.{ .root_module = module });
+    const compile_step = b.step(
+        "test-compile",
+        "Compile and link the external package consumer",
+    );
+    compile_step.dependOn(&tests.step);
+    const test_step = b.step("test", "Run the external package consumer");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}

--- a/conformance/package_consumer/build.zig.zon
+++ b/conformance/package_consumer/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .azure_sdk_core_symcrypt_consumer,
+    .version = "0.0.0",
+    .fingerprint = 0x3b8201e43e1af300,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "consumer.zig",
+    },
+}

--- a/conformance/package_consumer/consumer.zig
+++ b/conformance/package_consumer/consumer.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+const core_symcrypt = @import("azure_sdk_core_symcrypt");
+
+test "manifest-filtered package exports a usable provider" {
+    try std.testing.expectEqualStrings("0.1.0", core_symcrypt.version);
+    try std.testing.expectEqual(@as(u32, 103), core_symcrypt.symcrypt_version.api);
+
+    var provider = try core_symcrypt.Provider.init();
+    defer provider.deinit();
+    const digest = try provider.asProvider().sha256("package consumer");
+    try std.testing.expectEqual(@as(usize, 32), digest.len);
+}

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+const core_symcrypt = @import("azure_sdk_core_symcrypt");
+
+pub fn main() !void {
+    var provider = try core_symcrypt.Provider.init();
+    defer provider.deinit();
+
+    const digest = try provider.asProvider().sha256("Azure SDK for Zig");
+    std.debug.print(
+        "SymCrypt {d}.{d}.{d} ({s}) SHA-256: {x}\n",
+        .{
+            core_symcrypt.symcrypt_version.api,
+            core_symcrypt.symcrypt_version.minor,
+            core_symcrypt.symcrypt_version.patch,
+            @tagName(core_symcrypt.linkage),
+            digest,
+        },
+    );
+}

--- a/root.zig
+++ b/root.zig
@@ -1,341 +1,931 @@
-///! Azure SDK Test Framework — mock transport, recording/playback, helpers.
-///!
-///! Built on `std.testing` with Azure-specific utilities.
-///!
-///! Supports two test modes (controlled by `AZURE_TEST_MODE` env var):
-///!   - `record`   — runs live requests, records exchanges to JSON files
-///!   - `playback` — replays previously recorded exchanges (default)
+//! Optional Microsoft SymCrypt provider for Azure SDK Core.
+//!
+//! This package changes only SDK hashing, signing, and secure-random
+//! operations dispatched through `core.crypto.CryptoProvider`. It does not
+//! replace the TLS cryptography or X.509 trust used by `std.http.Client`.
 const std = @import("std");
 const core = @import("azure_sdk_core");
+const symcrypt = @import("symcrypt");
+const build_options = @import("build_options");
 
-// ──────────────────── Recorded Exchange ────────────────────
+pub const version: []const u8 = build_options.version;
+pub const Linkage = symcrypt.Linkage;
+pub const linkage: Linkage = symcrypt.linkage;
+pub const checked: bool = build_options.symcrypt_checked;
+pub const symcrypt_version: symcrypt.Version = symcrypt.header_version;
+pub const InitError = symcrypt.InitError;
+pub const PrimitiveError = symcrypt.Error;
 
-/// A recorded HTTP exchange for recording and playback.
-pub const RecordedExchange = struct {
-    request_method: core.http.Method,
-    request_url: []const u8,
-    request_headers: ?[]const HeaderPair = null,
-    request_body: ?[]const u8 = null,
-    response_status: u16,
-    response_body: []const u8,
-    response_headers: ?[]const HeaderPair = null,
-};
-
-pub const HeaderPair = struct {
-    name: []const u8,
-    value: []const u8,
-};
-
-// ──────────────────── Playback Transport ───────────────────
-
-/// Playback transport — replays a sequence of recorded exchanges in order.
-pub const PlaybackTransport = struct {
-    recordings: []const RecordedExchange,
-    index: usize = 0,
-    allocator: std.mem.Allocator,
-    transport: core.http.HttpTransport,
-
-    pub fn init(allocator: std.mem.Allocator, recordings: []const RecordedExchange) PlaybackTransport {
-        return .{
-            .recordings = recordings,
-            .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl },
-        };
+comptime {
+    if (!symcrypt.legacy_enabled) {
+        @compileError("azure_sdk_core_symcrypt requires zig-symcrypt legacy MD5 support");
     }
+}
 
-    pub fn asTransport(self: *PlaybackTransport) *core.http.HttpTransport {
-        return &self.transport;
-    }
+/// Explicitly perform the process-global, thread-safe SymCrypt handshake.
+///
+/// Dynamic linkage returns `error.IncompatibleSymCryptVersion` for an
+/// incompatible module and `error.SymCryptInitializationFailed` for other
+/// initialization failures. Static linkage follows SymCrypt's process-global
+/// initialization contract.
+pub fn ensureInitialized() InitError!void {
+    return symcrypt.ensureInitialized();
+}
 
-    fn sendImpl(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *PlaybackTransport = @alignCast(@fieldParentPtr("transport", transport));
-        if (self.index >= self.recordings.len) return error.NoMoreRecordings;
+/// A single-owner context for a copyable Core crypto-provider descriptor.
+///
+/// Call `deinit` only after all concurrent descriptor calls have completed.
+/// Descriptor copies borrow this value and return `error.ProviderDeinitialized`
+/// after `deinit` while this storage remains alive. The value must not be
+/// moved after `asProvider` is called and must outlive every descriptor copy.
+///
+/// Hash, HMAC, and default-provider random calls may execute concurrently.
+/// A provider made with `initWithScratchAllocator` additionally requires that
+/// allocator to permit concurrent allocation when `randomBytes` is concurrent.
+/// Incremental SHA-256 operations own independent allocator-backed state and
+/// remain valid after this provider is deinitialized.
+pub const Provider = struct {
+    scratch_allocator: std.mem.Allocator,
+    backend: Backend,
+    active: std.atomic.Value(bool),
 
-        const rec = self.recordings[self.index];
-        self.index += 1;
-
-        if (rec.request_method != request.method) return error.MethodMismatch;
-
-        const body_copy = try self.allocator.dupe(u8, rec.response_body);
-        const headers = std.StringHashMap([]const u8).init(self.allocator);
-        return .{
-            .status_code = rec.response_status,
-            .headers = headers,
-            .body = body_copy,
-            .allocator = self.allocator,
-        };
-    }
-};
-
-// ──────────────────── Recording Transport ─────────────────
-
-/// Recording transport — wraps a real transport, forwards requests,
-/// and captures all exchanges for later serialization.
-pub const RecordingTransport = struct {
-    inner: *core.http.HttpTransport,
-    exchanges: std.ArrayList(OwnedExchange),
-    allocator: std.mem.Allocator,
-    transport: core.http.HttpTransport,
-
-    const OwnedExchange = struct {
-        request_method: core.http.Method,
-        request_url: []u8,
-        response_status: u16,
-        response_body: []u8,
+    const vtable: core.crypto.CryptoProvider.VTable = .{
+        .random_bytes = &randomBytes,
+        .md5 = &md5,
+        .sha256 = &sha256,
+        .hmac_sha256 = &hmacSha256,
+        .sha256_init = &sha256Init,
     };
 
-    pub fn init(allocator: std.mem.Allocator, inner: *core.http.HttpTransport) RecordingTransport {
+    /// Initialize a concurrent provider using the page allocator only for the
+    /// temporary all-or-nothing random-output staging buffer.
+    pub fn init() InitError!Provider {
+        try ensureInitialized();
+        return initialized(std.heap.page_allocator, symcrypt_backend);
+    }
+
+    /// Initialize with a caller-selected random-output scratch allocator.
+    ///
+    /// The allocator is borrowed until `deinit`. It is not used by incremental
+    /// SHA-256, which always uses the allocator passed to `sha256Init`.
+    pub fn initWithScratchAllocator(
+        scratch_allocator: std.mem.Allocator,
+    ) InitError!Provider {
+        try ensureInitialized();
+        return initialized(scratch_allocator, symcrypt_backend);
+    }
+
+    pub fn asProvider(self: *Provider) core.crypto.CryptoProvider {
+        return .{ .context = self, .vtable = &vtable };
+    }
+
+    /// Invalidate borrowed descriptors. SymCrypt itself is process-global and
+    /// has no matching shutdown operation.
+    pub fn deinit(self: *Provider) void {
+        self.active.store(false, .release);
+    }
+
+    fn initialized(
+        scratch_allocator: std.mem.Allocator,
+        backend: Backend,
+    ) Provider {
         return .{
-            .inner = inner,
-            .exchanges = .empty,
-            .allocator = allocator,
-            .transport = .{ .sendFn = &sendImpl },
+            .scratch_allocator = scratch_allocator,
+            .backend = backend,
+            .active = .init(true),
         };
     }
 
-    pub fn asTransport(self: *RecordingTransport) *core.http.HttpTransport {
-        return &self.transport;
+    fn requireActive(self: *Provider) !void {
+        if (!self.active.load(.acquire)) return error.ProviderDeinitialized;
     }
 
-    pub fn deinit(self: *RecordingTransport) void {
-        for (self.exchanges.items) |ex| {
-            self.allocator.free(ex.request_url);
-            self.allocator.free(ex.response_body);
+    fn fromContext(context: *anyopaque) *Provider {
+        return @ptrCast(@alignCast(context));
+    }
+
+    fn randomBytes(context: *anyopaque, output: []u8) !void {
+        const self = fromContext(context);
+        try self.requireActive();
+
+        if (output.len == 0) {
+            return self.backend.randomFill(output);
         }
-        self.exchanges.deinit(self.allocator);
+
+        const temporary = try self.scratch_allocator.alloc(u8, output.len);
+        defer wipeAndFree(self.scratch_allocator, temporary);
+        try self.backend.randomFill(temporary);
+        @memcpy(output, temporary);
     }
 
-    /// Get the recorded exchanges as a slice.
-    pub fn getExchanges(self: *const RecordingTransport) []const OwnedExchange {
-        return self.exchanges.items;
+    fn md5(
+        context: *anyopaque,
+        data: []const u8,
+        output: *core.crypto.Md5Digest,
+    ) !void {
+        const self = fromContext(context);
+        try self.requireActive();
+
+        var temporary: core.crypto.Md5Digest = undefined;
+        defer wipe(std.mem.asBytes(&temporary));
+        try self.backend.md5(data, &temporary);
+        output.* = temporary;
     }
 
-    /// Serialize all recorded exchanges to a JSON string.
-    pub fn toJson(self: *const RecordingTransport, allocator: std.mem.Allocator) ![]u8 {
-        var aw: std.Io.Writer.Allocating = .init(allocator);
-        errdefer aw.deinit();
-        const writer = &aw.writer;
-        try writer.writeAll("[");
-        for (self.exchanges.items, 0..) |ex, i| {
-            if (i > 0) try writer.writeAll(",");
-            try writer.writeAll("\n  {");
-            try writer.writeAll("\"method\":\"");
-            try writer.writeAll(methodToString(ex.request_method));
-            try writer.writeAll("\",\"url\":");
-            try writeJsonString(writer, ex.request_url);
-            try writer.writeAll(",\"status\":");
-            try writer.print("{d}", .{ex.response_status});
-            try writer.writeAll(",\"body\":");
-            try writeJsonString(writer, sanitizeBody(ex.response_body));
-            try writer.writeAll("}");
-        }
-        try writer.writeAll("\n]\n");
-        return aw.toOwnedSlice();
+    fn sha256(
+        context: *anyopaque,
+        data: []const u8,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        const self = fromContext(context);
+        try self.requireActive();
+
+        var temporary: core.crypto.Sha256Digest = undefined;
+        defer wipe(std.mem.asBytes(&temporary));
+        try self.backend.sha256(data, &temporary);
+        output.* = temporary;
     }
 
-    fn sendImpl(transport: *core.http.HttpTransport, request: *core.http.Request) !core.http.Response {
-        const self: *RecordingTransport = @alignCast(@fieldParentPtr("transport", transport));
+    fn hmacSha256(
+        context: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        output: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self = fromContext(context);
+        try self.requireActive();
 
-        // Forward to inner transport.
-        const resp = try self.inner.send(request);
+        var temporary: core.crypto.HmacSha256Digest = undefined;
+        defer wipe(std.mem.asBytes(&temporary));
+        try self.backend.hmacSha256(key, message, &temporary);
+        output.* = temporary;
+    }
 
-        // Record the exchange.
-        try self.exchanges.append(self.allocator, .{
-            .request_method = request.method,
-            .request_url = try self.allocator.dupe(u8, request.url),
-            .response_status = resp.status_code,
-            .response_body = try self.allocator.dupe(u8, resp.body),
-        });
+    fn sha256Init(
+        context: *anyopaque,
+        allocator: std.mem.Allocator,
+    ) !core.crypto.Sha256Operation {
+        const self = fromContext(context);
+        try self.requireActive();
 
-        return resp;
+        const backend_hash = try self.backend.sha256Create(allocator);
+        errdefer backend_hash.deinit();
+
+        const state = try allocator.create(Sha256State);
+        state.* = .{
+            .allocator = allocator,
+            .backend_hash = backend_hash,
+        };
+        return .{ .context = state, .vtable = &Sha256State.vtable };
     }
 };
 
-// ──────────────────── Sanitization ────────────────────────
+const Sha256State = struct {
+    allocator: std.mem.Allocator,
+    backend_hash: BackendSha256,
+    finalized: bool = false,
 
-/// List of header names whose values should be redacted in recordings.
-const sensitive_headers = [_][]const u8{
-    "authorization",
-    "x-ms-client-secret",
-    "ocp-apim-subscription-key",
-    "api-key",
+    const vtable: core.crypto.Sha256Operation.VTable = .{
+        .update = &update,
+        .final = &final,
+        .deinit = &deinit,
+    };
+
+    fn fromContext(context: *anyopaque) *Sha256State {
+        return @ptrCast(@alignCast(context));
+    }
+
+    fn update(context: *anyopaque, data: []const u8) !void {
+        const self = fromContext(context);
+        if (self.finalized) return error.Sha256AlreadyFinalized;
+        return self.backend_hash.update(data);
+    }
+
+    fn final(
+        context: *anyopaque,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        const self = fromContext(context);
+        if (self.finalized) return error.Sha256AlreadyFinalized;
+
+        var temporary: core.crypto.Sha256Digest = undefined;
+        defer wipe(std.mem.asBytes(&temporary));
+        try self.backend_hash.final(&temporary);
+        output.* = temporary;
+        self.finalized = true;
+    }
+
+    fn deinit(context: *anyopaque) void {
+        const self = fromContext(context);
+        self.backend_hash.deinit();
+        const allocator = self.allocator;
+        wipe(std.mem.asBytes(self));
+        allocator.destroy(self);
+    }
 };
 
-/// Replace sensitive values in a body string.
-/// Currently redacts `access_token` values in JSON.
-fn sanitizeBody(body: []const u8) []const u8 {
-    // Light-touch: don't modify body in-place. Full sanitization
-    // would require JSON-aware rewriting. For now, return as-is;
-    // callers should avoid recording in production environments.
-    return body;
-}
+const Backend = struct {
+    context: *anyopaque,
+    vtable: *const VTable,
 
-/// Check if a header name is sensitive (case-insensitive).
-pub fn isSensitiveHeader(name: []const u8) bool {
-    for (sensitive_headers) |h| {
-        if (eqlIgnoreCase(name, h)) return true;
+    const VTable = struct {
+        ensure_initialized: *const fn (context: *anyopaque) anyerror!void,
+        random_fill: *const fn (context: *anyopaque, output: []u8) anyerror!void,
+        md5: *const fn (
+            context: *anyopaque,
+            data: []const u8,
+            output: *core.crypto.Md5Digest,
+        ) anyerror!void,
+        sha256: *const fn (
+            context: *anyopaque,
+            data: []const u8,
+            output: *core.crypto.Sha256Digest,
+        ) anyerror!void,
+        hmac_sha256: *const fn (
+            context: *anyopaque,
+            key: []const u8,
+            message: []const u8,
+            output: *core.crypto.HmacSha256Digest,
+        ) anyerror!void,
+        sha256_create: *const fn (
+            context: *anyopaque,
+            allocator: std.mem.Allocator,
+        ) anyerror!BackendSha256,
+    };
+
+    fn ensureInitialized(self: Backend) !void {
+        return self.vtable.ensure_initialized(self.context);
     }
-    return false;
+
+    fn randomFill(self: Backend, output: []u8) !void {
+        return self.vtable.random_fill(self.context, output);
+    }
+
+    fn md5(
+        self: Backend,
+        data: []const u8,
+        output: *core.crypto.Md5Digest,
+    ) !void {
+        return self.vtable.md5(self.context, data, output);
+    }
+
+    fn sha256(
+        self: Backend,
+        data: []const u8,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        return self.vtable.sha256(self.context, data, output);
+    }
+
+    fn hmacSha256(
+        self: Backend,
+        key: []const u8,
+        message: []const u8,
+        output: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return self.vtable.hmac_sha256(self.context, key, message, output);
+    }
+
+    fn sha256Create(
+        self: Backend,
+        allocator: std.mem.Allocator,
+    ) !BackendSha256 {
+        return self.vtable.sha256_create(self.context, allocator);
+    }
+};
+
+const BackendSha256 = struct {
+    context: *anyopaque,
+    vtable: *const VTable,
+
+    const VTable = struct {
+        update: *const fn (context: *anyopaque, data: []const u8) anyerror!void,
+        final: *const fn (
+            context: *anyopaque,
+            output: *core.crypto.Sha256Digest,
+        ) anyerror!void,
+        deinit: *const fn (context: *anyopaque) void,
+    };
+
+    fn update(self: BackendSha256, data: []const u8) !void {
+        return self.vtable.update(self.context, data);
+    }
+
+    fn final(
+        self: BackendSha256,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        return self.vtable.final(self.context, output);
+    }
+
+    fn deinit(self: BackendSha256) void {
+        self.vtable.deinit(self.context);
+    }
+};
+
+var symcrypt_backend_token: u8 = 0;
+
+const symcrypt_backend: Backend = .{
+    .context = &symcrypt_backend_token,
+    .vtable = &.{
+        .ensure_initialized = &SymCryptBackend.ensureInitialized,
+        .random_fill = &SymCryptBackend.randomFill,
+        .md5 = &SymCryptBackend.md5,
+        .sha256 = &SymCryptBackend.sha256,
+        .hmac_sha256 = &SymCryptBackend.hmacSha256,
+        .sha256_create = &SymCryptBackend.sha256Create,
+    },
+};
+
+const SymCryptBackend = struct {
+    fn ensureInitialized(_: *anyopaque) !void {
+        return symcrypt.ensureInitialized();
+    }
+
+    fn randomFill(_: *anyopaque, output: []u8) !void {
+        return symcrypt.random.fill(output);
+    }
+
+    fn md5(
+        _: *anyopaque,
+        data: []const u8,
+        output: *core.crypto.Md5Digest,
+    ) !void {
+        return symcrypt.hash.digestInto(.md5, data, output);
+    }
+
+    fn sha256(
+        _: *anyopaque,
+        data: []const u8,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        return symcrypt.hash.digestInto(.sha256, data, output);
+    }
+
+    fn hmacSha256(
+        _: *anyopaque,
+        key: []const u8,
+        message: []const u8,
+        output: *core.crypto.HmacSha256Digest,
+    ) !void {
+        return symcrypt.hmac.macInto(.sha256, key, message, output);
+    }
+
+    fn sha256Create(
+        _: *anyopaque,
+        allocator: std.mem.Allocator,
+    ) !BackendSha256 {
+        const state = try symcrypt.hash.Sha256.create(allocator);
+        return .{ .context = state, .vtable = &SymCryptSha256.vtable };
+    }
+};
+
+const SymCryptSha256 = struct {
+    const vtable: BackendSha256.VTable = .{
+        .update = &update,
+        .final = &final,
+        .deinit = &deinit,
+    };
+
+    fn state(context: *anyopaque) *symcrypt.hash.Sha256 {
+        return @ptrCast(@alignCast(context));
+    }
+
+    fn update(context: *anyopaque, data: []const u8) !void {
+        return state(context).update(data);
+    }
+
+    fn final(
+        context: *anyopaque,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        var temporary = try state(context).final();
+        defer wipe(std.mem.asBytes(&temporary));
+        output.* = temporary;
+    }
+
+    fn deinit(context: *anyopaque) void {
+        state(context).deinit();
+    }
+};
+
+fn wipe(bytes: []u8) void {
+    const volatile_bytes: []volatile u8 = bytes;
+    @memset(volatile_bytes, 0);
 }
 
-// ──────────────────── JSON Helpers ─────────────────────────
+fn wipeAndFree(allocator: std.mem.Allocator, bytes: []u8) void {
+    if (bytes.len == 0) return;
+    wipe(bytes);
+    allocator.rawFree(bytes, .fromByteUnits(1), @returnAddress());
+}
 
-fn methodToString(m: core.http.Method) []const u8 {
-    return switch (m) {
-        .GET => "GET",
-        .POST => "POST",
-        .PUT => "PUT",
-        .DELETE => "DELETE",
-        .PATCH => "PATCH",
-        .HEAD => "HEAD",
-        .OPTIONS => "OPTIONS",
+fn initWithBackend(
+    scratch_allocator: std.mem.Allocator,
+    backend: Backend,
+) !Provider {
+    try backend.ensureInitialized();
+    return Provider.initialized(scratch_allocator, backend);
+}
+
+const ConformanceState = struct {
+    allocator: std.mem.Allocator,
+    provider: Provider,
+
+    fn destroy(context: *anyopaque) void {
+        const self: *ConformanceState = @ptrCast(@alignCast(context));
+        self.provider.deinit();
+        const allocator = self.allocator;
+        wipe(std.mem.asBytes(self));
+        allocator.destroy(self);
+    }
+};
+
+fn createConformanceProvider(
+    _: ?*anyopaque,
+    allocator: std.mem.Allocator,
+    _: std.Io,
+) !@import("azure_sdk_core_crypto_conformance").ProviderInstance {
+    const state = try allocator.create(ConformanceState);
+    errdefer allocator.destroy(state);
+    state.* = .{
+        .allocator = allocator,
+        .provider = try Provider.init(),
+    };
+    return .{
+        .provider = state.provider.asProvider(),
+        .context = state,
+        .deinitFn = &ConformanceState.destroy,
     };
 }
 
-fn writeJsonString(writer: anytype, s: []const u8) !void {
-    try writer.writeByte('"');
-    for (s) |c| {
-        switch (c) {
-            '"' => try writer.writeAll("\\\""),
-            '\\' => try writer.writeAll("\\\\"),
-            '\n' => try writer.writeAll("\\n"),
-            '\r' => try writer.writeAll("\\r"),
-            '\t' => try writer.writeAll("\\t"),
-            else => {
-                if (c < 0x20) {
-                    const hex = "0123456789abcdef";
-                    try writer.writeAll("\\u00");
-                    try writer.writeByte(hex[c >> 4]);
-                    try writer.writeByte(hex[c & 0x0f]);
-                } else {
-                    try writer.writeByte(c);
-                }
+fn conformanceFactory() @import("azure_sdk_core_crypto_conformance").ProviderFactory {
+    return .{
+        .name = "Microsoft SymCrypt 103.13.0",
+        .capabilities = .{
+            .concurrency = .concurrent_safe,
+        },
+        .createFn = &createConformanceProvider,
+    };
+}
+
+test "Core CryptoProvider contracts pass with SymCrypt" {
+    const conformance = @import("azure_sdk_core_crypto_conformance");
+    try conformance.runCryptoContracts(
+        std.testing.allocator,
+        std.testing.io,
+        conformanceFactory(),
+    );
+    try conformance.runProviderBoundaryContracts();
+}
+
+test "build identity is the pinned SymCrypt configuration" {
+    try std.testing.expectEqual(@as(u32, 103), symcrypt_version.api);
+    try std.testing.expectEqual(@as(u32, 13), symcrypt_version.minor);
+    try std.testing.expectEqual(@as(u32, 0), symcrypt_version.patch);
+    try std.testing.expect(symcrypt.legacy_enabled);
+    try std.testing.expectEqual(linkage, symcrypt.linkage);
+}
+
+test "provider initialization errors propagate unchanged" {
+    var fault = FaultBackend{ .initialization_fails = true };
+    try std.testing.expectError(
+        error.IncompatibleSymCryptVersion,
+        initWithBackend(std.testing.allocator, fault.backend()),
+    );
+    try std.testing.expectEqual(@as(usize, 1), fault.initialization_calls);
+}
+
+test "primitive failures leave caller output unchanged" {
+    var fault = FaultBackend{};
+    var provider = try initWithBackend(std.testing.allocator, fault.backend());
+    defer provider.deinit();
+    const descriptor = provider.asProvider();
+
+    var random = [_]u8{0x11} ** 8;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        descriptor.vtable.random_bytes(descriptor.context, &random),
+    );
+    try std.testing.expectEqualSlices(u8, &([_]u8{0x11} ** 8), &random);
+
+    var md5_output = [_]u8{0x22} ** 16;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        descriptor.vtable.md5(descriptor.context, "data", &md5_output),
+    );
+    try std.testing.expectEqualSlices(u8, &([_]u8{0x22} ** 16), &md5_output);
+
+    var sha256_output = [_]u8{0x33} ** 32;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        descriptor.vtable.sha256(descriptor.context, "data", &sha256_output),
+    );
+    try std.testing.expectEqualSlices(u8, &([_]u8{0x33} ** 32), &sha256_output);
+
+    var hmac_output = [_]u8{0x44} ** 32;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        descriptor.vtable.hmac_sha256(
+            descriptor.context,
+            "key",
+            "message",
+            &hmac_output,
+        ),
+    );
+    try std.testing.expectEqualSlices(u8, &([_]u8{0x44} ** 32), &hmac_output);
+
+    try std.testing.expectError(
+        error.ProviderFailure,
+        descriptor.sha256Init(std.testing.allocator),
+    );
+    try std.testing.expectError(
+        error.ProviderFailure,
+        core.base64.hmacSha256Base64(
+            std.testing.allocator,
+            descriptor,
+            "key",
+            "message",
+        ),
+    );
+}
+
+test "random allocation failure and primitive failure are all-or-nothing" {
+    var provider = try Provider.initWithScratchAllocator(std.testing.failing_allocator);
+    defer provider.deinit();
+    const descriptor = provider.asProvider();
+    var output = [_]u8{0x7c} ** 32;
+    try std.testing.expectError(error.OutOfMemory, descriptor.randomBytes(&output));
+    try std.testing.expectEqualSlices(u8, &([_]u8{0x7c} ** 32), &output);
+
+    var tracker = WipeCheckingAllocator.init(std.testing.allocator);
+    var fault = FaultBackend{};
+    var failing_provider = try initWithBackend(tracker.allocator(), fault.backend());
+    defer failing_provider.deinit();
+    var failed_output = [_]u8{0x6d} ** 32;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        failing_provider.asProvider().randomBytes(&failed_output),
+    );
+    try std.testing.expectEqualSlices(u8, &([_]u8{0x6d} ** 32), &failed_output);
+    try std.testing.expectEqual(@as(usize, 1), tracker.allocations);
+    try std.testing.expectEqual(@as(usize, 1), tracker.frees);
+    try std.testing.expect(tracker.all_frees_zero);
+}
+
+test "incremental SHA-256 owns wiped state and enforces finalization" {
+    var provider = try Provider.init();
+    defer provider.deinit();
+
+    var tracker = WipeCheckingAllocator.init(std.testing.allocator);
+    var operation = try provider.asProvider().sha256Init(tracker.allocator());
+    try operation.update("secret data");
+    _ = try operation.final();
+    try std.testing.expectError(error.Sha256AlreadyFinalized, operation.final());
+    try std.testing.expectError(
+        error.Sha256AlreadyFinalized,
+        operation.update("after final"),
+    );
+    operation.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), tracker.allocations);
+    try std.testing.expectEqual(@as(usize, 2), tracker.frees);
+    try std.testing.expect(tracker.all_frees_zero);
+
+    var fail_second = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 1 },
+    );
+    try std.testing.expectError(
+        error.OutOfMemory,
+        provider.asProvider().sha256Init(fail_second.allocator()),
+    );
+}
+
+test "incremental provider failure leaves output and lifetime intact" {
+    var fault = FaultBackend{ .sha_create_fails = false };
+    var provider = try initWithBackend(std.testing.allocator, fault.backend());
+    defer provider.deinit();
+    var operation = try provider.asProvider().sha256Init(std.testing.allocator);
+
+    var output = [_]u8{0x5c} ** 32;
+    try std.testing.expectError(
+        error.ProviderFailure,
+        operation.vtable.final(operation.context, &output),
+    );
+    try std.testing.expectEqualSlices(u8, &([_]u8{0x5c} ** 32), &output);
+    try operation.update("retry remains permitted after failed final");
+    operation.deinit();
+    try std.testing.expectEqual(@as(usize, 1), fault.sha_deinits);
+}
+
+test "incremental operation is independent after provider deinit" {
+    var provider = try Provider.init();
+    const descriptor = provider.asProvider();
+    var operation = try descriptor.sha256Init(std.testing.allocator);
+    defer operation.deinit();
+
+    provider.deinit();
+    try operation.update("abc");
+    const digest = try operation.final();
+    try expectHex(
+        "ba7816bf8f01cfea414140de5dae2223" ++
+            "b00361a396177a9cb410ff61f20015ad",
+        &digest,
+    );
+    try std.testing.expectError(
+        error.ProviderDeinitialized,
+        descriptor.sha256("abc"),
+    );
+    provider.deinit();
+}
+
+test "Storage content hash and Shared Key vectors" {
+    const allocator = std.testing.allocator;
+    var provider = try Provider.init();
+    defer provider.deinit();
+    const descriptor = provider.asProvider();
+
+    const md5 = try core.base64.md5Base64(allocator, descriptor, "");
+    defer allocator.free(md5);
+    try std.testing.expectEqualStrings("1B2M2Y8AsgTpgAmY7PhCfg==", md5);
+
+    const sha256 = try core.base64.sha256Base64(allocator, descriptor, "hello");
+    defer allocator.free(sha256);
+    try std.testing.expectEqualStrings(
+        "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=",
+        sha256,
+    );
+
+    const key = try core.base64.decode(allocator, "YWNjb3VudEtleQ==");
+    defer wipeAndFree(allocator, key);
+    const canonical =
+        "GET\n" ++
+        "\n" ** 11 ++
+        "x-ms-blob-content-md5:2OD7XGeI0jSOrsBn8ZwHTw==\n" ++
+        "x-ms-client-request-id:8f978611-738a-4cd4-a318-33b2f31068d9\n" ++
+        "x-ms-creation-time:Tue, 25 Oct 2022 16:47:17 GMT\n" ++
+        "x-ms-date:Wed, 23 Feb 2022 02:39:43 GMT\n" ++
+        "x-ms-enabled-protocols:NFS\n" ++
+        "x-ms-enable-snapshot-virtual-directory-access:true\n" ++
+        "x-ms-lease-status:unlocked\n" ++
+        "x-ms-meta-capital:letter\n" ++
+        "x-ms-meta-foo:bar\n" ++
+        "x-ms-meta-meta:data\n" ++
+        "x-ms-meta-upper:case\n" ++
+        "x-ms-request-id:a12bc899-001e-003a-3a91-e8439e000000\n" ++
+        "x-ms-return-client-request-id:true\n" ++
+        "x-ms-version:2021-10-04\n" ++
+        "/accountName/";
+    const signature = try core.base64.hmacSha256Base64(
+        allocator,
+        descriptor,
+        key,
+        canonical,
+    );
+    defer wipeAndFree(allocator, signature);
+    try std.testing.expectEqualStrings(
+        "Wjhed5+kLPnT9/EhIgKd7e0y/AEau6G4KKxrUqZxA8s=",
+        signature,
+    );
+}
+
+test "Tables SharedKeyLite vectors" {
+    const allocator = std.testing.allocator;
+    var provider = try Provider.init();
+    defer provider.deinit();
+    const descriptor = provider.asProvider();
+
+    const published = try core.base64.hmacSha256Base64(
+        allocator,
+        descriptor,
+        "account-key",
+        "Thu, 23 Apr 2020 09:43:37 GMT\n/account-name/?comp=properties",
+    );
+    defer wipeAndFree(allocator, published);
+    try std.testing.expectEqualStrings(
+        "tW8SGePdivpFOEJfTxikbSwjdDWkpxSTfFtqUMED3v8=",
+        published,
+    );
+
+    const azurite_key = try core.base64.decode(
+        allocator,
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/" ++
+            "K1SZFPTOtr/KBHBeksoGMGw==",
+    );
+    defer wipeAndFree(allocator, azurite_key);
+    const azurite = try core.base64.hmacSha256Base64(
+        allocator,
+        descriptor,
+        azurite_key,
+        "Thu, 23 Apr 2020 09:43:37 GMT\n/devstoreaccount1/?comp=properties",
+    );
+    defer wipeAndFree(allocator, azurite);
+    try std.testing.expectEqualStrings(
+        "DKy2WIvWLvpXbgT2cc0NqjkcHYoV3AdwfcMHgV8UYd8=",
+        azurite,
+    );
+}
+
+const FaultBackend = struct {
+    initialization_fails: bool = false,
+    sha_create_fails: bool = true,
+    initialization_calls: usize = 0,
+    primitive_calls: usize = 0,
+    sha_deinits: usize = 0,
+
+    fn backend(self: *FaultBackend) Backend {
+        return .{
+            .context = self,
+            .vtable = &.{
+                .ensure_initialized = &FaultBackend.ensureInitialized,
+                .random_fill = &FaultBackend.randomFill,
+                .md5 = &FaultBackend.md5,
+                .sha256 = &FaultBackend.sha256,
+                .hmac_sha256 = &FaultBackend.hmacSha256,
+                .sha256_create = &FaultBackend.sha256Create,
             },
+        };
+    }
+
+    fn fromContext(context: *anyopaque) *FaultBackend {
+        return @ptrCast(@alignCast(context));
+    }
+
+    fn ensureInitialized(context: *anyopaque) !void {
+        const self = fromContext(context);
+        self.initialization_calls += 1;
+        if (self.initialization_fails) {
+            return error.IncompatibleSymCryptVersion;
         }
     }
-    try writer.writeByte('"');
-}
 
-fn eqlIgnoreCase(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |ca, cb| {
-        if (std.ascii.toLower(ca) != std.ascii.toLower(cb)) return false;
+    fn randomFill(context: *anyopaque, output: []u8) !void {
+        const self = fromContext(context);
+        self.primitive_calls += 1;
+        @memset(output, 0xa5);
+        return error.ProviderFailure;
     }
-    return true;
-}
 
-// ──────────────────── Test Helpers ─────────────────────────
-
-/// Assert a response is successful (2xx).
-pub fn expectSuccess(resp: core.http.Response) !void {
-    if (!resp.isSuccess()) {
-        std.log.err("Expected 2xx but got {d}", .{resp.status_code});
-        return error.UnexpectedStatus;
+    fn md5(
+        context: *anyopaque,
+        _: []const u8,
+        output: *core.crypto.Md5Digest,
+    ) !void {
+        const self = fromContext(context);
+        self.primitive_calls += 1;
+        @memset(output, 0xa5);
+        return error.ProviderFailure;
     }
-}
 
-/// Assert a response has a specific status code.
-pub fn expectStatus(resp: core.http.Response, expected: u16) !void {
-    try std.testing.expectEqual(expected, resp.status_code);
-}
+    fn sha256(
+        context: *anyopaque,
+        _: []const u8,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        const self = fromContext(context);
+        self.primitive_calls += 1;
+        @memset(output, 0xa5);
+        return error.ProviderFailure;
+    }
 
-// ─────────────────────── Tests ───────────────────────
+    fn hmacSha256(
+        context: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        output: *core.crypto.HmacSha256Digest,
+    ) !void {
+        const self = fromContext(context);
+        self.primitive_calls += 1;
+        @memset(output, 0xa5);
+        return error.ProviderFailure;
+    }
 
-test "PlaybackTransport replays recordings" {
-    const allocator = std.testing.allocator;
-    const recordings = [_]RecordedExchange{
-        .{ .request_method = .GET, .request_url = "/secrets/s1", .response_status = 200, .response_body = "{\"value\":\"v1\"}" },
-        .{ .request_method = .PUT, .request_url = "/secrets/s2", .response_status = 200, .response_body = "{\"value\":\"v2\"}" },
-    };
-    var playback = PlaybackTransport.init(allocator, &recordings);
+    fn sha256Create(
+        context: *anyopaque,
+        _: std.mem.Allocator,
+    ) !BackendSha256 {
+        const self = fromContext(context);
+        self.primitive_calls += 1;
+        if (self.sha_create_fails) return error.ProviderFailure;
+        return .{
+            .context = self,
+            .vtable = &.{
+                .update = &FaultBackend.shaUpdate,
+                .final = &FaultBackend.shaFinal,
+                .deinit = &FaultBackend.shaDeinit,
+            },
+        };
+    }
 
-    var req1 = core.http.Request.init(allocator, .GET, "/secrets/s1");
-    defer req1.deinit();
-    var resp1 = try playback.asTransport().send(&req1);
-    defer resp1.deinit();
-    try std.testing.expectEqual(@as(u16, 200), resp1.status_code);
+    fn shaUpdate(_: *anyopaque, _: []const u8) !void {}
 
-    var req2 = core.http.Request.init(allocator, .PUT, "/secrets/s2");
-    defer req2.deinit();
-    var resp2 = try playback.asTransport().send(&req2);
-    defer resp2.deinit();
-    try std.testing.expectEqualStrings("{\"value\":\"v2\"}", resp2.body);
-}
+    fn shaFinal(
+        _: *anyopaque,
+        output: *core.crypto.Sha256Digest,
+    ) !void {
+        @memset(output, 0xa5);
+        return error.ProviderFailure;
+    }
 
-test "PlaybackTransport detects method mismatch" {
-    const allocator = std.testing.allocator;
-    const recordings = [_]RecordedExchange{
-        .{ .request_method = .POST, .request_url = "/x", .response_status = 200, .response_body = "{}" },
-    };
-    var playback = PlaybackTransport.init(allocator, &recordings);
-    var req = core.http.Request.init(allocator, .GET, "/x");
-    defer req.deinit();
-    try std.testing.expectError(error.MethodMismatch, playback.asTransport().send(&req));
-}
+    fn shaDeinit(context: *anyopaque) void {
+        fromContext(context).sha_deinits += 1;
+    }
+};
 
-test "expectSuccess" {
-    var resp = core.http.Response{
-        .status_code = 200,
-        .headers = std.StringHashMap([]const u8).init(std.testing.allocator),
-        .body = try std.testing.allocator.dupe(u8, "ok"),
-        .allocator = std.testing.allocator,
-    };
-    defer resp.deinit();
-    try expectSuccess(resp);
-}
+const WipeCheckingAllocator = struct {
+    backing: std.mem.Allocator,
+    allocations: usize = 0,
+    frees: usize = 0,
+    all_frees_zero: bool = true,
 
-test "RecordingTransport captures exchanges" {
-    const allocator = std.testing.allocator;
+    fn init(backing: std.mem.Allocator) WipeCheckingAllocator {
+        return .{ .backing = backing };
+    }
 
-    // Inner mock transport.
-    var mock = core.http.MockTransport.init(allocator, 200, "{\"secret\":\"value\"}");
-    defer mock.deinit();
+    fn allocator(self: *WipeCheckingAllocator) std.mem.Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = &alloc,
+                .resize = &resize,
+                .remap = &remap,
+                .free = &free,
+            },
+        };
+    }
 
-    var recorder = RecordingTransport.init(allocator, mock.asTransport());
-    defer recorder.deinit();
+    fn alloc(
+        context: *anyopaque,
+        len: usize,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *WipeCheckingAllocator = @ptrCast(@alignCast(context));
+        const result = self.backing.rawAlloc(
+            len,
+            alignment,
+            return_address,
+        ) orelse return null;
+        self.allocations += 1;
+        return result;
+    }
 
-    var req = core.http.Request.init(allocator, .GET, "https://vault.azure.net/secrets/s1");
-    defer req.deinit();
-    var resp = try recorder.asTransport().send(&req);
-    defer resp.deinit();
+    fn resize(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) bool {
+        const self: *WipeCheckingAllocator = @ptrCast(@alignCast(context));
+        return self.backing.rawResize(
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        );
+    }
 
-    try std.testing.expectEqual(@as(u16, 200), resp.status_code);
-    try std.testing.expectEqualStrings("{\"secret\":\"value\"}", resp.body);
+    fn remap(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        return_address: usize,
+    ) ?[*]u8 {
+        const self: *WipeCheckingAllocator = @ptrCast(@alignCast(context));
+        return self.backing.rawRemap(
+            memory,
+            alignment,
+            new_len,
+            return_address,
+        );
+    }
 
-    // Verify the exchange was recorded.
-    const exchanges = recorder.getExchanges();
-    try std.testing.expectEqual(@as(usize, 1), exchanges.len);
-    try std.testing.expectEqual(core.http.Method.GET, exchanges[0].request_method);
-    try std.testing.expect(std.mem.find(u8, exchanges[0].request_url, "secrets/s1") != null);
-}
+    fn free(
+        context: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        return_address: usize,
+    ) void {
+        const self: *WipeCheckingAllocator = @ptrCast(@alignCast(context));
+        for (memory) |byte| {
+            if (byte != 0) self.all_frees_zero = false;
+        }
+        self.frees += 1;
+        self.backing.rawFree(memory, alignment, return_address);
+    }
+};
 
-test "RecordingTransport toJson" {
-    const allocator = std.testing.allocator;
-
-    var mock = core.http.MockTransport.init(allocator, 201, "{\"id\":\"123\"}");
-    defer mock.deinit();
-
-    var recorder = RecordingTransport.init(allocator, mock.asTransport());
-    defer recorder.deinit();
-
-    var req = core.http.Request.init(allocator, .POST, "https://example.com/items");
-    defer req.deinit();
-    var resp = try recorder.asTransport().send(&req);
-    defer resp.deinit();
-
-    const json = try recorder.toJson(allocator);
-    defer allocator.free(json);
-
-    // Verify JSON structure.
-    try std.testing.expect(std.mem.find(u8, json, "\"method\":\"POST\"") != null);
-    try std.testing.expect(std.mem.find(u8, json, "\"status\":201") != null);
-    try std.testing.expect(std.mem.find(u8, json, "example.com/items") != null);
-}
-
-test "isSensitiveHeader" {
-    try std.testing.expect(isSensitiveHeader("Authorization"));
-    try std.testing.expect(isSensitiveHeader("authorization"));
-    try std.testing.expect(isSensitiveHeader("Api-Key"));
-    try std.testing.expect(!isSensitiveHeader("Content-Type"));
-    try std.testing.expect(!isSensitiveHeader("Accept"));
+fn expectHex(expected: []const u8, actual: []const u8) !void {
+    const digits = "0123456789abcdef";
+    try std.testing.expectEqual(actual.len * 2, expected.len);
+    for (actual, 0..) |byte, index| {
+        try std.testing.expectEqual(digits[byte >> 4], expected[index * 2]);
+        try std.testing.expectEqual(
+            digits[byte & 0x0f],
+            expected[index * 2 + 1],
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- replace the bootstrapped testing template with branch-owned `azure_sdk_core_symcrypt` 0.1.0
- adapt pinned `zig_symcrypt` 0.1.0 to Core 0.3.0 `CryptoProvider` for secure random, compatibility-only MD5, SHA-256, HMAC-SHA256, and allocator-owned incremental SHA-256
- make provider/descriptor/operation lifetimes and concurrency explicit; eagerly ensure SymCrypt, preserve exact errors, stage all outputs, and wipe owned state and sensitive temporaries
- forward dynamic/static linkage, exact ordered libraries, complete headers, FRE/checked selection, target SDK includes, and fixture provenance while fixing legacy support to MD5-required mode and keeping SHA-1/legacy RSA outside the adapter API
- add a manifest-filtered external consumer, linkage example, detailed documentation, unsupported-target diagnostics, and source-only macOS validation
- build SymCrypt 103.13.0 from its pinned source in CI and verify released zig-symcrypt provenance for Linux/Windows x86_64 and Arm64 dynamic/static configurations

## Linkage matrix

| Target | Dynamic | Static | CI execution |
|---|---:|---:|---|
| x86_64-linux-gnu | yes | yes | native Debug + ReleaseSafe |
| aarch64-linux-gnu | yes | yes | native Debug + ReleaseSafe |
| x86_64-windows-msvc | yes | yes | native Debug + ReleaseSafe |
| aarch64-windows-msvc | yes | yes | native Debug + ReleaseSafe; verified x86-64 Zig runs under emulation |
| macOS/other targets | no | no | source/package checks; native request fails with supported triples |

## Local validation

Using SymCrypt `v103.13.0` / `286762b7730e2b780678f5ab11fef2b1bad639e0` fixtures built by the released zig-symcrypt tooling:

- dynamic Debug: 10/10 tests
- static Debug: 10/10 tests
- dynamic ReleaseSafe: 10/10 tests, example, provenance, package consumer
- static ReleaseSafe: 10/10 tests, example, provenance, package consumer
- x86_64/aarch64 FRE and checked header compilation
- source formatting and manifest-filtered package checks
- unsupported macOS/musl, missing libraries, and attempted legacy-option widening diagnostics

## Boundaries

This changes SDK hashing/signing only. It does not replace `std.http.Client` TLS cryptography or X.509 trust. MD5 is compatibility/integrity-only, and static linkage is not by itself a FIPS validation claim.

Closes #415