### PR TITLE
eventhubs: pin released AMQP 0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,10 +479,14 @@ try processor.close();
 
 `runOnce` is one balancing cycle rather than a thread, so the caller owns
 the loop and its shutdown. `close` is fallible and retryable: a detach timeout
-keeps the reader registered until its acknowledgement arrives. Call it while
-the connection is alive; `deinit` then releases local allocations. If the
+keeps the reader registered until its acknowledgement arrives, and every retry
+gets a fresh timeout duration on the current AMQP clock. Call it while the
+connection is alive; `deinit` then releases local allocations. If the
 connection must be terminated after an ambiguous close, `deinit` does not
-dereference the native receivers the connection already destroyed.
+dereference the native receivers the connection already destroyed. Processor
+readers also carry the recoverable connection generation, so a rebuild between
+cycles invalidates stale native pointers before receive or close and reopens
+the partition from its unchanged checkpoint.
 `nextIntervalMs` applies Go's 0.8–1.3 jitter to the update interval, which
 keeps a fleet that started together from rebalancing in lockstep.
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ Failures carry the broker's status and description, which a Zig error cannot,
 on `Management.last_error`. Both operations optionally run under the Event Hubs
 retry schedule, which classifies a management status into the AMQP condition it
 corresponds to — a 404 is fatal and is not retried, a 503 is not.
+On a recoverable transport, each attempt refetches the generation's management
+client. Read, write, remote-close, or settlement failure rebuilds the
+connection and session before retrying instead of repeatedly using the cached
+failed `$management` links.
 
 ## Event models
 
@@ -504,6 +508,9 @@ dereference the native receivers the connection already destroyed. Processor
 readers also carry the recoverable connection generation, so a rebuild between
 cycles invalidates stale native pointers before receive or close and reopens
 the partition from its unchanged checkpoint.
+Each cycle releases terminal readers before partition discovery, allowing a
+receiver that failed the shared connection to rebuild it before metadata uses
+that generation's cached management client.
 Closing one `ProcessorPartitionClient` removes it from `ownedPartitions`
 immediately after a confirmed detach; if storage still assigns the partition
 to this processor, the next balancing cycle opens a fresh reader.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the credential, the transport at the connection — so a copy would dangle.
 
 Nothing dials until the first operation runs, and `Options` carries the
 `ConnectionOptions` described below along with the container id, link id,
-consumer instance id, per-operation deadline, and retry jitter seed.
+consumer instance id, per-operation timeout, and retry jitter seed.
 
 `CbsAuthorizer` is the piece that satisfies `recovery.Authorizer`: before any
 link attaches on a connection generation, it opens `$cbs`, puts the client's
@@ -113,12 +113,15 @@ AMQP message. The service splits it back apart. Go and Rust produce the same
 shape.
 
 ```zig
-var pool = SenderPool.init(allocator, &session, .{ .deadline_ms = deadline });
+const operation_timeout_ms = 60_000;
+var pool = SenderPool.init(allocator, &session, .{
+    .deadline_ms = operation_timeout_ms,
+});
 defer pool.deinit();
 
 var transport = LinkTransport.init(management_client, .{
     .senders = &pool,
-    .deadline_ms = deadline,
+    .deadline_ms = operation_timeout_ms,
 });
 
 var batch = try producer.createBatch(allocator, .{ .partition_key = "orders" });
@@ -195,9 +198,10 @@ A partition is read through one receiver link held open for the life of a
 without advancing it replays events that were already handed to the caller.
 
 ```zig
+const receive_timeout_ms = 60_000;
 var pool = ReceiverPool.init(allocator, &session, .{
     .instance_id = "reader-1",
-    .deadline_ms = deadline,
+    .deadline_ms = receive_timeout_ms,
 });
 defer pool.deinit();
 
@@ -207,7 +211,7 @@ var transport = LinkTransport.init(management_client, .{
 });
 
 var partition: PartitionClient = undefined;
-try consumer.newPartitionClient(&partition, allocator, &session, "0", deadline, .{
+try consumer.newPartitionClient(&partition, allocator, &session, "0", receive_timeout_ms, .{
     .start_position = EventPosition.earliest(),
     .owner_level = 1,
 });
@@ -240,7 +244,9 @@ unsettled until its result and selector are ready for one atomic settlement;
 the eight-credit and byte windows continue to bound live payload retention.
 
 A receive that asks for more events than arrive returns the ones that did
-rather than failing: a quiet partition is not an error.
+rather than failing: a quiet partition is not an error. Its timeout is a
+duration renewed from the current AMQP clock for each `receiveEvents` call,
+not an absolute deadline captured when the link attached.
 
 ## Metadata
 
@@ -255,9 +261,10 @@ one, because the connection, its CBS authorisation, and its session outlive any
 single operation.
 
 ```zig
+const operation_timeout_ms = 60_000;
 var transport = LinkTransport.init(management_client, .{
     .security_token = token.token,
-    .deadline_ms = deadline,
+    .deadline_ms = operation_timeout_ms,
     .retry = .{ .sleeper = &sleeper, .random = prng.random() },
 });
 var props = try producer.getEventHubProperties(allocator);
@@ -478,7 +485,8 @@ try processor.close();
 ```
 
 `runOnce` is one balancing cycle rather than a thread, so the caller owns
-the loop and its shutdown. `close` is fallible and retryable: a detach timeout
+the loop and its shutdown. Keep the processor at a stable address after its
+first cycle because partition readers refer back to it. `close` is fallible and retryable: a detach timeout
 keeps the reader registered until its acknowledgement arrives, and every retry
 gets a fresh timeout duration on the current AMQP clock. Call it while the
 connection is alive; `deinit` then releases local allocations. If the
@@ -487,6 +495,9 @@ dereference the native receivers the connection already destroyed. Processor
 readers also carry the recoverable connection generation, so a rebuild between
 cycles invalidates stale native pointers before receive or close and reopens
 the partition from its unchanged checkpoint.
+Closing one `ProcessorPartitionClient` removes it from `ownedPartitions`
+immediately after a confirmed detach; if storage still assigns the partition
+to this processor, the next balancing cycle opens a fresh reader.
 `nextIntervalMs` applies Go's 0.8–1.3 jitter to the update interval, which
 keeps a fleet that started together from rebalancing in lockstep.
 

--- a/README.md
+++ b/README.md
@@ -228,10 +228,13 @@ first call for an address.
 `owner_level` attaches as an exclusive consumer via `com.microsoft:epoch`. A
 higher level detaches every lower one, which reports as `ownership_lost`.
 
-`prefetch` defaults to 300 credits, as Go and Rust do. A negative value
-disables prefetch and issues exactly the credit each receive needs, for a
-caller that wants to bound its own memory use. Neither prefetch nor a single
-receive may exceed 5000, the session's incoming window.
+`prefetch` defaults to a request for 300 credits, as Go and Rust do. Event Hubs
+receivers accept messages up to 32 MiB and retain at most 256 MiB of aggregate
+payload, so the link grants and replenishes at most eight credits at a time.
+A negative value disables prefetch and requests exactly the credit each receive
+needs; requests larger than eight are issued in bounded windows as deliveries
+release buffer space. Neither the requested prefetch nor a single receive may
+exceed 5000, the session's incoming window.
 
 A receive that asks for more events than arrive returns the ones that did
 rather than failing: a quiet partition is not an error.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,10 @@ payload, so the link grants and replenishes at most eight credits at a time.
 A negative value disables prefetch and requests exactly the credit each receive
 needs; requests larger than eight are issued in bounded windows as deliveries
 release buffer space. Neither the requested prefetch nor a single receive may
-exceed 5000, the session's incoming window.
+exceed 5000, the session's incoming window. The receiver also bounds unsettled
+delivery-id bookkeeping at 5000, allowing the largest public batch to remain
+unsettled until its result and selector are ready for one atomic settlement;
+the eight-credit and byte windows continue to bound live payload retention.
 
 A receive that asks for more events than arrive returns the ones that did
 rather than failing: a quiet partition is not an error.
@@ -441,7 +444,10 @@ partition's selector when it drops a client, so a reattach continues past
 the last sequence number handed to the caller instead of replaying from the
 configured start position. For the same reason, a receive that fails partway
 through a batch returns the events that did arrive rather than discarding
-them; the next call finds the link dead and recovers it.
+them when the wire fails. A local decode or allocation failure cannot return a
+valid batch, so it terminally detaches without advancing the selector; the
+next processor cycle reopens from the unchanged checkpoint and replays those
+sequences.
 
 ## Distributed consumption
 
@@ -468,12 +474,17 @@ while (running) {
     }
     std.Thread.sleep(@intCast(processor.nextIntervalMs() * std.time.ns_per_ms));
 }
+try processor.close();
 ```
 
 `runOnce` is one balancing cycle rather than a thread, so the caller owns
-the loop and its shutdown. `nextIntervalMs` applies Go's 0.8–1.3 jitter to
-the update interval, which keeps a fleet that started together from
-rebalancing in lockstep.
+the loop and its shutdown. `close` is fallible and retryable: a detach timeout
+keeps the reader registered until its acknowledgement arrives. Call it while
+the connection is alive; `deinit` then releases local allocations. If the
+connection must be terminated after an ambiguous close, `deinit` does not
+dereference the native receivers the connection already destroyed.
+`nextIntervalMs` applies Go's 0.8–1.3 jitter to the update interval, which
+keeps a fleet that started together from rebalancing in lockstep.
 
 Two strategies decide how fast a processor grows:
 

--- a/README.md
+++ b/README.md
@@ -449,12 +449,21 @@ rebuild would discard the first's healthy connection.
 Reattached receivers resume where they left off. The pool remembers each
 partition's selector when it drops a client, so a reattach continues past
 the last sequence number handed to the caller instead of replaying from the
-configured start position. For the same reason, a receive that fails partway
-through a batch returns the events that did arrive rather than discarding
-them when the wire fails. A local decode or allocation failure cannot return a
-valid batch, so it terminally detaches without advancing the selector; the
-next processor cycle reopens from the unchanged checkpoint and replays those
-sequences.
+configured start position. Its position slot is allocated before the link
+attaches; generation teardown swaps the current selector into that slot and
+removes every old wrapper without allocating, so allocator failure cannot
+leave a client pointing at a destroyed session.
+
+For the same reason, a receive that fails partway through a batch returns the
+events that did arrive rather than discarding them when the wire fails. A
+settlement write failure also returns the completed batch, but marks the link
+terminal so the next processor cycle replaces the failed connection. A local
+decode or allocation failure cannot return a valid batch, so it terminally
+detaches without advancing the selector; the next processor cycle reopens from
+the unchanged checkpoint and replays those sequences. If the service rejects
+a stored integer offset with `com.microsoft:georeplication:invalid-offset`,
+the replacement starts at earliest, inclusive, instead of retrying the
+unreadable offset.
 
 ## Distributed consumption
 

--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,15 @@
 const std = @import("std");
 
+/// Single source of truth for the package version: the manifest.
+const package_version = @import("build.zig.zon").version;
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    const options = b.addOptions();
+    options.addOption([]const u8, "version", package_version);
+    const options_mod = options.createModule();
 
     const core_dep = b.dependency("azure_sdk_core", .{
         .target = target,
@@ -51,6 +58,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "azure_sdk_amqp", .module = amqp_mod },
             .{ .name = "uamqp", .module = uamqp_mod },
             .{ .name = "serde", .module = serde_mod },
+            .{ .name = "build_options", .module = options_mod },
         },
     });
 
@@ -66,6 +74,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "azure_sdk_amqp", .module = amqp_mod },
                 .{ .name = "uamqp", .module = uamqp_mod },
                 .{ .name = "serde", .module = serde_mod },
+                .{ .name = "build_options", .module = options_mod },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d",
         },
         .azure_sdk_amqp = .{
-            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/1c5ba890ad9c2fcb366c8a18b24eb8d90976a4cc.tar.gz",
-            .hash = "azure_sdk_amqp-0.5.0-fUByf5TFCgBKs3NyXoM79xpHDwp7NExRKKj-YyZupvR8",
+            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b.tar.gz",
+            .hash = "azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b",
-            .hash = "azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#1f79509cef0bd4a85b913b0cd3457b2e22ba8297",
+            .hash = "azure_sdk_amqp-0.5.2-fUByfyGnCwCTf2xaEDjrtnKyBirhCDq8r7XxFJoYzXfN",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,7 +17,7 @@
             .hash = "azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d",
         },
         .azure_sdk_amqp = .{
-            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b.tar.gz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b",
             .hash = "azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam",
         },
         .serde = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "azure_sdk_storage_blobs-0.3.0-I5lGdpuWCgBfuhxSa_tltW_d6xEqEZEaanql3yI3GY-d",
         },
         .azure_sdk_amqp = .{
-            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#bd5330d983ca75a56771a085659ec1136c9a81f6",
-            .hash = "azure_sdk_amqp-0.4.0-fUByfyWRBwDU9pQlQL3AnageJI-noNZtH_5PxOJAk90U",
+            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/1c5ba890ad9c2fcb366c8a18b24eb8d90976a4cc.tar.gz",
+            .hash = "azure_sdk_amqp-0.5.0-fUByf5TFCgBKs3NyXoM79xpHDwp7NExRKKj-YyZupvR8",
         },
         .serde = .{
             .url = "git+https://github.com/cataggar/serde.zig#73d872776b0361b6fc92f6cecd7ccf2f05e77cdd",

--- a/connection_options.zig
+++ b/connection_options.zig
@@ -22,7 +22,7 @@ const recovery = @import("recovery.zig");
 const Allocator = std.mem.Allocator;
 
 /// Version reported to the service in the `open` properties.
-pub const sdk_version = "0.1.0";
+pub const sdk_version: []const u8 = @import("build_options").version;
 
 /// The product half of the user agent, matching the other SDKs' shape.
 pub const user_agent_product = "azsdk-zig-eventhubs";
@@ -344,14 +344,21 @@ test "the emulator is reached over plaintext on the AMQP port" {
 
 test "the application id leads the user agent" {
     const allocator = testing.allocator;
+    try testing.expectEqualStrings("0.6.0", sdk_version);
 
     const with_id = try (ConnectionOptions{ .application_id = "my-app/2.1" }).userAgent(allocator);
     defer allocator.free(with_id);
-    try testing.expect(std.mem.startsWith(u8, with_id, "my-app/2.1 azsdk-zig-eventhubs/"));
+    try testing.expectEqualStrings(
+        "my-app/2.1 azsdk-zig-eventhubs/0.6.0 (" ++ @tagName(builtin.os.tag) ++ ")",
+        with_id,
+    );
 
     const without = try (ConnectionOptions{}).userAgent(allocator);
     defer allocator.free(without);
-    try testing.expect(std.mem.startsWith(u8, without, "azsdk-zig-eventhubs/"));
+    try testing.expectEqualStrings(
+        "azsdk-zig-eventhubs/0.6.0 (" ++ @tagName(builtin.os.tag) ++ ")",
+        without,
+    );
 }
 
 test "the WebSocket URL names the namespace and the service bus path" {
@@ -455,8 +462,12 @@ test "a WebSocket hook is given the namespace URL and its stream opens the conne
     try testing.expectEqualStrings("container-1", open.container_id);
 
     const user_agent = propertyValue(open.properties.?, "user-agent").?;
-    try testing.expect(std.mem.startsWith(u8, user_agent, "my-app azsdk-zig-eventhubs/"));
+    try testing.expectEqualStrings(
+        "my-app azsdk-zig-eventhubs/0.6.0 (" ++ @tagName(builtin.os.tag) ++ ")",
+        user_agent,
+    );
     try testing.expectEqualStrings("azure-sdk-for-zig", propertyValue(open.properties.?, "product").?);
+    try testing.expectEqualStrings("0.6.0", propertyValue(open.properties.?, "version").?);
 
     // Geo-replication is only reported to a connection that asked for it.
     const capabilities = open.desired_capabilities.?;

--- a/connection_options.zig
+++ b/connection_options.zig
@@ -215,7 +215,7 @@ pub const AmqpConnectionFactory = struct {
     sasl: amqp.connection_driver.SaslMode = .anonymous,
     factory: recovery.ConnectionFactory = .{ .openFn = open, .closeFn = close },
 
-    fn open(f: *recovery.ConnectionFactory, deadline_ms: i64) anyerror!recovery.Plumbing {
+    fn open(f: *recovery.ConnectionFactory, timeout_ms: i64) anyerror!recovery.Plumbing {
         const self: *AmqpConnectionFactory = @fieldParentPtr("factory", f);
         const allocator = self.allocator;
 
@@ -276,6 +276,7 @@ pub const AmqpConnectionFactory = struct {
             .sasl = self.sasl,
         });
         errdefer driver.deinit();
+        const deadline_ms = driver.clock.nowMillis() +| @max(timeout_ms, 0);
         try driver.open(deadline_ms);
 
         const session = try allocator.create(amqp.Session);

--- a/examples/processor.zig
+++ b/examples/processor.zig
@@ -134,4 +134,5 @@ pub fn main(init: std.process.Init) !void {
             .awake,
         );
     }
+    try processor.close();
 }

--- a/live_tests/main.zig
+++ b/live_tests/main.zig
@@ -398,4 +398,5 @@ test "live: a lone processor claims every partition" {
         defer eh.freeReceivedEvents(allocator, events);
     }
     try testing.expectEqual(properties.partition_ids.len, handed_out);
+    try processor.close();
 }

--- a/management.zig
+++ b/management.zig
@@ -364,9 +364,9 @@ pub fn getEventHubPropertiesWithRetry(
                 self.hub_name,
                 self.security_token,
                 self.deadline_ms,
-            ) catch |e| {
-                recordCondition(self.mgmt, attempt);
-                return e;
+            ) catch |err| {
+                recordFailure(self.mgmt, attempt, err);
+                return err;
             };
         }
     };
@@ -407,9 +407,9 @@ pub fn getPartitionPropertiesWithRetry(
                 self.partition_id,
                 self.security_token,
                 self.deadline_ms,
-            ) catch |e| {
-                recordCondition(self.mgmt, attempt);
-                return e;
+            ) catch |err| {
+                recordFailure(self.mgmt, attempt, err);
+                return err;
             };
         }
     };
@@ -431,7 +431,12 @@ pub fn getPartitionPropertiesWithRetry(
 /// A management failure carries an HTTP-shaped status code rather than an AMQP
 /// error condition, so the mapping has to be made explicitly. Go does the same
 /// in `TransformError`.
-fn recordCondition(mgmt: *amqp.Management, attempt: *errors.Attempt) void {
+pub fn recordFailure(
+    mgmt: *amqp.Management,
+    attempt: *errors.Attempt,
+    err: anyerror,
+) void {
+    if (err != error.RequestFailed and err != error.Unauthorized) return;
     const status = mgmt.last_error orelse return;
     attempt.description = status.description;
     attempt.condition = switch (status.code) {

--- a/processor.zig
+++ b/processor.zig
@@ -308,6 +308,11 @@ pub const Processor = struct {
     /// One balancing cycle: claim, renew, open, and release.
     pub fn runOnce(self: *Processor) !void {
         if (self.closing or self.deinitialized) return error.ProcessorClosed;
+        // A receiver can be what invalidated the shared connection. Release
+        // it first so its production opener can rebuild the generation before
+        // partition discovery touches the cached `$management` client.
+        try self.releaseFailedReaders();
+
         const partition_ids = try self.opener.partitionIds(self.allocator);
         defer freePartitionIds(self.allocator, partition_ids);
 
@@ -330,6 +335,21 @@ pub const Processor = struct {
                 self.suppressed.contains(ownership.partition_id)) continue;
             try self.openPartition(ownership.partition_id, checkpoints);
         }
+    }
+
+    fn releaseFailedReaders(self: *Processor) !void {
+        var dropped: std.ArrayList([]const u8) = .empty;
+        defer dropped.deinit(self.allocator);
+
+        for (self.clients.keys(), self.clients.values()) |id, client| {
+            if (!client.link_closed) client.observeClientState();
+            if (!client.ownership_lost and !client.recoverable_failure) continue;
+            if (client.ownership_lost) try self.suppress(id);
+            if (client.geo_replication_fallback) try self.markGeoFallback(id);
+            try dropped.append(self.allocator, id);
+        }
+
+        for (dropped.items) |id| try self.releasePartition(id);
     }
 
     /// Close readers for partitions this cycle did not keep.

--- a/processor.zig
+++ b/processor.zig
@@ -10,6 +10,7 @@
 //! `nextPartitionClient` is `NextPartitionClient`.
 
 const std = @import("std");
+const amqp = @import("azure_sdk_amqp");
 const checkpoint_types = @import("checkpoint.zig");
 const errors = @import("errors.zig");
 const event_data = @import("event_data.zig");
@@ -79,11 +80,16 @@ pub const ProcessorPartitionClient = struct {
     store: *CheckpointStore,
     details: OwnershipDetails,
     opener: *PartitionOpener,
-    closed: bool = false,
+    link_closed: bool = false,
+    finalized: bool = false,
     /// Set when the broker says another processor took the partition. The
     /// processor releases rather than retries: the whole point of an owner
     /// level is that the newer reader wins.
     ownership_lost: bool = false,
+    /// A local post-consumption failure made the link terminal without
+    /// advancing its selector. The next balancing cycle replaces this reader
+    /// so the broker can replay from the checkpoint.
+    recoverable_failure: bool = false,
 
     pub fn partitionId(self: *const ProcessorPartitionClient) []const u8 {
         return self.partition_id;
@@ -96,9 +102,13 @@ pub const ProcessorPartitionClient = struct {
         allocator: Allocator,
         count: u32,
     ) ![]ReceivedEventData {
+        if (self.link_closed) return error.LinkDetached;
         return self.client.receiveEvents(allocator, count) catch |err| {
             if (self.client.last_error) |info| {
                 if (info.code == .ownership_lost) self.ownership_lost = true;
+            }
+            if (!self.ownership_lost and self.client.terminal) {
+                self.recoverable_failure = true;
             }
             return err;
         };
@@ -124,19 +134,19 @@ pub const ProcessorPartitionClient = struct {
     /// intact so the caller can retry the same close handshake.
     pub fn close(self: *ProcessorPartitionClient) !void {
         try self.closeReader();
-        self.finishClose();
     }
 
     fn closeReader(self: *ProcessorPartitionClient) !void {
-        if (self.closed) return;
+        if (self.link_closed) return;
         try self.opener.close(self.client);
+        self.link_closed = true;
     }
 
     fn finishClose(self: *ProcessorPartitionClient) void {
-        if (self.closed) return;
+        if (self.finalized) return;
         self.allocator.free(self.partition_id);
         self.partition_id = &.{};
-        self.closed = true;
+        self.finalized = true;
     }
 };
 
@@ -152,7 +162,14 @@ pub const Processor = struct {
     clients: std.StringArrayHashMapUnmanaged(*ProcessorPartitionClient) = .empty,
     /// Newly opened readers waiting to be handed out.
     pending: std.ArrayList(*ProcessorPartitionClient) = .empty,
+    /// Partitions whose broker link reported ownership loss. They are not
+    /// reopened while the store still claims them for this processor; seeing
+    /// a cycle where another owner holds them clears the suppression.
+    suppressed: std.StringHashMapUnmanaged(void) = .empty,
     deadline_ms: i64 = 60_000,
+    closing: bool = false,
+    relinquished: bool = false,
+    deinitialized: bool = false,
 
     pub fn init(
         allocator: Allocator,
@@ -181,36 +198,71 @@ pub const Processor = struct {
         };
     }
 
-    /// Close every reader and drop the ownership records.
+    /// Detach every reader while its connection is still alive.
     ///
-    /// Relinquishing is best effort: a processor whose store has gone away
-    /// still has to stop cleanly, and the records expire on their own.
-    /// A reader whose detach is ambiguous remains owned so another `deinit`
-    /// call can finish it after the session receives the acknowledgement.
-    pub fn deinit(self: *Processor) void {
-        var held: std.ArrayList([]const u8) = .empty;
-        defer held.deinit(self.allocator);
-        for (self.clients.keys()) |id| held.append(self.allocator, id) catch {};
-        self.balancer.relinquish(held.items) catch {};
+    /// An ambiguous detach is returned and its wrapper remains owned, so this
+    /// operation can be retried after the session receives more frames.
+    /// Relinquishing is best effort; ownership records also expire naturally.
+    pub fn close(self: *Processor) !void {
+        if (self.deinitialized) return;
+        self.closing = true;
+        self.relinquish();
 
+        var first_error: ?anyerror = null;
         var index: usize = 0;
         while (index < self.clients.count()) {
             const id = self.clients.keys()[index];
-            self.releasePartition(id) catch {
-                // An ambiguous detach must retain the wrapper and client so a
-                // later deinit can finish the same close handshake.
+            self.releasePartition(id) catch |err| {
+                if (first_error == null) first_error = err;
                 index += 1;
                 continue;
             };
         }
-        if (self.clients.count() == 0) {
-            self.clients.deinit(self.allocator);
-            self.pending.deinit(self.allocator);
+        if (first_error) |err| return err;
+    }
+
+    /// Release all processor-owned allocations.
+    ///
+    /// Call `close` first while the connection is usable. If closing remains
+    /// ambiguous, terminate the owning connection/session before `deinit`;
+    /// this method never dereferences a native receiver and leaves its final
+    /// destruction to that owner.
+    pub fn deinit(self: *Processor) void {
+        if (self.deinitialized) return;
+        self.relinquish();
+
+        for (self.clients.values()) |client| {
+            if (!client.link_closed) {
+                client.client.deinit();
+                client.client.allocator.destroy(client.client);
+            }
+            client.finishClose();
+            self.allocator.destroy(client);
         }
+        self.clients.deinit(self.allocator);
+        self.pending.deinit(self.allocator);
+        var suppressed = self.suppressed.keyIterator();
+        while (suppressed.next()) |id| self.allocator.free(id.*);
+        self.suppressed.deinit(self.allocator);
+        self.deinitialized = true;
+    }
+
+    fn relinquish(self: *Processor) void {
+        if (self.relinquished) return;
+        var held: std.ArrayList([]const u8) = .empty;
+        defer held.deinit(self.allocator);
+        for (self.clients.keys()) |id| held.append(self.allocator, id) catch {};
+        var suppressed = self.suppressed.keyIterator();
+        while (suppressed.next()) |id| {
+            if (!self.clients.contains(id.*)) held.append(self.allocator, id.*) catch {};
+        }
+        self.balancer.relinquish(held.items) catch {};
+        self.relinquished = true;
     }
 
     /// One balancing cycle: claim, renew, open, and release.
     pub fn runOnce(self: *Processor) !void {
+        if (self.closing or self.deinitialized) return error.ProcessorClosed;
         const partition_ids = try self.opener.partitionIds(self.allocator);
         defer freePartitionIds(self.allocator, partition_ids);
 
@@ -218,6 +270,7 @@ pub const Processor = struct {
         defer checkpoint_types.freeOwnerships(self.allocator, claimed);
 
         try self.releaseUnclaimed(claimed);
+        try self.clearUnclaimedSuppressions(claimed);
 
         const checkpoints = try self.store.listCheckpoints(
             self.allocator,
@@ -228,7 +281,8 @@ pub const Processor = struct {
         defer checkpoint_types.freeCheckpoints(self.allocator, checkpoints);
 
         for (claimed) |ownership| {
-            if (self.clients.contains(ownership.partition_id)) continue;
+            if (self.clients.contains(ownership.partition_id) or
+                self.suppressed.contains(ownership.partition_id)) continue;
             try self.openPartition(ownership.partition_id, checkpoints);
         }
     }
@@ -250,11 +304,44 @@ pub const Processor = struct {
                     break;
                 }
             }
-            if (kept and !client.ownership_lost) continue;
+            if (kept and !client.ownership_lost and !client.recoverable_failure) continue;
+            if (client.ownership_lost) try self.suppress(id);
             try dropped.append(self.allocator, id);
         }
 
         for (dropped.items) |id| try self.releasePartition(id);
+    }
+
+    fn suppress(self: *Processor, partition_id: []const u8) !void {
+        if (self.suppressed.contains(partition_id)) return;
+        const owned = try self.allocator.dupe(u8, partition_id);
+        errdefer self.allocator.free(owned);
+        try self.suppressed.put(self.allocator, owned, {});
+    }
+
+    fn clearUnclaimedSuppressions(
+        self: *Processor,
+        claimed: []const checkpoint_types.PartitionOwnership,
+    ) !void {
+        var cleared: std.ArrayList([]const u8) = .empty;
+        defer cleared.deinit(self.allocator);
+
+        var it = self.suppressed.keyIterator();
+        while (it.next()) |id| {
+            var still_claimed = false;
+            for (claimed) |ownership| {
+                if (std.mem.eql(u8, ownership.partition_id, id.*)) {
+                    still_claimed = true;
+                    break;
+                }
+            }
+            if (!still_claimed) try cleared.append(self.allocator, id.*);
+        }
+
+        for (cleared.items) |id| {
+            const removed = self.suppressed.fetchRemove(id) orelse continue;
+            self.allocator.free(removed.key);
+        }
     }
 
     fn releasePartition(self: *Processor, partition_id: []const u8) !void {
@@ -434,7 +521,6 @@ const FakeOpener = struct {
         const client = try allocator.create(PartitionClient);
         client.* = .{
             .allocator = allocator,
-            .receiver = undefined,
             .filter_expression = &.{},
             .prefetch = 0,
             .owner_level = null,
@@ -453,6 +539,116 @@ const FakeOpener = struct {
         client.allocator.destroy(client);
     }
 };
+
+const AmqpTestOpener = struct {
+    session: *amqp.Session,
+    opens: usize = 0,
+    closes: usize = 0,
+    filter_bufs: [4][128]u8 = undefined,
+    filter_lens: [4]usize = @splat(0),
+    opener: PartitionOpener = .{
+        .partitionIdsFn = partitionIds,
+        .openFn = open,
+        .closeFn = close,
+    },
+
+    const source = "my-hub/ConsumerGroups/$default/Partitions/0";
+    const instance_id = "processor-test";
+    const link_name = source ++ "-receiver-" ++ instance_id;
+
+    fn partitionIds(_: *PartitionOpener, allocator: Allocator) anyerror![][]const u8 {
+        const ids = try allocator.alloc([]const u8, 1);
+        errdefer allocator.free(ids);
+        ids[0] = try allocator.dupe(u8, "0");
+        return ids;
+    }
+
+    fn open(
+        o: *PartitionOpener,
+        allocator: Allocator,
+        _: []const u8,
+        position: EventPosition,
+        options: PartitionClientOptions,
+    ) anyerror!*PartitionClient {
+        const self: *AmqpTestOpener = @fieldParentPtr("opener", o);
+        const filter = try position.toFilterExpression(allocator);
+        defer allocator.free(filter);
+
+        const index = self.opens;
+        if (index < self.filter_bufs.len) {
+            const len = @min(filter.len, self.filter_bufs[index].len);
+            @memcpy(self.filter_bufs[index][0..len], filter[0..len]);
+            self.filter_lens[index] = len;
+        }
+
+        const client = try allocator.create(PartitionClient);
+        errdefer allocator.destroy(client);
+        try client.open(allocator, self.session, .{
+            .source_address = source,
+            .instance_id = instance_id,
+            .deadline_ms = 10_000,
+            .filter_expression = filter,
+        }, options);
+        self.opens += 1;
+        return client;
+    }
+
+    fn close(o: *PartitionOpener, client: *PartitionClient) anyerror!void {
+        const self: *AmqpTestOpener = @fieldParentPtr("opener", o);
+        try client.close(10_000);
+        client.allocator.destroy(client);
+        self.closes += 1;
+    }
+
+    fn filterAt(self: *const AmqpTestOpener, index: usize) []const u8 {
+        return self.filter_bufs[index][0..self.filter_lens[index]];
+    }
+};
+
+fn scriptProcessorAttach(peer: amqp.test_peer.Peer, handle: u32) !void {
+    try peer.push(0, .{ .attach = .{
+        .name = AmqpTestOpener.link_name,
+        .handle = handle,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+}
+
+fn pushProcessorEvent(
+    allocator: Allocator,
+    peer: amqp.test_peer.Peer,
+    handle: u32,
+    id: u32,
+    sequence_number: i64,
+    body: []const u8,
+) !void {
+    var annotations = [_]amqp.MapEntry{
+        .{
+            .key = .{ .symbol = event_data.sequence_number_annotation },
+            .value = .{ .long = sequence_number },
+        },
+        .{
+            .key = .{ .symbol = event_data.offset_annotation },
+            .value = .{ .string = "100" },
+        },
+    };
+    const bodies = [_][]const u8{body};
+    const payload = try amqp.encodeMessageAlloc(allocator, .{
+        .message_annotations = &annotations,
+        .body = .{ .data = &bodies },
+    });
+    defer allocator.free(payload);
+
+    const tag = std.mem.asBytes(&id);
+    try peer.pushTransfer(0, .{
+        .handle = handle,
+        .delivery_id = id,
+        .delivery_tag = tag,
+        .message_format = 0,
+        .settled = false,
+        .more = false,
+    }, payload);
+}
 
 const test_details = OwnershipDetails{
     .fully_qualified_namespace = "ns.servicebus.windows.net",
@@ -552,15 +748,27 @@ test "a reader that lost ownership is closed rather than reused" {
 
     try processor.runOnce();
 
-    // The link is gone, so the reader must be too. Go drops the client and
-    // lets the next cycle decide; because the store still says the partition
-    // is ours, that means a fresh reader rather than the dead one.
+    // The link is gone, so the reader must be too. The store has not observed
+    // the new owner yet, so reopening now would steal the partition straight
+    // back; ownership loss remains nonretryable until a cycle sees it held by
+    // somebody else.
     try testing.expectEqual(@as(usize, 1), opener.closed);
-    try testing.expectEqual(@as(usize, 2), opener.opened.items.len);
-    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+    try testing.expectEqual(@as(usize, 1), opener.opened.items.len);
+    try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+    try testing.expect(processor.nextPartitionClient() == null);
+    try testing.expect(processor.suppressed.contains("0"));
 
-    const second = processor.nextPartitionClient().?;
-    try testing.expect(!second.ownership_lost);
+    const stolen = [_]checkpoint_types.PartitionOwnership{.{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "0",
+        .owner_id = "processor-b",
+    }};
+    const taken = try store.store.claimOwnership(allocator, &stolen);
+    checkpoint_types.freeOwnerships(allocator, taken);
+    try processor.runOnce();
+    try testing.expect(!processor.suppressed.contains("0"));
 }
 
 test "a partition claimed by another processor is released" {
@@ -638,11 +846,151 @@ test "an ambiguous partition close retains ownership for retry" {
     try testing.expectError(error.Timeout, processor.runOnce());
     try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
     try testing.expect(processor.clients.get("0").? == retained);
-    try testing.expect(!retained.closed);
+    try testing.expect(!retained.link_closed);
 
     try processor.runOnce();
     try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
     try testing.expectEqual(@as(usize, 1), opener.closed);
+}
+
+test "Processor.close retains timed out readers for retry" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{"0"} };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(29);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const retained = processor.clients.get("0").?;
+
+    opener.close_failures_remaining = 1;
+    try testing.expectError(error.Timeout, processor.close());
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+    try testing.expect(processor.clients.get("0").? == retained);
+    try testing.expect(!retained.link_closed);
+
+    try processor.close();
+    try processor.close();
+    try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+    try testing.expectEqual(@as(usize, 1), opener.closed);
+}
+
+test "terminal allocation failure is reopened and replayed next cycle" {
+    const allocator = testing.allocator;
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var amqp_clock = amqp.connection_driver.ManualClock{};
+    var conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        mem.transport(),
+        amqp_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer conn.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+    try amqp.test_peer.scriptHandshake(peer, 512);
+    try scriptProcessorAttach(peer, 0);
+    try pushProcessorEvent(allocator, peer, 0, 0, 1, "first attempt");
+    try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    try scriptProcessorAttach(peer, 1);
+    try pushProcessorEvent(allocator, peer, 1, 1, 1, "replayed");
+    try peer.push(0, .{ .detach = .{ .handle = 1, .closed = true } });
+
+    var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
+    defer fixture.deinit();
+    var opener = AmqpTestOpener{ .session = &fixture.session };
+
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(31);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const first = processor.nextPartitionClient().?;
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .fail_index = 0 });
+    first.client.allocator = failing.allocator();
+    try testing.expectError(error.OutOfMemory, first.receiveEvents(allocator, 1));
+    try testing.expect(first.recoverable_failure);
+    try testing.expect(!first.ownership_lost);
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), opener.opens);
+    try testing.expectEqual(@as(usize, 1), opener.closes);
+    try testing.expectEqualStrings(opener.filterAt(0), opener.filterAt(1));
+
+    const replacement = processor.nextPartitionClient().?;
+    const replayed = try replacement.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, replayed);
+    try testing.expectEqual(@as(usize, 1), replayed.len);
+    try testing.expectEqual(@as(i64, 1), replayed[0].sequence_number);
+    try testing.expectEqualStrings("replayed", replayed[0].body());
+
+    try processor.close();
+}
+
+test "Processor.deinit after session termination never reads freed receivers" {
+    const allocator = testing.allocator;
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var amqp_clock = amqp.connection_driver.ManualClock{};
+    var conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        mem.transport(),
+        amqp_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer conn.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+    try amqp.test_peer.scriptHandshake(peer, 512);
+    try scriptProcessorAttach(peer, 0);
+
+    var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
+    var opener = AmqpTestOpener{ .session = &fixture.session };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(37);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 1), fixture.session.receivers.items.len);
+
+    fixture.deinit();
+    processor.deinit();
+    try testing.expect(processor.deinitialized);
 }
 
 test "a rejected offset reopens at earliest, inclusive" {
@@ -753,6 +1101,7 @@ test "shutdown relinquishes every partition it held" {
     );
     try processor.runOnce();
     try testing.expectEqual(@as(usize, 2), processor.ownedPartitions().len);
+    try processor.close();
     processor.deinit();
 
     try testing.expectEqual(@as(usize, 2), opener.closed);

--- a/processor.zig
+++ b/processor.zig
@@ -87,6 +87,7 @@ pub const ProcessorPartitionClient = struct {
     store: *CheckpointStore,
     details: OwnershipDetails,
     opener: *PartitionOpener,
+    processor: *Processor,
     link_closed: bool = false,
     finalized: bool = false,
     /// Set when the broker says another processor took the partition. The
@@ -147,10 +148,15 @@ pub const ProcessorPartitionClient = struct {
         });
     }
 
-    /// Close the underlying link. An ambiguous detach keeps this wrapper
-    /// intact so the caller can retry the same close handshake.
+    /// Close the underlying link and release it from the processor.
+    ///
+    /// An ambiguous detach keeps this wrapper registered so the caller can
+    /// retry the same close handshake. After success this pointer is invalid;
+    /// a later balancing cycle may open a replacement for the partition.
     pub fn close(self: *ProcessorPartitionClient) !void {
-        try self.closeReader();
+        const processor = self.processor;
+        const partition_id = self.partition_id;
+        try processor.releasePartition(partition_id);
     }
 
     fn closeReader(self: *ProcessorPartitionClient) !void {
@@ -183,11 +189,13 @@ pub const Processor = struct {
     /// reopened while the store still claims them for this processor; seeing
     /// a cycle where another owner holds them clears the suppression.
     suppressed: std.StringHashMapUnmanaged(void) = .empty,
-    deadline_ms: i64 = 60_000,
     closing: bool = false,
     relinquished: bool = false,
     deinitialized: bool = false,
 
+    /// Keep the returned value at a stable address after its first balancing
+    /// cycle. Partition readers retain a pointer to their owning processor so
+    /// a successful public close can unregister itself.
     pub fn init(
         allocator: Allocator,
         store: *CheckpointStore,
@@ -422,6 +430,7 @@ pub const Processor = struct {
             .store = self.store,
             .details = self.details,
             .opener = self.opener,
+            .processor = self,
         };
 
         try self.clients.put(self.allocator, owned_id, wrapper);
@@ -545,7 +554,7 @@ const FakeOpener = struct {
             .filter_expression = &.{},
             .prefetch = 0,
             .owner_level = null,
-            .deadline_ms = 0,
+            .receive_timeout_ms = 0,
         };
         return client;
     }
@@ -618,7 +627,7 @@ const AmqpTestOpener = struct {
         try client.open(allocator, self.session, .{
             .source_address = source,
             .instance_id = instance_id,
-            .deadline_ms = receiving.deadlineAfter(self.session, 10_000),
+            .deadline_ms = 10_000,
             .filter_expression = filter,
             .generation_guard = if (self.generation) |generation| .{
                 .context = generation,
@@ -823,6 +832,44 @@ test "each claimed partition is handed out once" {
     try testing.expectEqual(@as(usize, 2), seen);
     // A second drain yields nothing: the reader is already the caller's.
     try testing.expect(processor.nextPartitionClient() == null);
+}
+
+test "public partition close unregisters and reopens the claimed partition" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{"0"} };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(9);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const first = processor.nextPartitionClient().?;
+
+    opener.close_failures_remaining = 1;
+    try testing.expectError(error.Timeout, first.close());
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+    try testing.expect(processor.clients.get("0").? == first);
+
+    try first.close();
+    try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+    try testing.expect(processor.nextPartitionClient() == null);
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+    try testing.expectEqual(@as(usize, 2), opener.opened.items.len);
+    _ = processor.nextPartitionClient().?;
 }
 
 test "a reader that lost ownership is closed rather than reused" {
@@ -1166,6 +1213,73 @@ test "remote detach after a short batch is replaced next cycle" {
     const events = try replacement.receiveEvents(allocator, 1);
     defer event_data.freeReceivedEvents(allocator, events);
     try testing.expectEqual(@as(i64, 2), events[0].sequence_number);
+    try testing.expectEqualStrings("replacement", events[0].body());
+
+    try processor.close();
+}
+
+test "manual credit observes a detach pumped before receive and replaces the link" {
+    const allocator = testing.allocator;
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var amqp_clock = amqp.connection_driver.ManualClock{};
+    var conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        mem.transport(),
+        amqp_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer conn.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+    try amqp.test_peer.scriptHandshake(peer, 512);
+    try scriptProcessorAttach(peer, 0);
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{
+            .condition = errors.condition.detach_forced,
+            .description = "move",
+        },
+    } });
+    try scriptProcessorAttach(peer, 1);
+    try pushProcessorEvent(allocator, peer, 1, 0, 1, "replacement");
+    try peer.push(0, .{ .detach = .{ .handle = 1, .closed = true } });
+
+    var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
+    defer fixture.deinit();
+    var opener = AmqpTestOpener{ .session = &fixture.session };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(42);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy, .prefetch = -1 },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const first = processor.nextPartitionClient().?;
+
+    // Another user of the shared session can observe this detach before the
+    // partition asks for manual credit. The Flow call itself must classify
+    // the dead link so the processor does not retain it forever.
+    _ = try fixture.session.pump(receiving.deadlineAfter(&fixture.session, 10_000));
+    try testing.expectError(error.LinkDetached, first.receiveEvents(allocator, 1));
+    try testing.expect(first.recoverable_failure);
+    try testing.expect(!first.ownership_lost);
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), opener.opens);
+    const replacement = processor.nextPartitionClient().?;
+    const events = try replacement.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, events);
     try testing.expectEqualStrings("replacement", events[0].body());
 
     try processor.close();

--- a/processor.zig
+++ b/processor.zig
@@ -42,7 +42,7 @@ pub const PartitionOpener = struct {
         position: EventPosition,
         options: PartitionClientOptions,
     ) anyerror!*PartitionClient,
-    closeFn: *const fn (self: *PartitionOpener, client: *PartitionClient) void,
+    closeFn: *const fn (self: *PartitionOpener, client: *PartitionClient) anyerror!void,
 
     /// The hub's partition ids. Caller owns the slice and its strings.
     pub fn partitionIds(self: *PartitionOpener, allocator: Allocator) ![][]const u8 {
@@ -59,8 +59,8 @@ pub const PartitionOpener = struct {
         return self.openFn(self, allocator, partition_id, position, options);
     }
 
-    pub fn close(self: *PartitionOpener, client: *PartitionClient) void {
-        self.closeFn(self, client);
+    pub fn close(self: *PartitionOpener, client: *PartitionClient) !void {
+        try self.closeFn(self, client);
     }
 };
 
@@ -79,6 +79,7 @@ pub const ProcessorPartitionClient = struct {
     store: *CheckpointStore,
     details: OwnershipDetails,
     opener: *PartitionOpener,
+    closed: bool = false,
     /// Set when the broker says another processor took the partition. The
     /// processor releases rather than retries: the whole point of an owner
     /// level is that the newer reader wins.
@@ -119,9 +120,23 @@ pub const ProcessorPartitionClient = struct {
         });
     }
 
-    pub fn close(self: *ProcessorPartitionClient) void {
-        self.opener.close(self.client);
+    /// Close the underlying link. An ambiguous detach keeps this wrapper
+    /// intact so the caller can retry the same close handshake.
+    pub fn close(self: *ProcessorPartitionClient) !void {
+        try self.closeReader();
+        self.finishClose();
+    }
+
+    fn closeReader(self: *ProcessorPartitionClient) !void {
+        if (self.closed) return;
+        try self.opener.close(self.client);
+    }
+
+    fn finishClose(self: *ProcessorPartitionClient) void {
+        if (self.closed) return;
         self.allocator.free(self.partition_id);
+        self.partition_id = &.{};
+        self.closed = true;
     }
 };
 
@@ -170,18 +185,28 @@ pub const Processor = struct {
     ///
     /// Relinquishing is best effort: a processor whose store has gone away
     /// still has to stop cleanly, and the records expire on their own.
+    /// A reader whose detach is ambiguous remains owned so another `deinit`
+    /// call can finish it after the session receives the acknowledgement.
     pub fn deinit(self: *Processor) void {
         var held: std.ArrayList([]const u8) = .empty;
         defer held.deinit(self.allocator);
         for (self.clients.keys()) |id| held.append(self.allocator, id) catch {};
         self.balancer.relinquish(held.items) catch {};
 
-        for (self.clients.values()) |client| {
-            client.close();
-            self.allocator.destroy(client);
+        var index: usize = 0;
+        while (index < self.clients.count()) {
+            const id = self.clients.keys()[index];
+            self.releasePartition(id) catch {
+                // An ambiguous detach must retain the wrapper and client so a
+                // later deinit can finish the same close handshake.
+                index += 1;
+                continue;
+            };
         }
-        self.clients.deinit(self.allocator);
-        self.pending.deinit(self.allocator);
+        if (self.clients.count() == 0) {
+            self.clients.deinit(self.allocator);
+            self.pending.deinit(self.allocator);
+        }
     }
 
     /// One balancing cycle: claim, renew, open, and release.
@@ -229,11 +254,13 @@ pub const Processor = struct {
             try dropped.append(self.allocator, id);
         }
 
-        for (dropped.items) |id| self.releasePartition(id);
+        for (dropped.items) |id| try self.releasePartition(id);
     }
 
-    fn releasePartition(self: *Processor, partition_id: []const u8) void {
+    fn releasePartition(self: *Processor, partition_id: []const u8) !void {
         const client = self.clients.get(partition_id) orelse return;
+
+        try client.closeReader();
 
         var i: usize = 0;
         while (i < self.pending.items.len) {
@@ -244,7 +271,7 @@ pub const Processor = struct {
             i += 1;
         }
         _ = self.clients.orderedRemove(partition_id);
-        client.close();
+        client.finishClose();
         self.allocator.destroy(client);
     }
 
@@ -334,6 +361,7 @@ const FakeOpener = struct {
     /// Every position the processor asked to open at, in order.
     opened: std.ArrayList(Opened) = .empty,
     closed: usize = 0,
+    close_failures_remaining: usize = 0,
     /// Reject an offset once, as a geo-replicated namespace does.
     reject_offsets: bool = false,
     opener: PartitionOpener = .{
@@ -415,8 +443,12 @@ const FakeOpener = struct {
         return client;
     }
 
-    fn close(o: *PartitionOpener, client: *PartitionClient) void {
+    fn close(o: *PartitionOpener, client: *PartitionClient) anyerror!void {
         const self: *FakeOpener = @fieldParentPtr("opener", o);
+        if (self.close_failures_remaining > 0) {
+            self.close_failures_remaining -= 1;
+            return error.Timeout;
+        }
         self.closed += 1;
         client.allocator.destroy(client);
     }
@@ -563,6 +595,50 @@ test "a partition claimed by another processor is released" {
     }};
     const taken = try store.store.claimOwnership(allocator, &stolen);
     checkpoint_types.freeOwnerships(allocator, taken);
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+    try testing.expectEqual(@as(usize, 1), opener.closed);
+}
+
+test "an ambiguous partition close retains ownership for retry" {
+    const allocator = testing.allocator;
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var opener = FakeOpener{ .allocator = allocator, .partitions = &.{"0"} };
+    defer opener.deinit();
+
+    var random = std.Random.DefaultPrng.init(23);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const retained = processor.clients.get("0").?;
+
+    const stolen = [_]checkpoint_types.PartitionOwnership{.{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "0",
+        .owner_id = "processor-b",
+    }};
+    const taken = try store.store.claimOwnership(allocator, &stolen);
+    checkpoint_types.freeOwnerships(allocator, taken);
+
+    opener.close_failures_remaining = 1;
+    try testing.expectError(error.Timeout, processor.runOnce());
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+    try testing.expect(processor.clients.get("0").? == retained);
+    try testing.expect(!retained.closed);
 
     try processor.runOnce();
     try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);

--- a/processor.zig
+++ b/processor.zig
@@ -98,6 +98,10 @@ pub const ProcessorPartitionClient = struct {
     /// advancing its selector. The next balancing cycle replaces this reader
     /// so the broker can replay from the checkpoint.
     recoverable_failure: bool = false,
+    /// The service cannot interpret the stored integer offset after a
+    /// geo-replication failover. The replacement starts at earliest,
+    /// inclusive, rather than retrying the same rejected checkpoint forever.
+    geo_replication_fallback: bool = false,
 
     pub fn partitionId(self: *const ProcessorPartitionClient) []const u8 {
         return self.partition_id;
@@ -126,6 +130,9 @@ pub const ProcessorPartitionClient = struct {
         _ = self.client.refreshGeneration();
         if (self.client.last_error) |info| {
             if (info.code == .ownership_lost) self.ownership_lost = true;
+        }
+        if (self.client.geo_replication_fallback) {
+            self.geo_replication_fallback = true;
         }
         if (!self.ownership_lost and self.client.terminal) {
             self.recoverable_failure = true;
@@ -189,6 +196,10 @@ pub const Processor = struct {
     /// reopened while the store still claims them for this processor; seeing
     /// a cycle where another owner holds them clears the suppression.
     suppressed: std.StringHashMapUnmanaged(void) = .empty,
+    /// Partitions whose stored integer offset was rejected after a
+    /// geo-replication failover. Keys are owned and survive removal of the
+    /// failed reader until its replacement is fully registered.
+    geo_fallbacks: std.StringHashMapUnmanaged(void) = .empty,
     closing: bool = false,
     relinquished: bool = false,
     deinitialized: bool = false,
@@ -269,6 +280,9 @@ pub const Processor = struct {
         var suppressed = self.suppressed.keyIterator();
         while (suppressed.next()) |id| self.allocator.free(id.*);
         self.suppressed.deinit(self.allocator);
+        var fallbacks = self.geo_fallbacks.keyIterator();
+        while (fallbacks.next()) |id| self.allocator.free(id.*);
+        self.geo_fallbacks.deinit(self.allocator);
         self.deinitialized = true;
     }
 
@@ -280,6 +294,12 @@ pub const Processor = struct {
         var suppressed = self.suppressed.keyIterator();
         while (suppressed.next()) |id| {
             if (!self.clients.contains(id.*)) held.append(self.allocator, id.*) catch {};
+        }
+        var fallbacks = self.geo_fallbacks.keyIterator();
+        while (fallbacks.next()) |id| {
+            if (!self.clients.contains(id.*) and !self.suppressed.contains(id.*)) {
+                held.append(self.allocator, id.*) catch {};
+            }
         }
         self.balancer.relinquish(held.items) catch {};
         self.relinquished = true;
@@ -332,6 +352,7 @@ pub const Processor = struct {
             }
             if (kept and !client.ownership_lost and !client.recoverable_failure) continue;
             if (client.ownership_lost) try self.suppress(id);
+            if (client.geo_replication_fallback) try self.markGeoFallback(id);
             try dropped.append(self.allocator, id);
         }
 
@@ -343,6 +364,18 @@ pub const Processor = struct {
         const owned = try self.allocator.dupe(u8, partition_id);
         errdefer self.allocator.free(owned);
         try self.suppressed.put(self.allocator, owned, {});
+    }
+
+    fn markGeoFallback(self: *Processor, partition_id: []const u8) !void {
+        if (self.geo_fallbacks.contains(partition_id)) return;
+        const owned = try self.allocator.dupe(u8, partition_id);
+        errdefer self.allocator.free(owned);
+        try self.geo_fallbacks.put(self.allocator, owned, {});
+    }
+
+    fn clearGeoFallback(self: *Processor, partition_id: []const u8) void {
+        const removed = self.geo_fallbacks.fetchRemove(partition_id) orelse return;
+        self.allocator.free(removed.key);
     }
 
     fn clearUnclaimedSuppressions(
@@ -394,11 +427,15 @@ pub const Processor = struct {
             if (std.mem.eql(u8, c.partition_id, partition_id)) stored = c;
         }
 
-        const position = try balancing.resolveStartPosition(
-            self.options.start_positions,
-            partition_id,
-            stored,
-        );
+        const use_geo_fallback = self.geo_fallbacks.contains(partition_id);
+        const position = if (use_geo_fallback)
+            balancing.geo_replication_fallback
+        else
+            try balancing.resolveStartPosition(
+                self.options.start_positions,
+                partition_id,
+                stored,
+            );
 
         const options: PartitionClientOptions = .{ .prefetch = self.options.prefetch };
         const client = blk: {
@@ -436,6 +473,7 @@ pub const Processor = struct {
         try self.clients.put(self.allocator, owned_id, wrapper);
         errdefer _ = self.clients.orderedRemove(owned_id);
         try self.pending.append(self.allocator, wrapper);
+        if (use_geo_fallback) self.clearGeoFallback(partition_id);
     }
 
     /// The next newly claimed partition, or null when there is none.
@@ -644,7 +682,10 @@ const AmqpTestOpener = struct {
 
     fn close(o: *PartitionOpener, client: *PartitionClient) anyerror!void {
         const self: *AmqpTestOpener = @fieldParentPtr("opener", o);
-        try client.closeAfter(10_000);
+        client.closeAfter(10_000) catch |err| {
+            if (!receiving.isTerminalConnectionError(err)) return err;
+            client.deinit();
+        };
         client.allocator.destroy(client);
         self.closes += 1;
     }
@@ -1218,7 +1259,7 @@ test "remote detach after a short batch is replaced next cycle" {
     try processor.close();
 }
 
-test "manual credit observes a detach pumped before receive and replaces the link" {
+test "manual credit preserves ownership loss observed before receive" {
     const allocator = testing.allocator;
     var mem = amqp.MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -1238,13 +1279,10 @@ test "manual credit observes a detach pumped before receive and replaces the lin
         .handle = 0,
         .closed = true,
         .err = .{
-            .condition = errors.condition.detach_forced,
-            .description = "move",
+            .condition = errors.condition.link_stolen,
+            .description = "new owner",
         },
     } });
-    try scriptProcessorAttach(peer, 1);
-    try pushProcessorEvent(allocator, peer, 1, 0, 1, "replacement");
-    try peer.push(0, .{ .detach = .{ .handle = 1, .closed = true } });
 
     var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
     defer fixture.deinit();
@@ -1272,15 +1310,176 @@ test "manual credit observes a detach pumped before receive and replaces the lin
     // the dead link so the processor does not retain it forever.
     _ = try fixture.session.pump(receiving.deadlineAfter(&fixture.session, 10_000));
     try testing.expectError(error.LinkDetached, first.receiveEvents(allocator, 1));
-    try testing.expect(first.recoverable_failure);
-    try testing.expect(!first.ownership_lost);
+    try testing.expect(!first.recoverable_failure);
+    try testing.expect(first.ownership_lost);
 
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 1), opener.opens);
+    try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+    try testing.expect(processor.suppressed.contains("0"));
+
+    try processor.close();
+}
+
+test "manual credit write failure is terminal and replaced next cycle" {
+    const allocator = testing.allocator;
+    var first_mem = amqp.MemoryTransport.init(allocator);
+    defer first_mem.deinit();
+    var first_clock = amqp.connection_driver.ManualClock{};
+    var first_conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        first_mem.transport(),
+        first_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer first_conn.deinit();
+    const first_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &first_mem };
+    try amqp.test_peer.scriptHandshake(first_peer, 512);
+    try scriptProcessorAttach(first_peer, 0);
+    var first_fixture = try amqp.test_peer.Fixture.init(
+        allocator,
+        &first_mem,
+        &first_clock,
+        &first_conn,
+    );
+    defer first_fixture.deinit();
+
+    var next_mem = amqp.MemoryTransport.init(allocator);
+    defer next_mem.deinit();
+    var next_clock = amqp.connection_driver.ManualClock{};
+    var next_conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        next_mem.transport(),
+        next_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer next_conn.deinit();
+    const next_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &next_mem };
+    try amqp.test_peer.scriptHandshake(next_peer, 512);
+    try scriptProcessorAttach(next_peer, 0);
+    try pushProcessorEvent(allocator, next_peer, 0, 0, 1, "replacement");
+    try next_peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    var next_fixture = try amqp.test_peer.Fixture.init(
+        allocator,
+        &next_mem,
+        &next_clock,
+        &next_conn,
+    );
+    defer next_fixture.deinit();
+
+    var opener = AmqpTestOpener{ .session = &first_fixture.session };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(49);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy, .prefetch = -1 },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const failed = processor.nextPartitionClient().?;
+    first_mem.fail_write = true;
+    try testing.expectError(error.WriteFailed, failed.receiveEvents(allocator, 1));
+    try testing.expect(failed.recoverable_failure);
+    try testing.expect(!failed.ownership_lost);
+
+    opener.session = &next_fixture.session;
     try processor.runOnce();
     try testing.expectEqual(@as(usize, 2), opener.opens);
     const replacement = processor.nextPartitionClient().?;
     const events = try replacement.receiveEvents(allocator, 1);
     defer event_data.freeReceivedEvents(allocator, events);
     try testing.expectEqualStrings("replacement", events[0].body());
+
+    try processor.close();
+}
+
+test "settlement write failure returns the batch and replaces the link" {
+    const allocator = testing.allocator;
+    var first_mem = amqp.MemoryTransport.init(allocator);
+    defer first_mem.deinit();
+    var first_clock = amqp.connection_driver.ManualClock{};
+    var first_conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        first_mem.transport(),
+        first_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer first_conn.deinit();
+    const first_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &first_mem };
+    try amqp.test_peer.scriptHandshake(first_peer, 512);
+    try scriptProcessorAttach(first_peer, 0);
+    try pushProcessorEvent(allocator, first_peer, 0, 0, 1, "returned");
+    var first_fixture = try amqp.test_peer.Fixture.init(
+        allocator,
+        &first_mem,
+        &first_clock,
+        &first_conn,
+    );
+    defer first_fixture.deinit();
+
+    var next_mem = amqp.MemoryTransport.init(allocator);
+    defer next_mem.deinit();
+    var next_clock = amqp.connection_driver.ManualClock{};
+    var next_conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        next_mem.transport(),
+        next_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer next_conn.deinit();
+    const next_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &next_mem };
+    try amqp.test_peer.scriptHandshake(next_peer, 512);
+    try scriptProcessorAttach(next_peer, 0);
+    try pushProcessorEvent(allocator, next_peer, 0, 0, 1, "replayed");
+    try next_peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    var next_fixture = try amqp.test_peer.Fixture.init(
+        allocator,
+        &next_mem,
+        &next_clock,
+        &next_conn,
+    );
+    defer next_fixture.deinit();
+
+    var opener = AmqpTestOpener{ .session = &first_fixture.session };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(51);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const failed = processor.nextPartitionClient().?;
+    first_mem.fail_write = true;
+    const returned = try failed.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, returned);
+    try testing.expectEqual(@as(usize, 1), returned.len);
+    try testing.expectEqualStrings("returned", returned[0].body());
+    try testing.expect(failed.recoverable_failure);
+
+    opener.session = &next_fixture.session;
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), opener.opens);
+    const replacement = processor.nextPartitionClient().?;
+    const replayed = try replacement.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, replayed);
+    try testing.expectEqualStrings("replayed", replayed[0].body());
 
     try processor.close();
 }
@@ -1513,6 +1712,85 @@ test "a rejected offset reopens at earliest, inclusive" {
     try testing.expectEqual(start_position_types.StartLocation.earliest, retried.location);
     try testing.expect(retried.is_inclusive);
     try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+}
+
+test "a live invalid-offset detach reopens at earliest" {
+    const allocator = testing.allocator;
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var amqp_clock = amqp.connection_driver.ManualClock{};
+    var conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        mem.transport(),
+        amqp_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer conn.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+    try amqp.test_peer.scriptHandshake(peer, 512);
+    try scriptProcessorAttach(peer, 0);
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{
+            .condition = errors.condition.georeplication_invalid_offset,
+            .description = "integer offsets are not valid after failover",
+        },
+    } });
+    try scriptProcessorAttach(peer, 1);
+    try pushProcessorEvent(allocator, peer, 1, 0, 1, "earliest");
+    try peer.push(0, .{ .detach = .{ .handle = 1, .closed = true } });
+
+    var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
+    defer fixture.deinit();
+    var opener = AmqpTestOpener{ .session = &fixture.session };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    try store.store.updateCheckpoint(allocator, .{
+        .fully_qualified_namespace = test_details.fully_qualified_namespace,
+        .event_hub_name = test_details.event_hub_name,
+        .consumer_group = test_details.consumer_group,
+        .partition_id = "0",
+        .offset = "12345",
+    });
+    var random = std.Random.DefaultPrng.init(47);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const rejected = processor.nextPartitionClient().?;
+    try testing.expectError(error.LinkDetached, rejected.receiveEvents(allocator, 1));
+    try testing.expect(rejected.geo_replication_fallback);
+    try testing.expect(rejected.recoverable_failure);
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), opener.opens);
+    try testing.expectEqualStrings(
+        "amqp.annotation.x-opt-offset > '12345'",
+        opener.filterAt(0),
+    );
+    try testing.expectEqualStrings(
+        "amqp.annotation.x-opt-offset > '-1'",
+        opener.filterAt(1),
+    );
+    try testing.expect(!processor.geo_fallbacks.contains("0"));
+
+    const replacement = processor.nextPartitionClient().?;
+    const events = try replacement.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, events);
+    try testing.expectEqualStrings("earliest", events[0].body());
+
+    try processor.close();
 }
 
 test "the checkpoint decides where a reader starts" {

--- a/processor.zig
+++ b/processor.zig
@@ -44,6 +44,7 @@ pub const PartitionOpener = struct {
         options: PartitionClientOptions,
     ) anyerror!*PartitionClient,
     closeFn: *const fn (self: *PartitionOpener, client: *PartitionClient) anyerror!void,
+    abortFn: *const fn (self: *PartitionOpener, client: *PartitionClient) void,
 
     /// The hub's partition ids. Caller owns the slice and its strings.
     pub fn partitionIds(self: *PartitionOpener, allocator: Allocator) ![][]const u8 {
@@ -62,6 +63,12 @@ pub const PartitionOpener = struct {
 
     pub fn close(self: *PartitionOpener, client: *PartitionClient) !void {
         try self.closeFn(self, client);
+    }
+
+    /// Dispose a client that attached successfully but could not be registered
+    /// with its processor.
+    pub fn abort(self: *PartitionOpener, client: *PartitionClient) void {
+        self.abortFn(self, client);
     }
 };
 
@@ -103,15 +110,25 @@ pub const ProcessorPartitionClient = struct {
         count: u32,
     ) ![]ReceivedEventData {
         if (self.link_closed) return error.LinkDetached;
-        return self.client.receiveEvents(allocator, count) catch |err| {
-            if (self.client.last_error) |info| {
-                if (info.code == .ownership_lost) self.ownership_lost = true;
-            }
-            if (!self.ownership_lost and self.client.terminal) {
-                self.recoverable_failure = true;
-            }
+        const events = self.client.receiveEvents(allocator, count) catch |err| {
+            self.observeClientState();
             return err;
         };
+        // A receiver can return a valid short batch after the frame that
+        // terminally detached it. Preserve those events, but replace the link
+        // on the next cycle.
+        self.observeClientState();
+        return events;
+    }
+
+    fn observeClientState(self: *ProcessorPartitionClient) void {
+        _ = self.client.refreshGeneration();
+        if (self.client.last_error) |info| {
+            if (info.code == .ownership_lost) self.ownership_lost = true;
+        }
+        if (!self.ownership_lost and self.client.terminal) {
+            self.recoverable_failure = true;
+        }
     }
 
     /// Record `event` as processed, so a later owner resumes after it.
@@ -297,6 +314,7 @@ pub const Processor = struct {
         defer dropped.deinit(self.allocator);
 
         for (self.clients.keys(), self.clients.values()) |id, client| {
+            if (!client.link_closed) client.observeClientState();
             var kept = false;
             for (claimed) |ownership| {
                 if (std.mem.eql(u8, ownership.partition_id, id)) {
@@ -390,6 +408,7 @@ pub const Processor = struct {
                 );
             };
         };
+        errdefer self.opener.abort(client);
 
         const owned_id = try self.allocator.dupe(u8, partition_id);
         errdefer self.allocator.free(owned_id);
@@ -449,12 +468,14 @@ const FakeOpener = struct {
     opened: std.ArrayList(Opened) = .empty,
     closed: usize = 0,
     close_failures_remaining: usize = 0,
+    aborted: usize = 0,
     /// Reject an offset once, as a geo-replicated namespace does.
     reject_offsets: bool = false,
     opener: PartitionOpener = .{
         .partitionIdsFn = partitionIds,
         .openFn = open,
         .closeFn = close,
+        .abortFn = abort,
     },
 
     const Opened = struct {
@@ -538,18 +559,29 @@ const FakeOpener = struct {
         self.closed += 1;
         client.allocator.destroy(client);
     }
+
+    fn abort(o: *PartitionOpener, client: *PartitionClient) void {
+        const self: *FakeOpener = @fieldParentPtr("opener", o);
+        client.deinit();
+        client.allocator.destroy(client);
+        self.aborted += 1;
+    }
 };
 
 const AmqpTestOpener = struct {
     session: *amqp.Session,
+    generation: ?*TestGeneration = null,
+    post_open_fail: ?*PostOpenFailAllocator = null,
     opens: usize = 0,
     closes: usize = 0,
+    aborts: usize = 0,
     filter_bufs: [4][128]u8 = undefined,
     filter_lens: [4]usize = @splat(0),
     opener: PartitionOpener = .{
         .partitionIdsFn = partitionIds,
         .openFn = open,
         .closeFn = close,
+        .abortFn = abort,
     },
 
     const source = "my-hub/ConsumerGroups/$default/Partitions/0";
@@ -586,22 +618,96 @@ const AmqpTestOpener = struct {
         try client.open(allocator, self.session, .{
             .source_address = source,
             .instance_id = instance_id,
-            .deadline_ms = 10_000,
+            .deadline_ms = receiving.deadlineAfter(self.session, 10_000),
             .filter_expression = filter,
+            .generation_guard = if (self.generation) |generation| .{
+                .context = generation,
+                .generation = generation.current,
+                .isCurrentFn = TestGeneration.isCurrent,
+            } else null,
         }, options);
         self.opens += 1;
+        if (self.opens == 1) {
+            if (self.post_open_fail) |failing| failing.arm();
+        }
         return client;
     }
 
     fn close(o: *PartitionOpener, client: *PartitionClient) anyerror!void {
         const self: *AmqpTestOpener = @fieldParentPtr("opener", o);
-        try client.close(10_000);
+        try client.closeAfter(10_000);
         client.allocator.destroy(client);
         self.closes += 1;
     }
 
+    fn abort(o: *PartitionOpener, client: *PartitionClient) void {
+        const self: *AmqpTestOpener = @fieldParentPtr("opener", o);
+        client.closeAfter(10_000) catch client.deinit();
+        client.allocator.destroy(client);
+        self.aborts += 1;
+    }
+
     fn filterAt(self: *const AmqpTestOpener, index: usize) []const u8 {
         return self.filter_bufs[index][0..self.filter_lens[index]];
+    }
+};
+
+const TestGeneration = struct {
+    current: u64 = 0,
+
+    fn isCurrent(context: *anyopaque, generation: u64) bool {
+        const self: *TestGeneration = @ptrCast(@alignCast(context));
+        return self.current == generation;
+    }
+};
+
+const PostOpenFailAllocator = struct {
+    parent: Allocator,
+    fail_index: usize,
+    active: bool = false,
+    allocations: usize = 0,
+    failed: bool = false,
+
+    fn arm(self: *PostOpenFailAllocator) void {
+        self.active = true;
+        self.allocations = 0;
+    }
+
+    fn allocator(self: *PostOpenFailAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *PostOpenFailAllocator = @ptrCast(@alignCast(ctx));
+        if (self.active) {
+            if (self.allocations == self.fail_index) {
+                self.active = false;
+                self.failed = true;
+                return null;
+            }
+            self.allocations += 1;
+        }
+        return self.parent.rawAlloc(len, alignment, ra);
+    }
+
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *PostOpenFailAllocator = @ptrCast(@alignCast(ctx));
+        return self.parent.rawResize(memory, alignment, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *PostOpenFailAllocator = @ptrCast(@alignCast(ctx));
+        return self.parent.rawRemap(memory, alignment, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *PostOpenFailAllocator = @ptrCast(@alignCast(ctx));
+        self.parent.rawFree(memory, alignment, ra);
     }
 };
 
@@ -888,6 +994,53 @@ test "Processor.close retains timed out readers for retry" {
     try testing.expectEqual(@as(usize, 1), opener.closed);
 }
 
+test "Processor.close gives a late acknowledgement a fresh retry deadline" {
+    const allocator = testing.allocator;
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var amqp_clock = amqp.connection_driver.ManualClock{};
+    var conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        mem.transport(),
+        amqp_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer conn.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+    try amqp.test_peer.scriptHandshake(peer, 512);
+    try scriptProcessorAttach(peer, 0);
+    var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
+    defer fixture.deinit();
+    var opener = AmqpTestOpener{ .session = &fixture.session };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(30);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    mem.starve = true;
+    amqp_clock.auto_advance_ms = 1_000;
+    try testing.expectError(error.Timeout, processor.close());
+    try testing.expectEqual(@as(usize, 1), processor.ownedPartitions().len);
+
+    try pushProcessorEvent(allocator, peer, 0, 0, 1, "late");
+    try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    try processor.close();
+    try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+    try testing.expectEqual(@as(usize, 1), opener.closes);
+}
+
 test "terminal allocation failure is reopened and replayed next cycle" {
     const allocator = testing.allocator;
     var mem = amqp.MemoryTransport.init(allocator);
@@ -950,6 +1103,219 @@ test "terminal allocation failure is reopened and replayed next cycle" {
     try testing.expectEqualStrings("replayed", replayed[0].body());
 
     try processor.close();
+}
+
+test "remote detach after a short batch is replaced next cycle" {
+    const allocator = testing.allocator;
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var amqp_clock = amqp.connection_driver.ManualClock{};
+    var conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        mem.transport(),
+        amqp_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer conn.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+    try amqp.test_peer.scriptHandshake(peer, 512);
+    try scriptProcessorAttach(peer, 0);
+    try pushProcessorEvent(allocator, peer, 0, 0, 1, "before detach");
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{
+            .condition = errors.condition.detach_forced,
+            .description = "move",
+        },
+    } });
+    try scriptProcessorAttach(peer, 1);
+    try pushProcessorEvent(allocator, peer, 1, 1, 2, "replacement");
+    try peer.push(0, .{ .detach = .{ .handle = 1, .closed = true } });
+
+    var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
+    defer fixture.deinit();
+    var opener = AmqpTestOpener{ .session = &fixture.session };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(41);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const first = processor.nextPartitionClient().?;
+    const short = try first.receiveEvents(allocator, 2);
+    defer event_data.freeReceivedEvents(allocator, short);
+    try testing.expectEqual(@as(usize, 1), short.len);
+    try testing.expect(first.recoverable_failure);
+    try testing.expect(!first.ownership_lost);
+
+    try processor.runOnce();
+    try testing.expectEqual(@as(usize, 2), opener.opens);
+    const replacement = processor.nextPartitionClient().?;
+    const events = try replacement.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, events);
+    try testing.expectEqual(@as(i64, 2), events[0].sequence_number);
+    try testing.expectEqualStrings("replacement", events[0].body());
+
+    try processor.close();
+}
+
+test "generation recovery invalidates stale receive and close pointers" {
+    const allocator = testing.allocator;
+    var first_mem = amqp.MemoryTransport.init(allocator);
+    defer first_mem.deinit();
+    var first_clock = amqp.connection_driver.ManualClock{};
+    var first_conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        first_mem.transport(),
+        first_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer first_conn.deinit();
+    const first_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &first_mem };
+    try amqp.test_peer.scriptHandshake(first_peer, 512);
+    try scriptProcessorAttach(first_peer, 0);
+    var first_fixture = try amqp.test_peer.Fixture.init(
+        allocator,
+        &first_mem,
+        &first_clock,
+        &first_conn,
+    );
+
+    var next_mem = amqp.MemoryTransport.init(allocator);
+    defer next_mem.deinit();
+    var next_clock = amqp.connection_driver.ManualClock{};
+    var next_conn = try amqp.connection_driver.Driver.init(
+        allocator,
+        next_mem.transport(),
+        next_clock.clock(),
+        amqp.test_peer.driver_options,
+    );
+    defer next_conn.deinit();
+    const next_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &next_mem };
+    try amqp.test_peer.scriptHandshake(next_peer, 512);
+    try scriptProcessorAttach(next_peer, 0);
+    try pushProcessorEvent(allocator, next_peer, 0, 0, 1, "new generation");
+    try next_peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    var next_fixture = try amqp.test_peer.Fixture.init(
+        allocator,
+        &next_mem,
+        &next_clock,
+        &next_conn,
+    );
+    defer next_fixture.deinit();
+
+    var generation = TestGeneration{};
+    var opener = AmqpTestOpener{
+        .session = &first_fixture.session,
+        .generation = &generation,
+    };
+    var clock = ManualClock{};
+    var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+    defer store.deinit();
+    var random = std.Random.DefaultPrng.init(43);
+    var processor = Processor.init(
+        allocator,
+        &store.store,
+        &opener.opener,
+        test_details,
+        .{ .load_balancing_strategy = .greedy },
+        &clock.clock,
+        random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const stale = processor.nextPartitionClient().?;
+
+    first_fixture.deinit();
+    generation.current += 1;
+    opener.session = &next_fixture.session;
+
+    try testing.expectError(error.LinkDetached, stale.receiveEvents(allocator, 1));
+    try testing.expect(stale.recoverable_failure);
+    try testing.expect(stale.client.session == null);
+    try testing.expect(stale.client.receiver == null);
+    try stale.close();
+
+    try processor.runOnce();
+    const replacement = processor.nextPartitionClient().?;
+    const events = try replacement.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, events);
+    try testing.expectEqualStrings("new generation", events[0].body());
+
+    try processor.close();
+}
+
+test "post-attach allocation failures close and reopen the same link" {
+    const allocator = testing.allocator;
+
+    for (0..4) |fail_index| {
+        var mem = amqp.MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var amqp_clock = amqp.connection_driver.ManualClock{};
+        var conn = try amqp.connection_driver.Driver.init(
+            allocator,
+            mem.transport(),
+            amqp_clock.clock(),
+            amqp.test_peer.driver_options,
+        );
+        defer conn.deinit();
+
+        const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+        try amqp.test_peer.scriptHandshake(peer, 512);
+        try scriptProcessorAttach(peer, 0);
+        try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+        try scriptProcessorAttach(peer, 1);
+        try peer.push(0, .{ .detach = .{ .handle = 1, .closed = true } });
+
+        var fixture = try amqp.test_peer.Fixture.init(allocator, &mem, &amqp_clock, &conn);
+        defer fixture.deinit();
+        var failing = PostOpenFailAllocator{
+            .parent = allocator,
+            .fail_index = fail_index,
+        };
+        var opener = AmqpTestOpener{
+            .session = &fixture.session,
+            .post_open_fail = &failing,
+        };
+        var clock = ManualClock{};
+        var store = InMemoryCheckpointStore{ .allocator = allocator, .clock = &clock.clock };
+        defer store.deinit();
+        var random = std.Random.DefaultPrng.init(@intCast(47 + fail_index));
+        var processor = Processor.init(
+            failing.allocator(),
+            &store.store,
+            &opener.opener,
+            test_details,
+            .{ .load_balancing_strategy = .greedy },
+            &clock.clock,
+            random.random(),
+        );
+        defer processor.deinit();
+
+        try testing.expectError(error.OutOfMemory, processor.runOnce());
+        try testing.expect(failing.failed);
+        try testing.expectEqual(@as(usize, 1), opener.aborts);
+        try testing.expectEqual(@as(usize, 0), fixture.session.receivers.items.len);
+        try testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+
+        try processor.runOnce();
+        try testing.expectEqual(@as(usize, 2), opener.opens);
+        try testing.expectEqual(@as(usize, 1), fixture.session.receivers.items.len);
+        try processor.close();
+    }
 }
 
 test "Processor.deinit after session termination never reads freed receivers" {

--- a/receiver.zig
+++ b/receiver.zig
@@ -79,6 +79,7 @@ pub fn consumerPathFor(
 /// Reads events from one partition over a receiver link it keeps attached.
 pub const PartitionClient = struct {
     allocator: Allocator,
+    session: ?*amqp.Session = null,
     receiver: *amqp.Receiver,
     /// The selector the link was attached with, advanced past the last event
     /// delivered so a reattach resumes rather than replaying. Owned.
@@ -182,6 +183,7 @@ pub const PartitionClient = struct {
 
         self.* = .{
             .allocator = allocator,
+            .session = session,
             .receiver = receiver,
             .filter_expression = filter,
             .prefetch = options.prefetch,
@@ -198,10 +200,12 @@ pub const PartitionClient = struct {
         self.decode_arena = null;
     }
 
-    /// Detach the link and release the client.
+    /// Detach the link, remove it from its session, and release the client.
     pub fn close(self: *PartitionClient, deadline_ms: i64) !void {
         defer self.deinit();
-        try self.receiver.detach(deadline_ms);
+        const session = self.session orelse return;
+        self.session = null;
+        session.closeReceiver(self.receiver, deadline_ms);
     }
 
     /// The selector the next attach would use. Advances as events arrive.
@@ -241,11 +245,7 @@ pub const PartitionClient = struct {
             events.deinit(allocator);
         }
 
-        // One disposition per message meant a frame on the wire per event; a
-        // full prefetch window cost hundreds of round trips of bookkeeping.
-        // `SettleBatch` coalesces the ids into runs and only breaks a run
-        // where another link on the session took an id in between.
-        var settling = amqp.SettleBatch.init(self.receiver, .accepted);
+        var delivery_ids: [max_credit]u32 = undefined;
 
         while (events.items.len < count) {
             const delivery = self.receiver.receive(self.deadline_ms) catch |err| {
@@ -258,6 +258,7 @@ pub const PartitionClient = struct {
                 return err;
             };
 
+            delivery_ids[events.items.len] = delivery.id;
             const received = blk: {
                 // Decode into the client's scratch arena rather than a fresh
                 // one per message. Nothing survives the block: the decode
@@ -278,13 +279,15 @@ pub const PartitionClient = struct {
             // what would otherwise let a later failure in this iteration
             // free it twice.
             events.appendAssumeCapacity(received);
-            // `add` is not merely bookkeeping: it puts the open run on the
-            // wire whenever a delivery id is not the one after the last,
-            // which is whenever another link on the session took an id in
-            // between. So it fails for the same reasons the flush below
-            // does, and is swallowed for the same reason — see there.
-            settling.add(delivery) catch {};
         }
+
+        const advanced = try EventPosition.fromSequenceNumber(
+            events.items[events.items.len - 1].sequence_number,
+            false,
+        ).toFilterExpression(self.allocator);
+        errdefer self.allocator.free(advanced);
+
+        const result = try events.toOwnedSlice(allocator);
 
         // Settling tells the peer these will not be asked for again. It is
         // advisory here: an unsettled delivery is redelivered, and a consumer
@@ -292,20 +295,12 @@ pub const PartitionClient = struct {
         // So a settle write that does not land is never worth the events that
         // did arrive — least of all on the break above, where the link that
         // would carry it is the one that just failed.
-        settling.flush() catch {};
+        settleDeliveries(self.receiver, delivery_ids[0..result.len]);
 
-        if (events.items.len > 0) {
-            try self.advancePast(events.items[events.items.len - 1].sequence_number);
-        }
-        return events.toOwnedSlice(allocator);
-    }
-
-    /// Move the selector past `sequence_number` so a reattach resumes.
-    fn advancePast(self: *PartitionClient, sequence_number: i64) !void {
-        const advanced = try EventPosition.fromSequenceNumber(sequence_number, false)
-            .toFilterExpression(self.allocator);
-        self.allocator.free(self.filter_expression);
+        const previous = self.filter_expression;
         self.filter_expression = advanced;
+        self.allocator.free(previous);
+        return result;
     }
 
     fn recordDetach(self: *PartitionClient) void {
@@ -323,6 +318,15 @@ fn prefetchCredit(prefetch: i32) u32 {
 
 fn manualCreditOutstanding(receiver: *const amqp.Receiver) u32 {
     return receiver.credit +| receiver.deferred_credit;
+}
+
+fn settleDeliveries(receiver: *amqp.Receiver, delivery_ids: []const u32) void {
+    // One disposition per message meant a frame on the wire per event.
+    // `SettleBatch` coalesces contiguous ids and splits only around deliveries
+    // owned by another link on the session.
+    var settling = amqp.SettleBatch.init(receiver, .accepted);
+    for (delivery_ids) |id| settling.addId(id) catch {};
+    settling.flush() catch {};
 }
 
 fn rawFrom(message: *const amqp.message_codec.Message) event_data.RawMessage {
@@ -400,8 +404,10 @@ pub const ReceiverPool = struct {
         // rather than replaying everything already delivered.
         self.remember(entry.key, client.filterExpression()) catch {};
 
-        if (detach) self.session.closeReceiver(client.receiver, self.deadline_ms);
-        client.deinit();
+        if (detach)
+            client.close(self.deadline_ms) catch {}
+        else
+            client.deinit();
         self.allocator.destroy(client);
         self.allocator.free(entry.key);
     }
@@ -572,6 +578,27 @@ fn pushEvent(
     sequence_number: i64,
     body: []const u8,
 ) !void {
+    return pushEventWithSettlement(allocator, peer, id, sequence_number, body, true);
+}
+
+fn pushUnsettledEvent(
+    allocator: Allocator,
+    peer: Peer,
+    id: u32,
+    sequence_number: i64,
+    body: []const u8,
+) !void {
+    return pushEventWithSettlement(allocator, peer, id, sequence_number, body, false);
+}
+
+fn pushEventWithSettlement(
+    allocator: Allocator,
+    peer: Peer,
+    id: u32,
+    sequence_number: i64,
+    body: []const u8,
+    settled: bool,
+) !void {
     var annotations = [_]amqp.MapEntry{
         .{
             .key = .{ .symbol = event_data.sequence_number_annotation },
@@ -595,7 +622,7 @@ fn pushEvent(
         .delivery_id = id,
         .delivery_tag = &tag,
         .message_format = 0,
-        .settled = true,
+        .settled = settled,
         .more = false,
     }, payload);
 }
@@ -711,6 +738,48 @@ test "receiver uses the bounded Event Hubs delivery window" {
         @as(?u64, max_message_size),
         attach.performative.attach.max_message_size,
     );
+}
+
+test "close removes the receiver so the same partition can be reacquired" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    try peer.push(0, .{ .attach = .{
+        .name = test_link_name,
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var fixture = try Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var client: PartitionClient = undefined;
+    try client.open(allocator, &fixture.session, .{
+        .source_address = test_source,
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+    }, .{});
+    try testing.expectEqual(@as(usize, 1), fixture.session.receivers.items.len);
+
+    try client.close(10_000);
+    try client.close(10_000);
+    try testing.expectEqual(@as(usize, 0), fixture.session.receivers.items.len);
+
+    try client.open(allocator, &fixture.session, .{
+        .source_address = test_source,
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+    }, .{});
+    defer client.deinit();
+    try testing.expectEqual(@as(usize, 1), fixture.session.receivers.items.len);
 }
 
 test "attach carries the start position as a selector filter" {
@@ -880,6 +949,85 @@ test "receiveEvents settles a whole batch in one disposition" {
     try testing.expectEqual(@as(u32, batch - 1), covered_last.?);
 }
 
+test "selector allocation failure leaves events unsettled and position unchanged" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushEvent(allocator, peer, 0, 1, "warm");
+    try pushUnsettledEvent(allocator, peer, 1, 2, "fails");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    const advanced_filter = "amqp.annotation.x-opt-sequence-number > '2'";
+    var failing = SwitchAllocator{
+        .parent = allocator,
+        .fail_len = advanced_filter.len,
+    };
+    scripted.client.allocator = failing.allocator();
+    event_data.freeReceivedEvents(allocator, try scripted.client.receiveEvents(allocator, 1));
+
+    const previous = try allocator.dupe(u8, scripted.client.filterExpression());
+    defer allocator.free(previous);
+    mem.clearWritten();
+    failing.failing = true;
+    try testing.expectError(error.OutOfMemory, scripted.client.receiveEvents(allocator, 1));
+    failing.failing = false;
+
+    try testing.expect(failing.failures > 0);
+    try testing.expectEqualStrings(previous, scripted.client.filterExpression());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const dispositions = try frames.of(allocator, amqp.performative.descriptor.disposition);
+    defer allocator.free(dispositions);
+    try testing.expectEqual(@as(usize, 0), dispositions.len);
+}
+
+test "short-batch result allocation failure leaves events unsettled and position unchanged" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushUnsettledEvent(allocator, peer, 0, 1, "short");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    const previous = try allocator.dupe(u8, scripted.client.filterExpression());
+    defer allocator.free(previous);
+    mem.starve = true;
+    clock.auto_advance_ms = 1_000;
+    mem.clearWritten();
+
+    var failing = FailShrinkAllocator{ .parent = allocator };
+    try testing.expectError(
+        error.OutOfMemory,
+        scripted.client.receiveEvents(failing.allocator(), 10),
+    );
+    try testing.expect(failing.saw_shrink);
+    try testing.expectEqualStrings(previous, scripted.client.filterExpression());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const dispositions = try frames.of(allocator, amqp.performative.descriptor.disposition);
+    defer allocator.free(dispositions);
+    try testing.expectEqual(@as(usize, 0), dispositions.len);
+}
+
 test "decoding a batch costs the same whatever the batch size" {
     // `decodeMessage` charged an arena and its pages to the *events*
     // allocator, once per message, and the receive loop discarded each decode
@@ -1045,7 +1193,7 @@ test "a broken connection still hands back the events that arrived" {
     try testing.expectEqualStrings("second", events[1].body());
 }
 
-test "a settle write failing mid-batch costs no events either" {
+test "a split-batch settle write failure costs no events either" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -1056,11 +1204,10 @@ test "a settle write failing mid-batch costs no events either" {
     const peer = Peer{ .allocator = allocator, .mem = &mem };
     try scriptAttach(peer);
     // The gap at 2 is what another link on the session leaves behind. It
-    // makes `SettleBatch.add` close the open run mid-loop, so the settle
-    // write — and its failure — land inside the loop rather than after it.
-    try pushEvent(allocator, peer, 0, 1, "first");
-    try pushEvent(allocator, peer, 1, 2, "second");
-    try pushEvent(allocator, peer, 3, 3, "third");
+    // makes final settlement flush the first run before starting the second.
+    try pushUnsettledEvent(allocator, peer, 0, 1, "first");
+    try pushUnsettledEvent(allocator, peer, 1, 2, "second");
+    try pushUnsettledEvent(allocator, peer, 3, 3, "third");
 
     var scripted: Scripted = undefined;
     try scripted.open(allocator, &mem, &clock, &conn, .{});
@@ -1071,12 +1218,15 @@ test "a settle write failing mid-batch costs no events either" {
     const events = try scripted.client.receiveEvents(allocator, 3);
     defer event_data.freeReceivedEvents(allocator, events);
 
-    // The gap makes the settle write happen inside the loop rather than
-    // after it, which is the other place it can fail. It must cost the
-    // caller no more there than it does at the end.
+    // Settlement happens only after the result and selector are prepared.
+    // Its failure must cost none of the events already ready to return.
     try testing.expectEqual(@as(usize, 3), events.len);
     try testing.expectEqualStrings("first", events[0].body());
     try testing.expectEqualStrings("third", events[2].body());
+    try testing.expectEqualStrings(
+        "amqp.annotation.x-opt-sequence-number > '3'",
+        scripted.client.filterExpression(),
+    );
 }
 
 test "disabled prefetch issues credit per receive" {
@@ -1354,6 +1504,107 @@ const CountingAllocator = struct {
 
     fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
         const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.parent.rawFree(buf, alignment, ra);
+    }
+};
+
+const SwitchAllocator = struct {
+    parent: Allocator,
+    fail_len: usize,
+    failing: bool = false,
+    failures: usize = 0,
+
+    fn shouldFail(self: *const SwitchAllocator, len: usize) bool {
+        return self.failing and len == self.fail_len;
+    }
+
+    fn allocator(self: *SwitchAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
+        if (self.shouldFail(len)) {
+            self.failures += 1;
+            return null;
+        }
+        return self.parent.rawAlloc(len, alignment, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
+        if (self.shouldFail(new_len)) {
+            self.failures += 1;
+            return false;
+        }
+        return self.parent.rawResize(buf, alignment, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
+        if (self.shouldFail(new_len)) {
+            self.failures += 1;
+            return null;
+        }
+        return self.parent.rawRemap(buf, alignment, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *SwitchAllocator = @ptrCast(@alignCast(ctx));
+        self.parent.rawFree(buf, alignment, ra);
+    }
+};
+
+const FailShrinkAllocator = struct {
+    parent: Allocator,
+    saw_shrink: bool = false,
+    fail_next_alloc: bool = false,
+
+    fn allocator(self: *FailShrinkAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *FailShrinkAllocator = @ptrCast(@alignCast(ctx));
+        if (self.fail_next_alloc) {
+            self.fail_next_alloc = false;
+            return null;
+        }
+        return self.parent.rawAlloc(len, alignment, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *FailShrinkAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len < buf.len) {
+            self.saw_shrink = true;
+            self.fail_next_alloc = true;
+            return false;
+        }
+        return self.parent.rawResize(buf, alignment, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *FailShrinkAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len < buf.len) {
+            self.saw_shrink = true;
+            self.fail_next_alloc = true;
+            return null;
+        }
+        return self.parent.rawRemap(buf, alignment, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *FailShrinkAllocator = @ptrCast(@alignCast(ctx));
         self.parent.rawFree(buf, alignment, ra);
     }
 };

--- a/receiver.zig
+++ b/receiver.zig
@@ -17,14 +17,22 @@ const Allocator = std.mem.Allocator;
 const EventPosition = position.EventPosition;
 const ReceivedEventData = event_data.ReceivedEventData;
 
-/// Credit issued on attach when the caller expresses no preference. Go and
-/// Rust both use 300.
+/// Public prefetch request when the caller expresses no preference. Go and
+/// Rust both use 300; the AMQP link clamps it to the bounded delivery window.
 pub const default_prefetch: i32 = 300;
 
 /// The largest number of events a single receive may ask for, and the ceiling
 /// on prefetch. It is the session's incoming window in Go, so asking for more
 /// would let the peer overrun it.
 pub const max_credit: u32 = 5000;
+
+/// Event Hubs allows 20 MB events on Dedicated clusters. Leave room for the
+/// annotations the service adds while bounding reassembly above that limit.
+const max_message_size: u64 = 32 * 1024 * 1024;
+
+/// Retain at most eight worst-case Event Hubs deliveries per receiver.
+const max_buffered_bytes: u64 = 256 * 1024 * 1024;
+const max_prefetch: u32 = max_buffered_bytes / max_message_size;
 
 /// Names the reader in the broker's error text, so a stolen link says which
 /// receiver took it.
@@ -47,7 +55,8 @@ pub const PartitionClientOptions = struct {
     /// Claims exclusive ownership of the partition at this level. Absent
     /// leaves the reader non-exclusive.
     owner_level: ?i64 = null,
-    /// Credit issued up front. Zero takes `default_prefetch`; a negative value
+    /// Prefetch requested up front. Zero takes `default_prefetch`; the AMQP
+    /// link caps either value to its safe delivery window. A negative value
     /// disables prefetch and issues credit per receive, which is what a caller
     /// that wants to bound its own memory use asks for.
     prefetch: i32 = 0,
@@ -76,6 +85,9 @@ pub const PartitionClient = struct {
     filter_expression: []u8,
     /// As configured, before `default_prefetch` is substituted for zero.
     prefetch: i32,
+    /// Manual credit requested but not yet consumed by deliveries. AMQP may
+    /// defer part of a batch request until aggregate buffer space returns.
+    manual_credit_pending: u32 = 0,
     owner_level: ?i64,
     deadline_ms: i64,
     /// Set when the broker detached the link; a stolen link reports
@@ -167,6 +179,8 @@ pub const PartitionClient = struct {
             .properties = properties[0..property_count],
             .desired_capabilities = &.{amqp.georeplication_capability},
             .prefetch = prefetchCredit(options.prefetch),
+            .max_message_size = max_message_size,
+            .max_buffered_bytes = max_buffered_bytes,
         }, args.deadline_ms);
 
         self.* = .{
@@ -211,10 +225,14 @@ pub const PartitionClient = struct {
     ) ![]ReceivedEventData {
         if (count == 0 or count > max_credit) return ReceiveError.InvalidCount;
 
-        // Without prefetch the link holds no credit, so ask for exactly what
-        // this call needs on top of anything still outstanding.
-        if (self.prefetch < 0 and self.receiver.credit < count) {
-            try self.receiver.issueCredit(count - self.receiver.credit);
+        // A bounded AMQP receiver may defer part of a manual batch request
+        // until deliveries release aggregate buffer space. Track the whole
+        // request rather than only the credit currently on the wire, or a
+        // short batch would request the deferred remainder again next time.
+        if (self.prefetch < 0 and self.manual_credit_pending < count) {
+            const additional = count - self.manual_credit_pending;
+            try self.receiver.issueCredit(additional);
+            self.manual_credit_pending += additional;
         }
 
         var events: std.ArrayList(ReceivedEventData) = .empty;
@@ -243,6 +261,7 @@ pub const PartitionClient = struct {
                 if (events.items.len > 0) break;
                 return err;
             };
+            if (self.prefetch < 0) self.manual_credit_pending -|= 1;
 
             const received = blk: {
                 // Decode into the client's scratch arena rather than a fresh
@@ -303,8 +322,8 @@ pub const PartitionClient = struct {
 /// Translate the public prefetch setting into link credit.
 fn prefetchCredit(prefetch: i32) u32 {
     if (prefetch < 0) return 0;
-    if (prefetch == 0) return @intCast(default_prefetch);
-    return @intCast(prefetch);
+    const requested: u32 = @intCast(if (prefetch == 0) default_prefetch else prefetch);
+    return @min(requested, max_prefetch);
 }
 
 fn rawFrom(message: *const amqp.message_codec.Message) event_data.RawMessage {
@@ -654,11 +673,45 @@ test "consumerPathFor builds the consumer group address" {
 }
 
 test "prefetch maps onto link credit" {
-    // Zero means "no preference", not "no credit"; only a negative value
+    // Zero means "no preference", not "no credit"; requests above the
+    // service-specific bounded window are clamped, and only a negative value
     // disables prefetch.
-    try testing.expectEqual(@as(u32, 300), prefetchCredit(0));
-    try testing.expectEqual(@as(u32, 50), prefetchCredit(50));
+    try testing.expectEqual(@as(u32, 8), prefetchCredit(0));
+    try testing.expectEqual(@as(u32, 8), prefetchCredit(50));
+    try testing.expectEqual(@as(u32, 4), prefetchCredit(4));
     try testing.expectEqual(@as(u32, 0), prefetchCredit(-1));
+}
+
+test "receiver uses the bounded Event Hubs delivery window" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    try scriptAttach(.{ .allocator = allocator, .mem = &mem });
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    try testing.expectEqual(max_prefetch, scripted.client.receiver.credit);
+    try testing.expectEqual(
+        @as(?u64, max_message_size),
+        scripted.client.receiver.maxMessageSize(),
+    );
+    try testing.expectEqual(
+        @as(?u64, max_buffered_bytes),
+        scripted.client.receiver.max_buffered_bytes,
+    );
+
+    var attach = try sentAttach(allocator, &mem);
+    defer attach.deinit();
+    try testing.expectEqual(
+        @as(?u64, max_message_size),
+        attach.performative.attach.max_message_size,
+    );
 }
 
 test "attach carries the start position as a selector filter" {
@@ -1060,6 +1113,52 @@ test "disabled prefetch issues credit per receive" {
         if (amqp.performative.peekDescriptor(body) == amqp.performative.descriptor.flow) flows += 1;
     }
     try testing.expect(flows >= 1);
+}
+
+test "disabled prefetch carries a short batch request into the next receive" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushEvent(allocator, peer, 0, 1, "first");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{ .prefetch = -1 });
+    defer scripted.deinit();
+
+    mem.starve = true;
+    clock.auto_advance_ms = 1_000;
+    const first = try scripted.client.receiveEvents(allocator, 10);
+    defer event_data.freeReceivedEvents(allocator, first);
+    try testing.expectEqual(@as(usize, 1), first.len);
+    try testing.expectEqual(@as(u32, 9), scripted.client.manual_credit_pending);
+
+    var i: u32 = 0;
+    while (i < 10) : (i += 1) {
+        try pushEvent(allocator, peer, i + 1, @as(i64, i) + 2, "next");
+    }
+    mem.starve = false;
+    scripted.client.deadline_ms = 20_000;
+
+    const second = try scripted.client.receiveEvents(allocator, 10);
+    defer event_data.freeReceivedEvents(allocator, second);
+    try testing.expectEqual(@as(usize, 10), second.len);
+    try testing.expectEqual(@as(u32, 0), scripted.client.manual_credit_pending);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.flow) continue;
+        var decoded = try amqp.performative.decode(allocator, body);
+        defer decoded.deinit();
+        const credit = decoded.performative.flow.link_credit orelse continue;
+        try testing.expect(credit <= max_prefetch);
+    }
 }
 
 test "receiveEvents rejects counts outside the credit window" {

--- a/receiver.zig
+++ b/receiver.zig
@@ -85,9 +85,6 @@ pub const PartitionClient = struct {
     filter_expression: []u8,
     /// As configured, before `default_prefetch` is substituted for zero.
     prefetch: i32,
-    /// Manual credit requested but not yet consumed by deliveries. AMQP may
-    /// defer part of a batch request until aggregate buffer space returns.
-    manual_credit_pending: u32 = 0,
     owner_level: ?i64,
     deadline_ms: i64,
     /// Set when the broker detached the link; a stolen link reports
@@ -225,14 +222,13 @@ pub const PartitionClient = struct {
     ) ![]ReceivedEventData {
         if (count == 0 or count > max_credit) return ReceiveError.InvalidCount;
 
-        // A bounded AMQP receiver may defer part of a manual batch request
-        // until deliveries release aggregate buffer space. Track the whole
-        // request rather than only the credit currently on the wire, or a
-        // short batch would request the deferred remainder again next time.
-        if (self.prefetch < 0 and self.manual_credit_pending < count) {
-            const additional = count - self.manual_credit_pending;
+        // Credit is consumed by every initial transfer, including one the
+        // peer later aborts. Use AMQP's actual outstanding plus deferred
+        // request rather than counting only deliveries returned to callers.
+        const outstanding = manualCreditOutstanding(self.receiver);
+        if (self.prefetch < 0 and outstanding < count) {
+            const additional = count - outstanding;
             try self.receiver.issueCredit(additional);
-            self.manual_credit_pending += additional;
         }
 
         var events: std.ArrayList(ReceivedEventData) = .empty;
@@ -261,7 +257,6 @@ pub const PartitionClient = struct {
                 if (events.items.len > 0) break;
                 return err;
             };
-            if (self.prefetch < 0) self.manual_credit_pending -|= 1;
 
             const received = blk: {
                 // Decode into the client's scratch arena rather than a fresh
@@ -324,6 +319,10 @@ fn prefetchCredit(prefetch: i32) u32 {
     if (prefetch < 0) return 0;
     const requested: u32 = @intCast(if (prefetch == 0) default_prefetch else prefetch);
     return @min(requested, max_prefetch);
+}
+
+fn manualCreditOutstanding(receiver: *const amqp.Receiver) u32 {
+    return receiver.credit +| receiver.deferred_credit;
 }
 
 fn rawFrom(message: *const amqp.message_codec.Message) event_data.RawMessage {
@@ -1115,7 +1114,57 @@ test "disabled prefetch issues credit per receive" {
     try testing.expect(flows >= 1);
 }
 
-test "disabled prefetch carries a short batch request into the next receive" {
+test "disabled prefetch replenishes after an aborted delivery" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    const aborted_tag = [_]u8{0};
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = &aborted_tag,
+        .settled = true,
+        .aborted = true,
+    }, "");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{ .prefetch = -1 });
+    defer scripted.deinit();
+
+    mem.starve = true;
+    clock.auto_advance_ms = 1_000;
+    try testing.expectError(error.Timeout, scripted.client.receiveEvents(allocator, 1));
+    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver));
+
+    mem.clearWritten();
+    try pushEvent(allocator, peer, 1, 1, "after abort");
+    scripted.client.deadline_ms = 20_000;
+
+    const events = try scripted.client.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, events);
+    try testing.expectEqual(@as(usize, 1), events.len);
+    try testing.expectEqualStrings("after abort", events[0].body());
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    var flows: usize = 0;
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.flow) continue;
+        var decoded = try amqp.performative.decode(allocator, body);
+        defer decoded.deinit();
+        try testing.expectEqual(@as(?u32, 1), decoded.performative.flow.link_credit);
+        flows += 1;
+    }
+    try testing.expectEqual(@as(usize, 1), flows);
+}
+
+test "disabled prefetch preserves repeated short and large batch demand" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -1136,19 +1185,28 @@ test "disabled prefetch carries a short batch request into the next receive" {
     const first = try scripted.client.receiveEvents(allocator, 10);
     defer event_data.freeReceivedEvents(allocator, first);
     try testing.expectEqual(@as(usize, 1), first.len);
-    try testing.expectEqual(@as(u32, 9), scripted.client.manual_credit_pending);
+    try testing.expectEqual(@as(u32, 9), manualCreditOutstanding(scripted.client.receiver));
 
-    var i: u32 = 0;
-    while (i < 10) : (i += 1) {
-        try pushEvent(allocator, peer, i + 1, @as(i64, i) + 2, "next");
-    }
-    mem.starve = false;
+    try pushEvent(allocator, peer, 1, 2, "second");
     scripted.client.deadline_ms = 20_000;
 
     const second = try scripted.client.receiveEvents(allocator, 10);
     defer event_data.freeReceivedEvents(allocator, second);
-    try testing.expectEqual(@as(usize, 10), second.len);
-    try testing.expectEqual(@as(u32, 0), scripted.client.manual_credit_pending);
+    try testing.expectEqual(@as(usize, 1), second.len);
+    try testing.expectEqual(@as(u32, 9), manualCreditOutstanding(scripted.client.receiver));
+
+    var i: u32 = 0;
+    while (i < 10) : (i += 1) {
+        try pushEvent(allocator, peer, i + 2, @as(i64, i) + 3, "next");
+    }
+    scripted.client.deadline_ms = 30_000;
+
+    const third = try scripted.client.receiveEvents(allocator, 10);
+    defer event_data.freeReceivedEvents(allocator, third);
+    try testing.expectEqual(@as(usize, 10), third.len);
+    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver));
+
+    try testing.expectEqualStrings("next", third[0].body());
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();

--- a/receiver.zig
+++ b/receiver.zig
@@ -106,7 +106,9 @@ pub const PartitionClient = struct {
     /// As configured, before `default_prefetch` is substituted for zero.
     prefetch: i32,
     owner_level: ?i64,
-    deadline_ms: i64,
+    /// Per-receive duration converted to a fresh absolute AMQP deadline for
+    /// every operation.
+    receive_timeout_ms: i64,
     /// Set when the broker detached the link; a stolen link reports
     /// `amqp:link:stolen` here. The detail slices point into the fixed buffers
     /// below, so they remain valid after the AMQP receiver is destroyed.
@@ -142,6 +144,7 @@ pub const PartitionClient = struct {
         source_address: []const u8,
         /// Identifies this reader to the broker.
         instance_id: []const u8,
+        /// Per-operation timeout duration in milliseconds.
         deadline_ms: i64,
         /// Attach with this selector instead of rendering
         /// `options.start_position`. Used to resume from a position that was
@@ -208,7 +211,7 @@ pub const PartitionClient = struct {
             .max_message_size = max_message_size,
             .max_buffered_bytes = max_buffered_bytes,
             .max_unsettled_deliveries = max_credit,
-        }, args.deadline_ms);
+        }, deadlineAfter(session, args.deadline_ms));
 
         self.* = .{
             .allocator = allocator,
@@ -218,7 +221,7 @@ pub const PartitionClient = struct {
             .filter_expression = filter,
             .prefetch = options.prefetch,
             .owner_level = options.owner_level,
-            .deadline_ms = args.deadline_ms,
+            .receive_timeout_ms = args.deadline_ms,
         };
     }
 
@@ -304,8 +307,10 @@ pub const PartitionClient = struct {
     ) ![]ReceivedEventData {
         if (count == 0 or count > max_credit) return ReceiveError.InvalidCount;
         if (!self.refreshGeneration()) return error.LinkDetached;
-        if (self.terminal or self.session == null) return error.LinkDetached;
+        if (self.terminal) return error.LinkDetached;
+        const session = self.session orelse return error.LinkDetached;
         const receiver = self.receiver orelse return error.LinkDetached;
+        const deadline_ms = deadlineAfter(session, self.receive_timeout_ms);
 
         // Credit is consumed by every initial transfer, including one the
         // peer later aborts. Use AMQP's actual outstanding plus deferred
@@ -313,7 +318,11 @@ pub const PartitionClient = struct {
         const outstanding = manualCreditOutstanding(receiver);
         if (self.prefetch < 0 and outstanding < count) {
             const additional = count - outstanding;
-            try receiver.issueCredit(additional);
+            receiver.issueCredit(additional) catch |err| {
+                self.recordDetach();
+                self.observeTerminal(receiver, err);
+                return err;
+            };
         }
 
         var events: std.ArrayList(ReceivedEventData) = .empty;
@@ -331,7 +340,7 @@ pub const PartitionClient = struct {
         var delivery_ids: [max_credit]u32 = undefined;
 
         while (events.items.len < count) {
-            const delivery = receiver.receive(self.deadline_ms) catch |err| {
+            const delivery = receiver.receive(deadline_ms) catch |err| {
                 self.recordDetach();
                 self.observeTerminal(receiver, err);
                 // Events already in hand arrived, so dropping them here would
@@ -428,7 +437,8 @@ pub const PartitionClient = struct {
     /// safely finish the handshake later.
     fn abandonConsumedBatch(self: *PartitionClient) void {
         self.terminal = true;
-        self.detachReceiver(self.deadline_ms) catch {};
+        const session = self.session orelse return;
+        self.detachReceiver(deadlineAfter(session, self.receive_timeout_ms)) catch {};
     }
 
     /// Complete a two-phase receiver close using AMQP's public state.
@@ -543,7 +553,7 @@ pub const ReceiverPool = struct {
     session: *amqp.Session,
     options: PartitionClientOptions,
     instance_id: []const u8,
-    deadline_ms: i64,
+    timeout_ms: i64,
     /// Keyed by source address. The pool owns the keys; the session owns the
     /// links behind the clients.
     clients: std.StringHashMapUnmanaged(*PartitionClient) = .empty,
@@ -554,6 +564,8 @@ pub const ReceiverPool = struct {
 
     pub const Options = struct {
         instance_id: []const u8,
+        /// Per-operation timeout duration in milliseconds. The legacy field
+        /// name is retained for source compatibility.
         deadline_ms: i64,
         client: PartitionClientOptions = .{},
     };
@@ -564,7 +576,7 @@ pub const ReceiverPool = struct {
             .session = session,
             .options = options.client,
             .instance_id = options.instance_id,
-            .deadline_ms = options.deadline_ms,
+            .timeout_ms = options.deadline_ms,
         };
     }
 
@@ -594,7 +606,7 @@ pub const ReceiverPool = struct {
         self.remember(source_address, client.filterExpression()) catch {};
 
         if (detach)
-            client.close(self.deadline_ms) catch return
+            client.closeAfter(self.timeout_ms) catch return
         else
             client.deinit();
 
@@ -661,7 +673,7 @@ pub const ReceiverPool = struct {
         try client.open(self.allocator, self.session, .{
             .source_address = source_address,
             .instance_id = self.instance_id,
-            .deadline_ms = self.deadline_ms,
+            .deadline_ms = self.timeout_ms,
             .filter_expression = resume_from,
         }, self.options);
         errdefer client.deinit();
@@ -1799,7 +1811,7 @@ test "disabled prefetch replaces an aborted delivery in the same receive" {
     try testing.expectEqual(@as(?u32, 1), replacement.performative.flow.link_credit);
 }
 
-test "disabled prefetch preserves repeated short and large batch demand" {
+test "disabled prefetch renews deadlines across repeated short and large batches" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -1821,9 +1833,11 @@ test "disabled prefetch preserves repeated short and large batch demand" {
     defer event_data.freeReceivedEvents(allocator, first);
     try testing.expectEqual(@as(usize, 1), first.len);
     try testing.expectEqual(@as(u32, 9), manualCreditOutstanding(scripted.client.receiver.?));
+    try testing.expect(clock.millis >= scripted.client.receive_timeout_ms);
 
+    // The original attach-time absolute deadline has passed. A second call
+    // still gets a full duration from the clock as it exists now.
     try pushEvent(allocator, peer, 1, 2, "second");
-    scripted.client.deadline_ms = 20_000;
 
     const second = try scripted.client.receiveEvents(allocator, 10);
     defer event_data.freeReceivedEvents(allocator, second);
@@ -1834,7 +1848,6 @@ test "disabled prefetch preserves repeated short and large batch demand" {
     while (i < 10) : (i += 1) {
         try pushEvent(allocator, peer, i + 2, @as(i64, i) + 3, "next");
     }
-    scripted.client.deadline_ms = 30_000;
 
     const third = try scripted.client.receiveEvents(allocator, 10);
     defer event_data.freeReceivedEvents(allocator, third);

--- a/receiver.zig
+++ b/receiver.zig
@@ -80,7 +80,7 @@ pub fn consumerPathFor(
 pub const PartitionClient = struct {
     allocator: Allocator,
     session: ?*amqp.Session = null,
-    receiver: *amqp.Receiver,
+    receiver: ?*amqp.Receiver = null,
     /// No more deliveries may be consumed after a batch has failed locally.
     /// The unchanged selector is then safe to use on a replacement link.
     terminal: bool = false,
@@ -97,9 +97,15 @@ pub const PartitionClient = struct {
     owner_level: ?i64,
     deadline_ms: i64,
     /// Set when the broker detached the link; a stolen link reports
-    /// `amqp:link:stolen` here. Its strings belong to the receiver, so read it
-    /// before the session is torn down.
+    /// `amqp:link:stolen` here. The detail slices point into the fixed buffers
+    /// below, so they remain valid after the AMQP receiver is destroyed.
     last_error: ?errors.EventHubsError = null,
+    last_condition: ?[]const u8 = null,
+    last_description: ?[]const u8 = null,
+    condition_buf: [128]u8 = undefined,
+    condition_len: usize = 0,
+    description_buf: [512]u8 = undefined,
+    description_len: usize = 0,
     /// Scratch for decoding a received message, reset per event.
     ///
     /// `fromRawMessage` copies everything it keeps into the caller's
@@ -187,6 +193,7 @@ pub const PartitionClient = struct {
             .prefetch = prefetchCredit(options.prefetch),
             .max_message_size = max_message_size,
             .max_buffered_bytes = max_buffered_bytes,
+            .max_unsettled_deliveries = max_credit,
         }, args.deadline_ms);
 
         self.* = .{
@@ -200,9 +207,14 @@ pub const PartitionClient = struct {
         };
     }
 
-    /// Release the client. The link belongs to the session, which detaches it.
+    /// Release only this wrapper's allocations without touching the link.
+    ///
+    /// Normal callers use `close`. This is for teardown after the owning
+    /// session is ending; the session remains responsible for its receiver.
     pub fn deinit(self: *PartitionClient) void {
         if (self.deinitialized) return;
+        self.session = null;
+        self.receiver = null;
         self.allocator.free(self.filter_expression);
         self.filter_expression = &.{};
         if (self.decode_arena) |*a| a.deinit();
@@ -239,14 +251,15 @@ pub const PartitionClient = struct {
     ) ![]ReceivedEventData {
         if (count == 0 or count > max_credit) return ReceiveError.InvalidCount;
         if (self.terminal or self.session == null) return error.LinkDetached;
+        const receiver = self.receiver orelse return error.LinkDetached;
 
         // Credit is consumed by every initial transfer, including one the
         // peer later aborts. Use AMQP's actual outstanding plus deferred
         // request rather than counting only deliveries returned to callers.
-        const outstanding = manualCreditOutstanding(self.receiver);
+        const outstanding = manualCreditOutstanding(receiver);
         if (self.prefetch < 0 and outstanding < count) {
             const additional = count - outstanding;
-            try self.receiver.issueCredit(additional);
+            try receiver.issueCredit(additional);
         }
 
         var events: std.ArrayList(ReceivedEventData) = .empty;
@@ -264,7 +277,7 @@ pub const PartitionClient = struct {
         var delivery_ids: [max_credit]u32 = undefined;
 
         while (events.items.len < count) {
-            const delivery = self.receiver.receive(self.deadline_ms) catch |err| {
+            const delivery = receiver.receive(self.deadline_ms) catch |err| {
                 self.recordDetach();
                 // Events already in hand arrived, so dropping them here would
                 // lose them outright. Hand back the short batch and let the
@@ -312,7 +325,7 @@ pub const PartitionClient = struct {
         // So a settle write that does not land is never worth the events that
         // did arrive — least of all on the break above, where the link that
         // would carry it is the one that just failed.
-        settleDeliveries(self.receiver, delivery_ids[0..result.len]);
+        settleDeliveries(receiver, delivery_ids[0..result.len]);
 
         const previous = self.filter_expression;
         self.filter_expression = advanced;
@@ -321,8 +334,23 @@ pub const PartitionClient = struct {
     }
 
     fn recordDetach(self: *PartitionClient) void {
-        const remote = self.receiver.detach_error orelse return;
-        self.last_error = errors.EventHubsError.fromCondition(remote.condition, remote.description);
+        const receiver = self.receiver orelse return;
+        self.captureDetachError(receiver);
+    }
+
+    fn captureDetachError(self: *PartitionClient, receiver: *const amqp.Receiver) void {
+        const remote = receiver.detach_error orelse return;
+        self.condition_len = copyInto(&self.condition_buf, remote.condition);
+        self.last_condition = self.condition_buf[0..self.condition_len];
+        self.description_len = copyIntoOptional(&self.description_buf, remote.description);
+        self.last_description = if (remote.description != null)
+            self.description_buf[0..self.description_len]
+        else
+            null;
+        self.last_error = errors.EventHubsError.fromCondition(
+            self.last_condition.?,
+            self.last_description,
+        );
     }
 
     /// Stop a link whose caller-visible batch can no longer be completed.
@@ -345,7 +373,7 @@ pub const PartitionClient = struct {
     /// an unknown handle.
     fn detachReceiver(self: *PartitionClient, deadline_ms: i64) !void {
         const session = self.session orelse return;
-        const receiver = self.receiver;
+        const receiver = self.receiver orelse return;
 
         if (!session.ended and !self.detach_started) {
             if (!receiver.attached) {
@@ -381,11 +409,23 @@ pub const PartitionClient = struct {
             return error.DetachUnconfirmed;
         }
 
-        session.closeReceiver(receiver, deadline_ms);
+        self.captureDetachError(receiver);
+        self.receiver = null;
         self.session = null;
         self.detach_started = false;
+        session.closeReceiver(receiver, deadline_ms);
     }
 };
+
+fn copyInto(buffer: []u8, bytes: []const u8) usize {
+    const len = @min(buffer.len, bytes.len);
+    @memcpy(buffer[0..len], bytes[0..len]);
+    return len;
+}
+
+fn copyIntoOptional(buffer: []u8, bytes: ?[]const u8) usize {
+    return copyInto(buffer, bytes orelse return 0);
+}
 
 /// Translate the public prefetch setting into link credit.
 fn prefetchCredit(prefetch: i32) u32 {
@@ -586,9 +626,8 @@ pub const ReceiverPool = struct {
         attempt: *errors.Attempt,
     ) void {
         const client = self.clients.get(source_address) orelse return;
-        const detached = client.receiver.detach_error orelse return;
-        attempt.condition = detached.condition;
-        attempt.description = detached.description;
+        attempt.condition = client.last_condition;
+        attempt.description = client.last_description;
     }
 };
 
@@ -734,11 +773,11 @@ fn pushEventOnWithSettlement(
     });
     defer allocator.free(payload);
 
-    const tag = [_]u8{@intCast(id)};
+    const tag = std.mem.asBytes(&id);
     try peer.pushTransfer(0, .{
         .handle = handle,
         .delivery_id = id,
-        .delivery_tag = &tag,
+        .delivery_tag = tag,
         .message_format = 0,
         .settled = settled,
         .more = false,
@@ -772,7 +811,7 @@ fn pushChunkedEvent(
     });
     defer allocator.free(payload);
 
-    const tag = [_]u8{@intCast(id)};
+    const tag = std.mem.asBytes(&id);
     var offset: usize = 0;
     var first = true;
     while (offset < payload.len) {
@@ -782,7 +821,7 @@ fn pushChunkedEvent(
             try peer.pushTransfer(0, .{
                 .handle = 0,
                 .delivery_id = id,
-                .delivery_tag = &tag,
+                .delivery_tag = tag,
                 .message_format = 0,
                 .settled = true,
                 .more = more,
@@ -840,15 +879,16 @@ test "receiver uses the bounded Event Hubs delivery window" {
     try scripted.open(allocator, &mem, &clock, &conn, .{});
     defer scripted.deinit();
 
-    try testing.expectEqual(max_prefetch, scripted.client.receiver.credit);
+    try testing.expectEqual(max_prefetch, scripted.client.receiver.?.credit);
     try testing.expectEqual(
         @as(?u64, max_message_size),
-        scripted.client.receiver.maxMessageSize(),
+        scripted.client.receiver.?.maxMessageSize(),
     );
     try testing.expectEqual(
         @as(?u64, max_buffered_bytes),
-        scripted.client.receiver.max_buffered_bytes,
+        scripted.client.receiver.?.max_buffered_bytes,
     );
+    try testing.expectEqual(max_credit, scripted.client.receiver.?.max_unsettled_deliveries);
 
     var attach = try sentAttach(allocator, &mem);
     defer attach.deinit();
@@ -944,8 +984,8 @@ test "close timeout retains the receiver through late transfer and acknowledgeme
     try testing.expectEqual(@as(usize, 2), fixture.session.receivers.items.len);
     try testing.expect(closing.session != null);
     try testing.expect(closing.detach_started);
-    try testing.expect(closing.receiver.attached);
-    try testing.expect(closing.receiver.detach_sent);
+    try testing.expect(closing.receiver.?.attached);
+    try testing.expect(closing.receiver.?.detach_sent);
 
     // A transfer already in flight may arrive before the peer observes the
     // detach. Keeping the receiver registered lets the shared session route
@@ -979,6 +1019,39 @@ test "close timeout retains the receiver through late transfer and acknowledgeme
     defer event_data.freeReceivedEvents(allocator, reacquired);
     try testing.expectEqualStrings("reacquired", reacquired[0].body());
     try testing.expectEqual(@as(usize, 2), fixture.session.receivers.items.len);
+}
+
+test "detach error survives receiver destruction" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try peer.push(0, .{ .detach = .{
+        .handle = 0,
+        .closed = true,
+        .err = .{
+            .condition = errors.condition.link_stolen,
+            .description = "taken by another owner",
+        },
+    } });
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{});
+    defer scripted.deinit();
+
+    try testing.expectError(error.LinkDetached, scripted.client.receiveEvents(allocator, 1));
+    try scripted.client.close(10_000);
+    try testing.expect(scripted.client.receiver == null);
+
+    const last = scripted.client.last_error.?;
+    try testing.expectEqual(errors.ErrorCode.ownership_lost, last.code);
+    try testing.expectEqualStrings(errors.condition.link_stolen, last.amqp_condition.?);
+    try testing.expectEqualStrings("taken by another owner", last.description.?);
 }
 
 test "attach carries the start position as a selector filter" {
@@ -1094,7 +1167,7 @@ test "receiveEvents decodes events and advances past the last one" {
     );
 }
 
-test "receiveEvents settles a whole batch in one disposition" {
+test "receiveEvents atomically settles above the default unsettled window" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -1105,7 +1178,7 @@ test "receiveEvents settles a whole batch in one disposition" {
     const peer = Peer{ .allocator = allocator, .mem = &mem };
     try scriptAttach(peer);
 
-    const batch = 32;
+    const batch = 1025;
     var i: u32 = 0;
     while (i < batch) : (i += 1) {
         try pushEvent(allocator, peer, i, @as(i64, i) + 1, "event");
@@ -1127,7 +1200,16 @@ test "receiveEvents settles a whole batch in one disposition" {
     var covered_first: ?u32 = null;
     var covered_last: ?u32 = null;
     for (frames.bodies.items) |body| {
-        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.disposition) continue;
+        const descriptor = amqp.performative.peekDescriptor(body);
+        if (descriptor == amqp.performative.descriptor.flow) {
+            var decoded = try amqp.performative.decode(allocator, body);
+            defer decoded.deinit();
+            if (decoded.performative.flow.handle != null) {
+                try testing.expect(decoded.performative.flow.link_credit.? <= max_prefetch);
+            }
+            continue;
+        }
+        if (descriptor != amqp.performative.descriptor.disposition) continue;
         dispositions += 1;
         var decoded = try amqp.performative.decode(allocator, body);
         defer decoded.deinit();
@@ -1139,10 +1221,9 @@ test "receiveEvents settles a whole batch in one disposition" {
         covered_last = d.last orelse d.first;
     }
 
-    // Settling one at a time put a frame on the wire per event, so a 300-deep
-    // prefetch cost 300 round trips of nothing but bookkeeping. AMQP 1.0
-    // §2.6.10 lets one disposition cover a contiguous `first..last` run, which
-    // is what every other client does.
+    // This crosses AMQP's default 1024-id ceiling. Event Hubs permits batches
+    // up to `max_credit`, while the eight-delivery live-credit window and byte
+    // budget still bound payload retention independently of these ids.
     try testing.expectEqual(@as(usize, 1), dispositions);
     try testing.expectEqual(@as(u32, 0), covered_first.?);
     try testing.expectEqual(@as(u32, batch - 1), covered_last.?);
@@ -1251,6 +1332,7 @@ test "selector allocation failure replays without a sequence hole" {
     try testing.expectEqualStrings(previous, scripted.client.filterExpression());
     try testing.expect(scripted.client.terminal);
     try testing.expect(scripted.client.session == null);
+    try testing.expect(scripted.client.receiver == null);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
@@ -1277,6 +1359,48 @@ test "selector allocation failure replays without a sequence hole" {
         "amqp.annotation.x-opt-sequence-number > '3'",
         scripted.client.filterExpression(),
     );
+}
+
+test "pool records allocation failure after receiver destruction" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try pushUnsettledEvent(allocator, peer, 0, 1, "fails");
+    try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+
+    const advanced_filter = "amqp.annotation.x-opt-sequence-number > '1'";
+    var failing = SwitchAllocator{
+        .parent = allocator,
+        .fail_len = advanced_filter.len,
+    };
+    var fixture = try Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+    var pool = ReceiverPool.init(failing.allocator(), &fixture.session, .{
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+    });
+    defer pool.deinit();
+
+    _ = try pool.clientFor(test_source, null);
+    failing.failing = true;
+    try testing.expectError(error.OutOfMemory, pool.receive(allocator, test_source, null, 1));
+    failing.failing = false;
+
+    const client = pool.clients.get(test_source).?;
+    try testing.expect(client.terminal);
+    try testing.expect(client.session == null);
+    try testing.expect(client.receiver == null);
+
+    var attempt: errors.Attempt = .{};
+    pool.recordFailure(test_source, &attempt);
+    try testing.expect(attempt.condition == null);
+    try testing.expect(attempt.description == null);
 }
 
 test "short-batch result allocation failure leaves events unsettled and position unchanged" {
@@ -1538,7 +1662,7 @@ test "disabled prefetch issues credit per receive" {
     var attach = try sentAttach(allocator, &mem);
     defer attach.deinit();
     // Nothing was requested on attach, so no flow can have gone out yet.
-    try testing.expectEqual(@as(u32, 0), scripted.client.receiver.credit);
+    try testing.expectEqual(@as(u32, 0), scripted.client.receiver.?.credit);
 
     mem.clearWritten();
     const events = try scripted.client.receiveEvents(allocator, 1);
@@ -1583,7 +1707,7 @@ test "disabled prefetch replaces an aborted delivery in the same receive" {
     defer event_data.freeReceivedEvents(allocator, events);
     try testing.expectEqual(@as(usize, 1), events.len);
     try testing.expectEqualStrings("after abort", events[0].body());
-    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver));
+    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver.?));
     try testing.expectEqual(@as(usize, 0), mem.reads_with_pending_writes);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
@@ -1624,7 +1748,7 @@ test "disabled prefetch preserves repeated short and large batch demand" {
     const first = try scripted.client.receiveEvents(allocator, 10);
     defer event_data.freeReceivedEvents(allocator, first);
     try testing.expectEqual(@as(usize, 1), first.len);
-    try testing.expectEqual(@as(u32, 9), manualCreditOutstanding(scripted.client.receiver));
+    try testing.expectEqual(@as(u32, 9), manualCreditOutstanding(scripted.client.receiver.?));
 
     try pushEvent(allocator, peer, 1, 2, "second");
     scripted.client.deadline_ms = 20_000;
@@ -1632,7 +1756,7 @@ test "disabled prefetch preserves repeated short and large batch demand" {
     const second = try scripted.client.receiveEvents(allocator, 10);
     defer event_data.freeReceivedEvents(allocator, second);
     try testing.expectEqual(@as(usize, 1), second.len);
-    try testing.expectEqual(@as(u32, 9), manualCreditOutstanding(scripted.client.receiver));
+    try testing.expectEqual(@as(u32, 9), manualCreditOutstanding(scripted.client.receiver.?));
 
     var i: u32 = 0;
     while (i < 10) : (i += 1) {
@@ -1643,7 +1767,7 @@ test "disabled prefetch preserves repeated short and large batch demand" {
     const third = try scripted.client.receiveEvents(allocator, 10);
     defer event_data.freeReceivedEvents(allocator, third);
     try testing.expectEqual(@as(usize, 10), third.len);
-    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver));
+    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver.?));
 
     try testing.expectEqualStrings("next", third[0].body());
 

--- a/receiver.zig
+++ b/receiver.zig
@@ -1114,7 +1114,7 @@ test "disabled prefetch issues credit per receive" {
     try testing.expect(flows >= 1);
 }
 
-test "disabled prefetch replenishes after an aborted delivery" {
+test "disabled prefetch replaces an aborted delivery in the same receive" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -1132,36 +1132,35 @@ test "disabled prefetch replenishes after an aborted delivery" {
         .settled = true,
         .aborted = true,
     }, "");
+    try pushEvent(allocator, peer, 1, 1, "after abort");
 
     var scripted: Scripted = undefined;
     try scripted.open(allocator, &mem, &clock, &conn, .{ .prefetch = -1 });
     defer scripted.deinit();
 
-    mem.starve = true;
-    clock.auto_advance_ms = 1_000;
-    try testing.expectError(error.Timeout, scripted.client.receiveEvents(allocator, 1));
-    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver));
-
     mem.clearWritten();
-    try pushEvent(allocator, peer, 1, 1, "after abort");
-    scripted.client.deadline_ms = 20_000;
-
     const events = try scripted.client.receiveEvents(allocator, 1);
     defer event_data.freeReceivedEvents(allocator, events);
     try testing.expectEqual(@as(usize, 1), events.len);
     try testing.expectEqualStrings("after abort", events[0].body());
+    try testing.expectEqual(@as(u32, 0), manualCreditOutstanding(scripted.client.receiver));
+    try testing.expectEqual(@as(usize, 0), mem.reads_with_pending_writes);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
-    var flows: usize = 0;
-    for (frames.bodies.items) |body| {
-        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.flow) continue;
-        var decoded = try amqp.performative.decode(allocator, body);
-        defer decoded.deinit();
-        try testing.expectEqual(@as(?u32, 1), decoded.performative.flow.link_credit);
-        flows += 1;
-    }
-    try testing.expectEqual(@as(usize, 1), flows);
+    const flows = try frames.of(allocator, amqp.performative.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 2), flows.len);
+
+    var initial = try amqp.performative.decode(allocator, flows[0]);
+    defer initial.deinit();
+    try testing.expectEqual(@as(?u32, 0), initial.performative.flow.delivery_count);
+    try testing.expectEqual(@as(?u32, 1), initial.performative.flow.link_credit);
+
+    var replacement = try amqp.performative.decode(allocator, flows[1]);
+    defer replacement.deinit();
+    try testing.expectEqual(@as(?u32, 1), replacement.performative.flow.delivery_count);
+    try testing.expectEqual(@as(?u32, 1), replacement.performative.flow.link_credit);
 }
 
 test "disabled prefetch preserves repeated short and large batch demand" {

--- a/receiver.zig
+++ b/receiver.zig
@@ -78,9 +78,20 @@ pub fn consumerPathFor(
 
 /// Reads events from one partition over a receiver link it keeps attached.
 pub const PartitionClient = struct {
+    pub const GenerationGuard = struct {
+        context: *anyopaque,
+        generation: u64,
+        isCurrentFn: *const fn (context: *anyopaque, generation: u64) bool,
+
+        fn isCurrent(self: GenerationGuard) bool {
+            return self.isCurrentFn(self.context, self.generation);
+        }
+    };
+
     allocator: Allocator,
     session: ?*amqp.Session = null,
     receiver: ?*amqp.Receiver = null,
+    generation_guard: ?GenerationGuard = null,
     /// No more deliveries may be consumed after a batch has failed locally.
     /// The unchanged selector is then safe to use on a replacement link.
     terminal: bool = false,
@@ -136,6 +147,9 @@ pub const PartitionClient = struct {
         /// `options.start_position`. Used to resume from a position that was
         /// already reduced to an expression.
         filter_expression: ?[]const u8 = null,
+        /// Invalidates the native pointers when a recoverable connection moves
+        /// to another session generation.
+        generation_guard: ?GenerationGuard = null,
     };
 
     /// Attach the receiver link and start reading.
@@ -200,6 +214,7 @@ pub const PartitionClient = struct {
             .allocator = allocator,
             .session = session,
             .receiver = receiver,
+            .generation_guard = args.generation_guard,
             .filter_expression = filter,
             .prefetch = options.prefetch,
             .owner_level = options.owner_level,
@@ -215,6 +230,7 @@ pub const PartitionClient = struct {
         if (self.deinitialized) return;
         self.session = null;
         self.receiver = null;
+        self.generation_guard = null;
         self.allocator.free(self.filter_expression);
         self.filter_expression = &.{};
         if (self.decode_arena) |*a| a.deinit();
@@ -229,8 +245,45 @@ pub const PartitionClient = struct {
     /// later call continues waiting for the acknowledgement.
     pub fn close(self: *PartitionClient, deadline_ms: i64) !void {
         if (self.deinitialized) return;
+        if (!self.refreshGeneration()) {
+            self.deinit();
+            return;
+        }
         try self.detachReceiver(deadline_ms);
         self.deinit();
+    }
+
+    /// Close with a fresh absolute deadline on this receiver's AMQP clock.
+    pub fn closeAfter(self: *PartitionClient, timeout_ms: i64) !void {
+        if (self.deinitialized) return;
+        if (!self.refreshGeneration()) {
+            self.deinit();
+            return;
+        }
+        const session = self.session orelse {
+            self.deinit();
+            return;
+        };
+        try self.close(deadlineAfter(session, timeout_ms));
+    }
+
+    /// Reconcile a wrapper with the recoverable connection that created it.
+    ///
+    /// A stale generation has already destroyed the old session and receiver,
+    /// so invalidation must be allocation-only and must not inspect either.
+    pub fn refreshGeneration(self: *PartitionClient) bool {
+        const guard = self.generation_guard orelse return true;
+        if (guard.isCurrent()) return true;
+        self.session = null;
+        self.receiver = null;
+        self.generation_guard = null;
+        self.detach_started = false;
+        self.terminal = true;
+        return false;
+    }
+
+    pub fn generation(self: *const PartitionClient) ?u64 {
+        return if (self.generation_guard) |guard| guard.generation else null;
     }
 
     /// The selector the next attach would use. Advances as events arrive.
@@ -250,6 +303,7 @@ pub const PartitionClient = struct {
         count: u32,
     ) ![]ReceivedEventData {
         if (count == 0 or count > max_credit) return ReceiveError.InvalidCount;
+        if (!self.refreshGeneration()) return error.LinkDetached;
         if (self.terminal or self.session == null) return error.LinkDetached;
         const receiver = self.receiver orelse return error.LinkDetached;
 
@@ -279,6 +333,7 @@ pub const PartitionClient = struct {
         while (events.items.len < count) {
             const delivery = receiver.receive(self.deadline_ms) catch |err| {
                 self.recordDetach();
+                self.observeTerminal(receiver, err);
                 // Events already in hand arrived, so dropping them here would
                 // lose them outright. Hand back the short batch and let the
                 // next call surface the failure: the link is dead, so that
@@ -338,6 +393,18 @@ pub const PartitionClient = struct {
         self.captureDetachError(receiver);
     }
 
+    fn observeTerminal(self: *PartitionClient, receiver: *const amqp.Receiver, err: anyerror) void {
+        const session_ended = if (self.session) |session| session.ended else true;
+        if (session_ended or receiver.poisoned or !receiver.attached or receiver.detach_sent) {
+            self.terminal = true;
+            return;
+        }
+        self.terminal = switch (err) {
+            error.LinkDetached, error.ConnectionClosed, error.RemoteClosed => true,
+            else => self.terminal,
+        };
+    }
+
     fn captureDetachError(self: *PartitionClient, receiver: *const amqp.Receiver) void {
         const remote = receiver.detach_error orelse return;
         self.condition_len = copyInto(&self.condition_buf, remote.condition);
@@ -372,6 +439,7 @@ pub const PartitionClient = struct {
     /// as belonging to the closing link rather than poisoning the session as
     /// an unknown handle.
     fn detachReceiver(self: *PartitionClient, deadline_ms: i64) !void {
+        if (!self.refreshGeneration()) return;
         const session = self.session orelse return;
         const receiver = self.receiver orelse return;
 
@@ -416,6 +484,10 @@ pub const PartitionClient = struct {
         session.closeReceiver(receiver, deadline_ms);
     }
 };
+
+pub fn deadlineAfter(session: *const amqp.Session, timeout_ms: i64) i64 {
+    return session.driver.clock.nowMillis() +| @max(timeout_ms, 0);
+}
 
 fn copyInto(buffer: []u8, bytes: []const u8) usize {
     const len = @min(buffer.len, bytes.len);
@@ -980,7 +1052,7 @@ test "close timeout retains the receiver through late transfer and acknowledgeme
 
     mem.starve = true;
     clock.auto_advance_ms = 1_000;
-    try testing.expectError(error.Timeout, closing.close(10_000));
+    try testing.expectError(error.Timeout, closing.closeAfter(10_000));
     try testing.expectEqual(@as(usize, 2), fixture.session.receivers.items.len);
     try testing.expect(closing.session != null);
     try testing.expect(closing.detach_started);
@@ -994,8 +1066,8 @@ test "close timeout retains the receiver through late transfer and acknowledgeme
     try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
     try pushEventOn(allocator, peer, 1, 1, 50, "unrelated");
 
-    try closing.close(20_000);
-    try closing.close(20_000);
+    try closing.closeAfter(10_000);
+    try closing.closeAfter(10_000);
     try testing.expectEqual(@as(usize, 1), fixture.session.receivers.items.len);
 
     const survived = try unrelated.receiveEvents(allocator, 1);

--- a/receiver.zig
+++ b/receiver.zig
@@ -81,6 +81,14 @@ pub const PartitionClient = struct {
     allocator: Allocator,
     session: ?*amqp.Session = null,
     receiver: *amqp.Receiver,
+    /// No more deliveries may be consumed after a batch has failed locally.
+    /// The unchanged selector is then safe to use on a replacement link.
+    terminal: bool = false,
+    /// A detach was emitted but its peer acknowledgement has not necessarily
+    /// arrived. While this is set, `close` continues pumping the same receiver
+    /// rather than emitting a second detach or freeing its handle early.
+    detach_started: bool = false,
+    deinitialized: bool = false,
     /// The selector the link was attached with, advanced past the last event
     /// delivered so a reattach resumes rather than replaying. Owned.
     filter_expression: []u8,
@@ -194,18 +202,23 @@ pub const PartitionClient = struct {
 
     /// Release the client. The link belongs to the session, which detaches it.
     pub fn deinit(self: *PartitionClient) void {
+        if (self.deinitialized) return;
         self.allocator.free(self.filter_expression);
         self.filter_expression = &.{};
         if (self.decode_arena) |*a| a.deinit();
         self.decode_arena = null;
+        self.deinitialized = true;
     }
 
     /// Detach the link, remove it from its session, and release the client.
+    ///
+    /// A timeout is ambiguous: the peer may still send on the handle before
+    /// acknowledging the detach. In that case ownership is retained and a
+    /// later call continues waiting for the acknowledgement.
     pub fn close(self: *PartitionClient, deadline_ms: i64) !void {
-        defer self.deinit();
-        const session = self.session orelse return;
-        self.session = null;
-        session.closeReceiver(self.receiver, deadline_ms);
+        if (self.deinitialized) return;
+        try self.detachReceiver(deadline_ms);
+        self.deinit();
     }
 
     /// The selector the next attach would use. Advances as events arrive.
@@ -225,6 +238,7 @@ pub const PartitionClient = struct {
         count: u32,
     ) ![]ReceivedEventData {
         if (count == 0 or count > max_credit) return ReceiveError.InvalidCount;
+        if (self.terminal or self.session == null) return error.LinkDetached;
 
         // Credit is consumed by every initial transfer, including one the
         // peer later aborts. Use AMQP's actual outstanding plus deferred
@@ -236,6 +250,8 @@ pub const PartitionClient = struct {
         }
 
         var events: std.ArrayList(ReceivedEventData) = .empty;
+        var consumed_any = false;
+        errdefer if (consumed_any) self.abandonConsumedBatch();
         // `count` is exactly how many will be appended on the success path, and
         // a `ReceivedEventData` is large enough that regrowing a 300-deep
         // prefetch means repeatedly copying tens of kilobytes.
@@ -257,6 +273,7 @@ pub const PartitionClient = struct {
                 if (events.items.len > 0) break;
                 return err;
             };
+            consumed_any = true;
 
             delivery_ids[events.items.len] = delivery.id;
             const received = blk: {
@@ -306,6 +323,67 @@ pub const PartitionClient = struct {
     fn recordDetach(self: *PartitionClient) void {
         const remote = self.receiver.detach_error orelse return;
         self.last_error = errors.EventHubsError.fromCondition(remote.condition, remote.description);
+    }
+
+    /// Stop a link whose caller-visible batch can no longer be completed.
+    ///
+    /// Settlement and selector advancement have not happened yet, so removing
+    /// the link makes the broker replay from the unchanged selector. A detach
+    /// timeout leaves the receiver session-owned and terminal; `close` can
+    /// safely finish the handshake later.
+    fn abandonConsumedBatch(self: *PartitionClient) void {
+        self.terminal = true;
+        self.detachReceiver(self.deadline_ms) catch {};
+    }
+
+    /// Complete a two-phase receiver close using AMQP's public state.
+    ///
+    /// `Session.closeReceiver` is called only after the peer detach has made
+    /// the receiver inactive, or after the whole session has ended. Until
+    /// then the receiver remains registered so late transfers are recognized
+    /// as belonging to the closing link rather than poisoning the session as
+    /// an unknown handle.
+    fn detachReceiver(self: *PartitionClient, deadline_ms: i64) !void {
+        const session = self.session orelse return;
+        const receiver = self.receiver;
+
+        if (!session.ended and !self.detach_started) {
+            if (!receiver.attached) {
+                // A peer-initiated detach sends our response before setting
+                // this flag. Other local poison paths do not, and cannot be
+                // removed safely without ending the session.
+                if (!receiver.detach_sent) return error.DetachUnconfirmed;
+            } else {
+                self.detach_started = true;
+                receiver.detach(deadline_ms) catch |err| {
+                    // No detach frame reached the peer, so an attached link
+                    // can retry the initial phase. An inactive link without a
+                    // peer acknowledgement remains ambiguous and retained.
+                    if (!receiver.detach_sent and receiver.attached) {
+                        self.detach_started = false;
+                    }
+                    if (!session.ended) return err;
+                };
+            }
+        }
+
+        if (!session.ended and receiver.attached) {
+            if (!receiver.detach_sent) {
+                self.detach_started = false;
+                return self.detachReceiver(deadline_ms);
+            }
+            while (receiver.attached and !session.ended) {
+                _ = try session.pump(deadline_ms);
+            }
+        }
+
+        if (!session.ended and (receiver.attached or !receiver.detach_sent)) {
+            return error.DetachUnconfirmed;
+        }
+
+        session.closeReceiver(receiver, deadline_ms);
+        self.session = null;
+        self.detach_started = false;
     }
 };
 
@@ -397,17 +475,18 @@ pub const ReceiverPool = struct {
     /// into a dead connection would fail, and the link died with the session
     /// regardless.
     pub fn drop(self: *ReceiverPool, source_address: []const u8, detach: bool) void {
-        const entry = self.clients.fetchRemove(source_address) orelse return;
-        const client = entry.value;
+        const client = self.clients.get(source_address) orelse return;
 
         // Remembered before the client is torn down, so the reattach resumes
         // rather than replaying everything already delivered.
-        self.remember(entry.key, client.filterExpression()) catch {};
+        self.remember(source_address, client.filterExpression()) catch {};
 
         if (detach)
-            client.close(self.deadline_ms) catch {}
+            client.close(self.deadline_ms) catch return
         else
             client.deinit();
+
+        const entry = self.clients.fetchRemove(source_address) orelse return;
         self.allocator.destroy(client);
         self.allocator.free(entry.key);
     }
@@ -599,6 +678,45 @@ fn pushEventWithSettlement(
     body: []const u8,
     settled: bool,
 ) !void {
+    return pushEventOnWithSettlement(
+        allocator,
+        peer,
+        0,
+        id,
+        sequence_number,
+        body,
+        settled,
+    );
+}
+
+fn pushEventOn(
+    allocator: Allocator,
+    peer: Peer,
+    handle: u32,
+    id: u32,
+    sequence_number: i64,
+    body: []const u8,
+) !void {
+    return pushEventOnWithSettlement(
+        allocator,
+        peer,
+        handle,
+        id,
+        sequence_number,
+        body,
+        true,
+    );
+}
+
+fn pushEventOnWithSettlement(
+    allocator: Allocator,
+    peer: Peer,
+    handle: u32,
+    id: u32,
+    sequence_number: i64,
+    body: []const u8,
+    settled: bool,
+) !void {
     var annotations = [_]amqp.MapEntry{
         .{
             .key = .{ .symbol = event_data.sequence_number_annotation },
@@ -618,7 +736,7 @@ fn pushEventWithSettlement(
 
     const tag = [_]u8{@intCast(id)};
     try peer.pushTransfer(0, .{
-        .handle = 0,
+        .handle = handle,
         .delivery_id = id,
         .delivery_tag = &tag,
         .message_format = 0,
@@ -780,6 +898,87 @@ test "close removes the receiver so the same partition can be reacquired" {
     }, .{});
     defer client.deinit();
     try testing.expectEqual(@as(usize, 1), fixture.session.receivers.items.len);
+}
+
+test "close timeout retains the receiver through late transfer and acknowledgement" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const other_source = "my-hub/ConsumerGroups/$default/Partitions/1";
+    const other_link_name = other_source ++ "-receiver-" ++ test_instance;
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    try peer.push(0, .{ .attach = .{
+        .name = other_link_name,
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var fixture = try Fixture.init(allocator, &mem, &clock, &conn);
+    defer fixture.deinit();
+
+    var closing: PartitionClient = undefined;
+    try closing.open(allocator, &fixture.session, .{
+        .source_address = test_source,
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+    }, .{});
+    defer closing.deinit();
+
+    var unrelated: PartitionClient = undefined;
+    try unrelated.open(allocator, &fixture.session, .{
+        .source_address = other_source,
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+    }, .{});
+    defer unrelated.deinit();
+
+    mem.starve = true;
+    clock.auto_advance_ms = 1_000;
+    try testing.expectError(error.Timeout, closing.close(10_000));
+    try testing.expectEqual(@as(usize, 2), fixture.session.receivers.items.len);
+    try testing.expect(closing.session != null);
+    try testing.expect(closing.detach_started);
+    try testing.expect(closing.receiver.attached);
+    try testing.expect(closing.receiver.detach_sent);
+
+    // A transfer already in flight may arrive before the peer observes the
+    // detach. Keeping the receiver registered lets the shared session route
+    // and discard it when the acknowledgement arrives.
+    try pushEventOn(allocator, peer, 0, 0, 1, "late");
+    try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    try pushEventOn(allocator, peer, 1, 1, 50, "unrelated");
+
+    try closing.close(20_000);
+    try closing.close(20_000);
+    try testing.expectEqual(@as(usize, 1), fixture.session.receivers.items.len);
+
+    const survived = try unrelated.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, survived);
+    try testing.expectEqual(@as(usize, 1), survived.len);
+    try testing.expectEqual(@as(i64, 50), survived[0].sequence_number);
+
+    try peer.push(0, .{ .attach = .{
+        .name = test_link_name,
+        .handle = 2,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try pushEventOn(allocator, peer, 2, 2, 1, "reacquired");
+    try closing.open(allocator, &fixture.session, .{
+        .source_address = test_source,
+        .instance_id = test_instance,
+        .deadline_ms = 30_000,
+    }, .{});
+    const reacquired = try closing.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, reacquired);
+    try testing.expectEqualStrings("reacquired", reacquired[0].body());
+    try testing.expectEqual(@as(usize, 2), fixture.session.receivers.items.len);
 }
 
 test "attach carries the start position as a selector filter" {
@@ -949,7 +1148,65 @@ test "receiveEvents settles a whole batch in one disposition" {
     try testing.expectEqual(@as(u32, batch - 1), covered_last.?);
 }
 
-test "selector allocation failure leaves events unsettled and position unchanged" {
+test "decode failure detaches and replays the consumed sequence" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock = driver.ManualClock{};
+    var conn = try driver.Driver.init(allocator, mem.transport(), clock.clock(), harness.driver_options);
+    defer conn.deinit();
+
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+    try scriptAttach(peer);
+    const malformed_tag = [_]u8{0};
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = &malformed_tag,
+        .settled = false,
+    }, "not an AMQP message");
+    try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    try peer.push(0, .{ .attach = .{
+        .name = test_link_name,
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try pushEventOn(allocator, peer, 1, 1, 1, "replayed");
+
+    var scripted: Scripted = undefined;
+    try scripted.open(allocator, &mem, &clock, &conn, .{
+        .start_position = EventPosition.earliest(),
+    });
+    defer scripted.deinit();
+
+    const previous = try allocator.dupe(u8, scripted.client.filterExpression());
+    defer allocator.free(previous);
+
+    if (scripted.client.receiveEvents(allocator, 1)) |events| {
+        event_data.freeReceivedEvents(allocator, events);
+        return error.ExpectedDecodeFailure;
+    } else |_| {}
+
+    try testing.expect(scripted.client.terminal);
+    try testing.expect(scripted.client.session == null);
+    try testing.expectEqualStrings(previous, scripted.client.filterExpression());
+
+    try scripted.client.close(10_000);
+    try scripted.client.open(allocator, &scripted.fixture.session, .{
+        .source_address = test_source,
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+        .filter_expression = previous,
+    }, .{});
+
+    const replayed = try scripted.client.receiveEvents(allocator, 1);
+    defer event_data.freeReceivedEvents(allocator, replayed);
+    try testing.expectEqual(@as(i64, 1), replayed[0].sequence_number);
+    try testing.expectEqualStrings("replayed", replayed[0].body());
+}
+
+test "selector allocation failure replays without a sequence hole" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
     defer mem.deinit();
@@ -961,6 +1218,15 @@ test "selector allocation failure leaves events unsettled and position unchanged
     try scriptAttach(peer);
     try pushEvent(allocator, peer, 0, 1, "warm");
     try pushUnsettledEvent(allocator, peer, 1, 2, "fails");
+    try peer.push(0, .{ .detach = .{ .handle = 0, .closed = true } });
+    try peer.push(0, .{ .attach = .{
+        .name = test_link_name,
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try pushEventOn(allocator, peer, 1, 2, 2, "replayed");
+    try pushEventOn(allocator, peer, 1, 3, 3, "after");
 
     var scripted: Scripted = undefined;
     try scripted.open(allocator, &mem, &clock, &conn, .{});
@@ -983,12 +1249,34 @@ test "selector allocation failure leaves events unsettled and position unchanged
 
     try testing.expect(failing.failures > 0);
     try testing.expectEqualStrings(previous, scripted.client.filterExpression());
+    try testing.expect(scripted.client.terminal);
+    try testing.expect(scripted.client.session == null);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
     const dispositions = try frames.of(allocator, amqp.performative.descriptor.disposition);
     defer allocator.free(dispositions);
     try testing.expectEqual(@as(usize, 0), dispositions.len);
+
+    try scripted.client.close(10_000);
+    try scripted.client.open(allocator, &scripted.fixture.session, .{
+        .source_address = test_source,
+        .instance_id = test_instance,
+        .deadline_ms = 10_000,
+        .filter_expression = previous,
+    }, .{});
+
+    const retried = try scripted.client.receiveEvents(allocator, 2);
+    defer event_data.freeReceivedEvents(allocator, retried);
+    try testing.expectEqual(@as(usize, 2), retried.len);
+    try testing.expectEqual(@as(i64, 2), retried[0].sequence_number);
+    try testing.expectEqualStrings("replayed", retried[0].body());
+    try testing.expectEqual(@as(i64, 3), retried[1].sequence_number);
+    try testing.expectEqualStrings("after", retried[1].body());
+    try testing.expectEqualStrings(
+        "amqp.annotation.x-opt-sequence-number > '3'",
+        scripted.client.filterExpression(),
+    );
 }
 
 test "short-batch result allocation failure leaves events unsettled and position unchanged" {
@@ -1020,6 +1308,8 @@ test "short-batch result allocation failure leaves events unsettled and position
     );
     try testing.expect(failing.saw_shrink);
     try testing.expectEqualStrings(previous, scripted.client.filterExpression());
+    try testing.expect(scripted.client.terminal);
+    try testing.expectError(error.LinkDetached, scripted.client.receiveEvents(allocator, 1));
 
     var frames = try EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();

--- a/receiver.zig
+++ b/receiver.zig
@@ -103,12 +103,18 @@ pub const PartitionClient = struct {
     /// The selector the link was attached with, advanced past the last event
     /// delivered so a reattach resumes rather than replaying. Owned.
     filter_expression: []u8,
+    /// The receiver pool swapped this selector into its preallocated position
+    /// slot. Set once so a failed detach retry cannot swap the old value back.
+    pool_position_saved: bool = false,
     /// As configured, before `default_prefetch` is substituted for zero.
     prefetch: i32,
     owner_level: ?i64,
     /// Per-receive duration converted to a fresh absolute AMQP deadline for
     /// every operation.
     receive_timeout_ms: i64,
+    /// The service rejected an integer offset on a geo-replicated namespace.
+    /// A processor consumes this flag and reopens at earliest, inclusive.
+    geo_replication_fallback: bool = false,
     /// Set when the broker detached the link; a stolen link reports
     /// `amqp:link:stolen` here. The detail slices point into the fixed buffers
     /// below, so they remain valid after the AMQP receiver is destroyed.
@@ -389,7 +395,10 @@ pub const PartitionClient = struct {
         // So a settle write that does not land is never worth the events that
         // did arrive — least of all on the break above, where the link that
         // would carry it is the one that just failed.
-        settleDeliveries(receiver, delivery_ids[0..result.len]);
+        if (settleDeliveries(receiver, delivery_ids[0..result.len])) |err| {
+            self.recordDetach();
+            self.observeTerminal(receiver, err);
+        }
 
         const previous = self.filter_expression;
         self.filter_expression = advanced;
@@ -408,10 +417,9 @@ pub const PartitionClient = struct {
             self.terminal = true;
             return;
         }
-        self.terminal = switch (err) {
-            error.LinkDetached, error.ConnectionClosed, error.RemoteClosed => true,
-            else => self.terminal,
-        };
+        self.terminal = err == error.LinkDetached or
+            isTerminalConnectionError(err) or
+            self.terminal;
     }
 
     fn captureDetachError(self: *PartitionClient, receiver: *const amqp.Receiver) void {
@@ -427,6 +435,13 @@ pub const PartitionClient = struct {
             self.last_condition.?,
             self.last_description,
         );
+        if (std.mem.eql(
+            u8,
+            remote.condition,
+            errors.condition.georeplication_invalid_offset,
+        )) {
+            self.geo_replication_fallback = true;
+        }
     }
 
     /// Stop a link whose caller-visible batch can no longer be completed.
@@ -438,7 +453,11 @@ pub const PartitionClient = struct {
     fn abandonConsumedBatch(self: *PartitionClient) void {
         self.terminal = true;
         const session = self.session orelse return;
-        self.detachReceiver(deadlineAfter(session, self.receive_timeout_ms)) catch {};
+        self.detachReceiver(deadlineAfter(session, self.receive_timeout_ms)) catch |err| {
+            const receiver = self.receiver orelse return;
+            self.recordDetach();
+            self.observeTerminal(receiver, err);
+        };
     }
 
     /// Complete a two-phase receiver close using AMQP's public state.
@@ -499,6 +518,17 @@ pub fn deadlineAfter(session: *const amqp.Session, timeout_ms: i64) i64 {
     return session.driver.clock.nowMillis() +| @max(timeout_ms, 0);
 }
 
+pub fn isTerminalConnectionError(err: anyerror) bool {
+    return switch (err) {
+        error.ConnectionClosed,
+        error.RemoteClosed,
+        error.ReadFailed,
+        error.WriteFailed,
+        => true,
+        else => false,
+    };
+}
+
 fn copyInto(buffer: []u8, bytes: []const u8) usize {
     const len = @min(buffer.len, bytes.len);
     @memcpy(buffer[0..len], bytes[0..len]);
@@ -520,13 +550,14 @@ fn manualCreditOutstanding(receiver: *const amqp.Receiver) u32 {
     return receiver.credit +| receiver.deferred_credit;
 }
 
-fn settleDeliveries(receiver: *amqp.Receiver, delivery_ids: []const u32) void {
+fn settleDeliveries(receiver: *amqp.Receiver, delivery_ids: []const u32) ?anyerror {
     // One disposition per message meant a frame on the wire per event.
     // `SettleBatch` coalesces contiguous ids and splits only around deliveries
     // owned by another link on the session.
     var settling = amqp.SettleBatch.init(receiver, .accepted);
-    for (delivery_ids) |id| settling.addId(id) catch {};
-    settling.flush() catch {};
+    for (delivery_ids) |id| settling.addId(id) catch |err| return err;
+    settling.flush() catch |err| return err;
+    return null;
 }
 
 fn rawFrom(message: *const amqp.message_codec.Message) event_data.RawMessage {
@@ -601,9 +632,11 @@ pub const ReceiverPool = struct {
     pub fn drop(self: *ReceiverPool, source_address: []const u8, detach: bool) void {
         const client = self.clients.get(source_address) orelse return;
 
-        // Remembered before the client is torn down, so the reattach resumes
-        // rather than replaying everything already delivered.
-        self.remember(source_address, client.filterExpression()) catch {};
+        // The position slot and its previous value were allocated before the
+        // link attached. Swapping makes generation teardown infallible: even
+        // an allocator that now fails cannot leave this client pointing at a
+        // session the connection is about to destroy.
+        self.savePosition(source_address, client);
 
         if (detach)
             client.closeAfter(self.timeout_ms) catch return
@@ -617,12 +650,16 @@ pub const ReceiverPool = struct {
 
     /// Forget every client, remembering where each had read to.
     pub fn dropAll(self: *ReceiverPool, detach: bool) void {
-        var addresses: std.ArrayList([]const u8) = .empty;
-        defer addresses.deinit(self.allocator);
-
-        var it = self.clients.keyIterator();
-        while (it.next()) |key| addresses.append(self.allocator, key.*) catch return;
-        for (addresses.items) |address| self.drop(address, detach);
+        while (self.clients.count() > 0) {
+            var it = self.clients.keyIterator();
+            const address = (it.next() orelse unreachable).*;
+            const before = self.clients.count();
+            self.drop(address, detach);
+            // An ambiguous live detach deliberately retains its wrapper. The
+            // generation-invalidating `detach == false` path always removes,
+            // so it can never stop here.
+            if (self.clients.count() == before) return;
+        }
     }
 
     /// Point the pool at a rebuilt session.
@@ -632,23 +669,19 @@ pub const ReceiverPool = struct {
     /// clients resume.
     pub fn rebind(self: *ReceiverPool, session: *amqp.Session) void {
         self.dropAll(false);
+        std.debug.assert(self.clients.count() == 0);
         self.session = session;
     }
 
-    fn remember(self: *ReceiverPool, source_address: []const u8, expression: []const u8) !void {
-        const owned = try self.allocator.dupe(u8, expression);
-        errdefer self.allocator.free(owned);
-
-        const gop = try self.positions.getOrPut(self.allocator, source_address);
-        if (gop.found_existing) {
-            self.allocator.free(gop.value_ptr.*);
-        } else {
-            gop.key_ptr.* = self.allocator.dupe(u8, source_address) catch |err| {
-                _ = self.positions.remove(source_address);
-                return err;
-            };
-        }
-        gop.value_ptr.* = owned;
+    fn savePosition(
+        self: *ReceiverPool,
+        source_address: []const u8,
+        client: *PartitionClient,
+    ) void {
+        if (client.pool_position_saved) return;
+        const remembered = self.positions.getPtr(source_address) orelse unreachable;
+        std.mem.swap([]u8, remembered, &client.filter_expression);
+        client.pool_position_saved = true;
     }
 
     /// The client for `source_address`, attaching one if this is the first
@@ -663,24 +696,41 @@ pub const ReceiverPool = struct {
 
         // A remembered position wins: reapplying the original filter after a
         // recovery would replay every event already delivered.
-        const resume_from: ?[]const u8 = if (self.positions.get(source_address)) |remembered|
-            remembered
-        else
-            filter_expression;
+        const remembered = self.positions.get(source_address);
+        var new_position_key: ?[]u8 = null;
+        errdefer if (new_position_key) |key| self.allocator.free(key);
+        var new_position: ?[]u8 = null;
+        errdefer if (new_position) |selector| self.allocator.free(selector);
+
+        if (remembered == null) {
+            new_position_key = try self.allocator.dupe(u8, source_address);
+            new_position = if (filter_expression) |expression|
+                try self.allocator.dupe(u8, expression)
+            else
+                try self.options.start_position.toFilterExpression(self.allocator);
+            try self.positions.ensureUnusedCapacity(self.allocator, 1);
+        }
+        const resume_from: []const u8 = remembered orelse new_position.?;
 
         const client = try self.allocator.create(PartitionClient);
         errdefer self.allocator.destroy(client);
+        const key = try self.allocator.dupe(u8, source_address);
+        errdefer self.allocator.free(key);
+        try self.clients.ensureUnusedCapacity(self.allocator, 1);
+
         try client.open(self.allocator, self.session, .{
             .source_address = source_address,
             .instance_id = self.instance_id,
             .deadline_ms = self.timeout_ms,
             .filter_expression = resume_from,
         }, self.options);
-        errdefer client.deinit();
 
-        const key = try self.allocator.dupe(u8, source_address);
-        errdefer self.allocator.free(key);
-        try self.clients.put(self.allocator, key, client);
+        if (new_position_key) |position_key| {
+            self.positions.putAssumeCapacityNoClobber(position_key, new_position.?);
+            new_position_key = null;
+            new_position = null;
+        }
+        self.clients.putAssumeCapacityNoClobber(key, client);
         return client;
     }
 

--- a/recovery.zig
+++ b/recovery.zig
@@ -795,6 +795,16 @@ fn scriptReceiverAttach(peer: Peer, handle: u32) !void {
     } });
 }
 
+fn scriptReceiverOnly(_: Allocator, peer: Peer) anyerror!void {
+    try harness.scriptHandshake(peer, 512);
+    try scriptReceiverAttach(peer, 0);
+}
+
+fn scriptReceiverOneEvent(allocator: Allocator, peer: Peer) anyerror!void {
+    try scriptReceiverOnly(allocator, peer);
+    try pushEvent(allocator, peer, 0, 0, 50, "before recovery");
+}
+
 fn pushEvent(allocator: Allocator, peer: Peer, handle: u32, id: u32, sequence_number: i64, body: []const u8) !void {
     var annotations = [_]amqp.MapEntry{.{
         .key = .{ .symbol = event_data.sequence_number_annotation },
@@ -967,6 +977,45 @@ test "a reattached receiver resumes from the last sequence number" {
     // Reattaching with the original filter would replay event 40, which the
     // caller has already been given.
     try testing.expectEqualStrings("amqp.annotation.x-opt-sequence-number > '40'", filters[1]);
+}
+
+test "connection invalidation drops receiver wrappers without allocation" {
+    const allocator = testing.allocator;
+    var factory = ScriptedFactory{
+        .allocator = allocator,
+        .scripts = &.{ &scriptReceiverOneEvent, &scriptReceiverOnly },
+    };
+    defer factory.deinit();
+
+    var connection = RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+
+    const generation = try connection.ensureOpen();
+    const first_pool = try connection.receiverPool();
+    const first = try first_pool.receive(allocator, test_source, null, 1);
+    defer event_data.freeReceivedEvents(allocator, first);
+    try testing.expectEqual(@as(i64, 50), first[0].sequence_number);
+    try testing.expectEqual(@as(usize, 1), first_pool.clients.count());
+
+    var failing = testing.FailingAllocator.init(allocator, .{ .fail_index = 0 });
+    connection.receivers.allocator = failing.allocator();
+    connection.invalidateGeneration(generation);
+    try testing.expectEqual(@as(usize, 0), connection.receivers.clients.count());
+
+    connection.receivers.allocator = allocator;
+    _ = try connection.ensureOpen();
+    const rebound = try connection.receiverPool();
+    try testing.expect(rebound.session == factory.current().session);
+    _ = try rebound.clientFor(test_source, null);
+    try testing.expectEqual(@as(usize, 1), rebound.clients.count());
+
+    const filters = try attachedFilters(allocator, factory.current().mem);
+    defer freeFilters(allocator, filters);
+    try testing.expectEqual(@as(usize, 1), filters.len);
+    try testing.expectEqualStrings("amqp.annotation.x-opt-sequence-number > '50'", filters[0]);
 }
 
 test "the client's window reaches the sender links it is meant to size" {

--- a/recovery.zig
+++ b/recovery.zig
@@ -199,6 +199,11 @@ pub const RecoverableConnection = struct {
         return self.plumbing.?.session;
     }
 
+    /// Whether a wrapper still belongs to the live native session.
+    pub fn isGenerationCurrent(self: *const RecoverableConnection, generation: u64) bool {
+        return !self.closed and self.plumbing != null and self.generation == generation;
+    }
+
     /// The `$management` client, attached on first use.
     ///
     /// Lazily, as Go does: a producer that only ever sends never needs the
@@ -247,11 +252,20 @@ pub const RecoverableConnection = struct {
         if (self.closed) return RecoveryError.ConnectionClosedPermanently;
         if (their_generation != self.generation) return;
 
+        self.invalidateGeneration(their_generation);
+
+        _ = try self.ensureOpen();
+    }
+
+    /// Destroy one native generation without opening its replacement.
+    ///
+    /// Used when cleanup after an attached-but-untracked link cannot confirm a
+    /// detach. The next operation lazily opens a new generation.
+    pub fn invalidateGeneration(self: *RecoverableConnection, their_generation: u64) void {
+        if (self.closed or their_generation != self.generation) return;
         self.teardown();
         self.generation += 1;
         self.recoveries += 1;
-
-        _ = try self.ensureOpen();
     }
 
     /// Whether the connection currently has plumbing behind it.

--- a/recovery.zig
+++ b/recovery.zig
@@ -33,11 +33,11 @@ pub const Plumbing = struct {
 /// against a scripted peer, and because #207 will add custom endpoints and
 /// WebSockets without this file needing to know.
 pub const ConnectionFactory = struct {
-    openFn: *const fn (self: *ConnectionFactory, deadline_ms: i64) anyerror!Plumbing,
+    openFn: *const fn (self: *ConnectionFactory, timeout_ms: i64) anyerror!Plumbing,
     closeFn: *const fn (self: *ConnectionFactory, plumbing: Plumbing) void,
 
-    pub fn open(self: *ConnectionFactory, deadline_ms: i64) !Plumbing {
-        return self.openFn(self, deadline_ms);
+    pub fn open(self: *ConnectionFactory, timeout_ms: i64) !Plumbing {
+        return self.openFn(self, timeout_ms);
     }
 
     pub fn close(self: *ConnectionFactory, plumbing: Plumbing) void {
@@ -81,7 +81,7 @@ pub const RecoverableConnection = struct {
     /// Null skips re-authorisation, which is what a test peer or an emulator
     /// with authentication disabled wants.
     authorizer: ?*Authorizer,
-    deadline_ms: i64,
+    timeout_ms: i64,
     sender_options: SenderPool.Options,
     receiver_options: ReceiverPool.Options,
 
@@ -120,6 +120,8 @@ pub const RecoverableConnection = struct {
     pub const Options = struct {
         factory: *ConnectionFactory,
         authorizer: ?*Authorizer = null,
+        /// Per-operation timeout duration in milliseconds. The legacy field
+        /// name is retained for source compatibility.
         deadline_ms: i64,
         /// Identifies this reader to the broker on receiver links.
         instance_id: []const u8 = "eventhubs",
@@ -136,7 +138,7 @@ pub const RecoverableConnection = struct {
             .allocator = allocator,
             .factory = options.factory,
             .authorizer = options.authorizer,
-            .deadline_ms = options.deadline_ms,
+            .timeout_ms = options.deadline_ms,
             .sender_options = .{
                 .deadline_ms = options.deadline_ms,
                 .link_id = options.link_id,
@@ -168,14 +170,17 @@ pub const RecoverableConnection = struct {
         if (self.closed) return RecoveryError.ConnectionClosedPermanently;
         if (self.plumbing != null) return self.generation;
 
-        const plumbing = try self.factory.open(self.deadline_ms);
+        const plumbing = try self.factory.open(self.timeout_ms);
         errdefer self.factory.close(plumbing);
 
         // Before the pools, not after: a link that attaches without a claim is
         // refused with a condition classified fatal, so the recovery would
         // report as unrecoverable.
         if (self.authorizer) |authorizer| {
-            try authorizer.authorize(plumbing.session, self.deadline_ms);
+            try authorizer.authorize(
+                plumbing.session,
+                receiving.deadlineAfter(plumbing.session, self.timeout_ms),
+            );
             self.authorizations += 1;
         }
 
@@ -215,7 +220,7 @@ pub const RecoverableConnection = struct {
         const client = try amqp.Management.open(
             self.plumbing.?.session,
             .{ .link_id = self.management_link_id },
-            self.deadline_ms,
+            receiving.deadlineAfter(self.plumbing.?.session, self.timeout_ms),
         );
         self.management = client;
         return client;
@@ -447,7 +452,7 @@ const ScriptedFactory = struct {
         self.live.deinit(self.allocator);
     }
 
-    fn open(f: *ConnectionFactory, deadline_ms: i64) anyerror!Plumbing {
+    fn open(f: *ConnectionFactory, timeout_ms: i64) anyerror!Plumbing {
         const self: *ScriptedFactory = @fieldParentPtr("factory", f);
         if (self.opened >= self.scripts.len) return error.NoMoreConnections;
 
@@ -464,6 +469,7 @@ const ScriptedFactory = struct {
 
         const conn = try self.allocator.create(driver.Driver);
         conn.* = try driver.Driver.init(self.allocator, mem.transport(), clock.clock(), harness.driver_options);
+        const deadline_ms = conn.clock.nowMillis() +| @max(timeout_ms, 0);
         try conn.open(deadline_ms);
 
         const session = try self.allocator.create(amqp.Session);

--- a/root.zig
+++ b/root.zig
@@ -1058,13 +1058,14 @@ pub const ConsumerClient = struct {
     ///
     /// This is what a `Processor` reads through: it knows partition ids and
     /// how to attach a reader, which is everything the balancing loop needs
-    /// from a connection.
+    /// from a connection. `timeout_ms` is a duration renewed against the
+    /// current AMQP clock for every open and close attempt.
     pub fn partitionOpener(
         self: *ConsumerClient,
         connection: *recovery.RecoverableConnection,
-        deadline_ms: i64,
+        timeout_ms: i64,
     ) ConsumerPartitionOpener {
-        return .{ .client = self, .connection = connection, .deadline_ms = deadline_ms };
+        return .{ .client = self, .connection = connection, .timeout_ms = timeout_ms };
     }
 
     /// Build a processor that reads this hub through `opener`.
@@ -1132,11 +1133,14 @@ pub const ConsumerPartitionOpener = struct {
     /// connection has a new one, and a link attached to the old session would
     /// be attached to nothing.
     connection: *recovery.RecoverableConnection,
-    deadline_ms: i64,
+    /// Per-attempt duration. Each open and close converts it to a fresh
+    /// absolute deadline on the current AMQP generation's clock.
+    timeout_ms: i64,
     opener: PartitionOpener = .{
         .partitionIdsFn = partitionIds,
         .openFn = openPartition,
         .closeFn = closePartition,
+        .abortFn = abortPartition,
     },
 
     pub fn asOpener(self: *ConsumerPartitionOpener) *PartitionOpener {
@@ -1171,21 +1175,29 @@ pub const ConsumerPartitionOpener = struct {
         const client = try allocator.create(PartitionClient);
         errdefer allocator.destroy(client);
 
+        const generation = try self.connection.ensureOpen();
         const session = try self.connection.session();
+        const source = try self.client.consumerPath(allocator, partition_id);
+        defer allocator.free(source);
         var with_position = options;
         with_position.start_position = position;
-        self.client.newPartitionClient(
-            client,
-            allocator,
-            session,
-            partition_id,
-            self.deadline_ms,
-            with_position,
-        ) catch |err| {
+        client.open(allocator, session, .{
+            .source_address = source,
+            .instance_id = self.client.instanceId(),
+            .deadline_ms = receiving.deadlineAfter(session, self.timeout_ms),
+            .generation_guard = .{
+                .context = self.connection,
+                .generation = generation,
+                .isCurrentFn = generationIsCurrent,
+            },
+        }, with_position) catch |err| {
             // A replicated namespace refuses an offset carried over from
             // before a failover. Say so in the error so the processor can
             // restart the partition rather than abandon it.
-            if (err == error.LinkDetached and sawGeoReplicationRejection(session)) {
+            const geo_rejected =
+                err == error.LinkDetached and sawGeoReplicationRejection(session);
+            self.connection.invalidateGeneration(generation);
+            if (geo_rejected) {
                 return error.GeoReplicationOffsetRejected;
             }
             return err;
@@ -1206,8 +1218,28 @@ pub const ConsumerPartitionOpener = struct {
 
     fn closePartition(o: *PartitionOpener, client: *PartitionClient) anyerror!void {
         const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
-        try client.close(self.deadline_ms);
+        const generation = client.generation();
+        client.closeAfter(self.timeout_ms) catch |err| {
+            if (err != error.DetachUnconfirmed) return err;
+            if (generation) |value| self.connection.invalidateGeneration(value);
+            client.deinit();
+        };
         client.allocator.destroy(client);
+    }
+
+    fn abortPartition(o: *PartitionOpener, client: *PartitionClient) void {
+        const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
+        const generation = client.generation();
+        client.closeAfter(self.timeout_ms) catch {
+            if (generation) |value| self.connection.invalidateGeneration(value);
+            client.deinit();
+        };
+        client.allocator.destroy(client);
+    }
+
+    fn generationIsCurrent(context: *anyopaque, generation: u64) bool {
+        const connection: *recovery.RecoverableConnection = @ptrCast(@alignCast(context));
+        return connection.isGenerationCurrent(generation);
     }
 };
 

--- a/root.zig
+++ b/root.zig
@@ -1289,7 +1289,18 @@ pub const ConsumerPartitionOpener = struct {
                 .isCurrentFn = generationIsCurrent,
             },
         }, with_position) catch |err| {
+            var failed_open = if (err == error.LinkDetached)
+                session.takeFailedLinkOpen()
+            else
+                null;
+            defer if (failed_open) |*diagnostic| diagnostic.deinit();
+            const geo_rejected = if (failed_open) |diagnostic|
+                load_balancing.isGeoReplicationOffsetError(diagnostic.condition())
+            else
+                false;
+
             self.connection.invalidateGeneration(generation);
+            if (geo_rejected) return error.GeoReplicationOffsetRejected;
             return err;
         };
         return client;
@@ -1556,11 +1567,9 @@ const TestTransportSequence = struct {
 
 fn testNoSleep(_: *errors.Sleeper, _: u64) errors.SleepError!void {}
 
-fn scriptManagementAndPartition(
+fn scriptManagement(
     allocator: std.mem.Allocator,
     peer: amqp.test_peer.Peer,
-    event_body: []const u8,
-    close_ack: bool,
 ) !void {
     try amqp.test_peer.scriptHandshake(peer, 65536);
     try peer.push(0, .{ .attach = .{
@@ -1634,12 +1643,21 @@ fn scriptManagementAndPartition(
         .settled = true,
         .more = false,
     }, response);
+}
 
+fn scriptPartition(
+    allocator: std.mem.Allocator,
+    peer: amqp.test_peer.Peer,
+    handle: u32,
+    delivery_id: u32,
+    event_body: []const u8,
+    close_ack: bool,
+) !void {
     const receiver_name =
         "my-hub/ConsumerGroups/$Default/Partitions/0-receiver-eventhubs";
     try peer.push(0, .{ .attach = .{
         .name = receiver_name,
-        .handle = 2,
+        .handle = handle,
         .role = .sender,
         .initial_delivery_count = 0,
     } });
@@ -1660,19 +1678,74 @@ fn scriptManagementAndPartition(
         .body = .{ .data = &bodies },
     });
     defer allocator.free(event);
-    const tag = [_]u8{1};
+    const tag = std.mem.asBytes(&delivery_id);
     try peer.pushTransfer(0, .{
-        .handle = 2,
-        .delivery_id = 1,
-        .delivery_tag = &tag,
+        .handle = handle,
+        .delivery_id = delivery_id,
+        .delivery_tag = tag,
         .message_format = 0,
         .settled = false,
         .more = false,
     }, event);
 
     if (close_ack) {
-        try peer.push(0, .{ .detach = .{ .handle = 2, .closed = true } });
+        try peer.push(0, .{ .detach = .{ .handle = handle, .closed = true } });
     }
+}
+
+fn scriptManagementAndPartition(
+    allocator: std.mem.Allocator,
+    peer: amqp.test_peer.Peer,
+    event_body: []const u8,
+    close_ack: bool,
+) !void {
+    try scriptManagement(allocator, peer);
+    try scriptPartition(allocator, peer, 2, 1, event_body, close_ack);
+}
+
+fn scriptRejectedPartition(
+    peer: amqp.test_peer.Peer,
+    handle: u32,
+    condition: []const u8,
+) !void {
+    const receiver_name =
+        "my-hub/ConsumerGroups/$Default/Partitions/0-receiver-eventhubs";
+    try peer.pushExact(0, .{ .attach = .{
+        .name = receiver_name,
+        .handle = handle,
+        .role = .sender,
+        .source = null,
+        .target = .{},
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .detach = .{
+        .handle = handle,
+        .closed = true,
+        .err = .{
+            .condition = condition,
+            .description = "receiver open refused",
+        },
+    } });
+}
+
+fn attachedReceiverFilter(
+    allocator: std.mem.Allocator,
+    mem: *amqp.MemoryTransport,
+) ![]u8 {
+    var frames = try amqp.test_peer.EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    for (frames.bodies.items) |body| {
+        if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.attach) continue;
+        var decoded = try amqp.performative.decode(allocator, body);
+        defer decoded.deinit();
+        const attach = decoded.performative.attach;
+        if (!std.mem.endsWith(u8, attach.name, "-receiver-eventhubs")) continue;
+        const source = attach.source orelse continue;
+        const filters = source.filters orelse continue;
+        if (filters.len == 0) continue;
+        return allocator.dupe(u8, filters[0].value.string);
+    }
+    return error.ReceiverAttachNotFound;
 }
 
 test "processor recovers terminal receiver and cached management generations" {
@@ -1785,6 +1858,129 @@ test "processor recovers terminal receiver and cached management generations" {
     try std.testing.expectEqualStrings("metadata replay", final[0].body());
 
     try processor.close();
+}
+
+test "production partition opener maps only geo-replication failed opens" {
+    const cases = [_]struct {
+        condition: []const u8,
+        geo_fallback: bool,
+    }{
+        .{
+            .condition = errors.condition.georeplication_invalid_offset,
+            .geo_fallback = true,
+        },
+        .{
+            .condition = errors.condition.detach_forced,
+            .geo_fallback = false,
+        },
+    };
+
+    for (cases, 0..) |case, case_index| {
+        const allocator = std.testing.allocator;
+        var first_mem = amqp.MemoryTransport.init(allocator);
+        defer first_mem.deinit();
+        var second_mem = amqp.MemoryTransport.init(allocator);
+        defer second_mem.deinit();
+
+        const first_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &first_mem };
+        try scriptManagement(allocator, first_peer);
+        try scriptRejectedPartition(first_peer, 2, case.condition);
+        if (case.geo_fallback) {
+            const second_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &second_mem };
+            try amqp.test_peer.scriptHandshake(second_peer, 65536);
+            try scriptPartition(allocator, second_peer, 0, 0, "fallback", true);
+        }
+
+        var transports = TestTransportSequence{
+            .memories = &.{ &first_mem, &second_mem },
+        };
+        var wire_clock = amqp.connection_driver.ManualClock{};
+        var factory = connection_options.AmqpConnectionFactory{
+            .allocator = allocator,
+            .fully_qualified_namespace = "ns.servicebus.windows.net",
+            .container_id = "failed-open-test",
+            .options = .{ .web_socket = transports.hook() },
+            .clock = wire_clock.clock(),
+            .sasl = .none,
+        };
+        var connection = recovery.RecoverableConnection.init(allocator, .{
+            .factory = &factory.factory,
+            .deadline_ms = 10_000,
+        });
+        defer connection.deinit();
+        connection.management_link_id = "eh";
+
+        var sleeper = errors.Sleeper{ .sleepFn = testNoSleep };
+        var retry_random = std.Random.DefaultPrng.init(61 + case_index);
+        var link_transport = LinkTransport.initRecoverable(
+            &connection,
+            .{ .sleeper = &sleeper, .random = retry_random.random() },
+            .{ .deadline_ms = 10_000 },
+        );
+        var credential = ScopeRecordingCredential.init();
+        var consumer = ConsumerClient.init(.{
+            .runtime = testRuntime(),
+            .fully_qualified_namespace = "ns.servicebus.windows.net",
+            .event_hub_name = "my-hub",
+        }, credential.asCredential(), link_transport.asTransport());
+        defer consumer.deinit();
+
+        var opener = consumer.partitionOpener(&connection, 10_000);
+        var balance_clock = ManualClock{};
+        var store = InMemoryCheckpointStore{
+            .allocator = allocator,
+            .clock = &balance_clock.clock,
+        };
+        defer store.deinit();
+        try store.store.updateCheckpoint(allocator, .{
+            .fully_qualified_namespace = "ns.servicebus.windows.net",
+            .event_hub_name = "my-hub",
+            .consumer_group = "$Default",
+            .partition_id = "0",
+            .offset = "12345",
+        });
+        var balance_random = std.Random.DefaultPrng.init(67 + case_index);
+        var processor = consumer.newProcessor(
+            allocator,
+            &store.store,
+            opener.asOpener(),
+            .{ .load_balancing_strategy = .greedy },
+            &balance_clock.clock,
+            balance_random.random(),
+        );
+        defer processor.deinit();
+
+        if (case.geo_fallback) {
+            try processor.runOnce();
+            try std.testing.expectEqual(@as(u64, 1), connection.recoveries);
+            try std.testing.expectEqual(@as(usize, 2), transports.next);
+
+            const rejected_filter = try attachedReceiverFilter(allocator, &first_mem);
+            defer allocator.free(rejected_filter);
+            try std.testing.expectEqualStrings(
+                "amqp.annotation.x-opt-offset > '12345'",
+                rejected_filter,
+            );
+            const fallback_filter = try attachedReceiverFilter(allocator, &second_mem);
+            defer allocator.free(fallback_filter);
+            try std.testing.expectEqualStrings(
+                "amqp.annotation.x-opt-offset > '-1'",
+                fallback_filter,
+            );
+
+            const partition = processor.nextPartitionClient().?;
+            const events = try partition.receiveEvents(allocator, 1);
+            defer freeReceivedEvents(allocator, events);
+            try std.testing.expectEqualStrings("fallback", events[0].body());
+            try processor.close();
+        } else {
+            try std.testing.expectError(error.LinkDetached, processor.runOnce());
+            try std.testing.expectEqual(@as(u64, 1), connection.recoveries);
+            try std.testing.expectEqual(@as(usize, 1), transports.next);
+            try std.testing.expectEqual(@as(usize, 0), processor.ownedPartitions().len);
+            try processor.close();
+        }
+    }
 }
 
 const TestCryptoProvider = struct {

--- a/root.zig
+++ b/root.zig
@@ -379,6 +379,54 @@ pub const LinkTransport = struct {
         }
     };
 
+    const HubPropertiesOp = struct {
+        connection: *RecoverableConnection,
+        allocator: std.mem.Allocator,
+        hub_name: []const u8,
+        security_token: ?[]const u8,
+        timeout_ms: i64,
+
+        pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror!EventHubProperties {
+            const client = try op.connection.managementClient();
+            const deadline_ms = receiving.deadlineAfter(client.rpc_link.session, op.timeout_ms);
+            return management.getEventHubProperties(
+                op.allocator,
+                client,
+                op.hub_name,
+                op.security_token,
+                deadline_ms,
+            ) catch |err| {
+                management.recordFailure(client, attempt, err);
+                return err;
+            };
+        }
+    };
+
+    const PartitionPropertiesOp = struct {
+        connection: *RecoverableConnection,
+        allocator: std.mem.Allocator,
+        hub_name: []const u8,
+        partition_id: []const u8,
+        security_token: ?[]const u8,
+        timeout_ms: i64,
+
+        pub fn call(op: *const @This(), attempt: *errors.Attempt) anyerror!PartitionProperties {
+            const client = try op.connection.managementClient();
+            const deadline_ms = receiving.deadlineAfter(client.rpc_link.session, op.timeout_ms);
+            return management.getPartitionProperties(
+                op.allocator,
+                client,
+                op.hub_name,
+                op.partition_id,
+                op.security_token,
+                deadline_ms,
+            ) catch |err| {
+                management.recordFailure(client, attempt, err);
+                return err;
+            };
+        }
+    };
+
     fn maxMessageSizeImpl(t: *AmqpTransport, address: []const u8) !?u64 {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
         const pool = self.senderPool() catch return null;
@@ -418,6 +466,27 @@ pub const LinkTransport = struct {
 
     fn getHubPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) !EventHubProperties {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
+        if (self.connection) |conn| {
+            const config = self.retry orelse return error.Unimplemented;
+            var op = HubPropertiesOp{
+                .connection = conn,
+                .allocator = allocator,
+                .hub_name = hub_name,
+                .security_token = self.security_token,
+                .timeout_ms = self.timeout_ms,
+            };
+            return switch (recovery.runWithRecovery(
+                EventHubProperties,
+                conn,
+                null,
+                &op,
+                config,
+            )) {
+                .ok => |props| props,
+                .failed => |failure| failure.err,
+            };
+        }
+
         const client = try self.managementClient();
         const deadline_ms = receiving.deadlineAfter(client.rpc_link.session, self.timeout_ms);
         if (self.retry) |config| {
@@ -444,6 +513,28 @@ pub const LinkTransport = struct {
 
     fn getPartitionPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) !PartitionProperties {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
+        if (self.connection) |conn| {
+            const config = self.retry orelse return error.Unimplemented;
+            var op = PartitionPropertiesOp{
+                .connection = conn,
+                .allocator = allocator,
+                .hub_name = hub_name,
+                .partition_id = partition_id,
+                .security_token = self.security_token,
+                .timeout_ms = self.timeout_ms,
+            };
+            return switch (recovery.runWithRecovery(
+                PartitionProperties,
+                conn,
+                null,
+                &op,
+                config,
+            )) {
+                .ok => |props| props,
+                .failed => |failure| failure.err,
+            };
+        }
+
         const client = try self.managementClient();
         const deadline_ms = receiving.deadlineAfter(client.rpc_link.session, self.timeout_ms);
         if (self.retry) |config| {
@@ -1434,6 +1525,266 @@ fn testRuntimeWithCrypto(
         .{ .context = &unused_http_context, .vtable = &unused_http_vtable },
         provider,
     );
+}
+
+const TestTransportSequence = struct {
+    memories: []const *amqp.MemoryTransport,
+    next: usize = 0,
+
+    fn hook(self: *TestTransportSequence) connection_options.WebSocketHook {
+        return .{
+            .context = self,
+            .connectFn = connect,
+            .closeFn = close,
+        };
+    }
+
+    fn connect(
+        context: *anyopaque,
+        _: std.mem.Allocator,
+        _: []const u8,
+    ) anyerror!amqp.Transport {
+        const self: *TestTransportSequence = @ptrCast(@alignCast(context));
+        if (self.next >= self.memories.len) return error.NoMoreConnections;
+        const mem = self.memories[self.next];
+        self.next += 1;
+        return mem.transport();
+    }
+
+    fn close(_: *anyopaque, _: amqp.Transport) void {}
+};
+
+fn testNoSleep(_: *errors.Sleeper, _: u64) errors.SleepError!void {}
+
+fn scriptManagementAndPartition(
+    allocator: std.mem.Allocator,
+    peer: amqp.test_peer.Peer,
+    event_body: []const u8,
+    close_ack: bool,
+) !void {
+    try amqp.test_peer.scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "$management-sender-eh",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .attach = .{
+        .name = "$management-receiver-eh",
+        .handle = 1,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.push(0, .{ .flow = .{
+        .next_incoming_id = 0,
+        .incoming_window = 1000,
+        .next_outgoing_id = 1,
+        .outgoing_window = 1000,
+        .handle = 0,
+        .delivery_count = 0,
+        .link_credit = 10,
+    } });
+    try peer.push(0, .{ .disposition = .{
+        .role = .receiver,
+        .first = 0,
+        .last = 0,
+        .settled = true,
+        .state = .accepted,
+    } });
+
+    var partition_ids = [_]amqp.AmqpValue{.{ .string = "0" }};
+    var body_map = [_]amqp.MapEntry{
+        .{ .key = .{ .string = management.reply.name }, .value = .{ .string = "my-hub" } },
+        .{
+            .key = .{ .string = management.reply.partition_ids },
+            .value = .{ .array = &partition_ids },
+        },
+        .{
+            .key = .{ .string = management.reply.created_at },
+            .value = .{ .timestamp = 1_700_000_000_000 },
+        },
+        .{
+            .key = .{ .string = management.reply.georeplication_factor },
+            .value = .{ .int = 1 },
+        },
+    };
+    const response_properties = [_]amqp.MapEntry{
+        .{
+            .key = .{ .string = amqp.rpc.status_code_key },
+            .value = .{ .int = 200 },
+        },
+        .{
+            .key = .{ .string = amqp.rpc.status_description_key },
+            .value = .{ .string = "OK" },
+        },
+    };
+    const response = try amqp.encodeMessageAlloc(allocator, .{
+        .properties = .{
+            .correlation_id = .{ .string = "management-reply-to-eh:1" },
+        },
+        .application_properties = &response_properties,
+        .body = .{ .value = .{ .map = &body_map } },
+    });
+    defer allocator.free(response);
+    try peer.pushTransfer(0, .{
+        .handle = 1,
+        .delivery_id = 0,
+        .delivery_tag = "r",
+        .message_format = 0,
+        .settled = true,
+        .more = false,
+    }, response);
+
+    const receiver_name =
+        "my-hub/ConsumerGroups/$Default/Partitions/0-receiver-eventhubs";
+    try peer.push(0, .{ .attach = .{
+        .name = receiver_name,
+        .handle = 2,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var annotations = [_]amqp.MapEntry{
+        .{
+            .key = .{ .symbol = event_data.sequence_number_annotation },
+            .value = .{ .long = 1 },
+        },
+        .{
+            .key = .{ .symbol = event_data.offset_annotation },
+            .value = .{ .string = "100" },
+        },
+    };
+    const bodies = [_][]const u8{event_body};
+    const event = try amqp.encodeMessageAlloc(allocator, .{
+        .message_annotations = &annotations,
+        .body = .{ .data = &bodies },
+    });
+    defer allocator.free(event);
+    const tag = [_]u8{1};
+    try peer.pushTransfer(0, .{
+        .handle = 2,
+        .delivery_id = 1,
+        .delivery_tag = &tag,
+        .message_format = 0,
+        .settled = false,
+        .more = false,
+    }, event);
+
+    if (close_ack) {
+        try peer.push(0, .{ .detach = .{ .handle = 2, .closed = true } });
+    }
+}
+
+test "processor recovers terminal receiver and cached management generations" {
+    const allocator = std.testing.allocator;
+    var first_mem = amqp.MemoryTransport.init(allocator);
+    defer first_mem.deinit();
+    var second_mem = amqp.MemoryTransport.init(allocator);
+    defer second_mem.deinit();
+    var third_mem = amqp.MemoryTransport.init(allocator);
+    defer third_mem.deinit();
+
+    try scriptManagementAndPartition(
+        allocator,
+        .{ .allocator = allocator, .mem = &first_mem },
+        "first",
+        false,
+    );
+    try scriptManagementAndPartition(
+        allocator,
+        .{ .allocator = allocator, .mem = &second_mem },
+        "first replay",
+        false,
+    );
+    try scriptManagementAndPartition(
+        allocator,
+        .{ .allocator = allocator, .mem = &third_mem },
+        "metadata replay",
+        true,
+    );
+
+    var transports = TestTransportSequence{
+        .memories = &.{ &first_mem, &second_mem, &third_mem },
+    };
+    var wire_clock = amqp.connection_driver.ManualClock{};
+    var factory = connection_options.AmqpConnectionFactory{
+        .allocator = allocator,
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .container_id = "processor-recovery-test",
+        .options = .{ .web_socket = transports.hook() },
+        .clock = wire_clock.clock(),
+        .sasl = .none,
+    };
+    var connection = recovery.RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+    connection.management_link_id = "eh";
+
+    var sleeper = errors.Sleeper{ .sleepFn = testNoSleep };
+    var retry_random = std.Random.DefaultPrng.init(53);
+    var link_transport = LinkTransport.initRecoverable(
+        &connection,
+        .{ .sleeper = &sleeper, .random = retry_random.random() },
+        .{ .deadline_ms = 10_000 },
+    );
+    var credential = ScopeRecordingCredential.init();
+    var consumer = ConsumerClient.init(.{
+        .runtime = testRuntime(),
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .event_hub_name = "my-hub",
+    }, credential.asCredential(), link_transport.asTransport());
+    defer consumer.deinit();
+
+    var opener = consumer.partitionOpener(&connection, 10_000);
+    var balance_clock = ManualClock{};
+    var store = InMemoryCheckpointStore{
+        .allocator = allocator,
+        .clock = &balance_clock.clock,
+    };
+    defer store.deinit();
+    var balance_random = std.Random.DefaultPrng.init(59);
+    var processor = consumer.newProcessor(
+        allocator,
+        &store.store,
+        opener.asOpener(),
+        .{ .load_balancing_strategy = .greedy },
+        &balance_clock.clock,
+        balance_random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    const first = processor.nextPartitionClient().?;
+    first_mem.fail_write = true;
+    const returned = try first.receiveEvents(allocator, 1);
+    defer freeReceivedEvents(allocator, returned);
+    try std.testing.expectEqualStrings("first", returned[0].body());
+    try std.testing.expect(first.recoverable_failure);
+
+    // Preflight releases the failed reader and invalidates its generation
+    // before partition discovery touches that generation's management client.
+    try processor.runOnce();
+    try std.testing.expectEqual(@as(u64, 1), connection.recoveries);
+    const first_replay = processor.nextPartitionClient().?;
+    const replayed = try first_replay.receiveEvents(allocator, 1);
+    defer freeReceivedEvents(allocator, replayed);
+    try std.testing.expectEqualStrings("first replay", replayed[0].body());
+
+    // This time the reader is healthy and the cached management request itself
+    // fails. Its recovery wrapper must rebuild and refetch the client before
+    // the cycle can invalidate and replace the now-stale reader.
+    second_mem.fail_write = true;
+    try processor.runOnce();
+    try std.testing.expectEqual(@as(u64, 2), connection.recoveries);
+    try std.testing.expectEqual(@as(usize, 3), transports.next);
+    const metadata_replay = processor.nextPartitionClient().?;
+    const final = try metadata_replay.receiveEvents(allocator, 1);
+    defer freeReceivedEvents(allocator, final);
+    try std.testing.expectEqualStrings("metadata replay", final[0].body());
+
+    try processor.close();
 }
 
 const TestCryptoProvider = struct {

--- a/root.zig
+++ b/root.zig
@@ -1204,9 +1204,9 @@ pub const ConsumerPartitionOpener = struct {
         return false;
     }
 
-    fn closePartition(o: *PartitionOpener, client: *PartitionClient) void {
+    fn closePartition(o: *PartitionOpener, client: *PartitionClient) anyerror!void {
         const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
-        client.close(self.deadline_ms) catch {};
+        try client.close(self.deadline_ms);
         client.allocator.destroy(client);
     }
 };

--- a/root.zig
+++ b/root.zig
@@ -1294,13 +1294,19 @@ pub const ConsumerPartitionOpener = struct {
             else
                 null;
             defer if (failed_open) |*diagnostic| diagnostic.deinit();
-            const geo_rejected = if (failed_open) |diagnostic|
-                load_balancing.isGeoReplicationOffsetError(diagnostic.condition())
+            const clean_geo_rejection = if (failed_open) |diagnostic|
+                self.connection.isGenerationCurrent(generation) and
+                    !session.ended and
+                    load_balancing.isGeoReplicationOffsetError(diagnostic.condition())
             else
                 false;
 
+            // AMQP only returns this diagnostic after consuming the peer's
+            // Detach and removing the refused receiver. The session and links
+            // already opened on it remain usable.
+            if (clean_geo_rejection) return error.GeoReplicationOffsetRejected;
+
             self.connection.invalidateGeneration(generation);
-            if (geo_rejected) return error.GeoReplicationOffsetRejected;
             return err;
         };
         return client;
@@ -1567,9 +1573,10 @@ const TestTransportSequence = struct {
 
 fn testNoSleep(_: *errors.Sleeper, _: u64) errors.SleepError!void {}
 
-fn scriptManagement(
+fn scriptManagementForPartitions(
     allocator: std.mem.Allocator,
     peer: amqp.test_peer.Peer,
+    ids: []const []const u8,
 ) !void {
     try amqp.test_peer.scriptHandshake(peer, 65536);
     try peer.push(0, .{ .attach = .{
@@ -1601,12 +1608,14 @@ fn scriptManagement(
         .state = .accepted,
     } });
 
-    var partition_ids = [_]amqp.AmqpValue{.{ .string = "0" }};
+    const partition_ids = try allocator.alloc(amqp.AmqpValue, ids.len);
+    defer allocator.free(partition_ids);
+    for (partition_ids, ids) |*value, id| value.* = .{ .string = id };
     var body_map = [_]amqp.MapEntry{
         .{ .key = .{ .string = management.reply.name }, .value = .{ .string = "my-hub" } },
         .{
             .key = .{ .string = management.reply.partition_ids },
-            .value = .{ .array = &partition_ids },
+            .value = .{ .array = partition_ids },
         },
         .{
             .key = .{ .string = management.reply.created_at },
@@ -1645,16 +1654,28 @@ fn scriptManagement(
     }, response);
 }
 
+fn scriptManagement(
+    allocator: std.mem.Allocator,
+    peer: amqp.test_peer.Peer,
+) !void {
+    try scriptManagementForPartitions(allocator, peer, &.{"0"});
+}
+
 fn scriptPartition(
     allocator: std.mem.Allocator,
     peer: amqp.test_peer.Peer,
+    partition_id: []const u8,
     handle: u32,
     delivery_id: u32,
     event_body: []const u8,
     close_ack: bool,
 ) !void {
-    const receiver_name =
-        "my-hub/ConsumerGroups/$Default/Partitions/0-receiver-eventhubs";
+    const receiver_name = try std.fmt.allocPrint(
+        allocator,
+        "my-hub/ConsumerGroups/$Default/Partitions/{s}-receiver-eventhubs",
+        .{partition_id},
+    );
+    defer allocator.free(receiver_name);
     try peer.push(0, .{ .attach = .{
         .name = receiver_name,
         .handle = handle,
@@ -1700,16 +1721,22 @@ fn scriptManagementAndPartition(
     close_ack: bool,
 ) !void {
     try scriptManagement(allocator, peer);
-    try scriptPartition(allocator, peer, 2, 1, event_body, close_ack);
+    try scriptPartition(allocator, peer, "0", 2, 1, event_body, close_ack);
 }
 
 fn scriptRejectedPartition(
+    allocator: std.mem.Allocator,
     peer: amqp.test_peer.Peer,
+    partition_id: []const u8,
     handle: u32,
     condition: []const u8,
 ) !void {
-    const receiver_name =
-        "my-hub/ConsumerGroups/$Default/Partitions/0-receiver-eventhubs";
+    const receiver_name = try std.fmt.allocPrint(
+        allocator,
+        "my-hub/ConsumerGroups/$Default/Partitions/{s}-receiver-eventhubs",
+        .{partition_id},
+    );
+    defer allocator.free(receiver_name);
     try peer.pushExact(0, .{ .attach = .{
         .name = receiver_name,
         .handle = handle,
@@ -1731,18 +1758,32 @@ fn scriptRejectedPartition(
 fn attachedReceiverFilter(
     allocator: std.mem.Allocator,
     mem: *amqp.MemoryTransport,
+    partition_id: []const u8,
+    occurrence: usize,
 ) ![]u8 {
+    const receiver_name = try std.fmt.allocPrint(
+        allocator,
+        "my-hub/ConsumerGroups/$Default/Partitions/{s}-receiver-eventhubs",
+        .{partition_id},
+    );
+    defer allocator.free(receiver_name);
+
     var frames = try amqp.test_peer.EmittedFrames.parse(allocator, mem.written());
     defer frames.deinit();
+    var found: usize = 0;
     for (frames.bodies.items) |body| {
         if (amqp.performative.peekDescriptor(body) != amqp.performative.descriptor.attach) continue;
         var decoded = try amqp.performative.decode(allocator, body);
         defer decoded.deinit();
         const attach = decoded.performative.attach;
-        if (!std.mem.endsWith(u8, attach.name, "-receiver-eventhubs")) continue;
+        if (!std.mem.eql(u8, attach.name, receiver_name)) continue;
         const source = attach.source orelse continue;
         const filters = source.filters orelse continue;
         if (filters.len == 0) continue;
+        if (found != occurrence) {
+            found += 1;
+            continue;
+        }
         return allocator.dupe(u8, filters[0].value.string);
     }
     return error.ReceiverAttachNotFound;
@@ -1879,20 +1920,16 @@ test "production partition opener maps only geo-replication failed opens" {
         const allocator = std.testing.allocator;
         var first_mem = amqp.MemoryTransport.init(allocator);
         defer first_mem.deinit();
-        var second_mem = amqp.MemoryTransport.init(allocator);
-        defer second_mem.deinit();
 
         const first_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &first_mem };
         try scriptManagement(allocator, first_peer);
-        try scriptRejectedPartition(first_peer, 2, case.condition);
+        try scriptRejectedPartition(allocator, first_peer, "0", 2, case.condition);
         if (case.geo_fallback) {
-            const second_peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &second_mem };
-            try amqp.test_peer.scriptHandshake(second_peer, 65536);
-            try scriptPartition(allocator, second_peer, 0, 0, "fallback", true);
+            try scriptPartition(allocator, first_peer, "0", 3, 0, "fallback", true);
         }
 
         var transports = TestTransportSequence{
-            .memories = &.{ &first_mem, &second_mem },
+            .memories = &.{&first_mem},
         };
         var wire_clock = amqp.connection_driver.ManualClock{};
         var factory = connection_options.AmqpConnectionFactory{
@@ -1952,16 +1989,16 @@ test "production partition opener maps only geo-replication failed opens" {
 
         if (case.geo_fallback) {
             try processor.runOnce();
-            try std.testing.expectEqual(@as(u64, 1), connection.recoveries);
-            try std.testing.expectEqual(@as(usize, 2), transports.next);
+            try std.testing.expectEqual(@as(u64, 0), connection.recoveries);
+            try std.testing.expectEqual(@as(usize, 1), transports.next);
 
-            const rejected_filter = try attachedReceiverFilter(allocator, &first_mem);
+            const rejected_filter = try attachedReceiverFilter(allocator, &first_mem, "0", 0);
             defer allocator.free(rejected_filter);
             try std.testing.expectEqualStrings(
                 "amqp.annotation.x-opt-offset > '12345'",
                 rejected_filter,
             );
-            const fallback_filter = try attachedReceiverFilter(allocator, &second_mem);
+            const fallback_filter = try attachedReceiverFilter(allocator, &first_mem, "0", 1);
             defer allocator.free(fallback_filter);
             try std.testing.expectEqualStrings(
                 "amqp.annotation.x-opt-offset > '-1'",
@@ -1981,6 +2018,137 @@ test "production partition opener maps only geo-replication failed opens" {
             try processor.close();
         }
     }
+}
+
+test "geo-replication refusal preserves previously opened partition clients" {
+    const allocator = std.testing.allocator;
+    var mem = amqp.MemoryTransport.init(allocator);
+    defer mem.deinit();
+
+    const peer = amqp.test_peer.Peer{ .allocator = allocator, .mem = &mem };
+    try scriptManagementForPartitions(allocator, peer, &.{ "0", "1", "2" });
+    try scriptPartition(allocator, peer, "0", 2, 1, "partition 0", false);
+    try scriptRejectedPartition(
+        allocator,
+        peer,
+        "1",
+        3,
+        errors.condition.georeplication_invalid_offset,
+    );
+    try scriptPartition(allocator, peer, "1", 4, 2, "partition 1", false);
+    try scriptRejectedPartition(
+        allocator,
+        peer,
+        "2",
+        5,
+        errors.condition.georeplication_invalid_offset,
+    );
+    try scriptPartition(allocator, peer, "2", 6, 3, "partition 2", false);
+    try peer.push(0, .{ .detach = .{ .handle = 2, .closed = true } });
+    try peer.push(0, .{ .detach = .{ .handle = 4, .closed = true } });
+    try peer.push(0, .{ .detach = .{ .handle = 6, .closed = true } });
+
+    var transports = TestTransportSequence{ .memories = &.{&mem} };
+    var wire_clock = amqp.connection_driver.ManualClock{};
+    var factory = connection_options.AmqpConnectionFactory{
+        .allocator = allocator,
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .container_id = "multi-partition-failed-open-test",
+        .options = .{ .web_socket = transports.hook() },
+        .clock = wire_clock.clock(),
+        .sasl = .none,
+    };
+    var connection = recovery.RecoverableConnection.init(allocator, .{
+        .factory = &factory.factory,
+        .deadline_ms = 10_000,
+    });
+    defer connection.deinit();
+    connection.management_link_id = "eh";
+
+    var sleeper = errors.Sleeper{ .sleepFn = testNoSleep };
+    var retry_random = std.Random.DefaultPrng.init(71);
+    var link_transport = LinkTransport.initRecoverable(
+        &connection,
+        .{ .sleeper = &sleeper, .random = retry_random.random() },
+        .{ .deadline_ms = 10_000 },
+    );
+    var credential = ScopeRecordingCredential.init();
+    var consumer = ConsumerClient.init(.{
+        .runtime = testRuntime(),
+        .fully_qualified_namespace = "ns.servicebus.windows.net",
+        .event_hub_name = "my-hub",
+    }, credential.asCredential(), link_transport.asTransport());
+    defer consumer.deinit();
+
+    var opener = consumer.partitionOpener(&connection, 10_000);
+    var balance_clock = ManualClock{};
+    var store = InMemoryCheckpointStore{
+        .allocator = allocator,
+        .clock = &balance_clock.clock,
+    };
+    defer store.deinit();
+    for ([_][]const u8{ "0", "1", "2" }, [_][]const u8{ "10", "20", "30" }) |id, offset| {
+        try store.store.updateCheckpoint(allocator, .{
+            .fully_qualified_namespace = "ns.servicebus.windows.net",
+            .event_hub_name = "my-hub",
+            .consumer_group = "$Default",
+            .partition_id = id,
+            .offset = offset,
+        });
+    }
+    var balance_random = std.Random.DefaultPrng.init(0);
+    var processor = consumer.newProcessor(
+        allocator,
+        &store.store,
+        opener.asOpener(),
+        .{ .load_balancing_strategy = .greedy },
+        &balance_clock.clock,
+        balance_random.random(),
+    );
+    defer processor.deinit();
+
+    try processor.runOnce();
+    try std.testing.expectEqual(@as(u64, 0), connection.recoveries);
+    try std.testing.expectEqual(@as(usize, 1), transports.next);
+    try std.testing.expectEqual(@as(usize, 3), processor.ownedPartitions().len);
+
+    for ([_][]const u8{ "0", "1", "2" }, [_][]const u8{
+        "partition 0",
+        "partition 1",
+        "partition 2",
+    }) |id, body| {
+        const partition = processor.nextPartitionClient().?;
+        try std.testing.expectEqualStrings(id, partition.partitionId());
+        try std.testing.expectEqual(@as(?u64, 0), partition.client.generation());
+        const events = try partition.receiveEvents(allocator, 1);
+        defer freeReceivedEvents(allocator, events);
+        try std.testing.expectEqualStrings(body, events[0].body());
+    }
+    try std.testing.expect(processor.nextPartitionClient() == null);
+
+    const expected_filters = [_]struct {
+        partition_id: []const u8,
+        occurrence: usize,
+        expression: []const u8,
+    }{
+        .{ .partition_id = "0", .occurrence = 0, .expression = "amqp.annotation.x-opt-offset > '10'" },
+        .{ .partition_id = "1", .occurrence = 0, .expression = "amqp.annotation.x-opt-offset > '20'" },
+        .{ .partition_id = "1", .occurrence = 1, .expression = "amqp.annotation.x-opt-offset > '-1'" },
+        .{ .partition_id = "2", .occurrence = 0, .expression = "amqp.annotation.x-opt-offset > '30'" },
+        .{ .partition_id = "2", .occurrence = 1, .expression = "amqp.annotation.x-opt-offset > '-1'" },
+    };
+    for (expected_filters) |expected| {
+        const filter = try attachedReceiverFilter(
+            allocator,
+            &mem,
+            expected.partition_id,
+            expected.occurrence,
+        );
+        defer allocator.free(filter);
+        try std.testing.expectEqualStrings(expected.expression, filter);
+    }
+
+    try processor.close();
 }
 
 const TestCryptoProvider = struct {

--- a/root.zig
+++ b/root.zig
@@ -197,7 +197,7 @@ pub const LinkTransport = struct {
     /// The CBS token for the hub audience. Event Hubs wants it on the message
     /// as well as on the link.
     security_token: ?[]const u8 = null,
-    deadline_ms: i64,
+    timeout_ms: i64,
     /// When set, operations run under the Event Hubs retry schedule.
     retry: ?errors.RetryConfig = null,
     transport: AmqpTransport,
@@ -229,7 +229,7 @@ pub const LinkTransport = struct {
     fn initEmpty(options: Options) LinkTransport {
         return .{
             .security_token = options.security_token,
-            .deadline_ms = options.deadline_ms,
+            .timeout_ms = options.deadline_ms,
             .retry = options.retry,
             .transport = .{
                 .sendBatchFn = &sendBatchImpl,
@@ -247,6 +247,8 @@ pub const LinkTransport = struct {
         senders: ?*SenderPool = null,
         receivers: ?*ReceiverPool = null,
         security_token: ?[]const u8 = null,
+        /// Per-operation timeout duration in milliseconds. The legacy field
+        /// name is retained for source compatibility.
         deadline_ms: i64,
         retry: ?errors.RetryConfig = null,
     };
@@ -416,13 +418,15 @@ pub const LinkTransport = struct {
 
     fn getHubPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8) !EventHubProperties {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
+        const client = try self.managementClient();
+        const deadline_ms = receiving.deadlineAfter(client.rpc_link.session, self.timeout_ms);
         if (self.retry) |config| {
             return switch (management.getEventHubPropertiesWithRetry(
                 allocator,
-                try self.managementClient(),
+                client,
                 hub_name,
                 self.security_token,
-                self.deadline_ms,
+                deadline_ms,
                 config,
             )) {
                 .ok => |props| props,
@@ -431,23 +435,25 @@ pub const LinkTransport = struct {
         }
         return management.getEventHubProperties(
             allocator,
-            try self.managementClient(),
+            client,
             hub_name,
             self.security_token,
-            self.deadline_ms,
+            deadline_ms,
         );
     }
 
     fn getPartitionPropsImpl(t: *AmqpTransport, allocator: std.mem.Allocator, hub_name: []const u8, partition_id: []const u8) !PartitionProperties {
         const self: *LinkTransport = @fieldParentPtr("transport", t);
+        const client = try self.managementClient();
+        const deadline_ms = receiving.deadlineAfter(client.rpc_link.session, self.timeout_ms);
         if (self.retry) |config| {
             return switch (management.getPartitionPropertiesWithRetry(
                 allocator,
-                try self.managementClient(),
+                client,
                 hub_name,
                 partition_id,
                 self.security_token,
-                self.deadline_ms,
+                deadline_ms,
                 config,
             )) {
                 .ok => |props| props,
@@ -456,11 +462,11 @@ pub const LinkTransport = struct {
         }
         return management.getPartitionProperties(
             allocator,
-            try self.managementClient(),
+            client,
             hub_name,
             partition_id,
             self.security_token,
-            self.deadline_ms,
+            deadline_ms,
         );
     }
 
@@ -1035,13 +1041,14 @@ pub const ConsumerClient = struct {
     /// Initialise in place; `client` must outlive neither `session` nor the
     /// allocator. This mirrors Go's `NewPartitionClient` and is the path that
     /// supports prefetch, owner level, and resuming without replay.
+    /// `receive_timeout_ms` is renewed against the AMQP clock for every call.
     pub fn newPartitionClient(
         self: *ConsumerClient,
         client: *PartitionClient,
         allocator: std.mem.Allocator,
         session: *amqp.Session,
         partition_id: []const u8,
-        deadline_ms: i64,
+        receive_timeout_ms: i64,
         options: PartitionClientOptions,
     ) !void {
         const source = try self.consumerPath(allocator, partition_id);
@@ -1050,7 +1057,7 @@ pub const ConsumerClient = struct {
         try client.open(allocator, session, .{
             .source_address = source,
             .instance_id = self.instanceId(),
-            .deadline_ms = deadline_ms,
+            .deadline_ms = receive_timeout_ms,
         }, options);
     }
 
@@ -1184,7 +1191,7 @@ pub const ConsumerPartitionOpener = struct {
         client.open(allocator, session, .{
             .source_address = source,
             .instance_id = self.client.instanceId(),
-            .deadline_ms = receiving.deadlineAfter(session, self.timeout_ms),
+            .deadline_ms = self.timeout_ms,
             .generation_guard = .{
                 .context = self.connection,
                 .generation = generation,

--- a/root.zig
+++ b/root.zig
@@ -1198,38 +1198,24 @@ pub const ConsumerPartitionOpener = struct {
                 .isCurrentFn = generationIsCurrent,
             },
         }, with_position) catch |err| {
-            // A replicated namespace refuses an offset carried over from
-            // before a failover. Say so in the error so the processor can
-            // restart the partition rather than abandon it.
-            const geo_rejected =
-                err == error.LinkDetached and sawGeoReplicationRejection(session);
             self.connection.invalidateGeneration(generation);
-            if (geo_rejected) {
-                return error.GeoReplicationOffsetRejected;
-            }
             return err;
         };
         return client;
-    }
-
-    /// Whether the attach that just failed was refused for a geo-replicated
-    /// offset. The link never attached, so the condition is only readable
-    /// from the detached receiver the session still holds.
-    fn sawGeoReplicationRejection(session: *amqp.Session) bool {
-        for (session.receivers.items) |receiver| {
-            const remote = receiver.detach_error orelse continue;
-            if (load_balancing.isGeoReplicationOffsetError(remote.condition)) return true;
-        }
-        return false;
     }
 
     fn closePartition(o: *PartitionOpener, client: *PartitionClient) anyerror!void {
         const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
         const generation = client.generation();
         client.closeAfter(self.timeout_ms) catch |err| {
-            if (err != error.DetachUnconfirmed) return err;
-            if (generation) |value| self.connection.invalidateGeneration(value);
-            client.deinit();
+            if (err == error.DetachUnconfirmed or
+                receiving.isTerminalConnectionError(err))
+            {
+                if (generation) |value| self.connection.invalidateGeneration(value);
+                client.deinit();
+            } else {
+                return err;
+            }
         };
         client.allocator.destroy(client);
     }
@@ -1314,7 +1300,7 @@ pub const CbsAuthorizer = struct {
             },
             .refreshable = credential.isRefreshable(),
         }, deadline_ms);
-        client.close(deadline_ms) catch {};
+        try client.close(deadline_ms);
     }
 };
 

--- a/root.zig
+++ b/root.zig
@@ -10,6 +10,8 @@ const checkpoint = @import("checkpoint.zig");
 const event_data = @import("event_data.zig");
 const errors = @import("errors.zig");
 
+pub const version: []const u8 = @import("build_options").version;
+
 pub const ConnectionStringProperties = messaging_common.ConnectionStringProperties;
 pub const Checkpoint = checkpoint.Checkpoint;
 pub const PartitionOwnership = checkpoint.PartitionOwnership;
@@ -1205,7 +1207,6 @@ pub const ConsumerPartitionOpener = struct {
     fn closePartition(o: *PartitionOpener, client: *PartitionClient) void {
         const self: *ConsumerPartitionOpener = @fieldParentPtr("opener", o);
         client.close(self.deadline_ms) catch {};
-        client.deinit();
         client.allocator.destroy(client);
     }
 };
@@ -1374,6 +1375,10 @@ pub const HubConnection = struct {
 };
 
 // ─────────────────────── Tests ───────────────────────
+
+test "package version comes from the manifest" {
+    try std.testing.expectEqualStrings("0.6.0", version);
+}
 
 // Zig only analyses a file it is told to. Re-exporting a type is not
 // telling it: the decl is lazy, so the file's tests silently do not exist.

--- a/sender.zig
+++ b/sender.zig
@@ -82,7 +82,7 @@ pub const SenderPool = struct {
     /// and 1.68us at N=1024, against a flat 4.8ns hashed at every N. The
     /// hash never loses, including at N=4. The pool owns the keys.
     entries: std.StringHashMapUnmanaged(*amqp.Sender) = .empty,
-    deadline_ms: i64,
+    timeout_ms: i64,
     /// Distinguishes these links from any others on the connection.
     link_id: []const u8,
     /// Why the broker refused the most recent delivery. An error cannot carry
@@ -93,6 +93,8 @@ pub const SenderPool = struct {
     max_in_flight: u32 = 1,
 
     pub const Options = struct {
+        /// Per-operation timeout duration in milliseconds. The legacy field
+        /// name is retained for source compatibility.
         deadline_ms: i64,
         link_id: []const u8 = "eventhubs",
         /// How many batches a link may have on the wire unconfirmed.
@@ -112,7 +114,7 @@ pub const SenderPool = struct {
         return .{
             .allocator = allocator,
             .session = session,
-            .deadline_ms = options.deadline_ms,
+            .timeout_ms = options.deadline_ms,
             .link_id = options.link_id,
             .max_in_flight = @max(options.max_in_flight, 1),
         };
@@ -129,6 +131,14 @@ pub const SenderPool = struct {
 
     /// The sender attached to `address`, attaching one if there is none.
     pub fn senderFor(self: *SenderPool, address: []const u8) !*amqp.Sender {
+        return self.senderForDeadline(address, deadlineAfter(self.session, self.timeout_ms));
+    }
+
+    fn senderForDeadline(
+        self: *SenderPool,
+        address: []const u8,
+        deadline_ms: i64,
+    ) !*amqp.Sender {
         if (self.entries.get(address)) |sender| return sender;
 
         const name = try std.fmt.allocPrint(
@@ -150,7 +160,7 @@ pub const SenderPool = struct {
             .target_address = address,
             .desired_capabilities = &.{amqp.georeplication_capability},
             .max_in_flight = self.max_in_flight,
-        }, self.deadline_ms);
+        }, deadline_ms);
 
         self.entries.putAssumeCapacityNoClobber(owned, sender);
         return sender;
@@ -164,16 +174,25 @@ pub const SenderPool = struct {
     /// regardless.
     pub fn drop(self: *SenderPool, address: []const u8, detach: bool) void {
         const removed = self.entries.fetchRemove(address) orelse return;
-        if (detach) self.session.closeSender(removed.value, self.deadline_ms);
+        if (detach) {
+            self.session.closeSender(
+                removed.value,
+                deadlineAfter(self.session, self.timeout_ms),
+            );
+        }
         self.allocator.free(removed.key);
         self.last_rejection = null;
     }
 
     /// Forget every sender.
     pub fn dropAll(self: *SenderPool, detach: bool) void {
+        const deadline_ms = if (detach)
+            deadlineAfter(self.session, self.timeout_ms)
+        else
+            0;
         var it = self.entries.iterator();
         while (it.next()) |entry| {
-            if (detach) self.session.closeSender(entry.value_ptr.*, self.deadline_ms);
+            if (detach) self.session.closeSender(entry.value_ptr.*, deadline_ms);
             self.allocator.free(entry.key_ptr.*);
         }
         self.entries.clearRetainingCapacity();
@@ -192,7 +211,8 @@ pub const SenderPool = struct {
     /// The largest transfer the broker will take on `address`, or null when it
     /// advertised no limit.
     pub fn maxMessageSize(self: *SenderPool, address: []const u8) !?u64 {
-        const sender = try self.senderFor(address);
+        const deadline_ms = deadlineAfter(self.session, self.timeout_ms);
+        const sender = try self.senderForDeadline(address, deadline_ms);
         return sender.maxMessageSize();
     }
 
@@ -205,7 +225,8 @@ pub const SenderPool = struct {
     ) !void {
         if (batch.count() == 0) return SendError.EmptyBatch;
 
-        const sender = try self.senderFor(address);
+        const deadline_ms = deadlineAfter(self.session, self.timeout_ms);
+        const sender = try self.senderForDeadline(address, deadline_ms);
         const payload = try encodeBatchTransfer(allocator, batch);
         defer allocator.free(payload);
 
@@ -213,7 +234,7 @@ pub const SenderPool = struct {
         sender.sendBytesWithOptions(
             payload,
             .{ .message_format = batch_message_format },
-            self.deadline_ms,
+            deadline_ms,
         ) catch |err| {
             self.last_rejection = sender.rejection;
             return err;
@@ -239,14 +260,15 @@ pub const SenderPool = struct {
     ) !amqp.DeliveryToken {
         if (batch.count() == 0) return SendError.EmptyBatch;
 
-        const sender = try self.senderFor(address);
+        const deadline_ms = deadlineAfter(self.session, self.timeout_ms);
+        const sender = try self.senderForDeadline(address, deadline_ms);
         const payload = try encodeBatchTransfer(allocator, batch);
         defer allocator.free(payload);
 
         return sender.sendBytesAsync(
             payload,
             .{ .message_format = batch_message_format },
-            self.deadline_ms,
+            deadline_ms,
         );
     }
 
@@ -258,8 +280,9 @@ pub const SenderPool = struct {
     /// `lastError` describes it until the next `confirm` on the same address.
     /// An error here means the link itself failed.
     pub fn confirm(self: *SenderPool, address: []const u8) !amqp.Settlement {
-        const sender = try self.senderFor(address);
-        const settlement = try sender.awaitSettlement(self.deadline_ms);
+        const deadline_ms = deadlineAfter(self.session, self.timeout_ms);
+        const sender = try self.senderForDeadline(address, deadline_ms);
+        const settlement = try sender.awaitSettlement(deadline_ms);
         self.last_rejection = settlement.rejection;
         return settlement;
     }
@@ -283,6 +306,10 @@ pub const SenderPool = struct {
         /// given a verdict.
         err: ?anyerror = null,
     };
+
+    fn deadlineAfter(session: *const amqp.Session, timeout_ms: i64) i64 {
+        return session.driver.clock.nowMillis() +| @max(timeout_ms, 0);
+    }
 
     /// Send every batch to `address`, keeping up to `max_in_flight` of them on
     /// the wire at once.
@@ -1089,6 +1116,8 @@ test "a link is attached once and reused for the same address" {
 
     mem.clearWritten();
     try scripted.pool.send(allocator, "my-hub", first);
+    // Pool options are a duration, not an attach-time absolute deadline.
+    clock.advance(20_000);
     try scripted.pool.send(allocator, "my-hub", second);
 
     var frames = try EmittedFrames.parse(allocator, mem.written());


### PR DESCRIPTION
## Summary

- follow up to #438 using released AMQP 0.5.2 after #443
- pin `azure_sdk_amqp` 0.5.2 at `1f79509cef0bd4a85b913b0cd3457b2e22ba8297` with the required immutable internal `git+` URL and released package hash
- keep Event Hubs at 0.6.0 and derive runtime version metadata from the manifest
- configure receivers for 8 live credits, 32 MiB messages, 256 MiB aggregate payload, and 5000 bounded unsettled delivery IDs
- preserve manual/no-prefetch batch behavior, abort replacement credit, atomic selector/result preparation, replay after post-consumption failure, and batches beyond 1024 deliveries
- close receivers through confirmed detach/removal, make processor shutdown retryable, invalidate stale generation-bound wrappers without native dereference, and replace recoverable terminal readers while preserving ownership-loss semantics
- recover failed receiver generations before metadata discovery and refetch management clients through `RecoverableConnection.runWithRecovery`
- consume AMQP 0.5.2 `Session.takeFailedLinkOpen()` diagnostics before recovery; a clean `com.microsoft:georeplication:invalid-offset` refusal retries that partition at earliest on the same healthy session, preserving readers already opened in the cycle, while generic or connection-fatal failures still invalidate the generation

## Validation

- `zig fmt --check .`
- Debug: `zig build test --summary all` — 244/244 passed
- ReleaseSafe: `zig build test -Doptimize=ReleaseSafe --summary all` — 244/244 passed
- `zig build examples -Doptimize=ReleaseSafe --summary all`
- `zig build live-test -Doptimize=ReleaseSafe --summary all` — 4 skipped while unconfigured
- allocation, replay-without-hole, receiver lifecycle, close retry, >1024 atomic settlement, connection-generation recovery, cached management recovery, and failed-open geo-fallback regressions pass
- production multi-partition coverage opens one reader, retries two invalid checkpoints at earliest on the same generation, and proves all three readers remain live
- current `main` package-tree validation passes
- sealed AMQP dependency verification confirms lightweight tag `azure_sdk_amqp/v0.5.2` protects the pinned commit and `zig fetch` produces the declared hash
- package CI passes on Ubuntu, macOS, and Windows
