### PR TITLE
amqp: release 0.5.2 with failed-open diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,11 @@ const delivery = try receiver.receive(deadline_ms);
 try receiver.accept(delivery);
 ```
 
-If a peer rejects `openSender` or `openReceiver`, the call still returns
-`error.LinkDetached`. The session retains the peer's service-defined AMQP
-condition, description, and info map after the temporary link is removed:
+If a peer rejects `openSender` or `openReceiver` with the protocol-defined
+null target/source Attach followed by Detach, the call keeps pumping through
+the Detach and still returns `error.LinkDetached`. The session retains the
+peer's service-defined AMQP condition, description, and info map after the
+temporary link is removed:
 
 ```zig
 const receiver = amqp.openReceiver(&session, options, deadline_ms) catch |err| {

--- a/README.md
+++ b/README.md
@@ -148,6 +148,31 @@ const delivery = try receiver.receive(deadline_ms);
 try receiver.accept(delivery);
 ```
 
+If a peer rejects `openSender` or `openReceiver`, the call still returns
+`error.LinkDetached`. The session retains the peer's service-defined AMQP
+condition, description, and info map after the temporary link is removed:
+
+```zig
+const receiver = amqp.openReceiver(&session, options, deadline_ms) catch |err| {
+    if (err == error.LinkDetached) {
+        if (session.failedLinkOpen()) |diagnostic| {
+            std.log.err("link rejected: {s}", .{diagnostic.condition()});
+        }
+    }
+    return err;
+};
+```
+
+`failedLinkOpen` borrows session-owned diagnostics. They remain valid until the
+next sender/receiver open attempt, `takeFailedLinkOpen`, or session
+deinitialization. `takeFailedLinkOpen` instead transfers an owned value that
+the caller must `deinit`; taking also clears the session slot. Every open
+attempt clears the prior value before doing any allocation, and a successful
+open leaves it empty, so diagnostics cannot leak across retries or link names.
+Sessions and their diagnostic access are caller serialized, like the rest of
+the synchronous link API. Conditions are deliberately not interpreted by this
+package; service clients may map conditions they understand.
+
 `delivery` stays valid until the next `receive` returns, so copy anything you
 need to keep. Prefetched deliveries queue up and are drained with a cursor
 rather than by shifting the queue, which keeps a deep prefetch window linear.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .azure_sdk_amqp,
-    .version = "0.5.1",
+    .version = "0.5.2",
     .fingerprint = 0xe0a2f9e77f72407d,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/connection.zig
+++ b/connection.zig
@@ -176,24 +176,98 @@ pub fn buildProperties(allocator: Allocator, info: ClientInfo) Allocator.Error![
 
 /// An error condition reported by the peer, owned by the driver.
 pub const RemoteError = struct {
+    arena: ?*std.heap.ArenaAllocator = null,
     condition: []const u8,
     description: ?[]const u8,
+    info: ?[]MapEntry = null,
 
     /// Copy an inbound error so it outlives the frame it arrived in.
     pub fn dupe(allocator: Allocator, err: perf.AmqpError) Allocator.Error!RemoteError {
-        const condition = try allocator.dupe(u8, err.condition);
-        errdefer allocator.free(condition);
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = .init(allocator);
+        errdefer arena.deinit();
+
+        const owned = arena.allocator();
+        const condition = try owned.dupe(u8, err.condition);
+        const description = if (err.description) |d| try owned.dupe(u8, d) else null;
+        const info = if (err.info) |entries| blk: {
+            const cloned = try owned.alloc(MapEntry, entries.len);
+            for (entries, cloned) |entry, *copy| {
+                copy.* = .{
+                    .key = try entry.key.clone(owned),
+                    .value = try entry.value.clone(owned),
+                };
+            }
+            break :blk cloned;
+        } else null;
+
         return .{
+            .arena = arena,
             .condition = condition,
-            .description = if (err.description) |d| try allocator.dupe(u8, d) else null,
+            .description = description,
+            .info = info,
         };
     }
 
     pub fn deinit(self: RemoteError, allocator: Allocator) void {
+        if (self.arena) |arena| {
+            arena.deinit();
+            allocator.destroy(arena);
+            return;
+        }
         allocator.free(self.condition);
-        if (self.description) |d| allocator.free(d);
+        if (self.description) |description| allocator.free(description);
+        if (self.info) |entries| {
+            for (entries) |*entry| {
+                entry.key.deinit(allocator);
+                entry.value.deinit(allocator);
+            }
+            allocator.free(entries);
+        }
     }
 };
+
+fn remoteErrorUnderAllocator(allocator: Allocator) !void {
+    var condition = [_]u8{ 't', 'e', 's', 't', ':', 'e', 'r', 'r', 'o', 'r' };
+    var description = [_]u8{ 'd', 'e', 't', 'a', 'i', 'l' };
+    var info_key = [_]u8{ 'n', 'a', 'm', 'e' };
+    var info_value = [_]u8{ 'v', 'a', 'l', 'u', 'e' };
+    const info = [_]MapEntry{.{
+        .key = .{ .symbol = &info_key },
+        .value = .{ .string = &info_value },
+    }};
+
+    const remote = try RemoteError.dupe(allocator, .{
+        .condition = &condition,
+        .description = &description,
+        .info = &info,
+    });
+    defer remote.deinit(allocator);
+
+    @memset(&condition, 'x');
+    @memset(&description, 'x');
+    @memset(&info_key, 'x');
+    @memset(&info_value, 'x');
+
+    try std.testing.expectEqualStrings("test:error", remote.condition);
+    try std.testing.expectEqualStrings("detail", remote.description.?);
+    try std.testing.expectEqual(@as(usize, 1), remote.info.?.len);
+    try std.testing.expectEqualStrings("name", remote.info.?[0].key.symbol);
+    try std.testing.expectEqualStrings("value", remote.info.?[0].value.string);
+}
+
+test "remote error owns condition description and info" {
+    try remoteErrorUnderAllocator(std.testing.allocator);
+}
+
+test "remote error cloning survives every allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        remoteErrorUnderAllocator,
+        .{},
+    );
+}
 
 /// A frame handed back by `receiveFrame`. The body is owned by the driver and
 /// stays valid until the next receive.

--- a/link.zig
+++ b/link.zig
@@ -426,6 +426,28 @@ pub const Session = struct {
         return null;
     }
 
+    fn senderForDetach(self: *Session, handle: u32) ?*Sender {
+        for (self.senders.items) |s| {
+            if ((s.attached or (s.awaiting_attach and s.attach_refused)) and
+                s.remote_handle == handle)
+            {
+                return s;
+            }
+        }
+        return null;
+    }
+
+    fn receiverForDetach(self: *Session, handle: u32) ?*Receiver {
+        for (self.receivers.items) |r| {
+            if ((r.attached or (r.awaiting_attach and r.attach_refused)) and
+                r.remote_handle == handle)
+            {
+                return r;
+            }
+        }
+        return null;
+    }
+
     /// A receiver this endpoint has detached but the peer may not have.
     fn detachedReceiverFor(self: *Session, handle: u32) ?*Receiver {
         for (self.receivers.items) |r| {
@@ -621,11 +643,23 @@ pub const Session = struct {
     fn applyAttach(self: *Session, a: perf.Attach) LinkError!void {
         // Match by link name: the peer echoes it and picks its own handle.
         for (self.senders.items) |s| {
-            if (s.awaiting_attach and !s.poisoned and std.mem.eql(u8, s.name, a.name)) {
+            if (s.awaiting_attach and
+                !s.poisoned and
+                a.role == .receiver and
+                std.mem.eql(u8, s.name, a.name))
+            {
+                if (s.attach_refused) return error.MalformedFrame;
+                s.remote_handle = a.handle;
+                if (a.target == null) {
+                    // A receiver answers a locally initiated sender Attach
+                    // with a null target when it cannot create the terminus.
+                    // The required Detach carries the useful remote error.
+                    s.attach_refused = true;
+                    return;
+                }
                 // `openSender` initiated this link, so its Attach declared the
                 // actual mode. The receiver's response is advisory even when
                 // it expresses the opposite fixed preference.
-                s.remote_handle = a.handle;
                 s.max_message_size = a.max_message_size;
                 s.rcv_settle_mode = a.rcv_settle_mode;
                 if (a.initial_delivery_count) |c| s.delivery_count = c;
@@ -635,18 +669,46 @@ pub const Session = struct {
             }
         }
         for (self.receivers.items) |r| {
-            if (r.awaiting_attach and !r.poisoned and std.mem.eql(u8, r.name, a.name)) {
+            if (r.awaiting_attach and
+                !r.poisoned and
+                a.role == .sender and
+                std.mem.eql(u8, r.name, a.name))
+            {
+                if (r.attach_refused) return error.MalformedFrame;
                 r.remote_handle = a.handle;
+                if (a.source == null) {
+                    // A sender answers a locally initiated receiver Attach
+                    // with a null source when it cannot create the terminus.
+                    // Keep pumping until its required Detach supplies detail.
+                    r.attach_refused = true;
+                    return;
+                }
                 r.peer_max_message_size = a.max_message_size;
                 r.attached = true;
                 r.awaiting_attach = false;
                 return;
             }
         }
+        for (self.senders.items) |s| {
+            if (s.awaiting_attach and
+                !s.poisoned and
+                std.mem.eql(u8, s.name, a.name))
+            {
+                return error.MalformedFrame;
+            }
+        }
+        for (self.receivers.items) |r| {
+            if (r.awaiting_attach and
+                !r.poisoned and
+                std.mem.eql(u8, r.name, a.name))
+            {
+                return error.MalformedFrame;
+            }
+        }
     }
 
     fn applyDetach(self: *Session, d: perf.Detach) LinkError!void {
-        if (self.senderFor(d.handle)) |s| {
+        if (self.senderForDetach(d.handle)) |s| {
             const respond = !s.detach_sent;
             s.attached = false;
             s.awaiting_attach = false;
@@ -660,7 +722,7 @@ pub const Session = struct {
             }
             return;
         }
-        if (self.receiverFor(d.handle)) |r| {
+        if (self.receiverForDetach(d.handle)) |r| {
             const respond = !r.detach_sent;
             r.attached = false;
             r.awaiting_attach = false;
@@ -882,6 +944,7 @@ pub const Sender = struct {
     remote_handle: u32 = std.math.maxInt(u32),
     attached: bool = false,
     awaiting_attach: bool = true,
+    attach_refused: bool = false,
     poisoned: bool = false,
     detach_sent: bool = false,
 
@@ -1504,6 +1567,7 @@ pub fn openSender(
     deadline_ms: i64,
 ) LinkError!*Sender {
     session.clearFailedLinkOpen();
+    var opening_resolved = false;
 
     for (session.senders.items) |sender| {
         if (std.mem.eql(u8, sender.name, options.name)) return error.LinkNameInUse;
@@ -1548,17 +1612,21 @@ pub fn openSender(
         .properties = options.properties,
     } });
     errdefer {
-        session.driver.invalidate();
-        session.terminate();
+        if (!opening_resolved) {
+            session.driver.invalidate();
+            session.terminate();
+        }
     }
 
-    while (!sender.attached) {
-        if (sender.detach_error != null) {
-            session.preserveFailedLinkOpen(&sender.detach_error);
-            return error.LinkDetached;
-        }
+    while (sender.awaiting_attach) {
         _ = try session.pump(deadline_ms);
     }
+    if (!sender.attached) {
+        opening_resolved = true;
+        session.preserveFailedLinkOpen(&sender.detach_error);
+        return error.LinkDetached;
+    }
+    opening_resolved = true;
     session.clearFailedLinkOpen();
     return sender;
 }
@@ -1692,6 +1760,7 @@ pub const Receiver = struct {
     remote_handle: u32 = std.math.maxInt(u32),
     attached: bool = false,
     awaiting_attach: bool = true,
+    attach_refused: bool = false,
     poisoned: bool = false,
     detach_sent: bool = false,
 
@@ -2784,6 +2853,7 @@ pub fn openReceiver(
     deadline_ms: i64,
 ) LinkError!*Receiver {
     session.clearFailedLinkOpen();
+    var opening_resolved = false;
 
     for (session.receivers.items) |receiver| {
         if (std.mem.eql(u8, receiver.name, options.name)) return error.LinkNameInUse;
@@ -2835,19 +2905,23 @@ pub fn openReceiver(
         .properties = options.properties,
     } });
     errdefer {
-        session.driver.invalidate();
-        session.terminate();
+        if (!opening_resolved) {
+            session.driver.invalidate();
+            session.terminate();
+        }
     }
 
-    while (!receiver.attached) {
-        if (receiver.detach_error != null) {
-            session.preserveFailedLinkOpen(&receiver.detach_error);
-            return error.LinkDetached;
-        }
+    while (receiver.awaiting_attach) {
         _ = try session.pump(deadline_ms);
+    }
+    if (!receiver.attached) {
+        opening_resolved = true;
+        session.preserveFailedLinkOpen(&receiver.detach_error);
+        return error.LinkDetached;
     }
 
     if (options.prefetch > 0) try receiver.issueCredit(options.prefetch);
+    opening_resolved = true;
     session.clearFailedLinkOpen();
     return receiver;
 }
@@ -3000,6 +3074,288 @@ test "link open allocation failure cannot expose stale diagnostics" {
         .source_address = "source",
     }, 10_000));
     try testing.expect(session.failedLinkOpen() == null);
+}
+
+const RefusedLinkKind = enum { sender, receiver };
+
+fn pushRefusedAttach(
+    peer: Peer,
+    kind: RefusedLinkKind,
+    name: []const u8,
+    handle: u32,
+) !void {
+    try peer.pushExact(0, .{ .attach = .{
+        .name = name,
+        .handle = handle,
+        .role = if (kind == .sender) .receiver else .sender,
+        .source = if (kind == .sender) .{} else null,
+        .target = if (kind == .receiver) .{} else null,
+        .initial_delivery_count = if (kind == .receiver) 0 else null,
+    } });
+}
+
+test "sender and receiver refused Attach wait for Detach and preserve diagnostics" {
+    inline for (std.meta.tags(RefusedLinkKind)) |kind| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        try pushRefusedAttach(peer, kind, "refused", 40);
+        // Refusal is not complete at the Attach. Keep pumping even when an
+        // unrelated session frame separates it from the required Detach.
+        try peer.push(0, .{ .flow = .{
+            .next_incoming_id = 0,
+            .incoming_window = 1000,
+            .next_outgoing_id = 1,
+            .outgoing_window = 1000,
+        } });
+        const info = [_]uamqp.MapEntry{.{
+            .key = .{ .symbol = "tracking-id" },
+            .value = .{ .string = if (kind == .sender) "sender-id" else "receiver-id" },
+        }};
+        try peer.push(0, .{ .detach = .{
+            .handle = 40,
+            .closed = true,
+            .err = .{
+                .condition = if (kind == .sender)
+                    "amqp:unauthorized-access"
+                else
+                    "com.microsoft:georeplication:invalid-offset",
+                .description = if (kind == .sender)
+                    "sender refused"
+                else
+                    "receiver refused",
+                .info = &info,
+            },
+        } });
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        switch (kind) {
+            .sender => try testing.expectError(error.LinkDetached, openSender(&fixture.session, .{
+                .name = "refused",
+                .target_address = "entity",
+            }, 10_000)),
+            .receiver => try testing.expectError(error.LinkDetached, openReceiver(&fixture.session, .{
+                .name = "refused",
+                .source_address = "entity",
+            }, 10_000)),
+        }
+
+        try testing.expect(!fixture.session.ended);
+        try testing.expectEqual(connection.State.opened, driver.state);
+        try testing.expectEqual(@as(usize, 0), fixture.session.senders.items.len);
+        try testing.expectEqual(@as(usize, 0), fixture.session.receivers.items.len);
+
+        var diagnostic = fixture.session.takeFailedLinkOpen().?;
+        defer diagnostic.deinit();
+        try testing.expectEqualStrings(
+            if (kind == .sender)
+                "amqp:unauthorized-access"
+            else
+                "com.microsoft:georeplication:invalid-offset",
+            diagnostic.condition(),
+        );
+        try testing.expectEqualStrings(
+            if (kind == .sender) "sender refused" else "receiver refused",
+            diagnostic.description().?,
+        );
+        try testing.expectEqualStrings(
+            if (kind == .sender) "sender-id" else "receiver-id",
+            diagnostic.info().?[0].value.string,
+        );
+
+        // The completed refusal is link-scoped. A replacement can open on the
+        // same live session, while the taken diagnostics remain independently
+        // owned across the next performative decode.
+        try peer.push(0, .{ .attach = .{
+            .name = "replacement",
+            .handle = 41,
+            .role = if (kind == .sender) .receiver else .sender,
+            .initial_delivery_count = if (kind == .receiver) 1 else null,
+        } });
+        switch (kind) {
+            .sender => _ = try openSender(&fixture.session, .{
+                .name = "replacement",
+                .target_address = "entity",
+            }, 10_000),
+            .receiver => _ = try openReceiver(&fixture.session, .{
+                .name = "replacement",
+                .source_address = "entity",
+            }, 10_000),
+        }
+        try testing.expectEqualStrings(
+            if (kind == .sender) "sender refused" else "receiver refused",
+            diagnostic.description().?,
+        );
+    }
+}
+
+test "refused Attach without Detach times out and terminalizes opening" {
+    inline for (std.meta.tags(RefusedLinkKind)) |kind| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{ .auto_advance_ms = 1 };
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        try pushRefusedAttach(peer, kind, "refused", 40);
+        mem.starve = true;
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        const deadline = clock.millis + 10;
+        switch (kind) {
+            .sender => try testing.expectError(error.Timeout, openSender(&fixture.session, .{
+                .name = "refused",
+                .target_address = "entity",
+            }, deadline)),
+            .receiver => try testing.expectError(error.Timeout, openReceiver(&fixture.session, .{
+                .name = "refused",
+                .source_address = "entity",
+            }, deadline)),
+        }
+        try testing.expect(fixture.session.ended);
+        try testing.expectEqual(connection.State.err, driver.state);
+        try testing.expect(mem.closed);
+        try testing.expect(fixture.session.failedLinkOpen() == null);
+        const written = mem.written().len;
+        switch (kind) {
+            .sender => try testing.expectError(error.ConnectionClosed, openSender(&fixture.session, .{
+                .name = "retry",
+                .target_address = "entity",
+            }, deadline + 10)),
+            .receiver => try testing.expectError(error.ConnectionClosed, openReceiver(&fixture.session, .{
+                .name = "retry",
+                .source_address = "entity",
+            }, deadline + 10)),
+        }
+        try testing.expectEqual(written, mem.written().len);
+    }
+}
+
+test "malformed Detach after refused Attach terminalizes opening" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try pushRefusedAttach(peer, .receiver, "refused", 40);
+    // Detach descriptor with a string where its uint handle must be.
+    try peer.pushRaw(0, &.{ 0x00, 0x53, 0x16, 0xc0, 0x04, 0x01, 0xa1, 0x01, 'x' });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    try testing.expectError(error.MalformedFrame, openReceiver(&fixture.session, .{
+        .name = "refused",
+        .source_address = "entity",
+    }, 10_000));
+    try testing.expect(fixture.session.ended);
+    try testing.expectEqual(connection.State.err, driver.state);
+    try testing.expect(mem.closed);
+    try testing.expect(fixture.session.failedLinkOpen() == null);
+    const written = mem.written().len;
+    try testing.expectError(error.ConnectionClosed, openReceiver(&fixture.session, .{
+        .name = "retry",
+        .source_address = "entity",
+    }, 10_000));
+    try testing.expectEqual(written, mem.written().len);
+}
+
+test "Attach response role is validated before accepting a link" {
+    inline for (std.meta.tags(RefusedLinkKind)) |kind| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        try peer.pushExact(0, .{ .attach = .{
+            .name = "link",
+            .handle = 40,
+            .role = if (kind == .sender) .sender else .receiver,
+            .source = .{},
+            .target = .{},
+            .initial_delivery_count = 0,
+        } });
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        switch (kind) {
+            .sender => try testing.expectError(error.MalformedFrame, openSender(&fixture.session, .{
+                .name = "link",
+                .target_address = "entity",
+            }, 10_000)),
+            .receiver => try testing.expectError(error.MalformedFrame, openReceiver(&fixture.session, .{
+                .name = "link",
+                .source_address = "entity",
+            }, 10_000)),
+        }
+        try testing.expect(fixture.session.ended);
+        try testing.expectEqual(connection.State.err, driver.state);
+    }
+}
+
+test "only the peer role's authoritative terminus decides Attach refusal" {
+    const Kind = enum { sender_with_null_source, receiver_with_null_target };
+    inline for (std.meta.tags(Kind)) |kind| {
+        const allocator = testing.allocator;
+        var mem = MemoryTransport.init(allocator);
+        defer mem.deinit();
+        var clock: connection.ManualClock = .{};
+        const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+        try scriptHandshake(peer, 65536);
+        try peer.pushExact(0, .{ .attach = .{
+            .name = "link",
+            .handle = 40,
+            .role = if (kind == .sender_with_null_source) .receiver else .sender,
+            .source = if (kind == .sender_with_null_source) null else .{},
+            .target = if (kind == .receiver_with_null_target) null else .{},
+            .initial_delivery_count = if (kind == .receiver_with_null_target) 0 else null,
+        } });
+
+        var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+        defer driver.deinit();
+        var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+        defer fixture.deinit();
+
+        switch (kind) {
+            .sender_with_null_source => {
+                const sender = try openSender(&fixture.session, .{
+                    .name = "link",
+                    .target_address = "entity",
+                }, 10_000);
+                try testing.expect(sender.attached);
+            },
+            .receiver_with_null_target => {
+                const receiver = try openReceiver(&fixture.session, .{
+                    .name = "link",
+                    .source_address = "entity",
+                }, 10_000);
+                try testing.expect(receiver.attached);
+            },
+        }
+    }
 }
 
 const scriptHandshake = harness.scriptHandshake;

--- a/link.zig
+++ b/link.zig
@@ -70,6 +70,33 @@ pub const Rejection = struct {
 
 // ─────────────────────── Session ───────────────────────
 
+/// Structured remote diagnostics retained when a link-open attempt fails.
+///
+/// A value returned by `Session.takeFailedLinkOpen` belongs to the caller and
+/// remains valid until `deinit` is called. Diagnostics are service agnostic;
+/// callers interpret the peer-defined condition and info fields.
+pub const FailedLinkOpen = struct {
+    allocator: Allocator,
+    remote_error: connection.RemoteError,
+
+    pub fn condition(self: FailedLinkOpen) []const u8 {
+        return self.remote_error.condition;
+    }
+
+    pub fn description(self: FailedLinkOpen) ?[]const u8 {
+        return self.remote_error.description;
+    }
+
+    pub fn info(self: FailedLinkOpen) ?perf.Fields {
+        return self.remote_error.info;
+    }
+
+    pub fn deinit(self: *FailedLinkOpen) void {
+        self.remote_error.deinit(self.allocator);
+        self.* = undefined;
+    }
+};
+
 pub const SessionOptions = struct {
     /// Window sizes. Rust opens sessions with very large windows so the
     /// service is never the one throttling.
@@ -122,6 +149,7 @@ pub const Session = struct {
     senders: std.ArrayList(*Sender) = .empty,
     receivers: std.ArrayList(*Receiver) = .empty,
     incoming_deliveries: std.AutoHashMapUnmanaged(u32, *Receiver) = .empty,
+    failed_link_open: ?FailedLinkOpen = null,
 
     /// Begin a session on `channel`.
     pub fn begin(
@@ -166,7 +194,44 @@ pub const Session = struct {
         self.senders.deinit(self.allocator);
         self.receivers.deinit(self.allocator);
         self.incoming_deliveries.deinit(self.allocator);
+        self.clearFailedLinkOpen();
         self.* = undefined;
+    }
+
+    /// Borrow diagnostics from the most recent failed sender or receiver open.
+    ///
+    /// The returned pointer remains valid until the next link-open attempt,
+    /// `takeFailedLinkOpen`, or session deinitialization. Session operations
+    /// are caller serialized.
+    pub fn failedLinkOpen(self: *const Session) ?*const FailedLinkOpen {
+        return if (self.failed_link_open) |*diagnostic| diagnostic else null;
+    }
+
+    /// Transfer ownership of the most recent failed-link-open diagnostics.
+    ///
+    /// The caller must invoke `FailedLinkOpen.deinit` on the returned value.
+    pub fn takeFailedLinkOpen(self: *Session) ?FailedLinkOpen {
+        const diagnostic = self.failed_link_open;
+        self.failed_link_open = null;
+        return diagnostic;
+    }
+
+    fn clearFailedLinkOpen(self: *Session) void {
+        if (self.failed_link_open) |*diagnostic| diagnostic.deinit();
+        self.failed_link_open = null;
+    }
+
+    fn preserveFailedLinkOpen(
+        self: *Session,
+        remote_error: *?connection.RemoteError,
+    ) void {
+        const owned = remote_error.* orelse return;
+        self.clearFailedLinkOpen();
+        remote_error.* = null;
+        self.failed_link_open = .{
+            .allocator = self.allocator,
+            .remote_error = owned,
+        };
     }
 
     /// End the session on the wire.
@@ -1438,6 +1503,8 @@ pub fn openSender(
     options: SenderOptions,
     deadline_ms: i64,
 ) LinkError!*Sender {
+    session.clearFailedLinkOpen();
+
     for (session.senders.items) |sender| {
         if (std.mem.eql(u8, sender.name, options.name)) return error.LinkNameInUse;
     }
@@ -1466,6 +1533,7 @@ pub fn openSender(
 
     try session.senders.append(session.allocator, sender);
     errdefer _ = session.senders.pop();
+    errdefer session.preserveFailedLinkOpen(&sender.detach_error);
 
     try session.driver.sendPerformative(.amqp, session.channel, .{ .attach = .{
         .name = name,
@@ -1485,9 +1553,13 @@ pub fn openSender(
     }
 
     while (!sender.attached) {
-        if (sender.detach_error != null) return error.LinkDetached;
+        if (sender.detach_error != null) {
+            session.preserveFailedLinkOpen(&sender.detach_error);
+            return error.LinkDetached;
+        }
         _ = try session.pump(deadline_ms);
     }
+    session.clearFailedLinkOpen();
     return sender;
 }
 
@@ -2711,6 +2783,8 @@ pub fn openReceiver(
     options: ReceiverOptions,
     deadline_ms: i64,
 ) LinkError!*Receiver {
+    session.clearFailedLinkOpen();
+
     for (session.receivers.items) |receiver| {
         if (std.mem.eql(u8, receiver.name, options.name)) return error.LinkNameInUse;
     }
@@ -2743,6 +2817,7 @@ pub fn openReceiver(
 
     try session.receivers.append(session.allocator, receiver);
     errdefer _ = session.receivers.pop();
+    errdefer session.preserveFailedLinkOpen(&receiver.detach_error);
 
     try session.driver.sendPerformative(.amqp, session.channel, .{ .attach = .{
         .name = name,
@@ -2765,11 +2840,15 @@ pub fn openReceiver(
     }
 
     while (!receiver.attached) {
-        if (receiver.detach_error != null) return error.LinkDetached;
+        if (receiver.detach_error != null) {
+            session.preserveFailedLinkOpen(&receiver.detach_error);
+            return error.LinkDetached;
+        }
         _ = try session.pump(deadline_ms);
     }
 
     if (options.prefetch > 0) try receiver.issueCredit(options.prefetch);
+    session.clearFailedLinkOpen();
     return receiver;
 }
 
@@ -2783,6 +2862,146 @@ const Peer = harness.Peer;
 const EmittedFrames = harness.EmittedFrames;
 const test_options = harness.driver_options;
 const Fixture = harness.Fixture;
+
+fn testSession(allocator: Allocator) Session {
+    return .{
+        .allocator = allocator,
+        .driver = undefined,
+        .channel = 0,
+        .remote_channel = 0,
+        .incoming_window = 0,
+        .outgoing_window = 0,
+    };
+}
+
+fn failedLinkOpenUnderAllocator(allocator: Allocator) !void {
+    var session = testSession(allocator);
+    defer session.deinit();
+
+    const sender_info = [_]uamqp.MapEntry{.{
+        .key = .{ .symbol = "link-name" },
+        .value = .{ .string = "sender-a" },
+    }};
+    var sender = Sender{
+        .allocator = allocator,
+        .session = &session,
+        .name = "sender-a",
+        .handle = 0,
+    };
+    sender.detach_error = try connection.RemoteError.dupe(allocator, .{
+        .condition = "amqp:unauthorized-access",
+        .description = "sender rejected",
+        .info = &sender_info,
+    });
+    session.preserveFailedLinkOpen(&sender.detach_error);
+    try testing.expect(sender.detach_error == null);
+    // The open path also has an errdefer safety net; its second move is a
+    // no-op rather than clearing the diagnostic already retained above.
+    session.preserveFailedLinkOpen(&sender.detach_error);
+
+    const sender_diagnostic = session.failedLinkOpen().?;
+    try testing.expectEqualStrings("amqp:unauthorized-access", sender_diagnostic.condition());
+    try testing.expectEqualStrings("sender rejected", sender_diagnostic.description().?);
+    try testing.expectEqualStrings(
+        "sender-a",
+        sender_diagnostic.info().?[0].value.string,
+    );
+
+    const receiver_info = [_]uamqp.MapEntry{.{
+        .key = .{ .symbol = "link-name" },
+        .value = .{ .string = "receiver-b" },
+    }};
+    // A new open attempt clears the previous failure before doing anything
+    // that can allocate, so an OOM below cannot expose sender-a as its result.
+    session.clearFailedLinkOpen();
+    var receiver = Receiver{
+        .allocator = allocator,
+        .session = &session,
+        .name = "receiver-b",
+        .handle = 1,
+    };
+    receiver.detach_error = try connection.RemoteError.dupe(allocator, .{
+        .condition = "amqp:not-found",
+        .description = "receiver rejected",
+        .info = &receiver_info,
+    });
+    session.preserveFailedLinkOpen(&receiver.detach_error);
+    try testing.expect(receiver.detach_error == null);
+
+    const receiver_diagnostic = session.failedLinkOpen().?;
+    try testing.expectEqualStrings("amqp:not-found", receiver_diagnostic.condition());
+    try testing.expectEqualStrings("receiver rejected", receiver_diagnostic.description().?);
+    try testing.expectEqualStrings(
+        "receiver-b",
+        receiver_diagnostic.info().?[0].value.string,
+    );
+
+    var taken = session.takeFailedLinkOpen().?;
+    defer taken.deinit();
+    try testing.expect(session.failedLinkOpen() == null);
+    try testing.expectEqualStrings("amqp:not-found", taken.condition());
+
+    session.clearFailedLinkOpen();
+    try testing.expect(session.failedLinkOpen() == null);
+}
+
+test "failed sender and receiver opens preserve owned remote diagnostics" {
+    try failedLinkOpenUnderAllocator(testing.allocator);
+}
+
+test "failed link open diagnostics survive every allocation failure" {
+    try testing.checkAllAllocationFailures(
+        testing.allocator,
+        failedLinkOpenUnderAllocator,
+        .{},
+    );
+}
+
+test "starting or completing a link open clears stale diagnostics" {
+    var session = testSession(testing.allocator);
+    defer session.deinit();
+
+    var remote: ?connection.RemoteError = try connection.RemoteError.dupe(
+        testing.allocator,
+        .{ .condition = "amqp:link:stolen" },
+    );
+    session.preserveFailedLinkOpen(&remote);
+    try testing.expect(session.failedLinkOpen() != null);
+
+    try testing.expectError(error.InvalidReceiverOptions, openReceiver(&session, .{
+        .name = "receiver",
+        .source_address = "source",
+        .max_unsettled_deliveries = 0,
+    }, 10_000));
+    try testing.expect(session.failedLinkOpen() == null);
+    session.clearFailedLinkOpen();
+    try testing.expect(session.failedLinkOpen() == null);
+}
+
+test "link open allocation failure cannot expose stale diagnostics" {
+    // RemoteError with only a condition performs two backing allocations.
+    // Fail the first allocation in the following receiver-open attempt.
+    var failing = testing.FailingAllocator.init(testing.allocator, .{
+        .fail_index = 2,
+    });
+    const allocator = failing.allocator();
+    var session = testSession(allocator);
+    defer session.deinit();
+
+    var remote: ?connection.RemoteError = try connection.RemoteError.dupe(
+        allocator,
+        .{ .condition = "amqp:old-error" },
+    );
+    session.preserveFailedLinkOpen(&remote);
+    try testing.expect(session.failedLinkOpen() != null);
+
+    try testing.expectError(error.OutOfMemory, openReceiver(&session, .{
+        .name = "receiver",
+        .source_address = "source",
+    }, 10_000));
+    try testing.expect(session.failedLinkOpen() == null);
+}
+
 const scriptHandshake = harness.scriptHandshake;
 
 fn expectReceiverAccounting(receiver: *const Receiver) !void {
@@ -2865,6 +3084,40 @@ test "a sender attaches and reports the peer's max-message-size" {
         connection.georeplication_capability,
         a.desired_capabilities.?[0],
     );
+}
+
+test "a successful link open leaves no prior failed-open diagnostics" {
+    const allocator = testing.allocator;
+    var mem = MemoryTransport.init(allocator);
+    defer mem.deinit();
+    var clock: connection.ManualClock = .{};
+    const peer = Peer{ .allocator = allocator, .mem = &mem };
+
+    try scriptHandshake(peer, 65536);
+    try peer.push(0, .{ .attach = .{
+        .name = "producer",
+        .handle = 0,
+        .role = .receiver,
+        .initial_delivery_count = 0,
+    } });
+
+    var driver = try Driver.init(allocator, mem.transport(), clock.clock(), test_options);
+    defer driver.deinit();
+    var fixture = try Fixture.init(allocator, &mem, &clock, &driver);
+    defer fixture.deinit();
+
+    var remote: ?connection.RemoteError = try connection.RemoteError.dupe(
+        allocator,
+        .{ .condition = "amqp:link:stolen" },
+    );
+    fixture.session.preserveFailedLinkOpen(&remote);
+    try testing.expect(fixture.session.failedLinkOpen() != null);
+
+    _ = try openSender(&fixture.session, .{
+        .name = "producer",
+        .target_address = "eh",
+    }, 10_000);
+    try testing.expect(fixture.session.failedLinkOpen() == null);
 }
 
 test "a message past max-frame-size is split and reassembles to the original" {

--- a/root.zig
+++ b/root.zig
@@ -45,6 +45,7 @@ pub const georeplication_capability = connection_driver.georeplication_capabilit
 // Sessions and links.
 pub const Session = link.Session;
 pub const SessionOptions = link.SessionOptions;
+pub const FailedLinkOpen = link.FailedLinkOpen;
 pub const Sender = link.Sender;
 pub const SenderOptions = link.SenderOptions;
 pub const SendOptions = link.SendOptions;

--- a/test_peer.zig
+++ b/test_peer.zig
@@ -29,6 +29,27 @@ pub const Peer = struct {
     }
 
     pub fn push(self: Peer, channel: u16, p: perf.Performative) !void {
+        var normalized = p;
+        switch (normalized) {
+            .attach => |*attach| switch (attach.role) {
+                // An accepted sender Attach has a source, and an accepted
+                // receiver Attach has a target. Most tests only care about
+                // another field, so fill the mandatory terminus shorthand.
+                .sender => if (attach.source == null) {
+                    attach.source = .{};
+                },
+                .receiver => if (attach.target == null) {
+                    attach.target = .{};
+                },
+            },
+            else => {},
+        }
+        try self.pushExact(channel, normalized);
+    }
+
+    /// Push exactly the supplied performative without accepted-Attach
+    /// normalization. Used for protocol refusal and malformed-state tests.
+    pub fn pushExact(self: Peer, channel: u16, p: perf.Performative) !void {
         var buf = uamqp.encoder.Buffer.initDynamic(self.allocator);
         defer buf.deinit();
         try perf.encode(self.allocator, p, &buf);


### PR DESCRIPTION
## Summary
- release `azure_sdk_amqp` 0.5.2 from the merged 0.5.1 tip
- retain owned, service-agnostic remote condition, description, and info when a sender or receiver open fails
- recognize protocol refusal as peer Attach with null authoritative terminus followed by Detach, and keep pumping until the diagnostic-bearing Detach is consumed
- expose borrowed `Session.failedLinkOpen()` and ownership-transferring `Session.takeFailedLinkOpen()` diagnostics with explicit clearing/lifetime semantics
- deep-copy nested AMQP info data and preserve `error.LinkDetached` compatibility

Closes #453. Enables the Event Hubs invalid-offset mapping in #448.

## Validation
- `zig fmt --check .`
- `zig build --summary all`
- `zig build test --summary all` (261/261)
- `zig build test -Doptimize=ReleaseSafe --summary all` (261/261)
- `zig build test -Doptimize=ReleaseFast --summary all` (261/261)
- 20 repeated randomized Debug suites
- immutable candidate-manifest validation
- Event Hubs fork with temporary local AMQP path and end-to-end invalid-offset refused-open mapping test (243/243); downstream worktree restored clean
- Linux/macOS/Windows package CI passed

Candidate hash: `azure_sdk_amqp-0.5.2-fUByfyGnCwCTf2xaEDjrtnKyBirhCDq8r7XxFJoYzXfN`

No merge or auto-merge requested.