### PR TITLE
amqp: release 0.5.1 with abort replacement credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,17 @@ that know a smaller protocol maximum should set both limits explicitly to gain
 a deeper safe window. A sender that ignores the capped credit is detached with
 `amqp:resource-limit-exceeded` before the crossing chunk is retained.
 
-`issueCredit` also preserves one-shot manual receive requests. If a custom byte
-budget cannot safely put the whole request on the wire, the remainder is held
-and issued automatically as queued deliveries leave, so callers need not loop
-just to restate the same requested count.
+`issueCredit(count)` requests `count` additional completed application
+deliveries. In manual mode (`prefetch = 0`), if an authorized initial or
+continued transfer is aborted, it does not satisfy the request: exactly that
+consumed slot returns to deferred demand, and `receive` emits bounded
+replacement credit from inside its pump before waiting for the next transfer.
+Repeated aborts therefore keep live plus deferred demand constant. If a custom
+byte or settlement-slot budget cannot safely put the whole request on the
+wire, the remainder is held and issued automatically as capacity returns, so
+callers need not loop just to restate the same requested count. Prefetch links
+continue to replenish only through their automatic window and do not also
+restore manual abort demand.
 
 Credit issuance is transactional with its `Flow` frame. The prospective
 credit, deferred request, and overrun debt are committed only after the whole

--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ write or flush failure leaves the local counters uncommitted and terminalizes
 the dirty connection instead. Drain intent follows the same rule and becomes
 active only after its `Flow` is emitted. A compliant drain response may omit
 `link-credit`; the remaining credit is then derived with serial arithmetic
-from the prior delivery limit and the reported `delivery-count`.
+from the prior delivery limit and the reported `delivery-count`. Once a drain
+Flow is emitted, an acknowledgement timeout terminally detaches that receiver:
+silently clearing the flag would race a peer that may still process the drain,
+and stale drain state would suppress later manual abort-demand replacement.
 
 Only a locally emitted `Flow` advances that delivery limit. A sender's incoming
 `Flow` may reconcile its view and reduce remaining credit, but `link-credit`

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_amqp,
-    .version = "0.5.0",
+    .version = "0.5.1",
     .fingerprint = 0xe0a2f9e77f72407d,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/link.zig
+++ b/link.zig
@@ -2564,7 +2564,50 @@ pub const Receiver = struct {
         try self.settle(delivery, .released);
     }
 
+    /// A drain Flow is visible to the peer once emitted, so an ambiguous wait
+    /// failure cannot return this link to normal traffic. Close only this link
+    /// when the stream is still clean; a dirty/terminal driver already closes
+    /// the wider scope.
+    fn failPendingDrain(self: *Receiver, err: LinkError) LinkError {
+        const can_emit_detach = self.attached and
+            !self.poisoned and
+            !self.detach_sent and
+            !self.session.ended and
+            self.session.driver.state != .err;
+        self.drain = false;
+        self.credit = 0;
+        self.deferred_credit = 0;
+        self.delivery_limit = self.delivery_count;
+        self.attached = false;
+        self.awaiting_attach = false;
+        self.poisoned = true;
+        self.clearPartialAndFree();
+        self.session.releaseReceiverDeliveries(self);
+
+        if (!can_emit_detach) return err;
+        self.detach_sent = true;
+        self.session.driver.sendPerformative(.amqp, self.session.channel, .{
+            .detach = .{
+                .handle = self.handle,
+                .closed = true,
+                .err = .{
+                    .condition = "amqp:link:detach-forced",
+                    .description = "drain acknowledgement did not complete",
+                },
+            },
+        }) catch {
+            self.session.driver.invalidate();
+            self.session.terminate();
+        };
+        return err;
+    }
+
     /// Drain outstanding credit so the peer reports what it has left.
+    ///
+    /// Once the drain Flow is emitted, a timeout or other ambiguous wait
+    /// failure terminally detaches this link. Clearing `drain` and reusing it
+    /// would race a peer that may still process the old request, and would
+    /// suppress manual abort-demand replacement on later Transfers.
     pub fn drainCredit(self: *Receiver, deadline_ms: i64) LinkError!void {
         if (self.session.ended or self.poisoned or !self.attached or self.detach_sent)
             return error.LinkDetached;
@@ -2576,7 +2619,7 @@ pub const Receiver = struct {
         while (self.credit > 0 and self.attached) {
             _ = self.session.pump(deadline_ms) catch |e| switch (e) {
                 error.RemoteClosed, error.ConnectionClosed => break,
-                else => return e,
+                else => return self.failPendingDrain(e),
             };
         }
         self.drain = false;
@@ -7949,6 +7992,90 @@ test "draining a receiver waits for the sender to consume the outstanding credit
     try receiver.drainCredit(10_000);
     try testing.expectEqual(@as(u32, 0), receiver.credit);
     try testing.expect(!receiver.drain);
+
+    mem.clearWritten();
+    try receiver.issueCredit(1);
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expect(!decoded.performative.flow.drain);
+}
+
+test "drain acknowledgement timeout terminally detaches manual receiver" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "drainable",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "drainable",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+    try receiver.issueCredit(1);
+
+    mem.clearWritten();
+    mem.starve = true;
+    clock.auto_advance_ms = 1;
+    try testing.expectError(error.Timeout, receiver.drainCredit(clock.millis));
+    try testing.expect(!receiver.drain);
+    try testing.expect(receiver.poisoned);
+    try testing.expect(!receiver.attached);
+    try testing.expect(receiver.detach_sent);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+    try testing.expectEqual(connection.State.opened, driver.state);
+    try testing.expect(!fixture.session.ended);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    try testing.expectEqual(@as(usize, 2), frames.bodies.items.len);
+    try testing.expectEqual(
+        perf.descriptor.flow,
+        perf.peekDescriptor(frames.bodies.items[0]).?,
+    );
+    try testing.expectEqual(
+        perf.descriptor.detach,
+        perf.peekDescriptor(frames.bodies.items[1]).?,
+    );
+    var flow = try perf.decode(allocator, frames.bodies.items[0]);
+    defer flow.deinit();
+    try testing.expect(flow.performative.flow.drain);
+
+    const written = mem.written().len;
+    try testing.expectError(error.LinkDetached, receiver.issueCredit(1));
+    try testing.expectEqual(written, mem.written().len);
+
+    // A late aborted Transfer from a peer that processed the old drain is
+    // ignored as a detached-link straggler and cannot recreate demand.
+    mem.starve = false;
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .aborted = true,
+    }, "");
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+    try testing.expectEqual(written, mem.written().len);
 }
 
 test "omitted drain credit derives remaining across delivery-count wrap" {

--- a/link.zig
+++ b/link.zig
@@ -1660,6 +1660,9 @@ pub const Receiver = struct {
     partial_tag: std.ArrayList(u8) = .empty,
     partial_settled: bool = false,
     partial_rcv_settle_mode: perf.ReceiverSettleMode = .first,
+    /// This in-progress delivery consumed one application delivery requested
+    /// through manual credit. An abort restores exactly this one request.
+    partial_manual_demand: bool = false,
     /// Unsettled ids owned by this link, mirrored in the session-wide map so
     /// reuse is rejected across every receiver on the channel.
     unsettled_ids: std.ArrayList(IncomingUnsettled) = .empty,
@@ -1738,6 +1741,7 @@ pub const Receiver = struct {
         self.partial_id = null;
         self.partial_settled = false;
         self.partial_rcv_settle_mode = self.rcv_settle_mode;
+        self.partial_manual_demand = false;
     }
 
     fn clearPartialAndFree(self: *Receiver) void {
@@ -1750,6 +1754,7 @@ pub const Receiver = struct {
         self.partial_id = null;
         self.partial_settled = false;
         self.partial_rcv_settle_mode = self.rcv_settle_mode;
+        self.partial_manual_demand = false;
     }
 
     /// A consumed transfer cannot be replayed. Any failure incorporating it
@@ -1773,13 +1778,18 @@ pub const Receiver = struct {
         }) catch {};
     }
 
-    fn chargeDeliveryStart(self: *Receiver) void {
+    fn chargeDeliveryStart(self: *Receiver) bool {
         self.delivery_count +%= 1;
         if (self.credit == 0) {
             self.overrun +|= 1;
-        } else {
-            self.credit -= 1;
+            return false;
         }
+        self.credit -= 1;
+        return self.prefetch == 0 and !self.drain;
+    }
+
+    fn restoreAbortedManualDemand(self: *Receiver, consumed: bool) void {
+        if (consumed and !self.drain) self.deferred_credit +|= 1;
     }
 
     fn ensurePartialCapacity(self: *Receiver, needed: usize) Allocator.Error!void {
@@ -1894,7 +1904,9 @@ pub const Receiver = struct {
                 }
             }
             if (t.aborted) {
+                const restore_demand = self.partial_manual_demand;
                 self.clearPartialAndFree();
+                self.restoreAbortedManualDemand(restore_demand);
                 return;
             }
         } else {
@@ -1905,7 +1917,7 @@ pub const Receiver = struct {
             try self.refuseOverrun();
             // Link credit and delivery-count are consumed by the initial
             // transfer, whether the delivery later completes or is aborted.
-            self.chargeDeliveryStart();
+            const manual_demand = self.chargeDeliveryStart();
 
             const id = t.delivery_id.?;
             if (self.session.incoming_deliveries.contains(id)) {
@@ -1920,7 +1932,10 @@ pub const Receiver = struct {
                     self.poisonAfterConsumedTransfer();
                     return err;
                 };
-            if (t.aborted) return;
+            if (t.aborted) {
+                self.restoreAbortedManualDemand(manual_demand);
+                return;
+            }
             if (!settled) {
                 if (self.unsettled_ids.items.len >= self.max_unsettled_deliveries) {
                     try self.refuseSettlementLimit();
@@ -1960,6 +1975,7 @@ pub const Receiver = struct {
             self.partial_id = t.delivery_id.?;
             self.partial_settled = settled;
             self.partial_rcv_settle_mode = settle_mode;
+            self.partial_manual_demand = manual_demand;
             if (!self.partialReservationFits()) try self.refuseBufferLimit();
             if (t.delivery_tag) |tag| {
                 self.partial_tag.appendSlice(self.allocator, tag) catch |err| {
@@ -2004,6 +2020,7 @@ pub const Receiver = struct {
         const id = self.partial_id.?;
         const settled = self.partial_settled;
         self.partial_id = null;
+        self.partial_manual_demand = false;
 
         try self.enqueue(id, tag, payload, settled);
     }
@@ -2095,11 +2112,14 @@ pub const Receiver = struct {
         return self.reservedBufferedBytes(message_size) <= limit;
     }
 
-    /// Grant `count` more credit to the peer.
+    /// Request `count` additional application deliveries from the peer.
     ///
-    /// Anything the peer already took beyond its last grant is charged against
-    /// this one, so credit stays a running authorisation rather than resetting
-    /// and forgiving the overrun.
+    /// In manual mode (`prefetch = 0`), an authorized transfer that is later
+    /// aborted does not satisfy that request: `receive` reissues its one slot
+    /// from inside the pump. Completed deliveries do satisfy it. In prefetch
+    /// mode the automatic window, rather than manual demand replacement, owns
+    /// replenishment. Aggregate bytes, unsettled slots, and overrun debt may
+    /// defer or reduce what can be authorized on the wire at once.
     pub fn issueCredit(self: *Receiver, count: u32) LinkError!void {
         if (self.poisoned or !self.attached or self.detach_sent or self.session.ended)
             return error.LinkDetached;
@@ -7480,6 +7500,121 @@ test "prefetch replenishment commits only a completely emitted Flow" {
     }
 }
 
+fn abortedReplacementFlowFailureIsTransactional(failure: CreditFlowFailure) !void {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = std.math.maxInt(u32),
+        .aborted = true,
+    }, "");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    receiver.delivery_count = std.math.maxInt(u32);
+    receiver.delivery_limit = receiver.delivery_count;
+    try receiver.issueCredit(1);
+    try testing.expectEqual(@as(u32, 0), receiver.delivery_limit);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 1), receiver.deferred_credit);
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "replacement",
+        .settled = true,
+    }, "event");
+
+    const before = receiver.creditState();
+    const before_limit = receiver.delivery_limit;
+    mem.clearWritten();
+    const writes_before = mem.write_count;
+    var switching = SwitchAllocator{ .child = allocator };
+    switch (failure) {
+        .encode_oom => {
+            driver.allocator = switching.allocator();
+            switching.failing = true;
+        },
+        .pre_write => mem.fail_write = true,
+        .partial_write => mem.fail_write_after = writes_before + 1,
+        .flush => mem.fail_flush = true,
+    }
+
+    const result = receiver.receive(10_000);
+    switching.failing = false;
+    driver.allocator = allocator;
+    mem.fail_write = false;
+    mem.fail_write_after = null;
+    mem.fail_flush = false;
+
+    switch (failure) {
+        .encode_oom => try testing.expectError(error.OutOfMemory, result),
+        .pre_write, .partial_write, .flush => try testing.expectError(error.WriteFailed, result),
+    }
+    try testing.expectEqual(before.credit, receiver.credit);
+    try testing.expectEqual(before.deferred_credit, receiver.deferred_credit);
+    try testing.expectEqual(before.overrun, receiver.overrun);
+    try testing.expectEqual(before_limit, receiver.delivery_limit);
+    try testing.expectEqual(@as(usize, 0), mem.written().len);
+    try testing.expectEqual(@as(usize, 0), mem.pending.items.len);
+
+    if (failure == .encode_oom) {
+        try testing.expectEqual(connection.State.opened, driver.state);
+        const delivery = try receiver.receive(10_000);
+        try testing.expectEqualStrings("event", delivery.payload);
+        try testing.expectEqual(@as(u32, 0), receiver.credit);
+        try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+        try testing.expectEqual(@as(u32, 1), receiver.delivery_limit);
+        try testing.expectEqual(@as(u32, 1), receiver.delivery_count);
+
+        var frames = try EmittedFrames.parse(allocator, mem.written());
+        defer frames.deinit();
+        const flows = try frames.of(allocator, perf.descriptor.flow);
+        defer allocator.free(flows);
+        try testing.expectEqual(@as(usize, 1), flows.len);
+        var decoded = try perf.decode(allocator, flows[0]);
+        defer decoded.deinit();
+        try testing.expectEqual(@as(u32, 0), decoded.performative.flow.delivery_count.?);
+        try testing.expectEqual(@as(u32, 1), decoded.performative.flow.link_credit.?);
+        return;
+    }
+
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expectError(error.ConnectionClosed, receiver.receive(10_000));
+    try testing.expectEqual(before.credit, receiver.credit);
+    try testing.expectEqual(before.deferred_credit, receiver.deferred_credit);
+    try testing.expectEqual(before_limit, receiver.delivery_limit);
+}
+
+test "aborted replacement Flow is transactional across failure and wrap" {
+    inline for (std.meta.tags(CreditFlowFailure)) |failure| {
+        try abortedReplacementFlowFailureIsTransactional(failure);
+    }
+}
+
 test "drain state commits only after its Flow is emitted" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
@@ -9862,6 +9997,383 @@ test "one bounded manual credit request is issued repeatedly until satisfied" {
     try testing.expect(receiver.deferred_credit < 298);
 }
 
+test "manual batch larger than its live window survives aborted deliveries" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    var delivery_id: u32 = 0;
+    for (0..12) |i| {
+        if (i % 4 == 0) {
+            try peer.pushTransfer(0, .{
+                .handle = 0,
+                .delivery_id = delivery_id,
+                .aborted = true,
+            }, "");
+            delivery_id += 1;
+        }
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = delivery_id,
+            .delivery_tag = "t",
+            .settled = true,
+        }, "x");
+        delivery_id += 1;
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 1,
+        .max_buffered_bytes = 8,
+    }, 10_000);
+
+    try receiver.issueCredit(12);
+    try testing.expectEqual(@as(u32, 8), receiver.credit);
+    try testing.expectEqual(@as(u32, 4), receiver.deferred_credit);
+    for (0..12) |_| {
+        const delivery = try receiver.receive(10_000);
+        try testing.expectEqualStrings("x", delivery.payload);
+        try expectReceiverAccounting(receiver);
+    }
+
+    try testing.expectEqual(@as(u32, 15), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+    try testing.expectEqual(@as(u32, 0), receiver.overrun);
+    try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
+    try testing.expectEqual(@as(usize, 0), receiver.unsettled_ids.items.len);
+    try testing.expect(receiver.attached);
+}
+
+test "repeated manual aborts keep live plus deferred demand bounded" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    for (0..64) |i| {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = @intCast(i),
+            .aborted = true,
+        }, "");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    try receiver.issueCredit(1);
+    const partial_capacity = receiver.partial.capacity;
+    const ready_capacity = receiver.ready.capacity;
+    const unsettled_capacity = receiver.unsettled_ids.capacity;
+    mem.clearWritten();
+    for (0..64) |_| {
+        _ = try fixture.session.pump(10_000);
+        try testing.expectEqual(@as(u32, 0), receiver.credit);
+        try testing.expectEqual(@as(u32, 1), receiver.deferred_credit);
+        try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+        try testing.expectEqual(@as(?u32, null), receiver.partial_id);
+        try testing.expectEqual(@as(usize, 0), receiver.ready.items.len);
+        try testing.expectEqual(@as(usize, 0), receiver.unsettled_ids.items.len);
+        try testing.expectEqual(partial_capacity, receiver.partial.capacity);
+        try testing.expectEqual(ready_capacity, receiver.ready.capacity);
+        try testing.expectEqual(unsettled_capacity, receiver.unsettled_ids.capacity);
+        try testing.expectEqual(
+            @as(u32, 1),
+            receiver.credit + receiver.deferred_credit +
+                @intFromBool(receiver.partial_manual_demand),
+        );
+
+        try receiver.replenish();
+        try testing.expectEqual(@as(u32, 1), receiver.credit);
+        try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+        try testing.expectEqual(
+            @as(u32, 1),
+            receiver.credit + receiver.deferred_credit +
+                @intFromBool(receiver.partial_manual_demand),
+        );
+    }
+
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 64,
+        .delivery_tag = "valid",
+        .settled = true,
+    }, "event");
+    _ = try fixture.session.pump(10_000);
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("event", delivery.payload);
+    try testing.expectEqual(@as(u32, 65), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 64), flows.len);
+}
+
+test "an unauthorized aborted overrun cannot mint replacement demand" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    for (0..2) |i| {
+        try peer.pushTransfer(0, .{
+            .handle = 0,
+            .delivery_id = @intCast(i),
+            .aborted = true,
+        }, "");
+    }
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    try receiver.issueCredit(1);
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.deferred_credit);
+    try testing.expectEqual(@as(u32, 0), receiver.overrun);
+
+    // The second abort was never authorized. It is protocol debt and cannot
+    // create a second unit of application demand.
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(u32, 1), receiver.deferred_credit);
+    try testing.expectEqual(@as(u32, 1), receiver.overrun);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
+}
+
+test "draining an aborted manual slot does not recreate application demand" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .aborted = true,
+    }, "");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    try receiver.issueCredit(1);
+    mem.clearWritten();
+    try receiver.drainCredit(10_000);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+    try testing.expect(!receiver.drain);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expect(decoded.performative.flow.drain);
+    try testing.expectEqual(@as(u32, 1), decoded.performative.flow.link_credit.?);
+}
+
+test "prefetch abort replenishment does not also create manual demand" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .aborted = true,
+    }, "");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 1,
+        .delivery_tag = "valid",
+        .settled = true,
+    }, "event");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 1,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    mem.clearWritten();
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqualStrings("event", delivery.payload);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u32, 1), decoded.performative.flow.link_credit.?);
+}
+
+test "aborted manual demand remains bounded by byte and settlement slots" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 10,
+        .aborted = true,
+    }, "");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 11,
+        .delivery_tag = "valid",
+    }, "1234567890");
+    try peer.push(0, .{ .disposition = .{
+        .role = .sender,
+        .first = 11,
+        .settled = true,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 10,
+        .max_buffered_bytes = 10,
+        .rcv_settle_mode = .second,
+        .max_unsettled_deliveries = 1,
+    }, 10_000);
+
+    try receiver.issueCredit(3);
+    try testing.expectEqual(@as(u32, 1), receiver.credit);
+    try testing.expectEqual(@as(u32, 2), receiver.deferred_credit);
+    mem.clearWritten();
+
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 11), delivery.id);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 2), receiver.deferred_credit);
+    try testing.expectEqual(@as(usize, 1), receiver.unsettled_ids.items.len);
+    try receiver.accept(delivery);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 2), receiver.deferred_credit);
+
+    _ = try fixture.session.pump(10_000);
+    try testing.expectEqual(@as(usize, 0), receiver.unsettled_ids.items.len);
+    try testing.expectEqual(@as(u32, 1), receiver.credit);
+    try testing.expectEqual(@as(u32, 1), receiver.deferred_credit);
+    try expectReceiverAccounting(receiver);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 2), flows.len);
+    for (flows) |body| {
+        var decoded = try perf.decode(allocator, body);
+        defer decoded.deinit();
+        try testing.expectEqual(@as(u32, 1), decoded.performative.flow.link_credit.?);
+    }
+}
+
 test "a credit-ignoring sender cannot cross the aggregate buffered budget" {
     const allocator = testing.allocator;
     var mem = MemoryTransport.init(allocator);
@@ -10042,6 +10554,133 @@ test "an aborted multi-frame delivery consumes credit once and is not queued" {
     const delivery = try receiver.receive(10_000);
     try testing.expectEqual(@as(u32, 1), delivery.id);
     try testing.expectEqualStrings("good", delivery.payload);
+}
+
+test "manual one-credit receive replaces an initial aborted transfer in-pump" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 0,
+        .delivery_tag = "aborted",
+        .aborted = true,
+    }, "");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 1,
+        .delivery_tag = "valid",
+        .settled = true,
+    }, "event");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    try receiver.issueCredit(1);
+    mem.clearWritten();
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 1), delivery.id);
+    try testing.expectEqualStrings("event", delivery.payload);
+    try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+    try testing.expectEqual(@as(usize, 0), mem.reads_with_pending_writes);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u32, 1), decoded.performative.flow.delivery_count.?);
+    try testing.expectEqual(@as(u32, 1), decoded.performative.flow.link_credit.?);
+}
+
+test "manual one-credit receive replaces an aborted continuation in-pump" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "consumer",
+        .handle = 0,
+        .role = .sender,
+        .initial_delivery_count = 0,
+    } });
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 7,
+        .delivery_tag = "aborted",
+        .more = true,
+    }, "prefix");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 7,
+        .aborted = true,
+    }, "");
+    try peer.pushTransfer(0, .{
+        .handle = 0,
+        .delivery_id = 8,
+        .delivery_tag = "valid",
+        .settled = true,
+    }, "replacement");
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+    const receiver = try openReceiver(&fixture.session, .{
+        .name = "consumer",
+        .source_address = "partition/0",
+        .prefetch = 0,
+        .max_message_size = 16,
+        .max_buffered_bytes = 16,
+    }, 10_000);
+
+    try receiver.issueCredit(1);
+    mem.clearWritten();
+    const delivery = try receiver.receive(10_000);
+    try testing.expectEqual(@as(u32, 8), delivery.id);
+    try testing.expectEqualStrings("replacement", delivery.payload);
+    try testing.expectEqual(@as(u64, 0), receiver.bufferedBytes());
+    try testing.expectEqual(@as(u32, 2), receiver.delivery_count);
+    try testing.expectEqual(@as(u32, 0), receiver.credit);
+    try testing.expectEqual(@as(u32, 0), receiver.deferred_credit);
+    try testing.expectEqual(@as(?u32, null), receiver.partial_id);
+    try testing.expectEqual(@as(usize, 0), mem.reads_with_pending_writes);
+
+    var frames = try EmittedFrames.parse(allocator, mem.written());
+    defer frames.deinit();
+    const flows = try frames.of(allocator, perf.descriptor.flow);
+    defer allocator.free(flows);
+    try testing.expectEqual(@as(usize, 1), flows.len);
+    var decoded = try perf.decode(allocator, flows[0]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u32, 1), decoded.performative.flow.delivery_count.?);
+    try testing.expectEqual(@as(u32, 1), decoded.performative.flow.link_credit.?);
 }
 
 test "continuations may repeat the original delivery id without consuming credit" {


### PR DESCRIPTION
## Summary

Publish `azure_sdk_amqp` 0.5.1 with bounded replacement credit for manual receives whose authorized delivery is aborted.

`issueCredit(count)` now means `count` additional completed application deliveries. In manual mode (`prefetch = 0`), an initial or continued aborted Transfer does not satisfy that demand: the consumed authorized slot is restored to deferred demand, and `Receiver.receive` transactionally emits replacement Flow credit from inside the same pump before reading again.

Closes #450. This is the AMQP follow-up required by Event Hubs #448 and Service Bus #440; those packages can repin after 0.5.1 is tagged.

## Invariants

- Only an aborted Transfer that consumed locally authorized manual credit restores one slot; unauthorized overruns cannot mint demand.
- Live credit, deferred demand, and an in-progress manual delivery remain bounded by the original application request.
- Initial and continuation aborts release partial payload bytes and unsettled delivery IDs before replacement capacity is derived.
- Aggregate byte reservations and `max_unsettled_deliveries` still cap every grant. Mode-second demand remains deferred until the sender acknowledges settlement.
- Prefetch links use only their existing automatic top-up and do not also restore manual demand.
- Drain suppresses abort replacement, while overrun debt continues to reduce future authorization.
- Replacement Flow uses the existing prospective state transaction: encode OOM commits nothing and is retryable; header/body write and flush failures commit nothing and terminalize the dirty transport.
- Delivery count and delivery-limit arithmetic remain wrap-safe.

## Tests

Added coverage for:

- one manual credit, initial abort, replacement Flow, then valid delivery in the same `receive`
- continuation abort with repeated delivery ID, then valid replacement
- a 12-delivery batch through an eight-credit byte window with interspersed aborts
- 64 repeated abort/replacement cycles with stable credit and allocation capacities
- unauthorized aborted overrun debt
- prefetch replacement without double grant
- drain suppression
- combined byte and mode-second settlement-slot constraints
- replacement Flow encode OOM, pre-write, partial-write, and flush failures across delivery-count wrap

## Drain timeout safety

- An emitted drain remains protocol-visible even if its acknowledgement wait times out. The receiver now terminally poisons and closes only that link with `amqp:link:detach-forced`, rather than returning it to normal traffic with ambiguous peer state.
- Credit, deferred demand, delivery limit, partial bytes, and unsettled IDs are cleared at terminalization. Later `issueCredit` fails with `LinkDetached` and emits nothing; a late aborted Transfer is discarded as a detached-link straggler and cannot recreate demand.
- Dirty or already-terminal drain failures do not emit a duplicate Detach. Remote End/Close/Detach remain terminal, while a valid drain response clears the flag and subsequent Flow frames carry `drain = false`.
- Regression coverage exercises zero-byte timeout, exact Flow/Detach ordering, session survival, no reuse, late abort suppression, and successful remote-Flow clearing.

## Release metadata

- base: `1c5ba890ad9c2fcb366c8a18b24eb8d90976a4cc` (`sdk/amqp`)
- version: `0.5.1`
- fingerprint unchanged: `0xe0a2f9e77f72407d`
- `uamqp` pin unchanged: `7fe05747b219fa105d3d36dcf6eaebfe15d61d0e`
- candidate hash: `azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam`

## Validation

- `zig fmt --check .`
- `zig build --summary all`
- Debug: 249/249
- ReleaseSafe: 249/249
- ReleaseFast: 249/249
- 20 repeated Debug runs: 249/249 each
- candidate manifest immutable-dependency validation passed
- Event Hubs #448 against the worktree: 219/219, using only a temporary local AMQP path and updated abort expectations (`outstanding 0 -> 1`; second-call Flow count `1 -> 0` because replacement was already emitted in-pump)
- Service Bus #440 against the worktree: 126/126, using only a temporary local AMQP path and updated post-abort outstanding-demand expectation (`max_receive_count - 2 -> max_receive_count - 1`)

Both downstream worktrees were restored clean. Package CI passed Linux, macOS, and Windows validation at `19837ff2768d5c89f2955420ed0c7302b70675d9`. No AMQP examples or benchmark build steps are configured.

