### PR TITLE
Publish SDK Testing conformance source

### DIFF
--- a/eng/packages.zig
+++ b/eng/packages.zig
@@ -136,6 +136,7 @@ pub const all = [_]Package{
             ".gitignore",
             "build.zig",
             "build.zig.zon",
+            "conformance_test.zig",
             "root.zig",
             "README.md",
             "LICENSE.txt",


### PR DESCRIPTION
Adds `conformance_test.zig` to the exact `azure_sdk_testing` publish path set after the Core 0.3 migration in #445.

Sealed verification now succeeds for `azure_sdk_testing/v0.2.0`.

Closes the remaining SDK Testing registry synchronization work for #412 and #414.