### PR TITLE
Fix Service Bus AMQP dependency URL

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,7 +13,7 @@
             .hash = "azure_sdk_messaging_common-0.3.0-YklmSimrAABYnVM-KFESp7QVjZSRzJXVpQl3CJ8a_ZeO",
         },
         .azure_sdk_amqp = .{
-            .url = "https://github.com/cataggar/azure-sdk-for-zig/archive/86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b.tar.gz",
+            .url = "git+https://github.com/cataggar/azure-sdk-for-zig.git#86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b",
             .hash = "azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam",
         },
         .serde = .{


### PR DESCRIPTION
## Summary
- replace the Azure AMQP 0.5.1 archive URL with the required immutable full-commit git URL
- retain AMQP commit `86d1c4c1128d3751fb1df82a2f5fe88bcfb6706b`, package hash `azure_sdk_amqp-0.5.1-fUByf3Y7CwD-o1m2YhvpJdJbIXX70wNrulwKUFnp0vam`, and Service Bus version 0.2.0
- unblock publication of the Service Bus changes merged in #440; no package source or behavior changes

## Validation
- `zig fmt --check build.zig admin.zig amqp_transport.zig benchmarks/main.zig build.zig.zon management.zig message.zig root.zig`
- `zig build test --summary all` (Debug, 126/126)
- `zig build test -Doptimize=ReleaseSafe --summary all` (126/126)
- `zig build --summary all` (manifest/dependency validation)

Follow-up to #440.